### PR TITLE
LPS-113703 Clickable elements from variants are not marked as target for AB Testing by Click Goal

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
@@ -239,7 +239,8 @@ public class SegmentsExperienceUtil {
 				CounterLocalServiceUtil.increment());
 			newFragmentEntryLink.setCreateDate(new Date());
 			newFragmentEntryLink.setModifiedDate(new Date());
-			newFragmentEntryLink.setOriginalFragmentEntryLinkId(0);
+			newFragmentEntryLink.setOriginalFragmentEntryLinkId(
+				fragmentEntryLink.getFragmentEntryLinkId());
 			newFragmentEntryLink.setSegmentsExperienceId(
 				targetSegmentsExperienceId);
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
@@ -514,7 +514,6 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 				serviceContext.getCreateDate(new Date()));
 			newFragmentEntryLink.setModifiedDate(
 				serviceContext.getModifiedDate(new Date()));
-			newFragmentEntryLink.setOriginalFragmentEntryLinkId(0);
 			newFragmentEntryLink.setSegmentsExperienceId(
 				targetSegmentsExperienceId);
 			newFragmentEntryLink.setClassNameId(


### PR DESCRIPTION
**Motivation**

This regresion [LPS-113703 Clickable elements from variants are not marked as target for AB Testing by Click Goal
](https://issues.liferay.com/browse/LPS-113703) was caused by [LPS-110227 Category Navigation portlet is not shown for different experience segments](https://issues.liferay.com/browse/LPS-110227) since we decided to [recreate the namespace every time a FragmentEntryLink is created](https://github.com/liferay/liferay-portal/blob/80d7bbaa23c8ee6aecfab2953b64447e94103366/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java#L253). Due to this when creating a new experience the html id associated to a fragment entry link changes since It's the namespace is used to generate it.

**Proposed solution**

After a conversation with @pavel-savinov and @jkappler we decided to reuse the unused "originalFragmentEntryLinkId" column of the `FragmentEntryLink` table to keep track of the `FragmentEntryLink` associated with the experience of which a copy is being created. In this way, by retrieving the namespace to generate the html id of a fragment entry link we can [retrieve the namespace of the original fragment entry link](https://github.com/liferay-echo/liferay-portal/pull/1749/commits/5affa9b4b4bee67053899f7bde00760fc3ee9467#diff-817332586992aa6187141edfd8c7bb78R243).

In order to validate the solution, we've executed an upgrade process from 7.1.3.ga4 to master and the behaviour was the expected: the `originalFragmentEntryLinkId` props were set to 0.

 **How to test it DXP**

- Requirement: AC-DXP synced.
- Create a Content Page with a button
- Create an AB test by Click goal and set the button as clickable element
- The button is marked as "Target" only in Control version.

**How to test it CE**
- Create a Content Page with a button
- Create an experience from the default one
- The html id of the button must be the same in both experiences
