### PR TITLE
LPS-119891 Make sheets within responsive cols responsive

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -201,7 +201,9 @@
 			%>
 
 			<c:if test="<%= vocabulary != null %>">
-				<clay:sheet>
+				<clay:sheet
+					size="full"
+				>
 					<h2 class="sheet-title">
 						<clay:content-row
 							verticalAlign="center"

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_asset_list_entry_usages.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_asset_list_entry_usages.jsp
@@ -105,7 +105,9 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 		<clay:col
 			lg="9"
 		>
-			<clay:sheet>
+			<clay:sheet
+				size="full"
+			>
 				<h3 class="sheet-title">
 					<c:choose>
 						<c:when test='<%= Objects.equals(assetListEntryUsagesDisplayContext.getNavigation(), "pages") %>'>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_entry_usages/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_entry_usages/page.jsp
@@ -99,7 +99,9 @@ AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUs
 		<clay:col
 			lg="9"
 		>
-			<clay:sheet>
+			<clay:sheet
+				size="full"
+			>
 				<h3 class="sheet-title">
 					<c:choose>
 						<c:when test='<%= Objects.equals(assetEntryUsagesDisplayContext.getNavigation(), "pages") %>'>

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/edit_configuration.jsp
@@ -105,7 +105,9 @@ renderResponse.setTitle(categoryDisplayName);
 		<clay:col
 			md="9"
 		>
-			<clay:sheet>
+			<clay:sheet
+				size="full"
+			>
 				<aui:form action="<%= bindConfigurationActionURL %>" method="post" name="fm">
 					<aui:input name="redirect" type="hidden" value="<%= bindRedirectURL %>" />
 					<aui:input name="factoryPid" type="hidden" value="<%= configurationModel.getFactoryPid() %>" />

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_factory_instances.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view_factory_instances.jsp
@@ -74,7 +74,9 @@ renderResponse.setTitle(categoryDisplayName);
 		<clay:col
 			md="9"
 		>
-			<clay:sheet>
+			<clay:sheet
+				size="full"
+			>
 				<clay:content-row>
 					<clay:content-col>
 						<h2><%= factoryConfigurationModelName %></h2>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -239,7 +239,9 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 			lg="9"
 		>
 			<c:if test="<%= (fragmentDisplayContext.getFragmentCollection() != null) || (fragmentDisplayContext.getFragmentCollectionContributor() != null) %>">
-				<clay:sheet>
+				<clay:sheet
+					size="full"
+				>
 					<h2 class="sheet-title">
 						<clay:content-row
 							verticalAlign="center"

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entry_usages.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entry_usages.jsp
@@ -113,7 +113,9 @@ FragmentEntryUsageManagementToolbarDisplayContext fragmentEntryUsageManagementTo
 		<clay:col
 			lg="9"
 		>
-			<clay:sheet>
+			<clay:sheet
+				size="full"
+			>
 				<h2 class="sheet-title">
 					<clay:content-row
 						verticalAlign="center"

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
@@ -88,7 +88,9 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 		<clay:col
 			lg="9"
 		>
-			<clay:sheet>
+			<clay:sheet
+				size="full"
+			>
 				<h2 class="sheet-title">
 					<clay:content-row
 						verticalAlign="center"

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
@@ -154,7 +154,9 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 			%>
 
 			<c:if test="<%= layoutPageTemplateCollection != null %>">
-				<clay:sheet>
+				<clay:sheet
+					size="full"
+				>
 					<h2 class="sheet-title">
 						<clay:content-row
 							verticalAlign="center"

--- a/modules/apps/segments/segments-context-vocabulary/src/main/resources/META-INF/resources/edit_segments_context_vocabulary_configuration.jsp
+++ b/modules/apps/segments/segments-context-vocabulary/src/main/resources/META-INF/resources/edit_segments_context_vocabulary_configuration.jsp
@@ -75,7 +75,9 @@ segmentsContextVocabularyConfigurationDisplayContext.addPortletBreadcrumbEntries
 		<clay:col
 			md="9"
 		>
-			<clay:sheet>
+			<clay:sheet
+				size="full"
+			>
 				<aui:form action="<%= segmentsContextVocabularyConfigurationDisplayContext.getActionURL() %>" method="post" name="fm">
 					<aui:input name="factoryPid" type="hidden" value="<%= segmentsContextVocabularyConfigurationDisplayContext.getFactoryPid() %>" />
 					<aui:input name="pid" type="hidden" value="<%= segmentsContextVocabularyConfigurationDisplayContext.getPid() %>" />

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
@@ -185,7 +185,9 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 		<clay:col
 			lg="9"
 		>
-			<clay:sheet>
+			<clay:sheet
+				size="full"
+			>
 				<clay:sheet-header>
 					<h2 class="sheet-title"><liferay-ui:message key="review-data" /></h2>
 				</clay:sheet-header>


### PR DESCRIPTION
> This is technically a deviation from the standard pattern and Lexicon recommendations that states that all sheets should have one of the given sizes. However, this is how teams were likely using it before we enforced it, so we're implementing a way out of the new behaviour until we can agree on the pattern.

In this PR I've **added the `size="full"` attribute to every `clay:sheet` instance inside a `clay:col lg="9"`** that I've found (11), assuming that all were behaving in a responsive way before.

See some screenshots (not that the difference is super obvious, but there's indeed more space for the content in bigger screens).

<img width="1258" alt="Screen Shot 2020-08-27 at 11 04 24" src="https://user-images.githubusercontent.com/905006/91420565-2e9b1100-e855-11ea-8514-963e206af06a.png">
<img width="1257" alt="Screen Shot 2020-08-27 at 11 01 50" src="https://user-images.githubusercontent.com/905006/91420516-1a571400-e855-11ea-98f5-a4b90e86c825.png">
<img width="1275" alt="Screen Shot 2020-08-27 at 11 02 07" src="https://user-images.githubusercontent.com/905006/91420522-1b884100-e855-11ea-900a-e35af6b75807.png">
<img width="1260" alt="Screen Shot 2020-08-27 at 11 02 26" src="https://user-images.githubusercontent.com/905006/91420524-1b884100-e855-11ea-9169-e406d7cf5a45.png">

FYI, I reached out internally to @drewbrokke and @susanavr so they can check their usages. If this is not the case for them that they want responsive, I'll send a followup directly to Brian.