### PR TITLE
LPS-116291

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/EditEntryMVCActionCommand.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/portlet/action/EditEntryMVCActionCommand.java
@@ -362,8 +362,8 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 
 		String redirect = ParamUtil.getString(actionRequest, "redirect");
 
-		String portletResource = _http.getParameter(
-			redirect, "portletResource", false);
+		String portletResource = ParamUtil.getString(
+			actionRequest, "referringPortletResource");
 
 		if (Validator.isNotNull(portletResource)) {
 			String namespace = _portal.getPortletNamespace(portletResource);

--- a/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/portlet/action/EditEntryMVCActionCommand.java
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/portlet/action/EditEntryMVCActionCommand.java
@@ -168,8 +168,8 @@ public class EditEntryMVCActionCommand extends BaseMVCActionCommand {
 
 			if (Validator.isNotNull(redirect)) {
 				if (cmd.equals(Constants.ADD) && (entry != null)) {
-					String portletId = _http.getParameter(
-						redirect, "portletResource", false);
+					String portletId = ParamUtil.getString(
+						actionRequest, "referringPortletResource");
 
 					String namespace = _portal.getPortletNamespace(portletId);
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -304,8 +304,8 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 					if (Validator.isNotNull(redirect)) {
 						if (cmd.equals(Constants.ADD) && (fileEntry != null)) {
-							String portletResource = _http.getParameter(
-								redirect, "portletResource", false);
+							String portletResource = ParamUtil.getString(
+								actionRequest, "referringPortletResource");
 
 							String namespace = _portal.getPortletNamespace(
 								portletResource);

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -175,6 +175,7 @@ renderResponse.setTitle(headerTitle);
 		<aui:input name="<%= Constants.CMD %>" type="hidden" />
 		<aui:input name="redirect" type="hidden" value="<%= redirect %>" />
 		<aui:input name="portletResource" type="hidden" value='<%= ParamUtil.getString(request, "portletResource") %>' />
+		<aui:input name="referringPortletResource" type="hidden" value='<%= ParamUtil.getString(request, "referringPortletResource") %>' />
 		<aui:input name="uploadProgressId" type="hidden" value="<%= uploadProgressId %>" />
 		<aui:input name="repositoryId" type="hidden" value="<%= repositoryId %>" />
 		<aui:input name="folderId" type="hidden" value="<%= folderId %>" />

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -487,8 +487,8 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 		int workflowAction = ParamUtil.getInteger(
 			actionRequest, "workflowAction", WorkflowConstants.ACTION_PUBLISH);
 
-		String portletId = _http.getParameter(
-			redirect, "portletResource", false);
+		String portletId = ParamUtil.getString(
+			actionRequest, "referringPortletResource");
 
 		String namespace = _portal.getPortletNamespace(portletId);
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/AddContentPanelDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/AddContentPanelDisplayContext.java
@@ -49,13 +49,11 @@ import com.liferay.portal.kernel.service.PortletItemLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
-import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -588,13 +586,8 @@ public class AddContentPanelDisplayContext {
 	}
 
 	private String _getRedirectURL() throws Exception {
-		String redirectURL = PortalUtil.getLayoutFullURL(
+		return PortalUtil.getLayoutFullURL(
 			_themeDisplay.getLayout(), _themeDisplay);
-
-		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
-
-		return HttpUtil.addParameter(
-			redirectURL, "portletResource", portletDisplay.getId());
 	}
 
 	private List<Map<String, Object>> _getWidgetCategories(

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_icon.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/add_content_icon.jsp
@@ -36,10 +36,8 @@ addPanelURL.setWindowState(LiferayWindowState.EXCLUSIVE);
 AssetRenderer<?> assetRenderer = null;
 Map<String, Object> data = new HashMap<String, Object>();
 
-String portletResourceNamespace = PortalUtil.getPortletNamespace(ParamUtil.getString(request, "portletResource"));
-
-String className = ParamUtil.getString(request, portletResourceNamespace + "className");
-long classPK = ParamUtil.getLong(request, portletResourceNamespace + "classPK");
+String className = ParamUtil.getString(request, portletNamespace + "className");
+long classPK = ParamUtil.getLong(request, portletNamespace + "classPK");
 
 String portletId = PortletProviderUtil.getPortletId(className, PortletProvider.Action.ADD);
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-116291

* Solution to address some of the concerns raised in https://github.com/dacousalr/liferay-portal/pull/254
* Sent directly to product team, based on comment in https://github.com/dacousalr/liferay-portal/pull/268

The solution in this pull request updates all of the redirects to use the referringPortletResource parameter, which is mentioned in various places such as [BaseAssetRenderer](https://github.com/liferay/liferay-portal/blob/7.3.3-ga4/portal-kernel/src/com/liferay/asset/kernel/model/BaseAssetRenderer.java#L416-L426) and [AssetHelperImpl](https://github.com/liferay/liferay-portal/blob/7.3.3-ga4/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java#L161-L167).

In 7.2.x, a similar solution preserves the functionality of adding the content automatically after saving the Web Content. However, in master, adding the content automatically after saving the Web Content is currently broken, even without these changes (see [LPS-119149](https://issues.liferay.com/browse/LPS-119149)), most likely due to some of the React refactoring.