### PR TITLE
Journal Article - Basic Info Summary Editor Configuration is not taken into account

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/editor/configuration/JournalArticleDescriptionEditorConfigContributor.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/editor/configuration/JournalArticleDescriptionEditorConfigContributor.java
@@ -48,43 +48,25 @@ public class JournalArticleDescriptionEditorConfigContributor
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
 		jsonObject.put(
-			"allowedContent", "p br strong i ol ul li u link pre em a"
+			"allowedContent", "p br strong i ol ul li u link pre em a[href]"
 		).put(
 			"height", "120"
 		).put(
-			"pasteFilter", "p br strong i ol ul li u link pre em a"
+			"pasteFilter", "p br strong i ol ul li u link pre em a[href]"
 		).put(
-			"toolbars", getToolbarsJSONObject(themeDisplay.getLocale())
+			"resize_enabled", false
+		).put(
+			"toolbar", getToolbarJSONArray()
 		);
 	}
 
-	protected JSONObject getToolbarsJSONObject(Locale locale) {
-		return JSONUtil.put("styles", getToolbarsStylesJSONObject(locale));
-	}
+	protected JSONArray getToolbarJSONArray() {
+		JSONArray jsonArray = JSONUtil.putAll(
+			toJSONArray("['Bold', 'Italic', 'Underline']"),
+			toJSONArray("['NumberedList', 'BulletedList']"),
+			toJSONArray("['Link', Unlink]"));
 
-	protected JSONObject getToolbarsStylesJSONObject(Locale locale) {
-		return JSONUtil.put(
-			"selections", getToolbarsStylesSelectionsJSONArray(locale)
-		).put(
-			"tabIndex", 1
-		);
-	}
-
-	protected JSONArray getToolbarsStylesSelectionsJSONArray(Locale locale) {
-		return JSONUtil.put(getToolbarsStylesSelectionsTextJSONObject(locale));
-	}
-
-	protected JSONObject getToolbarsStylesSelectionsTextJSONObject(
-		Locale locale) {
-
-		return JSONUtil.put(
-			"buttons",
-			JSONUtil.putAll("bold", "italic", "underline", "ol", "ul", "link")
-		).put(
-			"name", "text"
-		).put(
-			"test", "AlloyEditor.SelectionTest.text"
-		);
+		return jsonArray;
 	}
 
 }


### PR DESCRIPTION
As part of the epic [Reduce variability in WYSIWYG Writing Experience](https://issues.liferay.com/browse/LPS-98577), we worked to [Replace AlloyEditor in the Summary field in Web Content](https://issues.liferay.com/browse/LPS-110011)

Doing so introduced a regression that caused the editor not to use its custom configuration but the default `toolbar_simple`configuration.

**Steps to Reproduce**
- Navigate to`Content & Data > Web Content > Add Basic Web Content`
- Check the Summary localized input on the sidebar panel

**Current Result:** The editor shows a Source button but no Link button

**Expected Result:** The editor should show the following buttons: `[bold, underline, italic, numbered list, bulleted list, link]`

**What was going on?**
The configuration wasn't specifically targetting AlloyEditor, but it was only generating valid configuation for that editor. As we are now using CKEditor, those settings were not being properly honoured.

Additionally, only `<a>` tags were allowed but no attribute, so in practice this editor did not support adding links since their href attributes would've been wiped out on save. This PR addresses this potential bug by adding `a[href]` to the allowedContent rule configuration.

Deploying this PR should make the Summary editor look like the following:

<img width="314" alt="Screen Shot 2020-07-28 at 15 08 47" src="https://user-images.githubusercontent.com/905006/88679721-a0adf800-d0e7-11ea-94c4-d9c76c3bad4d.png">

**Additional Considerations:**

One thing to take into consideration is that `Unlink` is a separate button. Adding it will make the toolbar break to 2 rows (Space being very limited here... :D). Not having it makes it so that the only way to remove links is to actually delete the text or use the contextual (right-click) menu. 

<img width="307" alt="Screen Shot 2020-07-28 at 15 24 24" src="https://user-images.githubusercontent.com/905006/88679949-e5d22a00-d0e7-11ea-91ca-012ef54b9fd5.png">

<img width="306" alt="Screen Shot 2020-07-28 at 15 24 36" src="https://user-images.githubusercontent.com/905006/88679960-e8cd1a80-d0e7-11ea-98d8-8123e8661690.png">

My suggestion would be to leave only the `Link` button and work to add the [linkballoon](https://ckeditor.com/docs/ckeditor4/latest/examples/balloontoolbar.html) behaviour so removing links is more obvious.

/cc @JorgeFerrer. I'll add this in an email to Tarik as well, since he's still NOT in GitHub 😂 