### PR TITLE
[TS] LPS-117593

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
@@ -122,7 +122,7 @@ Layout curLayout = (Layout)row.getObject();
 				id: '<portlet:namespace />copyLayoutDialog',
 				title: '<liferay-ui:message key="copy-page" />',
 				url:
-					'<%= layoutsAdminDisplayContext.getCopyLayoutRenderURL(layout) %>',
+					'<%= layoutsAdminDisplayContext.getCopyLayoutRenderURL(curLayout) %>',
 			});
 		}
 	);
@@ -136,7 +136,7 @@ Layout curLayout = (Layout)row.getObject();
 				id: '<portlet:namespace />viewCollectionItemsDialog',
 				title: '<liferay-ui:message key="collection-items" />',
 				url:
-					'<%= layoutsAdminDisplayContext.getViewCollectionItemsURL(layout) %>',
+					'<%= layoutsAdminDisplayContext.getViewCollectionItemsURL(curLayout) %>',
 			});
 		}
 	);

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
@@ -61,7 +61,7 @@ Layout curLayout = (Layout)row.getObject();
 
 	<c:if test="<%= layoutsAdminDisplayContext.isShowCopyLayoutAction(curLayout) %>">
 		<liferay-ui:icon
-			cssClass="copy-layout-action-option"
+			cssClass='<%= liferayPortletResponse.getNamespace() + "copy-layout-action-option" %>'
 			message="copy-page"
 			url="javascript:;"
 		/>
@@ -105,7 +105,7 @@ Layout curLayout = (Layout)row.getObject();
 
 	<c:if test="<%= layoutsAdminDisplayContext.isShowViewCollectionItemsAction(curLayout) %>">
 		<liferay-ui:icon
-			cssClass="view-collection-items-action-option"
+			cssClass='<%= liferayPortletResponse.getNamespace() + "view-collection-items-action-option" %>'
 			message="view-collection-items"
 			url="javascript:;"
 		/>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp
@@ -119,7 +119,7 @@ Layout curLayout = (Layout)row.getObject();
 		'.<portlet:namespace />copy-layout-action-option',
 		function (event) {
 			Liferay.Util.openModal({
-				id: '<portlet:namespace />copyLayoutDialog',
+				id: '<portlet:namespace />addLayoutDialog',
 				title: '<liferay-ui:message key="copy-page" />',
 				url:
 					'<%= layoutsAdminDisplayContext.getCopyLayoutRenderURL(curLayout) %>',


### PR DESCRIPTION
From @kevhlee:

> Relevant Tickets:
> 
> - [LPS-117593](<https://issues.liferay.com/browse/LPS-117593>)
> 
> The issue occurs because the "copy layout" action requires the portal namespace for its icon's cssClass, as seen [here](<https://github.com/kevhlee/liferay-portal/blob/LPS-117593/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_action.jsp#L119>). I append the namespace to the cssClass to resolve the problem of the dialog window not appearing. The same issue occurs for the "view collection items" action for collection pages. Thus, I append the namespace to the "view collection items" icon's cssClass as well.
> 
> Additionally, there is another issue where the dialog window does not exit and redirect the user when the user tries to create a copy. As a result, I've added additional changes so that the user gets redirected. My solution is based on code [here](<https://github.com/kevhlee/liferay-portal/blob/LPS-117593/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/actionHandlers.js#L18-L24>).

CC @wanderlast 