### PR TITLE
LPS-116805 Change button to small

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/page_template/edit_menu.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/page_template/edit_menu.jsp
@@ -26,4 +26,5 @@ EditDisplayPageMenuDisplayContext editDisplayPageMenuDisplayContext = new EditDi
 	dropdownItems="<%= editDisplayPageMenuDisplayContext.getDropdownItems() %>"
 	icon="pencil"
 	monospaced="<%= true %>"
+	small="<%= true %>"
 />


### PR DESCRIPTION
**Description:**
The control menu has more height because the edit dropdown button is taking more space.

* Bug: https://issues.liferay.com/browse/LPS-116805

**Fix:**
Add `btn-sm`class to the `<clay:dropdown-menu>`.

**Screenshoots:**

Before: control menu with 64px
<img width="652" alt="Screenshot 2020-07-11 at 10 16 20" src="https://user-images.githubusercontent.com/15845466/87015124-477c3400-c1cd-11ea-8634-d292336892b1.png">

After: control menu with 56px
<img width="653" alt="Screenshot 2020-07-11 at 10 11 54" src="https://user-images.githubusercontent.com/15845466/87014727-d2a8fa00-c1cc-11ea-9c20-847dae313330.png">

cc: @ealonso @jbalsas @marcoscv-work