### PR TITLE
LPS-116830 - Attribute names in OpenAPI YAML should follow pattern xyzSchemaName when they reference a schema (II)

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/FragmentFieldBackgroundImage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/FragmentFieldBackgroundImage.java
@@ -54,17 +54,52 @@ public class FragmentFieldBackgroundImage {
 
 	@Schema
 	@Valid
-	public FragmentImage getBackgroundImage() {
+	public FragmentImage getBackgroundFragmentImage() {
+		return backgroundFragmentImage;
+	}
+
+	public void setBackgroundFragmentImage(
+		FragmentImage backgroundFragmentImage) {
+
+		this.backgroundFragmentImage = backgroundFragmentImage;
+	}
+
+	@JsonIgnore
+	public void setBackgroundFragmentImage(
+		UnsafeSupplier<FragmentImage, Exception>
+			backgroundFragmentImageUnsafeSupplier) {
+
+		try {
+			backgroundFragmentImage =
+				backgroundFragmentImageUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected FragmentImage backgroundFragmentImage;
+
+	@Schema(
+		description = "Deprecated as of Athanasius (7.3.x), replaced by backgroundFragmentImage"
+	)
+	@Valid
+	public BackgroundImage getBackgroundImage() {
 		return backgroundImage;
 	}
 
-	public void setBackgroundImage(FragmentImage backgroundImage) {
+	public void setBackgroundImage(BackgroundImage backgroundImage) {
 		this.backgroundImage = backgroundImage;
 	}
 
 	@JsonIgnore
 	public void setBackgroundImage(
-		UnsafeSupplier<FragmentImage, Exception>
+		UnsafeSupplier<BackgroundImage, Exception>
 			backgroundImageUnsafeSupplier) {
 
 		try {
@@ -78,9 +113,12 @@ public class FragmentFieldBackgroundImage {
 		}
 	}
 
-	@GraphQLField
+	@Deprecated
+	@GraphQLField(
+		description = "Deprecated as of Athanasius (7.3.x), replaced by backgroundFragmentImage"
+	)
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
-	protected FragmentImage backgroundImage;
+	protected BackgroundImage backgroundImage;
 
 	@Override
 	public boolean equals(Object object) {
@@ -110,6 +148,16 @@ public class FragmentFieldBackgroundImage {
 		StringBundler sb = new StringBundler();
 
 		sb.append("{");
+
+		if (backgroundFragmentImage != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"backgroundFragmentImage\": ");
+
+			sb.append(String.valueOf(backgroundFragmentImage));
+		}
 
 		if (backgroundImage != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/FragmentFieldBackgroundImage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/FragmentFieldBackgroundImage.java
@@ -32,16 +32,41 @@ public class FragmentFieldBackgroundImage implements Cloneable {
 		return FragmentFieldBackgroundImageSerDes.toDTO(json);
 	}
 
-	public FragmentImage getBackgroundImage() {
+	public FragmentImage getBackgroundFragmentImage() {
+		return backgroundFragmentImage;
+	}
+
+	public void setBackgroundFragmentImage(
+		FragmentImage backgroundFragmentImage) {
+
+		this.backgroundFragmentImage = backgroundFragmentImage;
+	}
+
+	public void setBackgroundFragmentImage(
+		UnsafeSupplier<FragmentImage, Exception>
+			backgroundFragmentImageUnsafeSupplier) {
+
+		try {
+			backgroundFragmentImage =
+				backgroundFragmentImageUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected FragmentImage backgroundFragmentImage;
+
+	public BackgroundImage getBackgroundImage() {
 		return backgroundImage;
 	}
 
-	public void setBackgroundImage(FragmentImage backgroundImage) {
+	public void setBackgroundImage(BackgroundImage backgroundImage) {
 		this.backgroundImage = backgroundImage;
 	}
 
 	public void setBackgroundImage(
-		UnsafeSupplier<FragmentImage, Exception>
+		UnsafeSupplier<BackgroundImage, Exception>
 			backgroundImageUnsafeSupplier) {
 
 		try {
@@ -52,7 +77,7 @@ public class FragmentFieldBackgroundImage implements Cloneable {
 		}
 	}
 
-	protected FragmentImage backgroundImage;
+	protected BackgroundImage backgroundImage;
 
 	@Override
 	public FragmentFieldBackgroundImage clone()

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/FragmentFieldBackgroundImageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/FragmentFieldBackgroundImageSerDes.java
@@ -59,6 +59,18 @@ public class FragmentFieldBackgroundImageSerDes {
 
 		sb.append("{");
 
+		if (fragmentFieldBackgroundImage.getBackgroundFragmentImage() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"backgroundFragmentImage\": ");
+
+			sb.append(
+				String.valueOf(
+					fragmentFieldBackgroundImage.getBackgroundFragmentImage()));
+		}
+
 		if (fragmentFieldBackgroundImage.getBackgroundImage() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -93,6 +105,16 @@ public class FragmentFieldBackgroundImageSerDes {
 
 		Map<String, String> map = new TreeMap<>();
 
+		if (fragmentFieldBackgroundImage.getBackgroundFragmentImage() == null) {
+			map.put("backgroundFragmentImage", null);
+		}
+		else {
+			map.put(
+				"backgroundFragmentImage",
+				String.valueOf(
+					fragmentFieldBackgroundImage.getBackgroundFragmentImage()));
+		}
+
 		if (fragmentFieldBackgroundImage.getBackgroundImage() == null) {
 			map.put("backgroundImage", null);
 		}
@@ -124,10 +146,19 @@ public class FragmentFieldBackgroundImageSerDes {
 			FragmentFieldBackgroundImage fragmentFieldBackgroundImage,
 			String jsonParserFieldName, Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "backgroundImage")) {
+			if (Objects.equals(
+					jsonParserFieldName, "backgroundFragmentImage")) {
+
+				if (jsonParserFieldValue != null) {
+					fragmentFieldBackgroundImage.setBackgroundFragmentImage(
+						FragmentImageSerDes.toDTO(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "backgroundImage")) {
 				if (jsonParserFieldValue != null) {
 					fragmentFieldBackgroundImage.setBackgroundImage(
-						FragmentImageSerDes.toDTO(
+						BackgroundImageSerDes.toDTO(
 							(String)jsonParserFieldValue));
 				}
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -1146,6 +1146,8 @@ components:
             type: object
         FragmentFieldBackgroundImage:
             properties:
+                backgroundFragmentImage:
+                    $ref: "#/components/schemas/FragmentImage"
                 backgroundImage:
                     $ref: "#/components/schemas/FragmentImage"
             type: object

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -1149,7 +1149,21 @@ components:
                 backgroundFragmentImage:
                     $ref: "#/components/schemas/FragmentImage"
                 backgroundImage:
-                    $ref: "#/components/schemas/FragmentImage"
+                    deprecated: true
+                    description:
+                        "Deprecated as of Athanasius (7.3.x), replaced by backgroundFragmentImage"
+                    properties:
+                        description:
+                            oneOf:
+                                - $ref: "#/components/schemas/FragmentInlineValue"
+                        title:
+                            oneOf:
+                                - $ref: "#/components/schemas/FragmentInlineValue"
+                        url:
+                            oneOf:
+                                - $ref: "#/components/schemas/FragmentInlineValue"
+                                - $ref: "#/components/schemas/FragmentMappedValue"
+                    type: object
             type: object
         FragmentFieldHTML:
             properties:

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/converter/PageFragmentInstanceDefinitionDTOConverter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/converter/PageFragmentInstanceDefinitionDTOConverter.java
@@ -470,7 +470,7 @@ public class PageFragmentInstanceDefinitionDTOConverter {
 
 		return new FragmentFieldBackgroundImage() {
 			{
-				backgroundImage = new FragmentImage() {
+				backgroundFragmentImage = new FragmentImage() {
 					{
 						title = _toTitleFragmentInlineValue(
 							jsonObject, localeMap);

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/FragmentLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/FragmentLayoutStructureItemImporter.java
@@ -171,7 +171,8 @@ public class FragmentLayoutStructureItemImporter
 		JSONObject fragmentEntryProcessorValuesJSONObject = JSONUtil.put(
 			"com.liferay.fragment.entry.processor.background.image." +
 				"BackgroundImageFragmentEntryProcessor",
-			JSONFactoryUtil.createJSONObject());
+			_toBackgroundImageFragmentEntryProcessorJSONObject(
+				(List<Object>)definitionMap.get("fragmentFields")));
 
 		JSONObject editableFragmentEntryProcessorJSONObject =
 			_toEditableFragmentEntryProcessorJSONObject(
@@ -612,6 +613,56 @@ public class FragmentLayoutStructureItemImporter
 		}
 
 		return html;
+	}
+
+	private JSONObject _toBackgroundImageFragmentEntryProcessorJSONObject(
+		List<Object> fragmentFields) {
+
+		JSONObject backgroundImageFragmentEntryProcessorValuesJSONObject =
+			JSONFactoryUtil.createJSONObject();
+
+		for (Object fragmentField : fragmentFields) {
+			Map<String, Object> fragmentFieldMap =
+				(Map<String, Object>)fragmentField;
+
+			Map<String, Object> fragmentFieldValueMap =
+				(Map<String, Object>)fragmentFieldMap.get("value");
+
+			Map<String, Object> backgroundFragmentImageMap =
+				(Map<String, Object>)fragmentFieldValueMap.get(
+					"backgroundFragmentImage");
+
+			if (backgroundFragmentImageMap == null) {
+				backgroundFragmentImageMap =
+					(Map<String, Object>)fragmentFieldValueMap.get(
+						"backgroundImage");
+			}
+
+			if (backgroundFragmentImageMap == null) {
+				continue;
+			}
+
+			Map<String, Object> urlMap =
+				(Map<String, Object>)backgroundFragmentImageMap.get("url");
+
+			JSONObject fragmentFieldValueJSONObject =
+				_createBaseFragmentFieldJSONObject(urlMap);
+
+			Map<String, Object> titleMap =
+				(Map<String, Object>)backgroundFragmentImageMap.get("title");
+
+			if (titleMap != null) {
+				fragmentFieldValueJSONObject.put(
+					"config",
+					JSONUtil.put("imageTitle", titleMap.get("value")));
+			}
+
+			backgroundImageFragmentEntryProcessorValuesJSONObject.put(
+				(String)fragmentFieldMap.get("id"),
+				fragmentFieldValueJSONObject);
+		}
+
+		return backgroundImageFragmentEntryProcessorValuesJSONObject;
 	}
 
 	private JSONObject _toEditableFragmentEntryProcessorJSONObject(

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/validator/dependencies/page_definition_json_schema.json
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/validator/dependencies/page_definition_json_schema.json
@@ -268,6 +268,11 @@
 		"FragmentFieldBackgroundImage": {
 			"additionalProperties": false,
 			"properties": {
+				"backgroundFragmentImage": {
+					"$ref": "#/definitions/FragmentImage",
+					"title": "The backgroundFragmentImage Schema",
+					"type": "object"
+				},
 				"backgroundImage": {
 					"$ref": "#/definitions/FragmentImage"
 				}

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/validator/dependencies/page_definition_json_schema.json
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/validator/dependencies/page_definition_json_schema.json
@@ -274,7 +274,36 @@
 					"type": "object"
 				},
 				"backgroundImage": {
-					"$ref": "#/definitions/FragmentImage"
+					"additionalProperties": false,
+					"deprecationMessage": "Deprecated as of Athanasius (7.3.x), replaced by backgroundFragmentImage",
+					"properties": {
+						"description": {
+							"oneOf": [
+								{
+									"$ref": "#/definitions/FragmentInlineValue"
+								}
+							]
+						},
+						"title": {
+							"oneOf": [
+								{
+									"$ref": "#/definitions/FragmentInlineValue"
+								}
+							]
+						},
+						"url": {
+							"oneOf": [
+								{
+									"$ref": "#/definitions/FragmentInlineValue"
+								},
+								{
+									"$ref": "#/definitions/FragmentMappedValue"
+								}
+							]
+						}
+					},
+					"title": "The backgroundImage Schema",
+					"type": "object"
 				}
 			},
 			"title": "The FragmentFieldBackgroundImage Schema",

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/headless/delivery/dto/v1_0/test/PageDefinitionDTOConverterTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/headless/delivery/dto/v1_0/test/PageDefinitionDTOConverterTest.java
@@ -269,7 +269,7 @@ public class PageDefinitionDTOConverterTest {
 			(FragmentFieldBackgroundImage)fragmentField.getValue();
 
 		_validateFragmentBackgroundImage(
-			fragmentFieldBackgroundImage.getBackgroundImage());
+			fragmentFieldBackgroundImage.getBackgroundFragmentImage());
 	}
 
 	@Test
@@ -285,7 +285,7 @@ public class PageDefinitionDTOConverterTest {
 			(FragmentFieldBackgroundImage)fragmentField.getValue();
 
 		_validateFragmentBackgroundImageWithTitle(
-			fragmentFieldBackgroundImage.getBackgroundImage(),
+			fragmentFieldBackgroundImage.getBackgroundFragmentImage(),
 			"My Background Image Title");
 	}
 


### PR DESCRIPTION
This is a continuation of https://github.com/brianchandotcom/liferay-portal/pull/91121

In addition to deprecating attribute backgroundImage and adding attribute backgroundFragmentImage to FragmentFieldBackgroundImage, this PR fixes the import of background images in editable fields which was missing.

//cc @ealonso @jkappler