### PR TITLE
[TS] LPS-119187 New Draft version after task CheckAssetEntryMessageListener staging and page versioning and email notifications enabled

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/messaging/AssetEntriesCheckerHelper.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/messaging/AssetEntriesCheckerHelper.java
@@ -145,6 +145,10 @@ public class AssetEntriesCheckerHelper {
 			}
 		}
 
+		if (newAssetEntries.isEmpty()) {
+			return;
+		}
+
 		List<Subscription> subscriptions =
 			_subscriptionLocalService.getSubscriptions(
 				portletPreferencesModel.getCompanyId(),

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceStagingAdvice.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceStagingAdvice.java
@@ -278,6 +278,14 @@ public class LayoutLocalServiceStagingAdvice implements BeanFactoryAware {
 			boolean privateLayout, long layoutId, String typeSettings)
 		throws PortalException {
 
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			return layoutLocalService.updateLayout(
+				groupId, privateLayout, layoutId, typeSettings);
+		}
+
 		Layout layout = LayoutUtil.findByG_P_L(
 			groupId, privateLayout, layoutId);
 
@@ -294,18 +302,6 @@ public class LayoutLocalServiceStagingAdvice implements BeanFactoryAware {
 		}
 
 		layout.setTypeSettings(typeSettings);
-
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext == null) {
-			serviceContext = new ServiceContext();
-
-			long defaultUserId = UserLocalServiceUtil.getDefaultUserId(
-				layout.getCompanyId());
-
-			serviceContext.setUserId(defaultUserId);
-		}
 
 		boolean hasWorkflowTask = StagingUtil.hasWorkflowTask(
 			serviceContext.getUserId(), layoutRevision);
@@ -336,6 +332,14 @@ public class LayoutLocalServiceStagingAdvice implements BeanFactoryAware {
 			String colorSchemeId, String css)
 		throws PortalException {
 
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			return layoutLocalService.updateLookAndFeel(
+				groupId, privateLayout, layoutId, themeId, colorSchemeId, css);
+		}
+
 		Layout layout = LayoutUtil.findByG_P_L(
 			groupId, privateLayout, layoutId);
 
@@ -354,18 +358,6 @@ public class LayoutLocalServiceStagingAdvice implements BeanFactoryAware {
 		layout.setThemeId(themeId);
 		layout.setColorSchemeId(colorSchemeId);
 		layout.setCss(css);
-
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext == null) {
-			serviceContext = new ServiceContext();
-
-			long defaultUserId = UserLocalServiceUtil.getDefaultUserId(
-				layout.getCompanyId());
-
-			serviceContext.setUserId(defaultUserId);
-		}
 
 		boolean hasWorkflowTask = StagingUtil.hasWorkflowTask(
 			serviceContext.getUserId(), layoutRevision);
@@ -395,6 +387,13 @@ public class LayoutLocalServiceStagingAdvice implements BeanFactoryAware {
 			String languageId)
 		throws PortalException {
 
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext == null) {
+			return layoutLocalService.updateName(layout, name, languageId);
+		}
+
 		layout = wrapLayout(layout);
 
 		LayoutRevision layoutRevision = LayoutStagingUtil.getLayoutRevision(
@@ -407,18 +406,6 @@ public class LayoutLocalServiceStagingAdvice implements BeanFactoryAware {
 		layoutLocalServiceHelper.validateName(name, languageId);
 
 		layout.setName(name, LocaleUtil.fromLanguageId(languageId));
-
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		if (serviceContext == null) {
-			serviceContext = new ServiceContext();
-
-			long defaultUserId = UserLocalServiceUtil.getDefaultUserId(
-				layout.getCompanyId());
-
-			serviceContext.setUserId(defaultUserId);
-		}
 
 		boolean hasWorkflowTask = StagingUtil.hasWorkflowTask(
 			serviceContext.getUserId(), layoutRevision);


### PR DESCRIPTION
Hi @liferay-echo,

This pr aims to solve a problem caused by the particular implementation of the solution to [LPS-114872](https://issues.liferay.com/browse/LPS-114872). 

The solution in LPS-114872 made sure that the `serviceContext` was well informed when performing a layout update prompted by the task `AssetEntriesCheckerHelper` via an update in portlet preferences of the Asset Publisher in that layout. However this update would leave new draft versions of the layout when page versioning is active. 

Note that the changes in the portlet preferences introduced by the task (`notifiedAssetEntryIds`) is a piece of information that is not staged. This can be seen in the method `AssetPublisherExportImportPortletPreferencesProcessor#updateImportPortletPreferences` with the call:
```
restorePortletPreference(
	portletDataContext, "notifiedAssetEntryIds", portletPreferences);
```

The solution proposed here is to avoid updating the layout revision altogether.

Finally the second commit (85dbb40) is just an optimization to avoid trying to send notifications and updating portlet preferences when there's really nothing to notify about or update.

Please let me know if you have any questions. 

/cc @jorgediaz-lr (thanks for suggesting this kind of solution)