### PR TITLE
LPS-117376 Keep the originals only if they are not null.

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
@@ -265,7 +265,10 @@ public class JournalTransformer {
 					template.prepare(httpServletRequest);
 				}
 				finally {
-					if (portletRequestModel != null) {
+					if ((portletRequestModel != null) &&
+						(originalPortletRequest != null) &&
+						(originalPortletResponse != null)) {
+
 						httpServletRequest.setAttribute(
 							JavaConstants.JAVAX_PORTLET_REQUEST,
 							originalPortletRequest);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-117376

The issue here was caused by the changes made in LPS-106268. The attribute, javax.portlet.request, for the HttpServletRequest object was getting overwritten to null. This caused the porteletRequest object in BaseJournalFormNavigatorEntry -> isEditDefaultValues to be assigned to null when trying to get the javax.portlet.request attribute. Therefore, a NullPointerException was being thrown in ParamUtil -> get when trying to access a parameter of porteletRequest.

To fix the issue, we only set the attribute of httpServletRequest for originalPortletRequest and originalPortletResponse if they are not null.

Sincerely,
Brian Kim