### PR TITLE
[TS] LPS-119215

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getAlloyEditorProcessor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/getAlloyEditorProcessor.js
@@ -18,6 +18,7 @@ import {config} from '../config/index';
 
 const KEY_ENTER = 13;
 const KEY_SPACE = 32;
+const KEY_SHIFT_ENTER = CKEDITOR.SHIFT + KEY_ENTER;
 
 const defaultGetEditorWrapper = (element) => {
 	const wrapper = document.createElement('div');
@@ -127,7 +128,8 @@ export default function getAlloyEditorProcessor(
 			_eventHandlers = [
 				nativeEditor.on('key', (event) => {
 					if (
-						event.data.keyCode === KEY_ENTER &&
+						(event.data.keyCode === KEY_ENTER ||
+							event.data.keyCode === KEY_SHIFT_ENTER) &&
 						_element &&
 						(_element.getAttribute('type') === 'text' ||
 							_element.dataset.lfrEditableType === 'text')


### PR DESCRIPTION
From @kevhlee:

> LPS Ticket: <https://issues.liferay.com/browse/LPS-119215>
> 
> The issue is that when the key combination `Shift + Enter` is entered, the key code is `2228237` rather than `13`. This is expected as CKEditor creates a specific key code for `Shift + Enter` by adding the key codes of `Shift` (`2228224`) and `Enter` (`13`). Thus, we must explicitly check for this key combination and cancel the event when the combination occurs.
> 
> Let me know if you have any questions.