### PR TITLE
LPS-99703 Regen

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticle.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticle.java
@@ -115,8 +115,12 @@ public interface JournalArticle
 
 	public String getDescription(String languageId, boolean useDefault);
 
+	@com.liferay.portal.kernel.json.JSON
+	public String getDescriptionCurrentValue();
+
 	public java.util.Map<java.util.Locale, String> getDescriptionMap();
 
+	@com.liferay.portal.kernel.json.JSON
 	public String getDescriptionMapAsXML();
 
 	public com.liferay.portal.kernel.xml.Document getDocument();
@@ -196,6 +200,7 @@ public interface JournalArticle
 
 	public java.util.Map<java.util.Locale, String> getTitleMap();
 
+	@com.liferay.portal.kernel.json.JSON
 	public String getTitleMapAsXML();
 
 	public String getUrlTitle(java.util.Locale locale)

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleWrapper.java
@@ -495,6 +495,11 @@ public class JournalArticleWrapper
 	}
 
 	@Override
+	public String getDescriptionCurrentValue() {
+		return model.getDescriptionCurrentValue();
+	}
+
+	@Override
 	public Map<java.util.Locale, String> getDescriptionMap() {
 		return model.getDescriptionMap();
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -79,6 +79,7 @@ import java.util.TreeSet;
  * @author Brian Wing Shun Chan
  * @author Wesley Gong
  */
+@JSON(strict = true)
 public class JournalArticleImpl extends JournalArticleBaseImpl {
 
 	public static String getContentByLocale(
@@ -287,6 +288,14 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 		return StringPool.BLANK;
 	}
 
+	@JSON
+	@Override
+	public String getDescriptionCurrentValue() {
+		Locale locale = LocaleThreadLocal.getThemeDisplayLocale();
+
+		return getDescription(locale, true);
+	}
+
 	@Override
 	public Map<Locale, String> getDescriptionMap() {
 		if (_descriptionMap != null) {
@@ -299,6 +308,7 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 		return _descriptionMap;
 	}
 
+	@JSON
 	@Override
 	public String getDescriptionMapAsXML() {
 		return LocalizationUtil.updateLocalization(
@@ -306,6 +316,7 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 			getDefaultLanguageId());
 	}
 
+	@JSON
 	@Override
 	public Date getDisplayDate() {
 		if (!PropsValues.SCHEDULER_ENABLED) {
@@ -331,6 +342,7 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 		return _document;
 	}
 
+	@JSON
 	@Override
 	public Date getExpirationDate() {
 		if (!PropsValues.SCHEDULER_ENABLED) {
@@ -500,6 +512,7 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 		return _title;
 	}
 
+	@JSON
 	@Override
 	public Date getReviewDate() {
 		if (!PropsValues.SCHEDULER_ENABLED) {
@@ -619,6 +632,7 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 		return _titleMap;
 	}
 
+	@JSON
 	@Override
 	public String getTitleMapAsXML() {
 		return LocalizationUtil.updateLocalization(


### PR DESCRIPTION
This is a fix for [https://issues.liferay.com/browse/LPS-99703](https://issues.liferay.com/browse/LPS-99703).
Last version of the fix sent in [brianchandotcom#77977](https://github.com/brianchandotcom/liferay-portal/pull/77977) tried to leave the serialized JSON with the same fields it had in 7.0. This was done to avoid making changes in Screens but caused field duplication in serialized JSONs so it was reverted in https://github.com/brianchandotcom/liferay-portal/pull/78095.

The cause of this duplication was a technical limitation of the underlying serialization library Jodd JSON. So, as maintaining the same names was not possible in the end, missing fields (title, description) are now serialized using new names to avoid this duplication. I spoke with @victorg1991 and Screens will need to be updated in order to show this fields that were missing since 7.1. In the end only two fields changed their names:

- _title_ is now called _titleMapAsXML_
- _description_ is now called _descriptionMapAsXML_