### PR TITLE
chore: upgrade liferay-npm-scripts version

### DIFF
--- a/modules/package.json
+++ b/modules/package.json
@@ -5,7 +5,7 @@
 		"compass-mixins": "0.12.10",
 		"jsdoc": "3.6.3",
 		"liferay-frontend-common-css": "1.0.4",
-		"liferay-npm-scripts": "28.0.2",
+		"liferay-npm-scripts": "28.1.0",
 		"metal-jest-serializer": "2.0.0"
 	},
 	"private": true,

--- a/modules/yarn.lock
+++ b/modules/yarn.lock
@@ -3770,12 +3770,12 @@ babel-messages@^6.23.0:
   dependencies:
     babel-runtime "^6.22.0"
 
-babel-plugin-add-module-metadata@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-metadata/-/babel-plugin-add-module-metadata-2.18.2.tgz#629005a1ae924137ae4cd0c66d1b4821bf9c3839"
-  integrity sha512-rdalxLPxhmuhAqRx2pL0+aWm65oot3pLnuAPMGaMNdBVkdddcjYO76vEYoZ9BK8fICNL6T9Q9WFH+QP8Zy7dAw==
+babel-plugin-add-module-metadata@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-add-module-metadata/-/babel-plugin-add-module-metadata-2.18.4.tgz#38c058de65f8b8823ba12aff7fd77d3b53285a03"
+  integrity sha512-xQOyaIvxdyYyOAq5+8H15eoErNL/3WBZv/0VlUsS7Q750CuLCKcX0syZiDIxgyYa4wWLGtHE1QQaohM09mmvig==
   dependencies:
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
     read-json-sync "^2.0.1"
 
 babel-plugin-add-react-displayname@^0.0.5:
@@ -3783,12 +3783,12 @@ babel-plugin-add-react-displayname@^0.0.5:
   resolved "https://registry.yarnpkg.com/babel-plugin-add-react-displayname/-/babel-plugin-add-react-displayname-0.0.5.tgz#339d4cddb7b65fd62d1df9db9fe04de134122bd5"
   integrity sha1-M51M3be2X9YtHfnbn+BN4TQSK9U=
 
-babel-plugin-alias-modules@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-alias-modules/-/babel-plugin-alias-modules-2.18.2.tgz#afd3a5f4e95d749c8d76ac471279d457372b24d0"
-  integrity sha512-T8XehcIUR0qxB1/re2ffib8ZhMhdbj6cf3mapJfKwwXKwJ61bFldUh83Sq4F2UlSMIcYP+ehG8sw5Cv92oaIuA==
+babel-plugin-alias-modules@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-alias-modules/-/babel-plugin-alias-modules-2.18.4.tgz#afcfe695cc97264f5084936ad0858e5f3edd3adb"
+  integrity sha512-kdpcpVCuxAeyE3pe7gQqqd42gRUHws47SaAUIDUepGyv2YXdT84FaiqS3UyAN9btCazeAJlxEVfBo41cdifaGQ==
   dependencies:
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
 
 babel-plugin-dynamic-import-node@2.2.0:
   version "2.2.0"
@@ -3956,38 +3956,38 @@ babel-plugin-minify-type-constructors@^0.4.3:
   dependencies:
     babel-helper-is-void-0 "^0.4.3"
 
-babel-plugin-name-amd-modules@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.18.2.tgz#1a358f0ee889d25545e0b1c71163c468d663db3b"
-  integrity sha512-xaVH1Lf8xtPdIBNuSYvqFzh8VeINSzGskmdYdL93jPL/1OUmdb5ziIA4/VJ0ex1bGy/ogSW22LNaVjOeESNjGA==
+babel-plugin-name-amd-modules@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-name-amd-modules/-/babel-plugin-name-amd-modules-2.18.4.tgz#fca0a86a010415c6562133fbba27c4a8a4a4f868"
+  integrity sha512-lbsZm08gFFsLuGf8ULP9MVLZ7seLhJ3F6keeUX1J8cygKChrZW3U6StcY3YMviUUwXQKhamgxBt9g7581/64GQ==
   dependencies:
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
 
 babel-plugin-named-asset-import@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.2.tgz#20978ed446b8e1bf4a2f42d0a94c0ece85f75f4f"
   integrity sha512-CxwvxrZ9OirpXQ201Ec57OmGhmI8/ui/GwTDy0hSp6CmRvgRC0pSair6Z04Ck+JStA0sMPZzSJ3uE4n17EXpPQ==
 
-babel-plugin-namespace-amd-define@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.18.2.tgz#d580a673a9ffe89228e73790a0fc0a9c00773b8c"
-  integrity sha512-bTYBwsJv0HeYwM/THKQ4nn2Sedz5nGkxKxcs7r+0i/kIW2ocBtzJDvw2VQArZjIwRdciwqOcnJG+H2r7Ov8uhw==
+babel-plugin-namespace-amd-define@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-amd-define/-/babel-plugin-namespace-amd-define-2.18.4.tgz#c2321f3e49e0dc4f642fa268483c321b6580d361"
+  integrity sha512-fPc3ZQvN4lK6l9tuzQTGmnUMUG9EkH3YkxlzWkvuWXZOcweRMPfGAMhqkyAZHda31rpWkHGNd1zyiSolGT95Cg==
   dependencies:
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
 
-babel-plugin-namespace-modules@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.18.2.tgz#02ea3362250118fa24db134387002db82add68f8"
-  integrity sha512-GhiK7r/cSg1H6zttXw2O+jk9yuBV16rMntDHsWbEHR545hy7zbX8Eb1P5kjbF1L0+170X+/DiSFvBwIhITp2Gw==
+babel-plugin-namespace-modules@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-namespace-modules/-/babel-plugin-namespace-modules-2.18.4.tgz#1aec810576e2c4df917e9223c0b4d27397c44760"
+  integrity sha512-0X+CihcrU/suhjjSGH8/gvKvBbu9opYQKrjfv7+hzuOU3kM9Ay1cbayAUyzHcSmWZv+c4jfe1t1J/MWsw5tUkQ==
   dependencies:
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
 
-babel-plugin-normalize-requires@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.18.2.tgz#375fd4809a2c296ee9d62ff89b2fcd320badb5dc"
-  integrity sha512-iOIsWZH6uDM1eRGP6N75+UoDF2SrpXwrEHeGCS0VsezzeCnD6eQSqOYCnJUlDxKzRZAaNIYpMMD0+GDWpYXDcA==
+babel-plugin-normalize-requires@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-normalize-requires/-/babel-plugin-normalize-requires-2.18.4.tgz#52f0bc888aa46864d123b9ccf62112ffc773cd76"
+  integrity sha512-7MeV3/lXRCJ3GAGzpMUc1J5q4Nk2zJNL1+K9iLqe2Esz8CrSmUAhUFacYDFzzwFkW3LCGb9oVkKG3waber/wJg==
   dependencies:
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
 
 babel-plugin-react-docgen@^3.0.0:
   version "3.1.0"
@@ -4072,13 +4072,13 @@ babel-plugin-transform-undefined-to-void@^6.9.4:
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-undefined-to-void/-/babel-plugin-transform-undefined-to-void-6.9.4.tgz#be241ca81404030678b748717322b89d0c8fe280"
   integrity sha1-viQcqBQEAwZ4t0hxcyK4nQyP4oA=
 
-babel-plugin-wrap-modules-amd@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.18.2.tgz#8b4d9350c0cd03d7ecb7bfbef8eecd48e22a2812"
-  integrity sha512-yWTG8w0eKCNzT2zNM1mVjnYxXOYEpRJ6XnQu5IW1sy9WzFMyTNZ+Bkkn3FTtm17i3i2VLliNkbL3hVMOEgx9Jg==
+babel-plugin-wrap-modules-amd@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-wrap-modules-amd/-/babel-plugin-wrap-modules-amd-2.18.4.tgz#ea6c11fc8e73ce5607df68bcfe5b5b8da7f52d23"
+  integrity sha512-DZ11A7Krund256VetaIbFedpRreywnOR5ZJXoT1l6kjDG1yc6SGK6NlT/9qegndzO/QA/busR5dzUquREsPJ6A==
   dependencies:
     babel-template "^6.26.0"
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
     read-json-sync "^2.0.1"
 
 babel-preset-jest@^25.1.0:
@@ -4090,20 +4090,20 @@ babel-preset-jest@^25.1.0:
     "@babel/plugin-syntax-object-rest-spread" "^7.0.0"
     babel-plugin-jest-hoist "^25.1.0"
 
-babel-preset-liferay-standard@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.18.2.tgz#2cf98ecb8dca3721c6a04d7422dcc820daa74ae0"
-  integrity sha512-V2/i5ybsQbSZ51r66UpKGzYZKwLzVJ5JNvqj/OxQYiv+ETGm8dl3Sy12z6HVNTULTSS7l2ZKE7cTM7Xl/f5Bmw==
+babel-preset-liferay-standard@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/babel-preset-liferay-standard/-/babel-preset-liferay-standard-2.18.4.tgz#5a68a3f4447cce059f27f98d3265390043170cbf"
+  integrity sha512-X+cBFrLZb46zxMFjAa+CAldYSa+WCbLOZFOSBlD1hq/rZUv4n9phgq7PhPMLDtCJwJDSPTK1AUFWV5ks7iWTBg==
   dependencies:
-    babel-plugin-add-module-metadata "2.18.2"
-    babel-plugin-alias-modules "2.18.2"
+    babel-plugin-add-module-metadata "2.18.4"
+    babel-plugin-alias-modules "2.18.4"
     babel-plugin-minify-dead-code-elimination "0.5.1"
-    babel-plugin-name-amd-modules "2.18.2"
-    babel-plugin-namespace-amd-define "2.18.2"
-    babel-plugin-namespace-modules "2.18.2"
-    babel-plugin-normalize-requires "2.18.2"
+    babel-plugin-name-amd-modules "2.18.4"
+    babel-plugin-namespace-amd-define "2.18.4"
+    babel-plugin-namespace-modules "2.18.4"
+    babel-plugin-normalize-requires "2.18.4"
     babel-plugin-transform-node-env-inline "0.4.3"
-    babel-plugin-wrap-modules-amd "2.18.2"
+    babel-plugin-wrap-modules-amd "2.18.4"
 
 "babel-preset-minify@^0.5.0 || 0.6.0-alpha.5":
   version "0.5.0"
@@ -11353,25 +11353,25 @@ liferay-lang-key-dev-loader@^1.0.3:
     loader-utils "^1.1.0"
     properties "^1.2.1"
 
-liferay-npm-bridge-generator@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bridge-generator/-/liferay-npm-bridge-generator-2.18.2.tgz#983b9ac8c75c71581b33aebabc9b5d65763245ed"
-  integrity sha512-PrAPx4VJQDIeu0KoXE2UWUt7JWIsLwpA553C88iCfH/c1Votk+h/F1WbZ08ffLJJDTOYcp1GLnoQhsveWeyTPQ==
+liferay-npm-bridge-generator@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bridge-generator/-/liferay-npm-bridge-generator-2.18.4.tgz#dfc4d35026f1d998e8566b23a068ffc353e1fe02"
+  integrity sha512-yAQ+qzhg54F2S0HjlMVeQJtfbLb+nJzPguAlnAc2vFbFVyXmg/15RmwYyTuUJhuZ7zSRV++ZTCdg1bpyxOkNGg==
   dependencies:
     fs-extra "^8.1.0"
     globby "^10.0.1"
     read-json-sync "^2.0.1"
     yargs "^14.0.0"
 
-liferay-npm-build-tools-common@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.18.2.tgz#9c10f7f1e6be9ac34c1b895ddefeeeda2059179f"
-  integrity sha512-BYIS1yPGdHsoXFoo1S7dCh3YeX1rBeKu1KDpgyh9+QYAO1FLpbVyB9inHII4JejnptmgRiFOi6SOg4k9soGB7g==
+liferay-npm-build-tools-common@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-build-tools-common/-/liferay-npm-build-tools-common-2.18.4.tgz#bfda608b515d69b90b1f1d647f34fde9034466b9"
+  integrity sha512-OLpUIvbxeaaKPDFqsbd3VG0RO1AV3I7Xn1DK67qlmSRsG2YLb6fNW4FprRkZMV68YacHSvyqs9na2E0lucYDDg==
   dependencies:
     chalk "^2.4.2"
     dot-prop "^5.0.1"
     escape-string-regexp "^2.0.0"
-    liferay-npm-bundler-preset-standard "2.18.2"
+    liferay-npm-bundler-preset-standard "2.18.4"
     merge "^1.2.1"
     properties "^1.2.1"
     read-json-sync "^2.0.1"
@@ -11391,94 +11391,94 @@ liferay-npm-build-tools-common@3.0.0-snapshot.dda6cd1:
     resolve "^1.8.1"
     webpack "^4.41.6"
 
-liferay-npm-bundler-loader-css-loader@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.18.2.tgz#19ff90fff196ac6d9678f7c56afa3cb1d73803cd"
-  integrity sha512-ElrzOv3RUR1cDlBUvYUOUvBmfqoPxj5SLnBGNwHyL6cCjOFlyJK7Jxv4r9mixMf85IbeBbesfAadQ9Kv7ggm+w==
+liferay-npm-bundler-loader-css-loader@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-loader-css-loader/-/liferay-npm-bundler-loader-css-loader-2.18.4.tgz#b884fc5a2203cbd2509429ceff1c540ecadc7f3b"
+  integrity sha512-KGXdjdZkW3//zA5/VX9vlWFDuy5ss3bH18YAyJ9lZ7xT9WTAAlOSI3QLJiLTisjsCKgNDs4jWlrbXwuK+YZw6A==
   dependencies:
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
     read-json-sync "^2.0.1"
 
-liferay-npm-bundler-plugin-exclude-imports@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.18.2.tgz#f3e51c9b323e48f99aa3989165f284238131125f"
-  integrity sha512-mh8L71/tY9DHDyrCEaUY00OWMIIWqw0CEFKpECzXg01JjFqAHYKJQfW1fLA546vJWrH8WwCugyg9qNS5fKbEbQ==
+liferay-npm-bundler-plugin-exclude-imports@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-exclude-imports/-/liferay-npm-bundler-plugin-exclude-imports-2.18.4.tgz#091f5169b9be3618145958cb107f90910e27e4be"
+  integrity sha512-OSY128LVB19ppp3hKxMvX8LKDCV/0sXf2hBFXvpGt0+hQDuQ3Gqa5CTLu0hSR9vl8q5AuSVlUcD02sLsXog4Jg==
   dependencies:
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
 
-liferay-npm-bundler-plugin-inject-imports-dependencies@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.18.2.tgz#89082a103bb8362f5f95dc9ced948198496bb311"
-  integrity sha512-ptEcWfpOkaT0CwCS8W//TniC54Qh5nyCtQofrlmFKgYRtxbEZoJ+HPDGzLV3s0zW6C2mrNFk3ptfs1YwkWfAuw==
+liferay-npm-bundler-plugin-inject-imports-dependencies@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-imports-dependencies/-/liferay-npm-bundler-plugin-inject-imports-dependencies-2.18.4.tgz#24050cadd4fd578c69a0177ab995cad8b4dfa035"
+  integrity sha512-yrtBTdWhyhSJTix1S8cGC4rDZSPFis6RBmX27ChMMqd8qcqZWL+dKZAaPnSDyIaykhtHXFqjo8ssrUDzd7IVFw==
   dependencies:
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
 
-liferay-npm-bundler-plugin-inject-peer-dependencies@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.18.2.tgz#71014473f2b22ce0a83b05636c4ec15303b4707f"
-  integrity sha512-gT00Pizh1K9a6J7Zl68DGsXLLhmPxcIhtI/DbQ5IL+9EtPYxMsqlpyZT/Dd4hWRNVgL141GuJ+E8ZlgA9kcU6g==
+liferay-npm-bundler-plugin-inject-peer-dependencies@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-inject-peer-dependencies/-/liferay-npm-bundler-plugin-inject-peer-dependencies-2.18.4.tgz#2429e19ba2d13357b1334c9bdd7d064a58fe9fce"
+  integrity sha512-msQYO+e6APYZPU+LzlejOuHVBSQvo10R+IWWZ68XQ3cDvcat/Yoyv5Lb/RsFGu4KlUaRbce/YM+qBwCqedllLw==
   dependencies:
     globby "^10.0.1"
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
     read-json-sync "^2.0.1"
     resolve "^1.8.1"
 
-liferay-npm-bundler-plugin-namespace-packages@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.18.2.tgz#ebab67b760cd571d41f8cddfd34ba0de953c3470"
-  integrity sha512-p5E2dr26oCQhuaLnE0QSWM8Jpv1nhhNHThnjdZ93YQPHAXu4vIMPeNT9OcGg3AdN3W6EUbQ8tJCCNbDxxOINpw==
+liferay-npm-bundler-plugin-namespace-packages@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-namespace-packages/-/liferay-npm-bundler-plugin-namespace-packages-2.18.4.tgz#a202d330654fdd69c78110b3fdb04158d5b5487e"
+  integrity sha512-nzGRLmbKWb2Mr8ddzZwXiG+/XefyvAO4qYn3wMjVfDEtpiAH3zimOJgKyCxZZ26Qah/hotTa7XaM0UofhNWmFg==
   dependencies:
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
 
-liferay-npm-bundler-plugin-replace-browser-modules@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.18.2.tgz#7f28b61f364bf9c0b0245f6aa951be1180362dc5"
-  integrity sha512-MdlN6HSnBJK308VpiPuQyDzKDu3eTnqFtASv4mWsMMgMMKoTKHrbOAzn38fX10Dz4jmvW+avWmTVt26+uERezg==
+liferay-npm-bundler-plugin-replace-browser-modules@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-replace-browser-modules/-/liferay-npm-bundler-plugin-replace-browser-modules-2.18.4.tgz#9e9b2d5610239a96f3e6eee80ba3fdf53edc5643"
+  integrity sha512-DG1J1yFioVJKNxOX1bJuebezQXMYSMwnUTaqdRTr1HNxmJgdYQ6VyNgMttRISe2+AX0fA9FLZeo6aOZi4XEZcg==
   dependencies:
     dot-prop "^5.0.1"
     fs-extra "^8.1.0"
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
 
-liferay-npm-bundler-plugin-resolve-linked-dependencies@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.18.2.tgz#641f5b37c65326db59809c5dd5d9027d2eb6937d"
-  integrity sha512-/moWNeEbdmxodJvBG+vinACpAiqFwENRSE594+2IlF6weA1qWzGFRhCV/sHOpDReVhScgnHEPIae57JUrTJHrA==
+liferay-npm-bundler-plugin-resolve-linked-dependencies@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-plugin-resolve-linked-dependencies/-/liferay-npm-bundler-plugin-resolve-linked-dependencies-2.18.4.tgz#28e30efc8ec05d1d3fc91ff766cb539fea539354"
+  integrity sha512-uf8zYxwNi6nARZ3FCrhQw9M53an8m5IzAx96oE9HP9RYjZMS3UG7UKclzR9Pytv7Q7PSPXTqRNF7hrvtklpANg==
   dependencies:
-    liferay-npm-build-tools-common "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
     read-json-sync "^2.0.1"
     semver "^6.3.0"
 
-liferay-npm-bundler-preset-liferay-dev@4.2.5:
-  version "4.2.5"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-liferay-dev/-/liferay-npm-bundler-preset-liferay-dev-4.2.5.tgz#ec147eafc6e9aba4c6d4ad8422cfea590a235cd8"
-  integrity sha512-ODC1ZJoY1A27RqeTWvDZfVkytWJ/FUR9LMuJGZBaHqVlp7kMMxT5AdTaaREhFOGKsCT8eE770sYy3o5F6Eauuw==
+liferay-npm-bundler-preset-liferay-dev@4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-liferay-dev/-/liferay-npm-bundler-preset-liferay-dev-4.3.0.tgz#0a6c32a239917a6d2d59417cd065b2045007ece5"
+  integrity sha512-H5LgnqEGaIEoa+NGOpdrAkldmlSwialC88sglqPMq6WuYiafNWHbOc/AH3/FRFvs8mRQYMwnCf82YxBfg+6y4g==
   dependencies:
-    babel-preset-liferay-standard "2.18.2"
-    liferay-npm-bundler-loader-css-loader "2.18.2"
-    liferay-npm-bundler-plugin-exclude-imports "2.18.2"
-    liferay-npm-bundler-plugin-inject-imports-dependencies "2.18.2"
-    liferay-npm-bundler-plugin-inject-peer-dependencies "2.18.2"
-    liferay-npm-bundler-plugin-namespace-packages "2.18.2"
-    liferay-npm-bundler-plugin-replace-browser-modules "2.18.2"
-    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.18.2"
+    babel-preset-liferay-standard "2.18.4"
+    liferay-npm-bundler-loader-css-loader "2.18.4"
+    liferay-npm-bundler-plugin-exclude-imports "2.18.4"
+    liferay-npm-bundler-plugin-inject-imports-dependencies "2.18.4"
+    liferay-npm-bundler-plugin-inject-peer-dependencies "2.18.4"
+    liferay-npm-bundler-plugin-namespace-packages "2.18.4"
+    liferay-npm-bundler-plugin-replace-browser-modules "2.18.4"
+    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.18.4"
 
-liferay-npm-bundler-preset-standard@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.18.2.tgz#d2381c7a4fc91b82414a73465b50a44a9ee83c5e"
-  integrity sha512-ZMccTKMgbAMdLcVMFGL50ByuX8ddxAp/lsF8vQHPDvHxDE9QU1AV/Jzi+gXXOFKIfZMt/ECBK/AdFrz+MiM6WQ==
+liferay-npm-bundler-preset-standard@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler-preset-standard/-/liferay-npm-bundler-preset-standard-2.18.4.tgz#79a12aa3175e7fb4e78e49107a07e616a1341dca"
+  integrity sha512-dAyCfosB9XhrYQdkSRGTxPsu1oz75uzMZs3AkwPc9jNoznFRN0Dg9e+8WTGu6dfx7uyGSBd/iYTHk3liMeW/nA==
   dependencies:
-    babel-preset-liferay-standard "2.18.2"
-    liferay-npm-bundler-plugin-exclude-imports "2.18.2"
-    liferay-npm-bundler-plugin-inject-imports-dependencies "2.18.2"
-    liferay-npm-bundler-plugin-inject-peer-dependencies "2.18.2"
-    liferay-npm-bundler-plugin-namespace-packages "2.18.2"
-    liferay-npm-bundler-plugin-replace-browser-modules "2.18.2"
-    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.18.2"
+    babel-preset-liferay-standard "2.18.4"
+    liferay-npm-bundler-plugin-exclude-imports "2.18.4"
+    liferay-npm-bundler-plugin-inject-imports-dependencies "2.18.4"
+    liferay-npm-bundler-plugin-inject-peer-dependencies "2.18.4"
+    liferay-npm-bundler-plugin-namespace-packages "2.18.4"
+    liferay-npm-bundler-plugin-replace-browser-modules "2.18.4"
+    liferay-npm-bundler-plugin-resolve-linked-dependencies "2.18.4"
 
-liferay-npm-bundler@2.18.2:
-  version "2.18.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-bundler/-/liferay-npm-bundler-2.18.2.tgz#d4dad6211a029207dce7c4534ccea38a88ef4501"
-  integrity sha512-yK6rmSlrhU0Y0uEInGq4aPSAkbjnjTB0d2IgaFf4RBSzpBV+eY0UZRWeO6SwwN5MiD08VYX/Q2/E46fYxjN9dg==
+liferay-npm-bundler@2.18.4:
+  version "2.18.4"
+  resolved "https://registry.yarnpkg.com/liferay-npm-bundler/-/liferay-npm-bundler-2.18.4.tgz#009a6939b586e2ced8d592d53c35f02429756664"
+  integrity sha512-u5lp53zI7LujaD8VH13cSJDBYS8c6O+vrvE8TWVSigutEw0fipVGJJe+gRiRo805YgPn71QQ6++a+D7hh5c2eg==
   dependencies:
     babel-core "^6.26.3"
     clone "^2.1.2"
@@ -11488,8 +11488,8 @@ liferay-npm-bundler@2.18.2:
     globby "^10.0.1"
     insight "0.10.3"
     jszip "^3.1.5"
-    liferay-npm-build-tools-common "2.18.2"
-    liferay-npm-bundler-preset-standard "2.18.2"
+    liferay-npm-build-tools-common "2.18.4"
+    liferay-npm-bundler-preset-standard "2.18.4"
     merge "^1.2.1"
     pretty-time "^1.1.0"
     read-json-sync "^2.0.1"
@@ -11518,10 +11518,10 @@ liferay-npm-bundler@3.0.0-snapshot.dda6cd1:
     xml-js "^1.6.8"
     yargs "^14.0.0"
 
-liferay-npm-scripts@28.0.2:
-  version "28.0.2"
-  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-28.0.2.tgz#da329311fb0d28f5cb5c6f5dc44d2febf4bdad33"
-  integrity sha512-EeowxTEyRoAzBovLWAD6+zB/pSnwzMFyvK+m9c0Q0zkLeNDExQLIi9+B7JYgQ7/mPpktGcgaMeAmVZXjgpdanA==
+liferay-npm-scripts@28.1.0:
+  version "28.1.0"
+  resolved "https://registry.yarnpkg.com/liferay-npm-scripts/-/liferay-npm-scripts-28.1.0.tgz#c7dd0bb2d2a4a35673310c4658388e95e678c222"
+  integrity sha512-VzA374TcRVVoEecMcD8msq6TepvYk72RNIlOmvFtEdcT95j+ihAPg+gPWquPL6AlYxFAAKYG5QY6bDHQdSt+tQ==
   dependencies:
     "@babel/cli" "^7.2.3"
     "@babel/core" "^7.8.3"
@@ -11559,9 +11559,9 @@ liferay-npm-scripts@28.0.2:
     jest-fetch-mock "3.0.1"
     liferay-jest-junit-reporter "1.2.0"
     liferay-lang-key-dev-loader "^1.0.3"
-    liferay-npm-bridge-generator "2.18.2"
-    liferay-npm-bundler "2.18.2"
-    liferay-npm-bundler-preset-liferay-dev "4.2.5"
+    liferay-npm-bridge-generator "2.18.4"
+    liferay-npm-bundler "2.18.4"
+    liferay-npm-bundler-preset-liferay-dev "4.3.0"
     liferay-theme-tasks "9.4.3"
     metal-tools-soy "4.3.2"
     minimist "^1.2.0"


### PR DESCRIPTION
This is to fix an error with the bundler that was causing CSS modules to fail when required from the Liferay loader.