### PR TITLE
LPS-118408 and LPS-119754 Final Visual/Layout Improvements for Application Menu and Open/Close menu on keyboard shortcut

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/package.json
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/package.json
@@ -6,6 +6,7 @@
 		"@clayui/label": "3.3.1",
 		"@clayui/layout": "3.2.0",
 		"@clayui/sticker": "3.2.0",
+		"frontend-js-react-web": "*",
 		"frontend-js-web": "*",
 		"prop-types": "15.7.2",
 		"react": "16.12.0"

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/display/context/ApplicationsMenuDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/display/context/ApplicationsMenuDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.webserver.WebServerServletTokenUtil;
 import com.liferay.product.navigation.applications.menu.web.internal.constants.ProductNavigationApplicationsMenuPortletKeys;
@@ -77,6 +78,21 @@ public class ApplicationsMenuDisplayContext {
 			}
 		).put(
 			"selectedPortletId", themeDisplay.getPpid()
+		).put(
+			"virtualInstance",
+			HashMapBuilder.<String, Object>put(
+				"label", HtmlUtil.escape(company.getName())
+			).put(
+				"logoURL",
+				StringBundler.concat(
+					themeDisplay.getPathImage(), "/company_logo?img_id=",
+					company.getLogoId(), "&t=",
+					WebServerServletTokenUtil.getToken(company.getLogoId()))
+			).put(
+				"url",
+				PortalUtil.addPreservedParameters(
+					themeDisplay, themeDisplay.getURLPortal(), false, true)
+			).build()
 		).build();
 	}
 

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/display/context/ApplicationsMenuDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/display/context/ApplicationsMenuDisplayContext.java
@@ -54,13 +54,13 @@ public class ApplicationsMenuDisplayContext {
 		Company company = themeDisplay.getCompany();
 
 		return HashMapBuilder.<String, Object>put(
-			"companyName", HtmlUtil.escape(company.getName())
-		).put(
-			"logoURL",
+			"liferayLogoURL",
 			StringBundler.concat(
 				themeDisplay.getPathImage(), "/company_logo?img_id=",
 				company.getLogoId(), "&t=",
 				WebServerServletTokenUtil.getToken(company.getLogoId()))
+		).put(
+			"liferayName", HtmlUtil.escape(company.getName())
 		).put(
 			"panelAppsURL",
 			() -> {

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
@@ -112,13 +112,12 @@
 	}
 }
 
-.applications-menu-sites-label {
+.applications-menu-environments-label {
 	background-color: $light-l1;
 	color: $secondary;
 	font-size: 0.875rem;
 	font-weight: 600;
 	margin-bottom: 0;
-	text-transform: uppercase;
 
 	@include media-breakpoint-up(md) {
 		bottom: 100%;
@@ -128,7 +127,7 @@
 	}
 }
 
-.applications-menu-sites {
+.applications-menu-environments {
 	background-color: $light-l1;
 	height: 100%;
 }

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/css/ApplicationsMenu.scss
@@ -132,6 +132,11 @@
 	height: 100%;
 }
 
+.applications-menu-virtual-instance {
+	font-weight: 600;
+	text-transform: uppercase;
+}
+
 .applications-menu-shrink {
 	flex-shrink: 1;
 	min-width: 0;

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -22,9 +22,20 @@ import '../css/ApplicationsMenu.scss';
 import ClayLabel from '@clayui/label';
 import ClaySticker from '@clayui/sticker';
 import ClayTabs from '@clayui/tabs';
+import {useEventListener} from 'frontend-js-react-web';
 import {fetch, navigate, openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
+
+const OPEN_MENU_TITLE_TPL =
+	`<div>${Liferay.Language.get('open-menu')}</div>` +
+	'<kbd class="c-kbd c-kbd-dark">' +
+	'<kbd class="c-kbd">⌘</kbd>' +
+	'<span class="c-kbd-separator">+</span>' +
+	'<kbd class="c-kbd">⇧</kbd>' +
+	'<span class="c-kbd-separator">+</span>' +
+	'<kbd class="c-kbd">M</kbd>' +
+	'</kbd>';
 
 const Site = ({current, label, logoURL, url}) => {
 	return (
@@ -346,6 +357,27 @@ const ApplicationsMenu = ({
 		onClose: () => setVisible(false),
 	});
 
+	useEventListener(
+		'keydown',
+		(event) => {
+			const isCMDPressed = Liferay.Browser.isMac()
+				? event.metaKey
+				: event.ctrlKey;
+
+			if (
+				isCMDPressed &&
+				event.shiftKey &&
+				event.key.toLowerCase() === 'm'
+			) {
+				event.preventDefault();
+
+				handleTriggerButtonClick();
+			}
+		},
+		true,
+		window
+	);
+
 	const fetchCategoriesPromiseRef = useRef();
 
 	const fetchCategories = () => {
@@ -368,7 +400,7 @@ const ApplicationsMenu = ({
 
 	const handleTriggerButtonClick = () => {
 		fetchCategories();
-		setVisible(true);
+		setVisible(!visible);
 	};
 
 	return (
@@ -392,6 +424,7 @@ const ApplicationsMenu = ({
 			)}
 
 			<ClayButtonWithIcon
+				aria-label={Liferay.Language.get('open-menu')}
 				className="dropdown-toggle lfr-portal-tooltip"
 				data-qa-id="applicationsMenu"
 				displayType="unstyled"
@@ -400,7 +433,7 @@ const ApplicationsMenu = ({
 				onMouseOver={fetchCategories}
 				small
 				symbol="grid"
-				title={Liferay.Language.get('applications-menu')}
+				title={OPEN_MENU_TITLE_TPL}
 			/>
 		</>
 	);

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -188,9 +188,9 @@ const Sites = ({mySites, portletNamespace, recentSites, viewAllURL}) => {
 
 const AppsPanel = ({
 	categories = [],
-	companyName,
 	handleCloseButtonClick = () => {},
-	logoURL,
+	liferayLogoURL,
+	liferayName,
 	portletNamespace,
 	selectedPortletId,
 	sites,
@@ -360,14 +360,14 @@ const AppsPanel = ({
 												<img
 													alt=""
 													height="32px"
-													src={logoURL}
+													src={liferayLogoURL}
 												/>
 											</ClaySticker>
 										</ClayLayout.ContentCol>
 
 										<ClayLayout.ContentCol className="c-ml-2">
 											<div className="applications-menu-company c-mb-0">
-												{companyName}
+												{liferayName}
 											</div>
 										</ClayLayout.ContentCol>
 									</ClayLayout.ContentRow>
@@ -390,8 +390,8 @@ const AppsPanel = ({
 };
 
 const ApplicationsMenu = ({
-	companyName,
-	logoURL,
+	liferayLogoURL,
+	liferayName,
 	panelAppsURL,
 	selectedPortletId,
 	virtualInstance,
@@ -460,9 +460,9 @@ const ApplicationsMenu = ({
 				>
 					<ClayModal.Body>
 						<AppsPanel
-							companyName={companyName}
 							handleCloseButtonClick={onClose}
-							logoURL={logoURL}
+							liferayLogoURL={liferayLogoURL}
+							liferayName={liferayName}
 							virtualInstance={virtualInstance}
 							{...appsPanelData}
 						/>
@@ -487,10 +487,11 @@ const ApplicationsMenu = ({
 };
 
 ApplicationsMenu.propTypes = {
-	companyName: PropTypes.string,
-	logoURL: PropTypes.string,
+	liferayLogoURL: PropTypes.string,
+	liferayName: PropTypes.string,
 	panelAppsURL: PropTypes.string,
 	selectedPortletId: PropTypes.string,
+	virtualInstance: PropTypes.object,
 };
 
 export default ApplicationsMenu;

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -372,16 +372,6 @@ const AppsPanel = ({
 										</ClayLayout.ContentCol>
 									</ClayLayout.ContentRow>
 								</ClayLayout.ContentCol>
-
-								<ClayLayout.ContentCol expand>
-									<span className="applications-menu-powered c-mb-0">
-										Powered by
-									</span>
-
-									<span className="applications-menu-copyright c-mb-0 c-mt-n1">
-										Liferay DXP
-									</span>
-								</ClayLayout.ContentCol>
 							</ClayLayout.ContentRow>
 						</ClayLayout.Col>
 
@@ -390,7 +380,7 @@ const AppsPanel = ({
 							lg="3"
 							md="4"
 						>
-							<div className="applications-menu-sites"></div>
+							<div className="applications-menu-environments"></div>
 						</ClayLayout.Col>
 					</ClayLayout.Row>
 				</ClayLayout.ContainerFluid>

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -37,6 +37,27 @@ const OPEN_MENU_TITLE_TPL =
 	'<kbd class="c-kbd">M</kbd>' +
 	'</kbd>';
 
+const EnvironmentsPanel = ({portletNamespace, sites}) => {
+	return (
+		<div className="applications-menu-environments c-p-3 c-px-md-4">
+			<h2 className="applications-menu-environments-label c-mt-2 c-mt-md-0">
+				{Liferay.Language.get('environments')}
+			</h2>
+
+			<ul className="c-my-2 list-unstyled">
+				{sites && (
+					<Sites
+						mySites={sites.mySites}
+						portletNamespace={portletNamespace}
+						recentSites={sites.recentSites}
+						viewAllURL={sites.viewAllURL}
+					/>
+				)}
+			</ul>
+		</div>
+	)
+};
+
 const Site = ({current, label, logoURL, url}) => {
 	return (
 		<li className="c-mt-3">
@@ -65,9 +86,15 @@ const Site = ({current, label, logoURL, url}) => {
 	);
 };
 
-const SitesPanel = ({mySites, portletNamespace, recentSites, viewAllURL}) => {
+const Sites = ({mySites, portletNamespace, recentSites, viewAllURL}) => {
 	return (
 		<>
+			<li className="c-my-3">
+				<h2 className="applications-menu-nav-header">
+					{Liferay.Language.get('sites')}
+				</h2>
+			</li>
+
 			{recentSites?.length > 0 &&
 				recentSites.map(({current, key, label, logoURL, url}) => (
 					<Site
@@ -269,22 +296,10 @@ const AppsPanel = ({
 							lg="3"
 							md="4"
 						>
-							<div className="applications-menu-sites c-p-3 c-px-md-4">
-								<h2 className="applications-menu-sites-label c-mt-2 c-mt-md-0">
-									{Liferay.Language.get('sites')}
-								</h2>
-
-								<ul className="c-mb-2 list-unstyled">
-									{sites && (
-										<SitesPanel
-											mySites={sites.mySites}
-											portletNamespace={portletNamespace}
-											recentSites={sites.recentSites}
-											viewAllURL={sites.viewAllURL}
-										/>
-									)}
-								</ul>
-							</div>
+							<EnvironmentsPanel
+								portletNamespace={portletNamespace}
+								sites={sites}
+							/>
 						</ClayLayout.Col>
 					</ClayLayout.Row>
 				</ClayLayout.ContainerFluid>

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -55,49 +55,57 @@ const EnvironmentsPanel = ({portletNamespace, sites, virtualInstance}) => {
 				{Liferay.Language.get('environments')}
 			</h2>
 
-			<ul className="c-my-2 list-unstyled">
-				{virtualInstance && (
-					<Environment
-						name={Liferay.Language.get('virtual-instance')}
-					>
-						<li className="applications-menu-virtual-instance c-mb-4 c-mt-3">
-							<a
-								className="applications-menu-nav-link"
-								href={virtualInstance.url}
-							>
-								<ClayLayout.ContentRow verticalAlign="center">
-									<ClayLayout.ContentCol>
-										<ClaySticker>
-											<img
-												alt=""
-												height="32px"
-												src={virtualInstance.logoURL}
-											/>
-										</ClaySticker>
-									</ClayLayout.ContentCol>
+			<div className="c-my-2">
+				<ul className="list-unstyled">
+					{virtualInstance && (
+						<Environment
+							name={Liferay.Language.get('virtual-instance')}
+						>
+							<li className="applications-menu-virtual-instance c-mb-4 c-mt-3">
+								<a
+									className="applications-menu-nav-link"
+									href={virtualInstance.url}
+								>
+									<ClayLayout.ContentRow verticalAlign="center">
+										<ClayLayout.ContentCol>
+											<ClaySticker>
+												<img
+													alt=""
+													height="32px"
+													src={
+														virtualInstance.logoURL
+													}
+												/>
+											</ClaySticker>
+										</ClayLayout.ContentCol>
 
-									<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
-										<span className="text-truncate">
-											{virtualInstance.label}
-										</span>
-									</ClayLayout.ContentCol>
-								</ClayLayout.ContentRow>
-							</a>
-						</li>
-					</Environment>
-				)}
+										<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
+											<span className="text-truncate">
+												{virtualInstance.label}
+											</span>
+										</ClayLayout.ContentCol>
+									</ClayLayout.ContentRow>
+								</a>
+							</li>
+						</Environment>
+					)}
+				</ul>
+			</div>
 
-				{sites && (
-					<Environment name={Liferay.Language.get('sites')}>
-						<Sites
-							mySites={sites.mySites}
-							portletNamespace={portletNamespace}
-							recentSites={sites.recentSites}
-							viewAllURL={sites.viewAllURL}
-						/>
-					</Environment>
-				)}
-			</ul>
+			<div className="applications-menu-sites c-my-2">
+				<ul className="list-unstyled">
+					{sites && (
+						<Environment name={Liferay.Language.get('sites')}>
+							<Sites
+								mySites={sites.mySites}
+								portletNamespace={portletNamespace}
+								recentSites={sites.recentSites}
+								viewAllURL={sites.viewAllURL}
+							/>
+						</Environment>
+					)}
+				</ul>
+			</div>
 		</div>
 	);
 };

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -13,19 +13,18 @@
  */
 
 import ClayButton, {ClayButtonWithIcon} from '@clayui/button';
+import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import ClayModal, {useModal} from '@clayui/modal';
-import classNames from 'classnames';
-
-import '../css/ApplicationsMenu.scss';
-
-import ClayLabel from '@clayui/label';
 import ClaySticker from '@clayui/sticker';
 import ClayTabs from '@clayui/tabs';
+import classNames from 'classnames';
 import {useEventListener} from 'frontend-js-react-web';
 import {fetch, navigate, openSelectionModal} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useRef, useState} from 'react';
+
+import '../css/ApplicationsMenu.scss';
 
 const OPEN_MENU_TITLE_TPL =
 	`<div>${Liferay.Language.get('open-menu')}</div>` +

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -37,7 +37,19 @@ const OPEN_MENU_TITLE_TPL =
 	'<kbd class="c-kbd">M</kbd>' +
 	'</kbd>';
 
-const EnvironmentsPanel = ({portletNamespace, sites}) => {
+const Environment = ({children, name}) => {
+	return (
+		<>
+			<li className="c-my-3">
+				<h2 className="applications-menu-nav-header">{name}</h2>
+			</li>
+
+			{children}
+		</>
+	);
+};
+
+const EnvironmentsPanel = ({portletNamespace, sites, virtualInstance}) => {
 	return (
 		<div className="applications-menu-environments c-p-3 c-px-md-4">
 			<h2 className="applications-menu-environments-label c-mt-2 c-mt-md-0">
@@ -45,17 +57,50 @@ const EnvironmentsPanel = ({portletNamespace, sites}) => {
 			</h2>
 
 			<ul className="c-my-2 list-unstyled">
+				{virtualInstance && (
+					<Environment
+						name={Liferay.Language.get('virtual-instance')}
+					>
+						<li className="applications-menu-virtual-instance c-mb-4 c-mt-3">
+							<a
+								className="applications-menu-nav-link"
+								href={virtualInstance.url}
+							>
+								<ClayLayout.ContentRow verticalAlign="center">
+									<ClayLayout.ContentCol>
+										<ClaySticker>
+											<img
+												alt=""
+												height="32px"
+												src={virtualInstance.logoURL}
+											/>
+										</ClaySticker>
+									</ClayLayout.ContentCol>
+
+									<ClayLayout.ContentCol className="applications-menu-shrink c-ml-2">
+										<span className="text-truncate">
+											{virtualInstance.label}
+										</span>
+									</ClayLayout.ContentCol>
+								</ClayLayout.ContentRow>
+							</a>
+						</li>
+					</Environment>
+				)}
+
 				{sites && (
-					<Sites
-						mySites={sites.mySites}
-						portletNamespace={portletNamespace}
-						recentSites={sites.recentSites}
-						viewAllURL={sites.viewAllURL}
-					/>
+					<Environment name={Liferay.Language.get('sites')}>
+						<Sites
+							mySites={sites.mySites}
+							portletNamespace={portletNamespace}
+							recentSites={sites.recentSites}
+							viewAllURL={sites.viewAllURL}
+						/>
+					</Environment>
 				)}
 			</ul>
 		</div>
-	)
+	);
 };
 
 const Site = ({current, label, logoURL, url}) => {
@@ -89,12 +134,6 @@ const Site = ({current, label, logoURL, url}) => {
 const Sites = ({mySites, portletNamespace, recentSites, viewAllURL}) => {
 	return (
 		<>
-			<li className="c-my-3">
-				<h2 className="applications-menu-nav-header">
-					{Liferay.Language.get('sites')}
-				</h2>
-			</li>
-
 			{recentSites?.length > 0 &&
 				recentSites.map(({current, key, label, logoURL, url}) => (
 					<Site
@@ -156,6 +195,7 @@ const AppsPanel = ({
 	portletNamespace,
 	selectedPortletId,
 	sites,
+	virtualInstance,
 }) => {
 	let index = categories.findIndex((category) =>
 		category.childCategories.some((childCategory) =>
@@ -299,6 +339,7 @@ const AppsPanel = ({
 							<EnvironmentsPanel
 								portletNamespace={portletNamespace}
 								sites={sites}
+								virtualInstance={virtualInstance}
 							/>
 						</ClayLayout.Col>
 					</ClayLayout.Row>
@@ -364,6 +405,7 @@ const ApplicationsMenu = ({
 	logoURL,
 	panelAppsURL,
 	selectedPortletId,
+	virtualInstance,
 }) => {
 	const [appsPanelData, setAppsPanelData] = useState({});
 	const [visible, setVisible] = useState(false);
@@ -432,6 +474,7 @@ const ApplicationsMenu = ({
 							companyName={companyName}
 							handleCloseButtonClick={onClose}
 							logoURL={logoURL}
+							virtualInstance={virtualInstance}
 							{...appsPanelData}
 						/>
 					</ClayModal.Body>

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language.properties
@@ -1,4 +1,6 @@
 applications-menu=Applications Menu
+environments=Environments
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu
-recently-visited=Recently Visited
 open-menu=Open menu
+recently-visited=Recently Visited
+virtual-instance=Virtual Instance

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language.properties
@@ -1,3 +1,4 @@
 applications-menu=Applications Menu
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu
 recently-visited=Recently Visited
+open-menu=Open menu

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ar.properties
@@ -1,3 +1,6 @@
 applications-menu=قائمة التطبيقات
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=قائمة عمومية
+open-menu=Open menu (Automatic Copy)
 recently-visited=تمت زيارته مؤخرًا
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_bg.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ca.properties
@@ -1,3 +1,6 @@
 applications-menu=Menú d'aplicacions
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Menú global
+open-menu=Open menu (Automatic Copy)
 recently-visited=Visitats recentment
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_cs.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_da.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_da.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_de.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_de.properties
@@ -1,3 +1,6 @@
 applications-menu=Globales Menü
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Globales Menü
+open-menu=Open menu (Automatic Copy)
 recently-visited=Kürzlich besucht
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_el.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_el.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_en.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_en.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu
+environments=Environments
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu
+open-menu=Open menu
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_en_AU.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited (Automatic Copy)
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_en_GB.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited (Automatic Copy)
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_es.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_es.properties
@@ -1,3 +1,6 @@
 applications-menu=Menú de aplicaciones
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Menú global
+open-menu=Open menu (Automatic Copy)
 recently-visited=Visitadas recientemente
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_et.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_et.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_eu.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fa.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fi.properties
@@ -1,3 +1,6 @@
 applications-menu=Sovellusvalikko
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Globaali Valikko
+open-menu=Open menu (Automatic Copy)
 recently-visited=Äskettäin Vierailtu
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fr.properties
@@ -1,3 +1,6 @@
 applications-menu=Menu des applications
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Menu global
+open-menu=Open menu (Automatic Copy)
 recently-visited=Récemment visitée
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_fr_CA.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_gl.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_hi_IN.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_hr.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_hu.properties
@@ -1,3 +1,6 @@
 applications-menu=Alkalmazások menü
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Globális menü
+open-menu=Open menu (Automatic Copy)
 recently-visited=Nemrég meglátogatva
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_in.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_in.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_it.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_it.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Menu Globale
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_iw.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ja.properties
@@ -1,3 +1,6 @@
 applications-menu=アプリケーションメニュー
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=グローバルメニュー
+open-menu=Open menu (Automatic Copy)
 recently-visited=最近アクセス
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_kk.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ko.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_lo.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_lt.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_nb.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_nl.properties
@@ -1,3 +1,6 @@
 applications-menu=Applicatiemenu
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Algemeen menu
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recent bezocht
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_nl_BE.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_pl.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_pt_BR.properties
@@ -1,3 +1,6 @@
 applications-menu=Menu de aplicativos
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Menu global
+open-menu=Open menu (Automatic Copy)
 recently-visited=Visitado recentemente
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_pt_PT.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ro.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ru.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sk.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sl.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sr_RS.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sr_RS_latin.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_sv.properties
@@ -1,3 +1,6 @@
 applications-menu=Programmeny
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Global meny
+open-menu=Open menu (Automatic Copy)
 recently-visited=Nyligen besökt
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_ta_IN.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_th.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_th.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_tr.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_uk.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_vi.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_zh_CN.properties
@@ -1,3 +1,6 @@
 applications-menu=应用程序菜单
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=全局菜单
+open-menu=Open menu (Automatic Copy)
 recently-visited=最近​​访问
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/content/Language_zh_TW.properties
@@ -1,3 +1,6 @@
 applications-menu=Applications Menu (Automatic Copy)
+environments=Environments (Automatic Copy)
 javax.portlet.title.com_liferay_product_navigation_applications_menu_web_internal_portlet_ProductNavigationApplicationsMenuPortlet=Applications Menu (Automatic Copy)
+open-menu=Open menu (Automatic Copy)
 recently-visited=Recently Visited
+virtual-instance=Virtual Instance (Automatic Copy)

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/test/applications_menu/ApplicationsMenu.test.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/test/applications_menu/ApplicationsMenu.test.js
@@ -13,11 +13,16 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
+import {configure} from '@testing-library/dom';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 import React from 'react';
 import {act} from 'react-dom/test-utils';
 
 import ApplicationsMenu from '../../src/main/resources/META-INF/resources/js/ApplicationsMenu';
+
+configure({
+	testIdAttribute: 'data-qa-id',
+});
 
 const panelAppsURL = '/fetchUrl';
 
@@ -104,14 +109,14 @@ describe('ApplicationsMenu', () => {
 	});
 
 	it('renders Applications Menu button', () => {
-		const {getByTitle} = renderApplicationsMenu({});
+		const {getByTestId} = renderApplicationsMenu({});
 
-		expect(getByTitle('applications-menu')).toBeInTheDocument();
+		expect(getByTestId('applicationsMenu')).toBeInTheDocument();
 	});
 
 	it('fetches Applications Menu data when trigger button is focused', async () => {
-		const {getByTitle} = renderApplicationsMenu();
-		const trigger = getByTitle('applications-menu');
+		const {getByTestId} = renderApplicationsMenu();
+		const trigger = getByTestId('applicationsMenu');
 
 		await act(async () => {
 			fireEvent.focus(trigger);
@@ -128,8 +133,8 @@ describe('ApplicationsMenu', () => {
 	});
 
 	it('fetches Applications Menu data when trigger button is hovered', async () => {
-		const {getByTitle} = renderApplicationsMenu();
-		const trigger = getByTitle('applications-menu');
+		const {getByTestId} = renderApplicationsMenu();
+		const trigger = getByTestId('applicationsMenu');
 
 		await act(async () => {
 			fireEvent.mouseOver(trigger);
@@ -146,8 +151,8 @@ describe('ApplicationsMenu', () => {
 	});
 
 	it('fetches Applications Menu data when trigger button is clicked', async () => {
-		const {getByTitle} = renderApplicationsMenu();
-		const trigger = getByTitle('applications-menu');
+		const {getByTestId} = renderApplicationsMenu();
+		const trigger = getByTestId('applicationsMenu');
 
 		await act(async () => {
 			fireEvent.click(trigger);
@@ -164,8 +169,13 @@ describe('ApplicationsMenu', () => {
 	});
 
 	it('renders Applications Menu modal with a close button when trigger button is clicked', async () => {
-		const {getByTitle, queryByTitle} = renderApplicationsMenu();
-		const trigger = getByTitle('applications-menu');
+		const {
+			getByTestId,
+			getByTitle,
+			queryByTitle,
+		} = renderApplicationsMenu();
+
+		const trigger = getByTestId('applicationsMenu');
 
 		expect(queryByTitle('close')).not.toBeInTheDocument();
 
@@ -181,8 +191,8 @@ describe('ApplicationsMenu', () => {
 	});
 
 	it('closes Applications Menu modal when close button is clicked', async () => {
-		const {getByTitle} = renderApplicationsMenu();
-		const trigger = getByTitle('applications-menu');
+		const {getByTestId, getByTitle} = renderApplicationsMenu();
+		const trigger = getByTestId('applicationsMenu');
 
 		await act(async () => {
 			fireEvent.click(trigger);
@@ -206,8 +216,8 @@ describe('ApplicationsMenu', () => {
 	});
 
 	it('closes Applications Menu modal when clicking outside', async () => {
-		const {getByTitle} = renderApplicationsMenu();
-		const trigger = getByTitle('applications-menu');
+		const {getByTestId, getByTitle} = renderApplicationsMenu();
+		const trigger = getByTestId('applicationsMenu');
 
 		await act(async () => {
 			fireEvent.click(trigger);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-118408 and https://issues.liferay.com/browse/LPS-119754

Original PRs: 
https://github.com/liferay-frontend/liferay-portal/pull/309
https://github.com/liferay-frontend/liferay-portal/pull/322

Done:
- Open / Close the menu on CMD + SHIFT + M press
- Changed "Sites" for "Environments" at the menu top area
- Added Virtual Instance section inside Environments area.
- Removed "Powered by Liferay"

TODO:
- In the bottom left corner of the apps menu it should appear the DXP Logo + Liferay DXP in DXP version or the CE Liferay Logo + Liferay for CE version. JS component is prepared to render it as it should be but backend (`ApplicationsMenuDisplayContext.java`) needs to be updated to pass the correct values for `liferayLogoURL` and `liferayName`.

![image](https://user-images.githubusercontent.com/5803434/91464956-763d8f00-e88d-11ea-8b05-fca4e4314e3e.png)
