### PR TITLE
LPS-112298 Replace AUI-based Liferay.Util.selectEntity with Clay-based Liferay.Util.openModal

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCompositionDropdownDefaultEventHandler.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentCompositionDropdownDefaultEventHandler.es.js
@@ -87,19 +87,9 @@ class FragmentCompositionDropdownDefaultEventHandler extends DefaultEventHandler
 		selectFragmentCollectionURL,
 		targetFragmentCompositionURL
 	) {
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					destroyOnHide: true,
-					modal: true,
-				},
-				eventName: this.ns('selectFragmentCollection'),
-				id: this.ns('selectFragmentCollection'),
-				title: Liferay.Language.get('select-collection'),
-				uri: selectFragmentCollectionURL,
-			},
-			(selectedItem) => {
+		Liferay.Util.openModal({
+			id: this.ns('selectFragmentCollection'),
+			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					const form = this.one('#fragmentEntryFm');
 
@@ -113,8 +103,11 @@ class FragmentCompositionDropdownDefaultEventHandler extends DefaultEventHandler
 
 					submitForm(form, targetFragmentCompositionURL);
 				}
-			}
-		);
+			},
+			selectEventName: this.ns('selectFragmentCollection'),
+			title: Liferay.Language.get('select-collection'),
+			url: selectFragmentCollectionURL,
+		});
 	}
 
 	_send(url) {

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentEntryDropdownDefaultEventHandler.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/FragmentEntryDropdownDefaultEventHandler.es.js
@@ -28,19 +28,9 @@ class FragmentEntryDropdownDefaultEventHandler extends DefaultEventHandler {
 	}
 
 	copyToContributedFragmentEntry(itemData) {
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					destroyOnHide: true,
-					modal: true,
-				},
-				eventName: this.ns('selectFragmentCollection'),
-				id: this.ns('selectFragmentCollection'),
-				title: Liferay.Language.get('select-collection'),
-				uri: itemData.selectFragmentCollectionURL,
-			},
-			(selectedItem) => {
+		Liferay.Util.openModal({
+			id: this.ns('selectFragmentCollection'),
+			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					this.one('#fragmentCollectionId').value = selectedItem.id;
 					this.one('#fragmentEntryKeys').value =
@@ -51,8 +41,11 @@ class FragmentEntryDropdownDefaultEventHandler extends DefaultEventHandler {
 						itemData.copyContributedFragmentEntryURL
 					);
 				}
-			}
-		);
+			},
+			selectEventName: this.ns('selectFragmentCollection'),
+			title: Liferay.Language.get('select-collection'),
+			url: itemData.selectFragmentCollectionURL,
+		});
 	}
 
 	copyToFragmentEntry(itemData) {
@@ -129,19 +122,9 @@ class FragmentEntryDropdownDefaultEventHandler extends DefaultEventHandler {
 		selectFragmentCollectionURL,
 		targetFragmentEntryURL
 	) {
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					destroyOnHide: true,
-					modal: true,
-				},
-				eventName: this.ns('selectFragmentCollection'),
-				id: this.ns('selectFragmentCollection'),
-				title: Liferay.Language.get('select-collection'),
-				uri: selectFragmentCollectionURL,
-			},
-			(selectedItem) => {
+		Liferay.Util.openModal({
+			id: this.ns('selectFragmentCollection'),
+			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					const form = this.one('#fragmentEntryFm');
 
@@ -155,8 +138,11 @@ class FragmentEntryDropdownDefaultEventHandler extends DefaultEventHandler {
 
 					submitForm(form, targetFragmentEntryURL);
 				}
-			}
-		);
+			},
+			selectEventName: this.ns('selectFragmentCollection'),
+			title: Liferay.Language.get('select-collection'),
+			url: selectFragmentCollectionURL,
+		});
 	}
 
 	_send(url) {

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultEventHandler.es.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/ManagementToolbarDefaultEventHandler.es.js
@@ -50,19 +50,9 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 			this.ns('allRowIds')
 		);
 
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					destroyOnHide: true,
-					modal: true,
-				},
-				eventName: this.ns('selectFragmentCollection'),
-				id: this.ns('selectFragmentCollection'),
-				title: Liferay.Language.get('select-collection'),
-				uri: this.selectFragmentCollectionURL,
-			},
-			(selectedItem) => {
+		Liferay.Util.openModal({
+			id: this.ns('selectFragmentCollection'),
+			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					this.one('#fragmentCollectionId').value = selectedItem.id;
 					this.one('#fragmentEntryKeys').value = fragmentEntryKeys;
@@ -72,8 +62,11 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 						this.copyContributedFragmentEntryURL
 					);
 				}
-			}
-		);
+			},
+			selectEventName: this.ns('selectFragmentCollection'),
+			title: Liferay.Language.get('select-collection'),
+			url: this.selectFragmentCollectionURL,
+		});
 	}
 
 	deleteFragmentCompositionsAndFragmentEntries() {
@@ -115,19 +108,9 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 			this.ns('rowIdsFragmentEntry')
 		);
 
-		Liferay.Util.selectEntity(
-			{
-				dialog: {
-					constrain: true,
-					destroyOnHide: true,
-					modal: true,
-				},
-				eventName: this.ns('selectFragmentCollection'),
-				id: this.ns('selectFragmentCollection'),
-				title: Liferay.Language.get('select-collection'),
-				uri: this.selectFragmentCollectionURL,
-			},
-			(selectedItem) => {
+		Liferay.Util.openModal({
+			id: this.ns('selectFragmentCollection'),
+			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					const form = this.one('#fragmentEntryFm');
 
@@ -143,8 +126,11 @@ class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
 
 					submitForm(form, targetFragmentEntryURL);
 				}
-			}
-		);
+			},
+			selectEventName: this.ns('selectFragmentCollection'),
+			title: Liferay.Language.get('select-collection'),
+			url: this.selectFragmentCollectionURL,
+		});
 	}
 }
 

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/util.js
@@ -1336,7 +1336,11 @@
 
 						openingLiferay.fire(selectEventName, result);
 
-						Util.getWindow().hide();
+						const window = Util.getWindow();
+
+						if (window) {
+							window.hide();
+						}
 					}
 				},
 				'.selector-button'

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -106,6 +106,8 @@ const Modal = ({
 	id,
 	iframeBodyCssClass,
 	onClose,
+	onSelect,
+	selectEventName,
 	size,
 	title,
 	url,
@@ -173,6 +175,20 @@ const Modal = ({
 
 		return <div ref={bodyRef}></div>;
 	};
+
+	useEffect(() => {
+		let eventHandler;
+
+		if (onSelect && selectEventName) {
+			eventHandler = Liferay.on(selectEventName, onSelect);
+		}
+
+		return () => {
+			if (eventHandler) {
+				eventHandler.detach();
+			}
+		};
+	}, [onSelect, selectEventName]);
 
 	return (
 		<>
@@ -337,6 +353,8 @@ Modal.propTypes = {
 	headerHTML: PropTypes.string,
 	id: PropTypes.string,
 	onClose: PropTypes.func,
+	onSelect: PropTypes.func,
+	selectEventName: PropTypes.string,
 	size: PropTypes.oneOf(['full-screen', 'lg', 'sm']),
 	title: PropTypes.string,
 	url: PropTypes.string,


### PR DESCRIPTION
Originally sent to me here: https://github.com/wincent/liferay-portal/pull/265

Previously: https://github.com/wincent/liferay-portal/pull/263 and https://github.com/wincent/liferay-portal/pull/262

Tests [all passed](https://github.com/wincent/liferay-portal/pull/265#issuecomment-628563837) on my fork, so I'd say you could forward directly if you wanted to save another run (just link back to the successful run).

I did the test plan that @markocikos describes [here](https://github.com/wincent/liferay-portal/pull/262):

> To test fragment entry move 1
> 
> 1. Open Control Panel → Site → Site Builder → Page Fragments
> 2. Add two sample collections and a sample fragment component in the first
> 3. Click component dropdown → Move
> 4. Select second collection
> 
> To test fragment entry move 2
> 
> * The same as previous, except use management toolbar instead of component dropdown (select a card to open toolbar)
> 
> To test fragment entry copy 1
> 
> 1. On Page Fragments page, open Basic Components
> 2. Click component dropdown → Copy To
> 3. Select previously created sample collection
> 
> To test fragment entry copy 2
> 
> * The same as previous, except use management toolbar
> 
> I was not able to test fragment composition move, I could not find this in UI. WIP maybe? You need to create fragment composition somehow, and then it is the same dropdown as in the first test. I am pretty confident this would work, it is the same change as in other usages. Product team should be able to test this.

I'll post some screens in comments below to show the results of my testing, but it looks good to me. Please note though what @markocikos said [here](https://github.com/wincent/liferay-portal/pull/265):

> Please review the code, forwarding to Echo team. A reminder - there was one usage I didn't test live, related to fragment composition, so they should definitely doublecheck there.