### PR TITLE
[TECHNICAL-SUPPORT] LPS-116118 Unify lazy upgrade for 'layout-classed-model-usages-*' tags

### DIFF
--- a/modules/apps/layout/layout-taglib/bnd.bnd
+++ b/modules/apps/layout/layout-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Taglib
 Bundle-SymbolicName: com.liferay.layout.taglib
-Bundle-Version: 5.1.8
+Bundle-Version: 5.2.0
 Export-Package:\
 	com.liferay.layout.taglib.servlet.taglib,\
 	com.liferay.layout.taglib.servlet.taglib.react

--- a/modules/apps/layout/layout-taglib/package.json
+++ b/modules/apps/layout/layout-taglib/package.json
@@ -14,5 +14,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "5.1.8"
+	"version": "5.2.0"
 }

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/LayoutClassedModelUsagesAdminTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/LayoutClassedModelUsagesAdminTag.java
@@ -17,15 +17,8 @@ package com.liferay.layout.taglib.servlet.taglib;
 import com.liferay.fragment.constants.FragmentActionKeys;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorWebKeys;
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
-import com.liferay.layout.util.LayoutClassedModelUsageRecorder;
-import com.liferay.petra.string.StringBundler;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.layout.taglib.servlet.taglib.util.LayoutClassedModelUsagesTaglibUtil;
 import com.liferay.taglib.util.IncludeTag;
-
-import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.jsp.JspException;
@@ -38,28 +31,8 @@ public class LayoutClassedModelUsagesAdminTag extends IncludeTag {
 
 	@Override
 	public int doStartTag() throws JspException {
-		try {
-			Map<String, LayoutClassedModelUsageRecorder>
-				layoutClassedModelUsageRecorders =
-					ServletContextUtil.getLayoutClassedModelUsageRecorders();
-
-			LayoutClassedModelUsageRecorder layoutClassedModelUsageRecorder =
-				layoutClassedModelUsageRecorders.get(getClassName());
-
-			if (layoutClassedModelUsageRecorder != null) {
-				layoutClassedModelUsageRecorder.record(
-					PortalUtil.getClassNameId(getClassName()), getClassPK());
-			}
-		}
-		catch (PortalException portalException) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(
-					StringBundler.concat(
-						"Unable to check layout classed model usages for ",
-						"class name ", _className, " and class PK ", _classPK),
-					portalException);
-			}
-		}
+		LayoutClassedModelUsagesTaglibUtil.recordLayoutClassedModelUsage(
+			getClassName(), getClassPK());
 
 		request.setAttribute(
 			ContentPageEditorWebKeys.FRAGMENT_COLLECTION_CONTRIBUTOR_TRACKER,
@@ -119,9 +92,6 @@ public class LayoutClassedModelUsagesAdminTag extends IncludeTag {
 
 	private static final String _PAGE =
 		"/layout_classed_model_usages_admin/page.jsp";
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		LayoutClassedModelUsagesAdminTag.class);
 
 	private String _className;
 	private long _classPK;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/LayoutClassedModelUsagesViewTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/LayoutClassedModelUsagesViewTag.java
@@ -15,15 +15,25 @@
 package com.liferay.layout.taglib.servlet.taglib;
 
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.layout.taglib.servlet.taglib.util.LayoutClassedModelUsagesTaglibUtil;
 import com.liferay.taglib.util.IncludeTag;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.jsp.JspException;
 import javax.servlet.jsp.PageContext;
 
 /**
  * @author Eudaldo Alonso
  */
 public class LayoutClassedModelUsagesViewTag<R> extends IncludeTag {
+
+	@Override
+	public int doStartTag() throws JspException {
+		LayoutClassedModelUsagesTaglibUtil.recordLayoutClassedModelUsage(
+			getClassName(), getClassPK());
+
+		return super.doStartTag();
+	}
 
 	public String getClassName() {
 		return _className;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/util/LayoutClassedModelUsagesTaglibUtil.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/util/LayoutClassedModelUsagesTaglibUtil.java
@@ -1,0 +1,62 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.taglib.servlet.taglib.util;
+
+import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.layout.util.LayoutClassedModelUsageRecorder;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.util.Map;
+
+/**
+ * @author Eudaldo Alonso
+ */
+public class LayoutClassedModelUsagesTaglibUtil {
+
+	public static void recordLayoutClassedModelUsage(
+		String className, long classPK) {
+
+		try {
+			Map<String, LayoutClassedModelUsageRecorder>
+				layoutClassedModelUsageRecorders =
+					ServletContextUtil.getLayoutClassedModelUsageRecorders();
+
+			LayoutClassedModelUsageRecorder layoutClassedModelUsageRecorder =
+				layoutClassedModelUsageRecorders.get(className);
+
+			if (layoutClassedModelUsageRecorder != null) {
+				layoutClassedModelUsageRecorder.record(
+					PortalUtil.getClassNameId(className), classPK);
+			}
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"Unable to check layout classed model usages for ",
+						"class name ", className, " and class PK ", classPK),
+					portalException);
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LayoutClassedModelUsagesTaglibUtil.class);
+
+}

--- a/modules/apps/layout/layout-taglib/src/main/resources/com/liferay/layout/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/layout/layout-taglib/src/main/resources/com/liferay/layout/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.6.0
+version 1.7.0


### PR DESCRIPTION
Dear @liferay-echo team,

`layout-classed-model-usages-admin` tag executes a "lazy upgrade" ([LPS-88698](https://issues.liferay.com/browse/LPS-88698)) in its doStartTag() method, while `layout-classed-model-usages-view` doesn't. I separated out a method into a utility class, so both can execute it and show the correct data.
This might not be the best solution, I just wanted to avoid code duplication.

Please review my changes.

Thanks,
Vendel