### PR TITLE
[TS] LPS-114872 ServiceContext is null when it is executed by scheduled job AssetEntriesCheckerUtil.checkAssetEntries()

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceStagingAdvice.java
@@ -298,6 +298,15 @@ public class LayoutLocalServiceStagingAdvice implements BeanFactoryAware {
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
+		if (serviceContext == null) {
+			serviceContext = new ServiceContext();
+
+			long defaultUserId = UserLocalServiceUtil.getDefaultUserId(
+				layout.getCompanyId());
+
+			serviceContext.setUserId(defaultUserId);
+		}
+
 		boolean hasWorkflowTask = StagingUtil.hasWorkflowTask(
 			serviceContext.getUserId(), layoutRevision);
 
@@ -349,6 +358,15 @@ public class LayoutLocalServiceStagingAdvice implements BeanFactoryAware {
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
+		if (serviceContext == null) {
+			serviceContext = new ServiceContext();
+
+			long defaultUserId = UserLocalServiceUtil.getDefaultUserId(
+				layout.getCompanyId());
+
+			serviceContext.setUserId(defaultUserId);
+		}
+
 		boolean hasWorkflowTask = StagingUtil.hasWorkflowTask(
 			serviceContext.getUserId(), layoutRevision);
 
@@ -392,6 +410,15 @@ public class LayoutLocalServiceStagingAdvice implements BeanFactoryAware {
 
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			serviceContext = new ServiceContext();
+
+			long defaultUserId = UserLocalServiceUtil.getDefaultUserId(
+				layout.getCompanyId());
+
+			serviceContext.setUserId(defaultUserId);
+		}
 
 		boolean hasWorkflowTask = StagingUtil.hasWorkflowTask(
 			serviceContext.getUserId(), layoutRevision);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-114872