### PR TITLE
LPS-116830 - Attribute names in OpenAPI YAML should follow pattern xyzSchemaName when they reference a schema

### DIFF
--- a/modules/apps/fragment/fragment-test/src/testIntegration/resources/com/liferay/fragment/dependencies/fragments/import/fragment-collection/fragment-composition/definition.json
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/resources/com/liferay/fragment/dependencies/fragments/import/fragment-collection/fragment-composition/definition.json
@@ -11,9 +11,7 @@
 		{
 			"definition": {
 				"fragment": {
-					"collectionName": "Basic Components",
-					"key": "BASIC_COMPONENT-heading",
-					"name": "Heading"
+					"key": "BASIC_COMPONENT-heading"
 				},
 				"fragmentConfig": {
 					"bottomSpacing": "3",

--- a/modules/apps/fragment/fragment-test/src/testIntegration/resources/com/liferay/fragment/dependencies/fragments/import/page-template/page-definition.json
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/resources/com/liferay/fragment/dependencies/fragments/import/page-template/page-definition.json
@@ -4,9 +4,7 @@
 			{
 				"definition": {
 					"fragment": {
-						"collectionName": "Basic Components",
-						"key": "BASIC_COMPONENT-heading",
-						"name": "Heading"
+						"key": "BASIC_COMPONENT-heading"
 					},
 					"fragmentConfig": {
 						"bottomSpacing": "3",

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 24.1.0
+Bundle-Version: 25.0.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.resource.v1_0

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/BackgroundImage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/BackgroundImage.java
@@ -42,30 +42,31 @@ import javax.xml.bind.annotation.XmlRootElement;
  * @generated
  */
 @Generated("")
-@GraphQLName("PageSectionDefinition")
+@GraphQLName("BackgroundImage")
 @JsonFilter("Liferay.Vulcan")
-@XmlRootElement(name = "PageSectionDefinition")
-public class PageSectionDefinition {
+@XmlRootElement(name = "BackgroundImage")
+public class BackgroundImage {
 
-	public static PageSectionDefinition toDTO(String json) {
-		return ObjectMapperUtil.readValue(PageSectionDefinition.class, json);
+	public static BackgroundImage toDTO(String json) {
+		return ObjectMapperUtil.readValue(BackgroundImage.class, json);
 	}
 
 	@Schema
-	public String getBackgroundColor() {
-		return backgroundColor;
+	@Valid
+	public Object getDescription() {
+		return description;
 	}
 
-	public void setBackgroundColor(String backgroundColor) {
-		this.backgroundColor = backgroundColor;
+	public void setDescription(Object description) {
+		this.description = description;
 	}
 
 	@JsonIgnore
-	public void setBackgroundColor(
-		UnsafeSupplier<String, Exception> backgroundColorUnsafeSupplier) {
+	public void setDescription(
+		UnsafeSupplier<Object, Exception> descriptionUnsafeSupplier) {
 
 		try {
-			backgroundColor = backgroundColorUnsafeSupplier.get();
+			description = descriptionUnsafeSupplier.get();
 		}
 		catch (RuntimeException re) {
 			throw re;
@@ -77,28 +78,24 @@ public class PageSectionDefinition {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected String backgroundColor;
+	protected Object description;
 
 	@Schema
 	@Valid
-	public FragmentImage getBackgroundFragmentImage() {
-		return backgroundFragmentImage;
+	public Object getTitle() {
+		return title;
 	}
 
-	public void setBackgroundFragmentImage(
-		FragmentImage backgroundFragmentImage) {
-
-		this.backgroundFragmentImage = backgroundFragmentImage;
+	public void setTitle(Object title) {
+		this.title = title;
 	}
 
 	@JsonIgnore
-	public void setBackgroundFragmentImage(
-		UnsafeSupplier<FragmentImage, Exception>
-			backgroundFragmentImageUnsafeSupplier) {
+	public void setTitle(
+		UnsafeSupplier<Object, Exception> titleUnsafeSupplier) {
 
 		try {
-			backgroundFragmentImage =
-				backgroundFragmentImageUnsafeSupplier.get();
+			title = titleUnsafeSupplier.get();
 		}
 		catch (RuntimeException re) {
 			throw re;
@@ -110,59 +107,22 @@ public class PageSectionDefinition {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected FragmentImage backgroundFragmentImage;
-
-	@Schema(
-		description = "Deprecated as of Athanasius (7.3.x), replaced by backgroundFragmentImage"
-	)
-	@Valid
-	public BackgroundImage getBackgroundImage() {
-		return backgroundImage;
-	}
-
-	public void setBackgroundImage(BackgroundImage backgroundImage) {
-		this.backgroundImage = backgroundImage;
-	}
-
-	@JsonIgnore
-	public void setBackgroundImage(
-		UnsafeSupplier<BackgroundImage, Exception>
-			backgroundImageUnsafeSupplier) {
-
-		try {
-			backgroundImage = backgroundImageUnsafeSupplier.get();
-		}
-		catch (RuntimeException re) {
-			throw re;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@Deprecated
-	@GraphQLField(
-		description = "Deprecated as of Athanasius (7.3.x), replaced by backgroundFragmentImage"
-	)
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected BackgroundImage backgroundImage;
+	protected Object title;
 
 	@Schema
 	@Valid
-	public FragmentLink getFragmentLink() {
-		return fragmentLink;
+	public Object getUrl() {
+		return url;
 	}
 
-	public void setFragmentLink(FragmentLink fragmentLink) {
-		this.fragmentLink = fragmentLink;
+	public void setUrl(Object url) {
+		this.url = url;
 	}
 
 	@JsonIgnore
-	public void setFragmentLink(
-		UnsafeSupplier<FragmentLink, Exception> fragmentLinkUnsafeSupplier) {
-
+	public void setUrl(UnsafeSupplier<Object, Exception> urlUnsafeSupplier) {
 		try {
-			fragmentLink = fragmentLinkUnsafeSupplier.get();
+			url = urlUnsafeSupplier.get();
 		}
 		catch (RuntimeException re) {
 			throw re;
@@ -174,36 +134,7 @@ public class PageSectionDefinition {
 
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected FragmentLink fragmentLink;
-
-	@Schema
-	@Valid
-	public Layout getLayout() {
-		return layout;
-	}
-
-	public void setLayout(Layout layout) {
-		this.layout = layout;
-	}
-
-	@JsonIgnore
-	public void setLayout(
-		UnsafeSupplier<Layout, Exception> layoutUnsafeSupplier) {
-
-		try {
-			layout = layoutUnsafeSupplier.get();
-		}
-		catch (RuntimeException re) {
-			throw re;
-		}
-		catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	@GraphQLField
-	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected Layout layout;
+	protected Object url;
 
 	@Override
 	public boolean equals(Object object) {
@@ -211,14 +142,13 @@ public class PageSectionDefinition {
 			return true;
 		}
 
-		if (!(object instanceof PageSectionDefinition)) {
+		if (!(object instanceof BackgroundImage)) {
 			return false;
 		}
 
-		PageSectionDefinition pageSectionDefinition =
-			(PageSectionDefinition)object;
+		BackgroundImage backgroundImage = (BackgroundImage)object;
 
-		return Objects.equals(toString(), pageSectionDefinition.toString());
+		return Objects.equals(toString(), backgroundImage.toString());
 	}
 
 	@Override
@@ -233,58 +163,34 @@ public class PageSectionDefinition {
 
 		sb.append("{");
 
-		if (backgroundColor != null) {
+		if (description != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"backgroundColor\": ");
+			sb.append("\"description\": ");
 
-			sb.append("\"");
-
-			sb.append(_escape(backgroundColor));
-
-			sb.append("\"");
+			sb.append(String.valueOf(description));
 		}
 
-		if (backgroundFragmentImage != null) {
+		if (title != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"backgroundFragmentImage\": ");
+			sb.append("\"title\": ");
 
-			sb.append(String.valueOf(backgroundFragmentImage));
+			sb.append(String.valueOf(title));
 		}
 
-		if (backgroundImage != null) {
+		if (url != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
 			}
 
-			sb.append("\"backgroundImage\": ");
+			sb.append("\"url\": ");
 
-			sb.append(String.valueOf(backgroundImage));
-		}
-
-		if (fragmentLink != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"fragmentLink\": ");
-
-			sb.append(String.valueOf(fragmentLink));
-		}
-
-		if (layout != null) {
-			if (sb.length() > 1) {
-				sb.append(", ");
-			}
-
-			sb.append("\"layout\": ");
-
-			sb.append(String.valueOf(layout));
+			sb.append(String.valueOf(url));
 		}
 
 		sb.append("}");
@@ -293,7 +199,7 @@ public class PageSectionDefinition {
 	}
 
 	@Schema(
-		defaultValue = "com.liferay.headless.delivery.dto.v1_0.PageSectionDefinition",
+		defaultValue = "com.liferay.headless.delivery.dto.v1_0.BackgroundImage",
 		name = "x-class-name"
 	)
 	public String xClassName;

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 13.1.0
+version 14.0.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/BackgroundImage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/BackgroundImage.java
@@ -1,0 +1,127 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.delivery.client.dto.v1_0;
+
+import com.liferay.headless.delivery.client.function.UnsafeSupplier;
+import com.liferay.headless.delivery.client.serdes.v1_0.BackgroundImageSerDes;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class BackgroundImage implements Cloneable {
+
+	public static BackgroundImage toDTO(String json) {
+		return BackgroundImageSerDes.toDTO(json);
+	}
+
+	public Object getDescription() {
+		return description;
+	}
+
+	public void setDescription(Object description) {
+		this.description = description;
+	}
+
+	public void setDescription(
+		UnsafeSupplier<Object, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Object description;
+
+	public Object getTitle() {
+		return title;
+	}
+
+	public void setTitle(Object title) {
+		this.title = title;
+	}
+
+	public void setTitle(
+		UnsafeSupplier<Object, Exception> titleUnsafeSupplier) {
+
+		try {
+			title = titleUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Object title;
+
+	public Object getUrl() {
+		return url;
+	}
+
+	public void setUrl(Object url) {
+		this.url = url;
+	}
+
+	public void setUrl(UnsafeSupplier<Object, Exception> urlUnsafeSupplier) {
+		try {
+			url = urlUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Object url;
+
+	@Override
+	public BackgroundImage clone() throws CloneNotSupportedException {
+		return (BackgroundImage)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof BackgroundImage)) {
+			return false;
+		}
+
+		BackgroundImage backgroundImage = (BackgroundImage)object;
+
+		return Objects.equals(toString(), backgroundImage.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return BackgroundImageSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageSectionDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageSectionDefinition.java
@@ -53,16 +53,41 @@ public class PageSectionDefinition implements Cloneable {
 
 	protected String backgroundColor;
 
-	public FragmentImage getBackgroundImage() {
+	public FragmentImage getBackgroundFragmentImage() {
+		return backgroundFragmentImage;
+	}
+
+	public void setBackgroundFragmentImage(
+		FragmentImage backgroundFragmentImage) {
+
+		this.backgroundFragmentImage = backgroundFragmentImage;
+	}
+
+	public void setBackgroundFragmentImage(
+		UnsafeSupplier<FragmentImage, Exception>
+			backgroundFragmentImageUnsafeSupplier) {
+
+		try {
+			backgroundFragmentImage =
+				backgroundFragmentImageUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected FragmentImage backgroundFragmentImage;
+
+	public BackgroundImage getBackgroundImage() {
 		return backgroundImage;
 	}
 
-	public void setBackgroundImage(FragmentImage backgroundImage) {
+	public void setBackgroundImage(BackgroundImage backgroundImage) {
 		this.backgroundImage = backgroundImage;
 	}
 
 	public void setBackgroundImage(
-		UnsafeSupplier<FragmentImage, Exception>
+		UnsafeSupplier<BackgroundImage, Exception>
 			backgroundImageUnsafeSupplier) {
 
 		try {
@@ -73,7 +98,7 @@ public class PageSectionDefinition implements Cloneable {
 		}
 	}
 
-	protected FragmentImage backgroundImage;
+	protected BackgroundImage backgroundImage;
 
 	public FragmentLink getFragmentLink() {
 		return fragmentLink;

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/BackgroundImageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/BackgroundImageSerDes.java
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.delivery.client.serdes.v1_0;
+
+import com.liferay.headless.delivery.client.dto.v1_0.BackgroundImage;
+import com.liferay.headless.delivery.client.json.BaseJSONParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class BackgroundImageSerDes {
+
+	public static BackgroundImage toDTO(String json) {
+		BackgroundImageJSONParser backgroundImageJSONParser =
+			new BackgroundImageJSONParser();
+
+		return backgroundImageJSONParser.parseToDTO(json);
+	}
+
+	public static BackgroundImage[] toDTOs(String json) {
+		BackgroundImageJSONParser backgroundImageJSONParser =
+			new BackgroundImageJSONParser();
+
+		return backgroundImageJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(BackgroundImage backgroundImage) {
+		if (backgroundImage == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (backgroundImage.getDescription() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(backgroundImage.getDescription()));
+
+			sb.append("\"");
+		}
+
+		if (backgroundImage.getTitle() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"title\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(backgroundImage.getTitle()));
+
+			sb.append("\"");
+		}
+
+		if (backgroundImage.getUrl() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"url\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(backgroundImage.getUrl()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		BackgroundImageJSONParser backgroundImageJSONParser =
+			new BackgroundImageJSONParser();
+
+		return backgroundImageJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(BackgroundImage backgroundImage) {
+		if (backgroundImage == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (backgroundImage.getDescription() == null) {
+			map.put("description", null);
+		}
+		else {
+			map.put(
+				"description",
+				String.valueOf(backgroundImage.getDescription()));
+		}
+
+		if (backgroundImage.getTitle() == null) {
+			map.put("title", null);
+		}
+		else {
+			map.put("title", String.valueOf(backgroundImage.getTitle()));
+		}
+
+		if (backgroundImage.getUrl() == null) {
+			map.put("url", null);
+		}
+		else {
+			map.put("url", String.valueOf(backgroundImage.getUrl()));
+		}
+
+		return map;
+	}
+
+	public static class BackgroundImageJSONParser
+		extends BaseJSONParser<BackgroundImage> {
+
+		@Override
+		protected BackgroundImage createDTO() {
+			return new BackgroundImage();
+		}
+
+		@Override
+		protected BackgroundImage[] createDTOArray(int size) {
+			return new BackgroundImage[size];
+		}
+
+		@Override
+		protected void setField(
+			BackgroundImage backgroundImage, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "description")) {
+				if (jsonParserFieldValue != null) {
+					backgroundImage.setDescription(
+						(Object)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "title")) {
+				if (jsonParserFieldValue != null) {
+					backgroundImage.setTitle((Object)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "url")) {
+				if (jsonParserFieldValue != null) {
+					backgroundImage.setUrl((Object)jsonParserFieldValue);
+				}
+			}
+			else {
+				throw new IllegalArgumentException(
+					"Unsupported field name " + jsonParserFieldName);
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\":");
+
+			Object value = entry.getValue();
+
+			Class<?> valueClass = value.getClass();
+
+			if (value instanceof Map) {
+				sb.append(_toJSON((Map)value));
+			}
+			else if (valueClass.isArray()) {
+				Object[] values = (Object[])value;
+
+				sb.append("[");
+
+				for (int i = 0; i < values.length; i++) {
+					sb.append("\"");
+					sb.append(_escape(values[i]));
+					sb.append("\"");
+
+					if ((i + 1) < values.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(entry.getValue()));
+				sb.append("\"");
+			}
+			else {
+				sb.append(String.valueOf(entry.getValue()));
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(",");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageSectionDefinitionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageSectionDefinitionSerDes.java
@@ -69,6 +69,18 @@ public class PageSectionDefinitionSerDes {
 			sb.append("\"");
 		}
 
+		if (pageSectionDefinition.getBackgroundFragmentImage() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"backgroundFragmentImage\": ");
+
+			sb.append(
+				String.valueOf(
+					pageSectionDefinition.getBackgroundFragmentImage()));
+		}
+
 		if (pageSectionDefinition.getBackgroundImage() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -130,6 +142,16 @@ public class PageSectionDefinitionSerDes {
 				String.valueOf(pageSectionDefinition.getBackgroundColor()));
 		}
 
+		if (pageSectionDefinition.getBackgroundFragmentImage() == null) {
+			map.put("backgroundFragmentImage", null);
+		}
+		else {
+			map.put(
+				"backgroundFragmentImage",
+				String.valueOf(
+					pageSectionDefinition.getBackgroundFragmentImage()));
+		}
+
 		if (pageSectionDefinition.getBackgroundImage() == null) {
 			map.put("backgroundImage", null);
 		}
@@ -183,10 +205,19 @@ public class PageSectionDefinitionSerDes {
 						(String)jsonParserFieldValue);
 				}
 			}
+			else if (Objects.equals(
+						jsonParserFieldName, "backgroundFragmentImage")) {
+
+				if (jsonParserFieldValue != null) {
+					pageSectionDefinition.setBackgroundFragmentImage(
+						FragmentImageSerDes.toDTO(
+							(String)jsonParserFieldValue));
+				}
+			}
 			else if (Objects.equals(jsonParserFieldName, "backgroundImage")) {
 				if (jsonParserFieldValue != null) {
 					pageSectionDefinition.setBackgroundImage(
-						FragmentImageSerDes.toDTO(
+						BackgroundImageSerDes.toDTO(
 							(String)jsonParserFieldValue));
 				}
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -2123,6 +2123,8 @@ components:
             properties:
                 backgroundColor:
                     type: string
+                backgroundFragmentImage:
+                    $ref: "#/components/schemas/FragmentImage"
                 backgroundImage:
                     deprecated: true
                     description:

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -2124,7 +2124,21 @@ components:
                 backgroundColor:
                     type: string
                 backgroundImage:
-                    $ref: "#/components/schemas/FragmentImage"
+                    deprecated: true
+                    description:
+                        "Deprecated as of Athanasius (7.3.x), replaced by backgroundFragmentImage"
+                    properties:
+                        description:
+                            oneOf:
+                                - $ref: "#/components/schemas/FragmentInlineValue"
+                        title:
+                            oneOf:
+                                - $ref: "#/components/schemas/FragmentInlineValue"
+                        url:
+                            oneOf:
+                                - $ref: "#/components/schemas/FragmentInlineValue"
+                                - $ref: "#/components/schemas/FragmentMappedValue"
+                    type: object
                 fragmentLink:
                     $ref: "#/components/schemas/FragmentLink"
                 layout:

--- a/modules/apps/layout/layout-admin-web/src/main/resources/com/liferay/layout/admin/web/internal/portlet/action/collection_definition.json
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/com/liferay/layout/admin/web/internal/portlet/action/collection_definition.json
@@ -13,9 +13,7 @@
 		{
 			"definition": {
 				"fragment": {
-					"collectionName": "Basic Components",
-					"key": "BASIC_COMPONENT-heading",
-					"name": "Heading"
+					"key": "BASIC_COMPONENT-heading"
 				},
 				"fragmentConfig": {
 					"headingLevel": "h1",

--- a/modules/apps/layout/layout-admin-web/src/main/resources/com/liferay/layout/admin/web/internal/portlet/action/collection_provider_definition.json
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/com/liferay/layout/admin/web/internal/portlet/action/collection_provider_definition.json
@@ -13,9 +13,7 @@
 		{
 			"definition": {
 				"fragment": {
-					"collectionName": "Basic Components",
-					"key": "BASIC_COMPONENT-heading",
-					"name": "Heading"
+					"key": "BASIC_COMPONENT-heading"
 				},
 				"fragmentConfig": {
 					"headingLevel": "h1",

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/resources/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/dependencies/expected_fragment_composition_data.json
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/resources/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/dependencies/expected_fragment_composition_data.json
@@ -21,9 +21,7 @@
 		{
 			"definition": {
 				"fragment": {
-					"collectionName": "${FRAGMENT_COLLECTION_NAME}",
-					"key": "${FRAGMENT_ENTRY_KEY}",
-					"name": "${FRAGMENT_ENTRY_NAME}"
+					"key": "${FRAGMENT_ENTRY_KEY}"
 				},
 				"fragmentConfig": {
 					"buttonAlign": "left",

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/resources/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/dependencies/expected_fragment_composition_data.json
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/resources/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/dependencies/expected_fragment_composition_data.json
@@ -1,6 +1,6 @@
 {
 	"definition": {
-		"backgroundImage": {
+		"backgroundFragmentImage": {
 		},
 		"layout": {
 			"borderWidth": 0,

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
@@ -127,6 +127,29 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 	}
 
 	@Test
+	public void testImportExportLayoutPageTemplateEntryContainerBackgroundFragmentImage()
+		throws Exception {
+
+		Map<String, String> valuesMap = HashMapBuilder.put(
+			"CLASS_PK",
+			() -> {
+				JournalArticle journalArticle = _addJournalArticle(
+					_group.getGroupId());
+
+				return String.valueOf(journalArticle.getResourcePrimKey());
+			}
+		).build();
+
+		File expectedFile = _generateZipFile(
+			"container/background_fragment_image/expected", valuesMap);
+
+		File inputFile = _generateZipFile(
+			"container/background_fragment_image/input", valuesMap);
+
+		_validateImportExport(expectedFile, inputFile);
+	}
+
+	@Test
 	public void testImportExportLayoutPageTemplateEntryContainerBackgroundImage()
 		throws Exception {
 

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
@@ -747,11 +747,17 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 	private void _validateImportExport(File expectedFile, File inputFile)
 		throws Exception {
 
-		File outputFile = _importExportLayoutPageTemplateEntry(
+		File outputFile1 = _importExportLayoutPageTemplateEntry(
 			inputFile, _group.getGroupId(), false,
 			LayoutPageTemplatesImporterResultEntry.Status.IMPORTED);
 
-		_validateFile(expectedFile, outputFile);
+		_validateFile(expectedFile, outputFile1);
+
+		File outputFile2 = _importExportLayoutPageTemplateEntry(
+			outputFile1, _group.getGroupId(), true,
+			LayoutPageTemplatesImporterResultEntry.Status.IMPORTED);
+
+		_validateFile(expectedFile, outputFile2);
 	}
 
 	private static final String _LAYOUT_PATE_TEMPLATES_PATH =

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
@@ -146,11 +146,7 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 		File inputFile = _generateZipFile(
 			"container/background_image/input", valuesMap);
 
-		File outputFile = _importExportLayoutPageTemplateEntry(
-			inputFile, _group.getGroupId(), false,
-			LayoutPageTemplatesImporterResultEntry.Status.IMPORTED);
-
-		_validateFile(expectedFile, outputFile);
+		_validateImportExport(expectedFile, inputFile);
 	}
 
 	@Test
@@ -162,11 +158,7 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 
 		File inputFile = _generateZipFile("container/default/input", null);
 
-		File outputFile = _importExportLayoutPageTemplateEntry(
-			inputFile, _group.getGroupId(), false,
-			LayoutPageTemplatesImporterResultEntry.Status.IMPORTED);
-
-		_validateFile(expectedFile, outputFile);
+		_validateImportExport(expectedFile, inputFile);
 	}
 
 	@Test
@@ -177,11 +169,7 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 
 		File inputFile = _generateZipFile("container/empty/input", null);
 
-		File outputFile = _importExportLayoutPageTemplateEntry(
-			inputFile, _group.getGroupId(), false,
-			LayoutPageTemplatesImporterResultEntry.Status.IMPORTED);
-
-		_validateFile(expectedFile, outputFile);
+		_validateImportExport(expectedFile, inputFile);
 	}
 
 	@Test
@@ -192,11 +180,7 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 
 		File inputFile = _generateZipFile("container/layout/input", null);
 
-		File outputFile = _importExportLayoutPageTemplateEntry(
-			inputFile, _group.getGroupId(), false,
-			LayoutPageTemplatesImporterResultEntry.Status.IMPORTED);
-
-		_validateFile(expectedFile, outputFile);
+		_validateImportExport(expectedFile, inputFile);
 	}
 
 	@Test
@@ -224,11 +208,7 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 			"fragment/text_field/mapped_value/class_pk_reference/input",
 			valuesMap);
 
-		File outputFile = _importExportLayoutPageTemplateEntry(
-			inputFile, _group.getGroupId(), false,
-			LayoutPageTemplatesImporterResultEntry.Status.IMPORTED);
-
-		_validateFile(expectedFile, outputFile);
+		_validateImportExport(expectedFile, inputFile);
 	}
 
 	@Test
@@ -256,11 +236,7 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 			"fragment/text_field/mapped_value/class_pk_reference/input",
 			valuesMap);
 
-		File outputFile = _importExportLayoutPageTemplateEntry(
-			inputFile, _group.getGroupId(), false,
-			LayoutPageTemplatesImporterResultEntry.Status.IMPORTED);
-
-		_validateFile(expectedFile, outputFile);
+		_validateImportExport(expectedFile, inputFile);
 	}
 
 	@Test
@@ -415,11 +391,7 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 			"fragment/text_field/mapped_value/class_pk_reference/input",
 			valuesMap);
 
-		File outputFile = _importExportLayoutPageTemplateEntry(
-			inputFile, _group.getGroupId(), false,
-			LayoutPageTemplatesImporterResultEntry.Status.IMPORTED);
-
-		_validateFile(expectedFile, outputFile);
+		_validateImportExport(expectedFile, inputFile);
 	}
 
 	@Test
@@ -445,11 +417,7 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 			"fragment/text_field/mapped_value/class_pk_reference/input",
 			valuesMap);
 
-		File outputFile = _importExportLayoutPageTemplateEntry(
-			inputFile, _group.getGroupId(), false,
-			LayoutPageTemplatesImporterResultEntry.Status.IMPORTED);
-
-		_validateFile(expectedFile, outputFile);
+		_validateImportExport(expectedFile, inputFile);
 	}
 
 	@Test
@@ -460,11 +428,7 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 
 		File inputFile = _generateZipFile("row/container/input", null);
 
-		File outputFile = _importExportLayoutPageTemplateEntry(
-			inputFile, _group.getGroupId(), false,
-			LayoutPageTemplatesImporterResultEntry.Status.IMPORTED);
-
-		_validateFile(expectedFile, outputFile);
+		_validateImportExport(expectedFile, inputFile);
 	}
 
 	private FragmentEntry _addFragmentEntry(
@@ -778,6 +742,16 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 
 		Assert.assertEquals(numberOfInputFiles, numberOfOutputFiles);
 		Assert.assertTrue(numberOfInputFiles > 0);
+	}
+
+	private void _validateImportExport(File expectedFile, File inputFile)
+		throws Exception {
+
+		File outputFile = _importExportLayoutPageTemplateEntry(
+			inputFile, _group.getGroupId(), false,
+			LayoutPageTemplatesImporterResultEntry.Status.IMPORTED);
+
+		_validateFile(expectedFile, outputFile);
 	}
 
 	private static final String _LAYOUT_PATE_TEMPLATES_PATH =

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/expected/page-templates/test-page-template-collection/page-template-collection.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/expected/page-templates/test-page-template-collection/page-template-collection.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template Collection"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,0 +1,91 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"backgroundFragmentImage": {
+					},
+					"layout": {
+						"borderWidth": 0,
+						"contentDisplay": "Block",
+						"marginBottom": 0,
+						"marginLeft": 0,
+						"marginRight": 0,
+						"marginTop": 0,
+						"opacity": 100,
+						"paddingBottom": 0,
+						"paddingLeft": 0,
+						"paddingRight": 0,
+						"paddingTop": 0,
+						"widthType": "Fluid"
+					}
+				},
+				"pageElements": [
+					{
+						"definition": {
+							"backgroundFragmentImage": {
+								"url": {
+									"value": "https://upload.wikimedia.org/wikipedia/commons/b/b2/Liferay-logo-full-color-2x.png"
+								}
+							},
+							"layout": {
+								"borderWidth": 0,
+								"contentDisplay": "Block",
+								"marginBottom": 0,
+								"marginLeft": 0,
+								"marginRight": 0,
+								"marginTop": 0,
+								"opacity": 100,
+								"paddingBottom": 0,
+								"paddingLeft": 0,
+								"paddingRight": 0,
+								"paddingTop": 0,
+								"widthType": "Fluid"
+							}
+						},
+						"type": "Section"
+					},
+					{
+						"definition": {
+							"backgroundFragmentImage": {
+								"url": {
+									"defaultValue": {
+										"value": "https://avatars1.githubusercontent.com/u/131436"
+									},
+									"mapping": {
+										"fieldKey": "smallImage",
+										"itemReference": {
+											"className": "com.liferay.journal.model.JournalArticle",
+											"classPK": "${CLASS_PK}"
+										}
+									}
+								}
+							},
+							"layout": {
+								"borderWidth": 0,
+								"contentDisplay": "Block",
+								"marginBottom": 0,
+								"marginLeft": 0,
+								"marginRight": 0,
+								"marginTop": 0,
+								"opacity": 100,
+								"paddingBottom": 0,
+								"paddingLeft": 0,
+								"paddingRight": 0,
+								"paddingTop": 0,
+								"widthType": "Fluid"
+							}
+						},
+						"type": "Section"
+					}
+				],
+				"type": "Section"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"colorSchemeName": "01",
+		"themeName": "Classic"
+	}
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/expected/page-templates/test-page-template-collection/test-page-template/page-template.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/expected/page-templates/test-page-template-collection/test-page-template/page-template.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/input/page-templates/test-page-template-collection/page-template-collection.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/input/page-templates/test-page-template-collection/page-template-collection.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template Collection"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,0 +1,91 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"backgroundFragmentImage": {
+					},
+					"layout": {
+						"borderWidth": 0,
+						"contentDisplay": "Block",
+						"marginBottom": 0,
+						"marginLeft": 0,
+						"marginRight": 0,
+						"marginTop": 0,
+						"opacity": 100,
+						"paddingBottom": 0,
+						"paddingLeft": 0,
+						"paddingRight": 0,
+						"paddingTop": 0,
+						"widthType": "Fluid"
+					}
+				},
+				"pageElements": [
+					{
+						"definition": {
+							"backgroundFragmentImage": {
+								"url": {
+									"value": "https://upload.wikimedia.org/wikipedia/commons/b/b2/Liferay-logo-full-color-2x.png"
+								}
+							},
+							"layout": {
+								"borderWidth": 0,
+								"contentDisplay": "Block",
+								"marginBottom": 0,
+								"marginLeft": 0,
+								"marginRight": 0,
+								"marginTop": 0,
+								"opacity": 100,
+								"paddingBottom": 0,
+								"paddingLeft": 0,
+								"paddingRight": 0,
+								"paddingTop": 0,
+								"widthType": "Fluid"
+							}
+						},
+						"type": "Section"
+					},
+					{
+						"definition": {
+							"backgroundFragmentImage": {
+								"url": {
+									"defaultValue": {
+										"value": "https://avatars1.githubusercontent.com/u/131436"
+									},
+									"mapping": {
+										"fieldKey": "smallImage",
+										"itemReference": {
+											"className": "com.liferay.journal.model.JournalArticle",
+											"classPK": "${CLASS_PK}"
+										}
+									}
+								}
+							},
+							"layout": {
+								"borderWidth": 0,
+								"contentDisplay": "Block",
+								"marginBottom": 0,
+								"marginLeft": 0,
+								"marginRight": 0,
+								"marginTop": 0,
+								"opacity": 100,
+								"paddingBottom": 0,
+								"paddingLeft": 0,
+								"paddingRight": 0,
+								"paddingTop": 0,
+								"widthType": "Fluid"
+							}
+						},
+						"type": "Section"
+					}
+				],
+				"type": "Section"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"colorSchemeName": "01",
+		"themeName": "Classic"
+	}
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/input/page-templates/test-page-template-collection/test-page-template/page-template.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/input/page-templates/test-page-template-collection/test-page-template/page-template.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_image/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_image/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -3,7 +3,7 @@
 		"pageElements": [
 			{
 				"definition": {
-					"backgroundImage": {
+					"backgroundFragmentImage": {
 					},
 					"layout": {
 						"borderWidth": 0,
@@ -23,7 +23,7 @@
 				"pageElements": [
 					{
 						"definition": {
-							"backgroundImage": {
+							"backgroundFragmentImage": {
 								"url": {
 									"value": "https://upload.wikimedia.org/wikipedia/commons/b/b2/Liferay-logo-full-color-2x.png"
 								}
@@ -47,7 +47,7 @@
 					},
 					{
 						"definition": {
-							"backgroundImage": {
+							"backgroundFragmentImage": {
 								"url": {
 									"defaultValue": {
 										"value": "https://avatars1.githubusercontent.com/u/131436"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/default/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/default/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -3,7 +3,7 @@
 		"pageElements": [
 			{
 				"definition": {
-					"backgroundImage": {
+					"backgroundFragmentImage": {
 					},
 					"layout": {
 						"borderWidth": 0,

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/default/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/default/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -3,7 +3,7 @@
 		"pageElements": [
 			{
 				"definition": {
-					"backgroundImage": {
+					"backgroundFragmentImage": {
 					},
 					"layout": {
 						"borderRadius": "None",

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/empty/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/empty/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -3,7 +3,7 @@
 		"pageElements": [
 			{
 				"definition": {
-					"backgroundImage": {
+					"backgroundFragmentImage": {
 					},
 					"layout": {
 						"borderWidth": 0,

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/layout/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/layout/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -3,7 +3,7 @@
 		"pageElements": [
 			{
 				"definition": {
-					"backgroundImage": {
+					"backgroundFragmentImage": {
 					},
 					"layout": {
 						"borderColor": "danger",

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/layout/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/layout/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -3,7 +3,7 @@
 		"pageElements": [
 			{
 				"definition": {
-					"backgroundImage": {
+					"backgroundFragmentImage": {
 					},
 					"layout": {
 						"borderColor": "danger",

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/fragment/text_field/mapped_value/class_pk_reference/expected/fragment_available/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/fragment/text_field/mapped_value/class_pk_reference/expected/fragment_available/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -4,9 +4,7 @@
 			{
 				"definition": {
 					"fragment": {
-						"collectionName": "Test Collection",
-						"key": "test-text-fragment",
-						"name": "Test Text Fragment"
+						"key": "test-text-fragment"
 					},
 					"fragmentConfig": {
 					},

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/fragment/text_field/mapped_value/class_pk_reference/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/fragment/text_field/mapped_value/class_pk_reference/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -4,9 +4,7 @@
 			{
 				"definition": {
 					"fragment": {
-						"collectionName": "Test Collection",
-						"key": "test-text-fragment",
-						"name": "Test Text Fragment"
+						"key": "test-text-fragment"
 					},
 					"fragmentConfig": {
 					},

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/row/container/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/row/container/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -52,9 +52,7 @@
 									{
 										"definition": {
 											"fragment": {
-												"collectionName": "Basic Components",
-												"key": "BASIC_COMPONENT-paragraph",
-												"name": "Paragraph"
+												"key": "BASIC_COMPONENT-paragraph"
 											},
 											"fragmentConfig": {
 												"marginBottom": "3",

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/row/container/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/row/container/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -31,7 +31,7 @@
 						"pageElements": [
 							{
 								"definition": {
-									"backgroundImage": {
+									"backgroundFragmentImage": {
 									},
 									"layout": {
 										"borderWidth": 0,

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/row/container/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/row/container/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -52,9 +52,7 @@
 									{
 										"definition": {
 											"fragment": {
-												"collectionName": "Basic Components",
-												"key": "BASIC_COMPONENT-paragraph",
-												"name": "Paragraph"
+												"key": "BASIC_COMPONENT-paragraph"
 											},
 											"fragmentConfig": {
 												"marginBottom": "3",

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/row/container/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/row/container/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -31,7 +31,7 @@
 						"pageElements": [
 							{
 								"definition": {
-									"backgroundImage": {
+									"backgroundFragmentImage": {
 									},
 									"layout": {
 										"borderWidth": 0,

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/converter/PageFragmentInstanceDefinitionDTOConverter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/converter/PageFragmentInstanceDefinitionDTOConverter.java
@@ -14,17 +14,11 @@
 
 package com.liferay.layout.page.template.admin.web.internal.headless.delivery.dto.v1_0.converter;
 
-import com.liferay.fragment.contributor.FragmentCollectionContributor;
 import com.liferay.fragment.contributor.FragmentCollectionContributorTracker;
 import com.liferay.fragment.entry.processor.util.EditableFragmentEntryProcessorUtil;
-import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.PortletRegistry;
-import com.liferay.fragment.renderer.FragmentRenderer;
-import com.liferay.fragment.renderer.FragmentRendererTracker;
-import com.liferay.fragment.renderer.constants.FragmentRendererConstants;
-import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
@@ -54,13 +48,11 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -113,11 +105,7 @@ public class PageFragmentInstanceDefinitionDTOConverter {
 			{
 				fragment = new Fragment() {
 					{
-						collectionName = _getFragmentCollectionName(
-							fragmentEntry, rendererKey);
 						key = _getFragmentKey(fragmentEntry, rendererKey);
-						name = _getFragmentName(
-							fragmentEntry, fragmentEntryLink, rendererKey);
 					}
 				};
 				fragmentConfig = _getFragmentConfig(fragmentEntryLink);
@@ -164,58 +152,6 @@ public class PageFragmentInstanceDefinitionDTOConverter {
 		}
 
 		return fragmentFields;
-	}
-
-	private String _getFragmentCollectionName(
-		FragmentEntry fragmentEntry, String rendererKey) {
-
-		if (fragmentEntry == null) {
-			if (Validator.isNull(rendererKey)) {
-				rendererKey =
-					FragmentRendererConstants.
-						FRAGMENT_ENTRY_FRAGMENT_RENDERER_KEY;
-			}
-
-			FragmentRenderer fragmentRenderer =
-				_fragmentRendererTracker.getFragmentRenderer(rendererKey);
-
-			return LanguageUtil.get(
-				ResourceBundleUtil.getBundle(
-					LocaleUtil.getSiteDefault(), fragmentRenderer.getClass()),
-				"fragment.collection.label." +
-					fragmentRenderer.getCollectionKey());
-		}
-
-		FragmentCollection fragmentCollection =
-			_fragmentCollectionLocalService.fetchFragmentCollection(
-				fragmentEntry.getFragmentCollectionId());
-
-		if (fragmentCollection != null) {
-			return fragmentCollection.getName();
-		}
-
-		String[] parts = StringUtil.split(rendererKey, StringPool.DASH);
-
-		if (ArrayUtil.isEmpty(parts)) {
-			return null;
-		}
-
-		List<FragmentCollectionContributor> fragmentCollectionContributors =
-			_fragmentCollectionContributorTracker.
-				getFragmentCollectionContributors();
-
-		for (FragmentCollectionContributor fragmentCollectionContributor :
-				fragmentCollectionContributors) {
-
-			if (Objects.equals(
-					fragmentCollectionContributor.getFragmentCollectionKey(),
-					parts[0])) {
-
-				return fragmentCollectionContributor.getName();
-			}
-		}
-
-		return null;
 	}
 
 	private Map<String, Object> _getFragmentConfig(
@@ -324,42 +260,6 @@ public class PageFragmentInstanceDefinitionDTOConverter {
 		}
 
 		return rendererKey;
-	}
-
-	private String _getFragmentName(
-		FragmentEntry fragmentEntry, FragmentEntryLink fragmentEntryLink,
-		String rendererKey) {
-
-		if (fragmentEntry != null) {
-			return fragmentEntry.getName();
-		}
-
-		JSONObject editableValuesJSONObject = null;
-
-		try {
-			editableValuesJSONObject = JSONFactoryUtil.createJSONObject(
-				fragmentEntryLink.getEditableValues());
-		}
-		catch (JSONException jsonException) {
-			return null;
-		}
-
-		String portletId = editableValuesJSONObject.getString("portletId");
-
-		if (Validator.isNotNull(portletId)) {
-			return _portal.getPortletTitle(
-				portletId, LocaleUtil.getSiteDefault());
-		}
-
-		if (Validator.isNull(rendererKey)) {
-			rendererKey =
-				FragmentRendererConstants.FRAGMENT_ENTRY_FRAGMENT_RENDERER_KEY;
-		}
-
-		FragmentRenderer fragmentRenderer =
-			_fragmentRendererTracker.getFragmentRenderer(rendererKey);
-
-		return fragmentRenderer.getLabel(LocaleUtil.getSiteDefault());
 	}
 
 	private Function<Object, String> _getImageURLTransformerFunction() {
@@ -941,9 +841,6 @@ public class PageFragmentInstanceDefinitionDTOConverter {
 		_fragmentCollectionContributorTracker;
 
 	@Reference
-	private FragmentCollectionLocalService _fragmentCollectionLocalService;
-
-	@Reference
 	private FragmentEntryConfigurationParser _fragmentEntryConfigurationParser;
 
 	@Reference
@@ -951,9 +848,6 @@ public class PageFragmentInstanceDefinitionDTOConverter {
 
 	@Reference
 	private FragmentEntryLocalService _fragmentEntryLocalService;
-
-	@Reference
-	private FragmentRendererTracker _fragmentRendererTracker;
 
 	@Reference
 	private InfoDisplayContributorTracker _infoDisplayContributorTracker;

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/exporter/ContainerLayoutStructureItemExporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/exporter/ContainerLayoutStructureItemExporter.java
@@ -79,7 +79,7 @@ public class ContainerLayoutStructureItemExporter
 							containerLayoutStructureItem.
 								getBackgroundColorCssClass(),
 							null);
-						backgroundImage = _toBackgroundFragmentImage(
+						backgroundFragmentImage = _toBackgroundFragmentImage(
 							containerLayoutStructureItem.
 								getBackgroundImageJSONObject(),
 							saveMappingConfiguration);

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/ContainerLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/ContainerLayoutStructureItemImporter.java
@@ -69,21 +69,28 @@ public class ContainerLayoutStructureItemImporter
 			containerLayoutStructureItem.setBackgroundColorCssClass(
 				(String)definitionMap.get("backgroundColor"));
 
-			Map<String, Object> backgroundImageMap =
-				(Map<String, Object>)definitionMap.get("backgroundImage");
+			Map<String, Object> backgroundFragmentImageMap =
+				(Map<String, Object>)definitionMap.get(
+					"backgroundFragmentImage");
 
-			if (backgroundImageMap != null) {
+			if (backgroundFragmentImageMap == null) {
+				backgroundFragmentImageMap =
+					(Map<String, Object>)definitionMap.get("backgroundImage");
+			}
+
+			if (backgroundFragmentImageMap != null) {
 				JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
 				Map<String, Object> titleMap =
-					(Map<String, Object>)backgroundImageMap.get("title");
+					(Map<String, Object>)backgroundFragmentImageMap.get(
+						"title");
 
 				if (titleMap != null) {
 					jsonObject.put("title", _getLocalizedValue(titleMap));
 				}
 
 				Map<String, Object> urlMap =
-					(Map<String, Object>)backgroundImageMap.get("url");
+					(Map<String, Object>)backgroundFragmentImageMap.get("url");
 
 				if (urlMap != null) {
 					jsonObject.put("url", _getLocalizedValue(urlMap));

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/validator/dependencies/page_definition_json_schema.json
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/validator/dependencies/page_definition_json_schema.json
@@ -787,6 +787,11 @@
 					"title": "The backgroundColor Schema",
 					"type": "string"
 				},
+				"backgroundFragmentImage": {
+					"$ref": "#/definitions/FragmentImage",
+					"title": "The backgroundFragmentImage Schema",
+					"type": "object"
+				},
 				"backgroundImage": {
 					"additionalProperties": false,
 					"deprecationMessage": "Deprecated as of Athanasius (7.3.x), replaced by backgroundFragmentImage",

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/validator/dependencies/page_definition_json_schema.json
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/validator/dependencies/page_definition_json_schema.json
@@ -788,7 +788,34 @@
 					"type": "string"
 				},
 				"backgroundImage": {
-					"$ref": "#/definitions/FragmentImage",
+					"additionalProperties": false,
+					"deprecationMessage": "Deprecated as of Athanasius (7.3.x), replaced by backgroundFragmentImage",
+					"properties": {
+						"description": {
+							"oneOf": [
+								{
+									"$ref": "#/definitions/FragmentInlineValue"
+								}
+							]
+						},
+						"title": {
+							"oneOf": [
+								{
+									"$ref": "#/definitions/FragmentInlineValue"
+								}
+							]
+						},
+						"url": {
+							"oneOf": [
+								{
+									"$ref": "#/definitions/FragmentInlineValue"
+								},
+								{
+									"$ref": "#/definitions/FragmentMappedValue"
+								}
+							]
+						}
+					},
 					"title": "The backgroundImage Schema",
 					"type": "object"
 				},

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/headless/delivery/dto/v1_0/test/PageDefinitionDTOConverterTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/headless/delivery/dto/v1_0/test/PageDefinitionDTOConverterTest.java
@@ -537,7 +537,7 @@ public class PageDefinitionDTOConverterTest {
 			"primary", pageSectionDefinition1.getBackgroundColor());
 
 		FragmentImage fragmentImage1 =
-			pageSectionDefinition1.getBackgroundImage();
+			pageSectionDefinition1.getBackgroundFragmentImage();
 
 		FragmentInlineValue titleFragmentInlineValue =
 			(FragmentInlineValue)fragmentImage1.getTitle();
@@ -573,7 +573,7 @@ public class PageDefinitionDTOConverterTest {
 			(PageSectionDefinition)sectionPageElement2.getDefinition();
 
 		FragmentImage fragmentImage2 =
-			pageSectionDefinition2.getBackgroundImage();
+			pageSectionDefinition2.getBackgroundFragmentImage();
 
 		Assert.assertNull(fragmentImage2.getTitle());
 

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/headless/delivery/dto/v1_0/test/PageDefinitionDTOConverterTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/headless/delivery/dto/v1_0/test/PageDefinitionDTOConverterTest.java
@@ -611,10 +611,7 @@ public class PageDefinitionDTOConverterTest {
 
 		Fragment fragment = pageFragmentInstanceDefinition.getFragment();
 
-		Assert.assertEquals(
-			_fragmentCollection.getName(), fragment.getCollectionName());
 		Assert.assertEquals(fragmentEntryKey, fragment.getKey());
-		Assert.assertEquals(fragmentName, fragment.getName());
 
 		FragmentField[] fragmentFields =
 			pageFragmentInstanceDefinition.getFragmentFields();

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/resources/com/liferay/layout/page/template/internal/importer/test/dependencies/html-fragment/page-templates/test-collection/test-layout-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/resources/com/liferay/layout/page/template/internal/importer/test/dependencies/html-fragment/page-templates/test-collection/test-layout-page-template/page-definition.json
@@ -4,9 +4,7 @@
 			{
 				"definition": {
 					"fragment": {
-						"collectionName": "Test Collection",
-						"key": "test-html-fragment",
-						"name": "Test HTML Fragment"
+						"key": "test-html-fragment"
 					},
 					"fragmentFields": [
 						{

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/resources/com/liferay/layout/page/template/internal/importer/test/dependencies/image-fragment/page-templates/test-collection/test-layout-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/resources/com/liferay/layout/page/template/internal/importer/test/dependencies/image-fragment/page-templates/test-collection/test-layout-page-template/page-definition.json
@@ -4,9 +4,7 @@
 			{
 				"definition": {
 					"fragment": {
-						"collectionName": "Test Collection",
-						"key": "test-image-fragment",
-						"name": "Test Image Fragment"
+						"key": "test-image-fragment"
 					},
 					"fragmentConfig": {
 						"bottomSpacing": "4",

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/resources/com/liferay/layout/page/template/internal/importer/test/dependencies/link-fragment/page-templates/test-collection/test-layout-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/resources/com/liferay/layout/page/template/internal/importer/test/dependencies/link-fragment/page-templates/test-collection/test-layout-page-template/page-definition.json
@@ -4,9 +4,7 @@
 			{
 				"definition": {
 					"fragment": {
-						"collectionName": "Test Collection",
-						"key": "test-link-fragment",
-						"name": "Test Link Fragment"
+						"key": "test-link-fragment"
 					},
 					"fragmentFields": [
 						{

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/resources/com/liferay/layout/page/template/internal/importer/test/dependencies/text-fragment/page-templates/test-collection/test-layout-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/resources/com/liferay/layout/page/template/internal/importer/test/dependencies/text-fragment/page-templates/test-collection/test-layout-page-template/page-definition.json
@@ -4,9 +4,7 @@
 			{
 				"definition": {
 					"fragment": {
-						"collectionName": "Test Collection",
-						"key": "test-text-fragment",
-						"name": "Test Text Fragment"
+						"key": "test-text-fragment"
 					},
 					"fragmentConfig": {
 						"bottomSpacing": "2",

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/resources/com/liferay/layout/page/template/validator/test/dependencies/page_definition_valid_fragment_complete.json
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/resources/com/liferay/layout/page/template/validator/test/dependencies/page_definition_valid_fragment_complete.json
@@ -4,9 +4,7 @@
 			{
 				"definition": {
 					"fragment": {
-						"collectionName": "My Fragment Collection",
-						"key": "my-key",
-						"name": "My Fragment"
+						"key": "my-key"
 					},
 					"fragmentConfig": {
 						"fieldOne": 1,

--- a/modules/apps/layout/layout-service/src/main/resources/com/liferay/layout/internal/service/default-layout-definition.json
+++ b/modules/apps/layout/layout-service/src/main/resources/com/liferay/layout/internal/service/default-layout-definition.json
@@ -54,9 +54,7 @@
 				{
 					"definition": {
 						"fragment": {
-							"collectionName": "Basic Components",
-							"key": "BASIC_COMPONENT-heading",
-							"name": "Heading"
+							"key": "BASIC_COMPONENT-heading"
 						},
 						"fragmentConfig": {
 							"headingLevel": "h1",
@@ -131,8 +129,7 @@
 					"definition": {
 						"fragment": {
 							"collectionName": "Basic Components",
-							"key": "BASIC_COMPONENT-paragraph",
-							"name": "Paragraph"
+							"key": "BASIC_COMPONENT-paragraph"
 						},
 						"fragmentConfig": {
 							"marginBottom": "3",

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/collections-InlineContent-edited.zip/collection-name/fragments/new-fragment-name/fragment-composition-definition.json
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/collections-InlineContent-edited.zip/collection-name/fragments/new-fragment-name/fragment-composition-definition.json
@@ -11,9 +11,7 @@
 	    {
 	      "definition": {
 	        "fragment": {
-	          "collectionName": "Basic Components",
-	          "key": "BASIC_COMPONENT-heading",
-	          "name": "Heading"
+	          "key": "BASIC_COMPONENT-heading"
 	        },
 	        "fragmentConfig": {
 	          "textAlign": "left",

--- a/portal-web/test/functional/com/liferay/portalweb/dependencies/collections-duplcatefragment.zip/collection-name/fragments/new-fragment-name/fragment-composition-definition.json
+++ b/portal-web/test/functional/com/liferay/portalweb/dependencies/collections-duplcatefragment.zip/collection-name/fragments/new-fragment-name/fragment-composition-definition.json
@@ -22,9 +22,7 @@
             {
               "definition": {
                 "fragment": {
-                  "collectionName": "Basic Components",
-                  "key": "BASIC_COMPONENT-heading",
-                  "name": "Heading"
+                  "key": "BASIC_COMPONENT-heading"
                 },
                 "fragmentConfig": {
                   "textAlign": "left",
@@ -40,8 +38,7 @@
               "definition": {
                 "fragment": {
                   "collectionName": "Basic Components",
-                  "key": "BASIC_COMPONENT-heading",
-                  "name": "Heading"
+                  "key": "BASIC_COMPONENT-heading"
                 },
                 "fragmentConfig": {
                   "textAlign": "left",
@@ -75,8 +72,7 @@
       "definition": {
         "fragment": {
           "collectionName": "Basic Components",
-          "key": "BASIC_COMPONENT-heading",
-          "name": "Heading"
+          "key": "BASIC_COMPONENT-heading"
         },
         "fragmentConfig": {
           "textAlign": "left",


### PR DESCRIPTION
//cc @ealonso @jkappler @nhpatt

This a first follow-up PR on the changes requested [here](https://github.com/brianchandotcom/liferay-portal/pull/90995#issuecomment-655275715). I would like to validate the approach on one field before applying it to other fields.

Instead of renaming the existing field, a new field has been added and the already existing one has been deprecated.
The Importer code has been adapted so that:
- Previously created Fragment Compositions work correctly when dragged into a page
- Page templates previously exported are imported correctly

It contains changes done as part of LPS-116835 to avoid tests failing.