### PR TITLE
LPS-119659 Makes ProductMenuApp take priority over other buttons since it should always show at the left.

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/product/navigation/control/menu/ApplicationsMenuApplicationMenuProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/product/navigation/control/menu/ApplicationsMenuApplicationMenuProductNavigationControlMenuEntry.java
@@ -43,7 +43,7 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true,
 	property = {
 		"product.navigation.control.menu.category.key=" + ProductNavigationControlMenuCategoryKeys.SITES,
-		"product.navigation.control.menu.entry.order:Integer=600"
+		"product.navigation.control.menu.entry.order:Integer=100"
 	},
 	service = ProductNavigationControlMenuEntry.class
 )


### PR DESCRIPTION
Setting entry.order=100 which is the same value as the ProductMenu entry that this replaces when the AppMenu is enabled so it positions in the same way.

Reported by @victorvalle: 

> I see in the screenshot something that is wrong, it should be
> Apps button + [Back] + selector
> Vertical bar shouldn’t be there

This is not reflected in any of the current designs, so this is a best estimate of what's needed.

Changing the entry order to `100` so it shows to the left. Doing so also makes the separator disappear since that only shows when the element is not the first one in a list.

**Before**

<img width="374" alt="current" src="https://user-images.githubusercontent.com/905006/91061163-2318d180-e62c-11ea-8bc5-d617854e27a2.png">

**After**

<img width="583" alt="expected" src="https://user-images.githubusercontent.com/905006/91061178-27dd8580-e62c-11ea-80e5-ab50b54fe594.png">
