### PR TITLE
LPS-119053 Checking default language

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.AggregateResourceBundle;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Http;
@@ -169,9 +170,16 @@ public class JournalConverterImpl implements JournalConverter {
 		rootElement.addAttribute(
 			"available-locales", getAvailableLocales(ddmFields));
 
+		Long groupId = GroupThreadLocal.getGroupId();
+
+		Locale defaultLocale = ddmFields.getDefaultLocale();
+
+		if (!LanguageUtil.isAvailableLocale(groupId, defaultLocale)) {
+			defaultLocale = LocaleUtil.getSiteDefault();
+		}
+
 		rootElement.addAttribute(
-			"default-locale",
-			LocaleUtil.toLanguageId(ddmFields.getDefaultLocale()));
+			"default-locale", LocaleUtil.toLanguageId(defaultLocale));
 
 		DDMFieldsCounter ddmFieldsCounter = new DDMFieldsCounter();
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -55,6 +55,7 @@ import com.liferay.portal.kernel.servlet.MultiSessionMessages;
 import com.liferay.portal.kernel.upload.LiferayFileItemException;
 import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.upload.UploadPortletRequest;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -181,6 +182,8 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 			fields = DDMUtil.getFields(
 				ddmStructure.getStructureId(), serviceContext);
 		}
+
+		GroupThreadLocal.setGroupId(groupId);
 
 		String content = _journalConverter.getContent(ddmStructure, fields);
 


### PR DESCRIPTION
Hi guys,

Can you review this pull request, please?

You can find more information in [LPS-119053](https://issues.liferay.com/browse/LPS-119053).

The reason why the behavior is not as expected is because [here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java#L110-L129) we are throwing a LocaleException because the defaultLocale from the article's content (structure's default locale) is not among the available locales for the site.

My proposal is updating content's default locale to retrieve site's default locale in case the structure's default locale is not one of the available locales.

I was not completely sure about how to get the available locales for the site at that point without breaking anything else and I used this hacky way using GroupThreadLocal, but you might have a better idea about how to do it.

Thanks in advance.

Regards.