### PR TITLE
[TS] LPS-115024

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -65,6 +65,7 @@ import com.liferay.portal.kernel.model.ClassedModel;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletModel;
 import com.liferay.portal.kernel.model.ResourcedModel;
@@ -80,6 +81,7 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
@@ -1432,7 +1434,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 
 			if (isPrivateLayout() &&
 				resourceName.equals(Layout.class.getName()) &&
-				roleName.equals(RoleConstants.GUEST)) {
+				roleName.equals(RoleConstants.GUEST) && !_isSiteTemplate()) {
 
 				continue;
 			}
@@ -2663,6 +2665,19 @@ public class PortletDataContextImpl implements PortletDataContext {
 				}
 			}
 		}
+	}
+
+	private boolean _isSiteTemplate() throws PortalException {
+		Group group = GroupLocalServiceUtil.getGroup(getGroupId());
+
+		long layoutSetPrototypeClassNameId =
+			ClassNameLocalServiceUtil.getClassNameId(LayoutSetPrototype.class);
+
+		if (layoutSetPrototypeClassNameId == group.getClassNameId()) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private static final Class<?>[] _XSTREAM_DEFAULT_ALLOWED_TYPES = {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -72,6 +72,7 @@ import com.liferay.portal.kernel.model.LayoutFriendlyURL;
 import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.model.LayoutStagingHandler;
 import com.liferay.portal.kernel.model.LayoutTemplate;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
@@ -79,6 +80,7 @@ import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.model.adapter.StagedTheme;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ImageLocalService;
 import com.liferay.portal.kernel.service.LayoutFriendlyURLLocalService;
@@ -1902,7 +1904,8 @@ public class LayoutStagedModelDataHandler
 
 		if (!privateLayout ||
 			Objects.equals(
-				layout.getType(), LayoutConstants.TYPE_CONTROL_PANEL)) {
+				layout.getType(), LayoutConstants.TYPE_CONTROL_PANEL) ||
+			_isSiteTemplate(group)) {
 
 			addGuestPermissions = true;
 		}
@@ -2398,6 +2401,17 @@ public class LayoutStagedModelDataHandler
 		return null;
 	}
 
+	private boolean _isSiteTemplate(Group group) {
+		long layoutSetPrototypeClassNameId =
+			_classNameLocalService.getClassNameId(LayoutSetPrototype.class);
+
+		if (layoutSetPrototypeClassNameId == group.getClassNameId()) {
+			return true;
+		}
+
+		return false;
+	}
+
 	private static final String _SAME_GROUP_FRIENDLY_URL =
 		"/[$SAME_GROUP_FRIENDLY_URL$]";
 
@@ -2408,6 +2422,9 @@ public class LayoutStagedModelDataHandler
 		TransactionConfig.Factory.create(
 			Propagation.SUPPORTS,
 			new Class<?>[] {PortalException.class, SystemException.class});
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
 
 	private CounterLocalService _counterLocalService;
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-115024

Although Site Template pages are technically private pages and thus should not have any Guest permissions, it is possible to create public pages in a site when creating from the site template.  This results in the Guest view permission always being revoked when creating a site from a site template, even though the permission is enabled by default.

Using _isSiteTemplate() logic from [LayoutsAdminManagementToolbarDisplayContext._isSiteTemplate()](https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContext.java#L280).

Please let me know if you have any questions, thanks!