### PR TITLE
LPS-119736 Menu must be closed using the modal closing method to correctly handle the animation

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -425,7 +425,12 @@ const ApplicationsMenu = ({
 			) {
 				event.preventDefault();
 
-				handleTriggerButtonClick();
+				if (visible) {
+					onClose();
+				}
+				else {
+					handleTriggerButtonClick();
+				}
 			}
 		},
 		true,
@@ -454,7 +459,7 @@ const ApplicationsMenu = ({
 
 	const handleTriggerButtonClick = () => {
 		fetchCategories();
-		setVisible(!visible);
+		setVisible(true);
 	};
 
 	return (


### PR DESCRIPTION
Manual forward of https://github.com/liferay-frontend/liferay-portal/pull/350

[Tests are green](https://github.com/liferay-frontend/liferay-portal/pull/350#issuecomment-685653421)
✔️ ci:test:stable - 21 out of 21 jobs passed
✔️ ci:test:relevant - 57 out of 57 jobs passed in 1 hour 56 minutes

This is a small issue detected while reviewing the last UX changes to Applications Menu.
---

https://issues.liferay.com/browse/LPS-119736

Applications Menu fading / sliding on close animation wasn't working when closing the menu with the keyboard shortcut (CMD + SHIFT + M).

Modal's hook `onClose` method needs to be used to close the menu to make this work.

Steps to reproduce:
- Go to Home
- Press `CMD` + `SHIFT` + `M`. The Menu should open sliding from top.
- Press `CMD` + `SHIFT` + `M`. The Menu should close sliding and fading to top.
