### PR TITLE
[TS] LPS-117050

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -180,6 +180,13 @@ public class FriendlyURLServlet extends HttpServlet {
 		if ((pos != -1) && ((pos + 1) != path.length())) {
 			friendlyURL = path.substring(pos);
 
+			if (friendlyURL.charAt(friendlyURL.length() - 1) ==
+					CharPool.SLASH) {
+
+				friendlyURL = friendlyURL.substring(
+					0, friendlyURL.length() - 1);
+			}
+
 			RedirectEntry redirectEntry =
 				redirectEntryLocalService.fetchRedirectEntry(
 					group.getGroupId(), _normalizeFriendlyURL(friendlyURL),

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/servlet/FriendlyURLServlet.java
@@ -180,9 +180,7 @@ public class FriendlyURLServlet extends HttpServlet {
 		if ((pos != -1) && ((pos + 1) != path.length())) {
 			friendlyURL = path.substring(pos);
 
-			if (friendlyURL.charAt(friendlyURL.length() - 1) ==
-					CharPool.SLASH) {
-
+			if (StringUtil.endsWith(friendlyURL, CharPool.SLASH)) {
 				friendlyURL = friendlyURL.substring(
 					0, friendlyURL.length() - 1);
 			}


### PR DESCRIPTION
[**LPS-117050**](https://issues.liferay.com/browse/LPS-117050)

From @jesseyeh-liferay 

> This solution accounts for an edge case in which a trailing slash in a URL to a `JournalArticle` results in a `NoSuchLayoutException`, which in turn yields a "requested resource could not be found error."