### PR TITLE
LPS-111480 | Page structure does not follow fragment configuration

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateConfigurationValuesMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateConfigurationValuesMVCActionCommand.java
@@ -125,16 +125,26 @@ public class UpdateConfigurationValuesMVCActionCommand
 		Iterator<String> keys =
 			defaultEditableFragmentEntryProcessorJSONObject.keys();
 
+		JSONObject mergedEditableFragmentEntryProcessorJSONObject =
+			JSONFactoryUtil.createJSONObject();
+
 		while (keys.hasNext()) {
 			String key = keys.next();
 
 			if (editableFragmentEntryProcessorJSONObject.has(key)) {
-				continue;
+				mergedEditableFragmentEntryProcessorJSONObject.put(
+					key, editableFragmentEntryProcessorJSONObject.get(key));
 			}
-
-			editableFragmentEntryProcessorJSONObject.put(
-				key, defaultEditableFragmentEntryProcessorJSONObject.get(key));
+			else {
+				mergedEditableFragmentEntryProcessorJSONObject.put(
+					key,
+					defaultEditableFragmentEntryProcessorJSONObject.get(key));
+			}
 		}
+
+		editableValuesJSONObject.put(
+			_KEY_EDITABLE_FRAGMENT_ENTRY_PROCESSOR,
+			mergedEditableFragmentEntryProcessorJSONObject);
 
 		return editableValuesJSONObject;
 	}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/updateFragmentEntryLinkContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/updateFragmentEntryLinkContent.js
@@ -16,10 +16,12 @@ import {UPDATE_FRAGMENT_ENTRY_LINK_CONTENT} from './types';
 
 export default function updateFragmentEntryLinkContent({
 	content,
+	editableValues,
 	fragmentEntryLinkId,
 }) {
 	return {
 		content,
+		editableValues,
 		fragmentEntryLinkId,
 		type: UPDATE_FRAGMENT_ENTRY_LINK_CONTENT,
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/FragmentContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/FragmentContent.js
@@ -64,9 +64,15 @@ const FragmentContent = React.forwardRef(
 
 		const updateEditables = useCallback(
 			parent => {
+				let updatedEditableValues = [];
 				if (isMounted()) {
-					setEditables(parent ? getAllEditables(parent) : []);
+					updatedEditableValues = parent
+						? getAllEditables(parent)
+						: [];
+					setEditables(updatedEditableValues);
 				}
+
+				return updatedEditableValues;
 			},
 			[isMounted]
 		);
@@ -101,15 +107,22 @@ const FragmentContent = React.forwardRef(
 				dispatch(
 					updateFragmentEntryLinkContent({
 						content,
+						editableValues,
 						fragmentEntryLinkId,
 					})
 				)
 			);
-		}, [dispatch, fragmentEntryLinkId, segmentsExperienceId]);
+		}, [
+			dispatch,
+			editableValues,
+			fragmentEntryLinkId,
+			segmentsExperienceId,
+		]);
 
 		useEffect(() => {
 			let element = document.createElement('div');
 			element.innerHTML = defaultContent;
+			const updatedEditables = updateEditables(element);
 
 			const updateContent = debounce(() => {
 				if (isMounted() && element) {
@@ -118,7 +131,7 @@ const FragmentContent = React.forwardRef(
 			}, 50);
 
 			if (!editableProcessorUniqueId) {
-				editables.forEach(editable => {
+				updatedEditables.forEach(editable => {
 					resolveEditableValue(
 						editableValues,
 						editable.editableId,
@@ -147,11 +160,11 @@ const FragmentContent = React.forwardRef(
 			defaultContent,
 			editableProcessorUniqueId,
 			editableValues,
-			editables,
 			getFieldValue,
 			isMounted,
 			languageId,
 			prefixedSegmentsExperienceId,
+			updateEditables,
 		]);
 
 		const dropZones = useSelector(state => {
@@ -237,15 +250,16 @@ const FragmentContent = React.forwardRef(
 					fragmentEntryLinkId={fragmentEntryLinkId}
 				/>
 
-				{editableElements.map(editableElement => (
-					<FragmentContentDecoration
-						editableElement={editableElement}
-						element={element}
-						fragmentEntryLinkId={fragmentEntryLinkId}
-						itemId={itemId}
-						key={getEditableElementId(editableElement)}
-					/>
-				))}
+				{element &&
+					editableElements.map(editableElement => (
+						<FragmentContentDecoration
+							editableElement={editableElement}
+							element={element}
+							fragmentEntryLinkId={fragmentEntryLinkId}
+							itemId={itemId}
+							key={getEditableElementId(editableElement)}
+						/>
+					))}
 			</>
 		);
 	}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/reducers/fragmentEntryLinksReducer.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/reducers/fragmentEntryLinksReducer.js
@@ -171,6 +171,10 @@ export default function fragmentEntryLinksReducer(
 				[action.fragmentEntryLinkId]: {
 					...fragmentEntryLinks[action.fragmentEntryLinkId],
 					content: action.content,
+					editableValues:
+						action.editableValues ||
+						fragmentEntryLinks[action.fragmentEntryLinkId]
+							.editableValues,
 				},
 			};
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateFragmentConfiguration.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateFragmentConfiguration.js
@@ -12,7 +12,6 @@
  * details.
  */
 
-import updateEditableValues from '../actions/updateEditableValues';
 import updateFragmentEntryLinkContent from '../actions/updateFragmentEntryLinkContent';
 import {FREEMARKER_FRAGMENT_ENTRY_PROCESSOR} from '../config/constants/freemarkerFragmentEntryProcessor';
 import FragmentService from '../services/FragmentService';
@@ -21,7 +20,6 @@ export default function updateFragmentConfiguration({
 	configurationValues,
 	fragmentEntryLink,
 	prefixedSegmentsExperienceId,
-	segmentsExperienceId,
 }) {
 	const {editableValues, fragmentEntryLinkId} = fragmentEntryLink;
 
@@ -42,16 +40,9 @@ export default function updateFragmentConfiguration({
 			onNetworkStatus: dispatch,
 		}).then(({content, editableValues}) => {
 			dispatch(
-				updateEditableValues({
-					editableValues,
-					fragmentEntryLinkId,
-					segmentsExperienceId,
-				})
-			);
-
-			dispatch(
 				updateFragmentEntryLinkContent({
 					content,
+					editableValues,
 					fragmentEntryLinkId,
 				})
 			);


### PR DESCRIPTION
Hi, 
This solution has two parts: 
- The backend part that merges correctly editables and default editables and stores them correctly in the database, and
 - The front end part that keeps both editableValues and editables in sync (thanks to @p2kmgcl for providing the fix!).

Please let me know if you have any questions. Thanks!