### PR TITLE
[TS] LPS-117777 Only convert to string if 'hash' is not undefined

### DIFF
--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
@@ -40,7 +40,11 @@
 
 			var hashObj = A.QueryString.parse(hash);
 
-			hash = String(hashObj['<portlet:namespace />']);
+			hash = hashObj['<portlet:namespace />'];
+
+			if (hash) {
+				hash = String(hash);
+			}
 
 			var iframe = A.one('#<portlet:namespace />iframe');
 


### PR DESCRIPTION
Dear @liferay-echo Team,

[LPS-117777](https://issues.liferay.com/browse/LPS-117777) was most probably caused by [LPS-105535](https://issues.liferay.com/browse/LPS-105535) (commit: https://github.com/liferay/liferay-portal/commit/ede7ccf2b6ef554fefe50f4f3bfb842888fbb579 ).

When `hash` is undefined and it is converted to a string, its value will be used in the IFrame URL. To avoid this, I've added a condition to check whether its value is undefined.

Please review my changes.

Thanks,
Vendel