### PR TITLE
LPS-119582 - Reindexing all index searches loses all the content from Content Pages

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -131,10 +131,8 @@ public class LayoutModelDocumentContributor
 					actionException);
 			}
 
-			if (httpServletRequest != null) {
-				httpServletRequest = DynamicServletRequest.addQueryString(
-					httpServletRequest, "p_l_id=" + layout.getPlid(), false);
-			}
+			httpServletRequest = DynamicServletRequest.addQueryString(
+				httpServletRequest, "p_l_id=" + layout.getPlid(), false);
 
 			long[] segmentsExperienceIds = {
 				SegmentsExperienceConstants.ID_DEFAULT

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -14,7 +14,6 @@
 
 package com.liferay.layout.internal.search.spi.model.index.contributor;
 
-import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.fragment.constants.FragmentEntryLinkConstants;
 import com.liferay.fragment.renderer.FragmentRendererController;
 import com.liferay.layout.internal.search.util.LayoutPageTemplateStructureRenderUtil;
@@ -22,24 +21,14 @@ import com.liferay.layout.internal.search.util.SyntheticHttpServletRequest;
 import com.liferay.layout.internal.search.util.SyntheticHttpServletResponse;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.events.EventsProcessorUtil;
 import com.liferay.portal.kernel.events.ActionException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.search.BooleanClause;
-import com.liferay.portal.kernel.search.BooleanClauseFactoryUtil;
-import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
-import com.liferay.portal.kernel.search.Hits;
-import com.liferay.portal.kernel.search.Indexer;
-import com.liferay.portal.kernel.search.IndexerRegistryUtil;
-import com.liferay.portal.kernel.search.Query;
-import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -127,7 +127,7 @@ public class LayoutModelDocumentContributor
 			}
 			catch (ActionException actionException) {
 				throw new RuntimeException(
-					"Unable to initialize syntetic request and response",
+					"Unable to initialize synthetic request and response",
 					actionException);
 			}
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -170,54 +170,6 @@ public class LayoutModelDocumentContributor
 		}
 	}
 
-	private String _getStagedContent(Layout layout, Locale locale)
-		throws PortalException {
-
-		Group group = _groupLocalService.getGroup(layout.getGroupId());
-
-		Group stagingGroup = null;
-
-		if (ExportImportThreadLocal.isInitialLayoutStagingInProcess()) {
-			stagingGroup = _stagingGroupHelper.fetchLiveGroup(group);
-		}
-		else if (!group.isStaged() || group.isStagingGroup()) {
-			stagingGroup = group;
-		}
-		else {
-			stagingGroup = group.getStagingGroup();
-		}
-
-		Layout stagingLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
-			layout.getUuid(), stagingGroup.getGroupId(),
-			layout.isPrivateLayout());
-
-		SearchContext searchContext = new SearchContext();
-
-		BooleanClause<Query> booleanClause = BooleanClauseFactoryUtil.create(
-			Field.ENTRY_CLASS_PK, String.valueOf(stagingLayout.getPlid()),
-			BooleanClauseOccur.MUST.getName());
-
-		searchContext.setBooleanClauses(new BooleanClause[] {booleanClause});
-
-		searchContext.setCompanyId(stagingGroup.getCompanyId());
-		searchContext.setGroupIds(new long[] {stagingGroup.getGroupId()});
-		searchContext.setEntryClassNames(new String[] {Layout.class.getName()});
-
-		Indexer<Layout> indexer = IndexerRegistryUtil.getIndexer(Layout.class);
-
-		Hits hits = indexer.search(searchContext);
-
-		Document[] documents = hits.getDocs();
-
-		if (documents.length != 1) {
-			return StringPool.BLANK;
-		}
-
-		Document document = documents[0];
-
-		return document.get(Field.getLocalizedName(locale, Field.CONTENT));
-	}
-
 	@Reference
 	private FragmentRendererController _fragmentRendererController;
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/util/SyntheticHttpServletRequest.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/util/SyntheticHttpServletRequest.java
@@ -14,7 +14,14 @@
 
 package com.liferay.layout.internal.search.util;
 
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.servlet.DirectRequestDispatcherFactoryUtil;
+import com.liferay.portal.kernel.servlet.HttpMethods;
+import com.liferay.portal.kernel.servlet.RequestDispatcherUtil;
+import com.liferay.portal.kernel.servlet.ServletContextPool;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.servlet.DirectRequestDispatcher;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -123,7 +130,7 @@ public class SyntheticHttpServletRequest implements HttpServletRequest {
 	}
 
 	@Override
-	public String getHeader(String s) {
+	public String getHeader(String name) {
 		return null;
 	}
 
@@ -133,7 +140,7 @@ public class SyntheticHttpServletRequest implements HttpServletRequest {
 	}
 
 	@Override
-	public Enumeration<String> getHeaders(String s) {
+	public Enumeration<String> getHeaders(String name) {
 		return null;
 	}
 
@@ -174,11 +181,11 @@ public class SyntheticHttpServletRequest implements HttpServletRequest {
 
 	@Override
 	public String getMethod() {
-		return null;
+		return HttpMethods.GET;
 	}
 
 	@Override
-	public String getParameter(String s) {
+	public String getParameter(String name) {
 		return null;
 	}
 
@@ -193,7 +200,7 @@ public class SyntheticHttpServletRequest implements HttpServletRequest {
 	}
 
 	@Override
-	public String[] getParameterValues(String s) {
+	public String[] getParameterValues(String name) {
 		return new String[0];
 	}
 
@@ -258,8 +265,9 @@ public class SyntheticHttpServletRequest implements HttpServletRequest {
 	}
 
 	@Override
-	public RequestDispatcher getRequestDispatcher(String s) {
-		return null;
+	public RequestDispatcher getRequestDispatcher(String path) {
+		return DirectRequestDispatcherFactoryUtil.getRequestDispatcher(
+			ServletContextPool.get(StringPool.BLANK), path);
 	}
 
 	@Override
@@ -269,7 +277,7 @@ public class SyntheticHttpServletRequest implements HttpServletRequest {
 
 	@Override
 	public String getRequestURI() {
-		return Portal.PATH_MAIN;
+		return StringPool.BLANK;
 	}
 
 	@Override
@@ -353,12 +361,12 @@ public class SyntheticHttpServletRequest implements HttpServletRequest {
 	}
 
 	@Override
-	public boolean isUserInRole(String s) {
+	public boolean isUserInRole(String user) {
 		return false;
 	}
 
 	@Override
-	public void login(String s, String s1) throws ServletException {
+	public void login(String user, String password) throws ServletException {
 	}
 
 	@Override
@@ -372,11 +380,13 @@ public class SyntheticHttpServletRequest implements HttpServletRequest {
 
 	@Override
 	public void setAttribute(String name, Object value) {
-		_attributes.put(name, value);
+		if ((name != null) && (value != null)) {
+			_attributes.put(name, value);
+		}
 	}
 
 	@Override
-	public void setCharacterEncoding(String s)
+	public void setCharacterEncoding(String encoding)
 		throws UnsupportedEncodingException {
 	}
 
@@ -394,7 +404,7 @@ public class SyntheticHttpServletRequest implements HttpServletRequest {
 	}
 
 	@Override
-	public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass)
+	public <T extends HttpUpgradeHandler> T upgrade(Class<T> clazz)
 		throws IOException, ServletException {
 
 		return null;

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/util/SyntheticHttpServletRequest.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/util/SyntheticHttpServletRequest.java
@@ -1,0 +1,489 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.internal.search.util;
+
+import com.liferay.portal.kernel.util.Portal;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
+import java.security.Principal;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.servlet.AsyncContext;
+import javax.servlet.DispatcherType;
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.ServletInputStream;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionContext;
+import javax.servlet.http.HttpUpgradeHandler;
+import javax.servlet.http.Part;
+
+/**
+ * @author Pavel Savinov
+ */
+public class SyntheticHttpServletRequest implements HttpServletRequest {
+
+	@Override
+	public boolean authenticate(HttpServletResponse httpServletResponse)
+		throws IOException, ServletException {
+
+		return false;
+	}
+
+	@Override
+	public String changeSessionId() {
+		return null;
+	}
+
+	@Override
+	public AsyncContext getAsyncContext() {
+		return null;
+	}
+
+	@Override
+	public Object getAttribute(String name) {
+		return _attributes.get(name);
+	}
+
+	@Override
+	public Enumeration<String> getAttributeNames() {
+		return null;
+	}
+
+	@Override
+	public String getAuthType() {
+		return null;
+	}
+
+	@Override
+	public String getCharacterEncoding() {
+		return null;
+	}
+
+	@Override
+	public int getContentLength() {
+		return 0;
+	}
+
+	@Override
+	public long getContentLengthLong() {
+		return 0;
+	}
+
+	@Override
+	public String getContentType() {
+		return null;
+	}
+
+	@Override
+	public String getContextPath() {
+		return null;
+	}
+
+	@Override
+	public Cookie[] getCookies() {
+		return new Cookie[0];
+	}
+
+	@Override
+	public long getDateHeader(String s) {
+		return 0;
+	}
+
+	@Override
+	public DispatcherType getDispatcherType() {
+		return null;
+	}
+
+	@Override
+	public String getHeader(String s) {
+		return null;
+	}
+
+	@Override
+	public Enumeration<String> getHeaderNames() {
+		return null;
+	}
+
+	@Override
+	public Enumeration<String> getHeaders(String s) {
+		return null;
+	}
+
+	@Override
+	public ServletInputStream getInputStream() throws IOException {
+		return null;
+	}
+
+	@Override
+	public int getIntHeader(String s) {
+		return 0;
+	}
+
+	@Override
+	public String getLocalAddr() {
+		return null;
+	}
+
+	@Override
+	public Locale getLocale() {
+		return null;
+	}
+
+	@Override
+	public Enumeration<Locale> getLocales() {
+		return null;
+	}
+
+	@Override
+	public String getLocalName() {
+		return null;
+	}
+
+	@Override
+	public int getLocalPort() {
+		return 0;
+	}
+
+	@Override
+	public String getMethod() {
+		return null;
+	}
+
+	@Override
+	public String getParameter(String s) {
+		return null;
+	}
+
+	@Override
+	public Map<String, String[]> getParameterMap() {
+		return Collections.emptyMap();
+	}
+
+	@Override
+	public Enumeration<String> getParameterNames() {
+		return null;
+	}
+
+	@Override
+	public String[] getParameterValues(String s) {
+		return new String[0];
+	}
+
+	@Override
+	public Part getPart(String s) throws IOException, ServletException {
+		return null;
+	}
+
+	@Override
+	public Collection<Part> getParts() throws IOException, ServletException {
+		return null;
+	}
+
+	@Override
+	public String getPathInfo() {
+		return null;
+	}
+
+	@Override
+	public String getPathTranslated() {
+		return null;
+	}
+
+	@Override
+	public String getProtocol() {
+		return null;
+	}
+
+	@Override
+	public String getQueryString() {
+		return null;
+	}
+
+	@Override
+	public BufferedReader getReader() throws IOException {
+		return null;
+	}
+
+	@Override
+	public String getRealPath(String s) {
+		return null;
+	}
+
+	@Override
+	public String getRemoteAddr() {
+		return null;
+	}
+
+	@Override
+	public String getRemoteHost() {
+		return null;
+	}
+
+	@Override
+	public int getRemotePort() {
+		return 0;
+	}
+
+	@Override
+	public String getRemoteUser() {
+		return null;
+	}
+
+	@Override
+	public RequestDispatcher getRequestDispatcher(String s) {
+		return null;
+	}
+
+	@Override
+	public String getRequestedSessionId() {
+		return null;
+	}
+
+	@Override
+	public String getRequestURI() {
+		return Portal.PATH_MAIN;
+	}
+
+	@Override
+	public StringBuffer getRequestURL() {
+		return null;
+	}
+
+	@Override
+	public String getScheme() {
+		return null;
+	}
+
+	@Override
+	public String getServerName() {
+		return null;
+	}
+
+	@Override
+	public int getServerPort() {
+		return 0;
+	}
+
+	@Override
+	public ServletContext getServletContext() {
+		return null;
+	}
+
+	@Override
+	public String getServletPath() {
+		return null;
+	}
+
+	@Override
+	public HttpSession getSession() {
+		return _httpSession;
+	}
+
+	@Override
+	public HttpSession getSession(boolean createIfAbsent) {
+		return _httpSession;
+	}
+
+	@Override
+	public Principal getUserPrincipal() {
+		return null;
+	}
+
+	@Override
+	public boolean isAsyncStarted() {
+		return false;
+	}
+
+	@Override
+	public boolean isAsyncSupported() {
+		return false;
+	}
+
+	@Override
+	public boolean isRequestedSessionIdFromCookie() {
+		return false;
+	}
+
+	@Override
+	public boolean isRequestedSessionIdFromUrl() {
+		return false;
+	}
+
+	@Override
+	public boolean isRequestedSessionIdFromURL() {
+		return false;
+	}
+
+	@Override
+	public boolean isRequestedSessionIdValid() {
+		return false;
+	}
+
+	@Override
+	public boolean isSecure() {
+		return false;
+	}
+
+	@Override
+	public boolean isUserInRole(String s) {
+		return false;
+	}
+
+	@Override
+	public void login(String s, String s1) throws ServletException {
+	}
+
+	@Override
+	public void logout() throws ServletException {
+	}
+
+	@Override
+	public void removeAttribute(String name) {
+		_attributes.remove(name);
+	}
+
+	@Override
+	public void setAttribute(String name, Object value) {
+		_attributes.put(name, value);
+	}
+
+	@Override
+	public void setCharacterEncoding(String s)
+		throws UnsupportedEncodingException {
+	}
+
+	@Override
+	public AsyncContext startAsync() throws IllegalStateException {
+		return null;
+	}
+
+	@Override
+	public AsyncContext startAsync(
+			ServletRequest servletRequest, ServletResponse servletResponse)
+		throws IllegalStateException {
+
+		return null;
+	}
+
+	@Override
+	public <T extends HttpUpgradeHandler> T upgrade(Class<T> aClass)
+		throws IOException, ServletException {
+
+		return null;
+	}
+
+	private final Map<String, Object> _attributes = new ConcurrentHashMap<>();
+
+	private final HttpSession _httpSession = new HttpSession() {
+
+		@Override
+		public Object getAttribute(String name) {
+			return _attributes.get(name);
+		}
+
+		@Override
+		public Enumeration<String> getAttributeNames() {
+			return null;
+		}
+
+		@Override
+		public long getCreationTime() {
+			return 0;
+		}
+
+		@Override
+		public String getId() {
+			return null;
+		}
+
+		@Override
+		public long getLastAccessedTime() {
+			return 0;
+		}
+
+		@Override
+		public int getMaxInactiveInterval() {
+			return 0;
+		}
+
+		@Override
+		public ServletContext getServletContext() {
+			return null;
+		}
+
+		@Override
+		public HttpSessionContext getSessionContext() {
+			return null;
+		}
+
+		@Override
+		public Object getValue(String name) {
+			return null;
+		}
+
+		@Override
+		public String[] getValueNames() {
+			return new String[0];
+		}
+
+		@Override
+		public void invalidate() {
+		}
+
+		@Override
+		public boolean isNew() {
+			return true;
+		}
+
+		@Override
+		public void putValue(String name, Object value) {
+		}
+
+		@Override
+		public void removeAttribute(String name) {
+		}
+
+		@Override
+		public void removeValue(String name) {
+		}
+
+		@Override
+		public void setAttribute(String name, Object value) {
+			_attributes.put(name, value);
+		}
+
+		@Override
+		public void setMaxInactiveInterval(int interval) {
+		}
+
+	};
+
+}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/util/SyntheticHttpServletRequest.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/util/SyntheticHttpServletRequest.java
@@ -17,11 +17,7 @@ package com.liferay.layout.internal.search.util;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.servlet.DirectRequestDispatcherFactoryUtil;
 import com.liferay.portal.kernel.servlet.HttpMethods;
-import com.liferay.portal.kernel.servlet.RequestDispatcherUtil;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
-import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.servlet.DirectRequestDispatcher;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/util/SyntheticHttpServletResponse.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/util/SyntheticHttpServletResponse.java
@@ -1,0 +1,202 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.internal.search.util;
+
+import com.liferay.portal.kernel.io.unsync.UnsyncPrintWriter;
+import com.liferay.portal.kernel.io.unsync.UnsyncStringWriter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import java.util.Collection;
+import java.util.Locale;
+
+import javax.servlet.ServletOutputStream;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
+/**
+ * @author Pavel Savinov
+ */
+public class SyntheticHttpServletResponse implements HttpServletResponse {
+
+	@Override
+	public void addCookie(Cookie cookie) {
+	}
+
+	@Override
+	public void addDateHeader(String s, long l) {
+	}
+
+	@Override
+	public void addHeader(String s, String s1) {
+	}
+
+	@Override
+	public void addIntHeader(String s, int i) {
+	}
+
+	@Override
+	public boolean containsHeader(String s) {
+		return false;
+	}
+
+	@Override
+	public String encodeRedirectUrl(String s) {
+		return null;
+	}
+
+	@Override
+	public String encodeRedirectURL(String s) {
+		return null;
+	}
+
+	@Override
+	public String encodeUrl(String s) {
+		return null;
+	}
+
+	@Override
+	public String encodeURL(String s) {
+		return null;
+	}
+
+	@Override
+	public void flushBuffer() throws IOException {
+	}
+
+	@Override
+	public int getBufferSize() {
+		return 0;
+	}
+
+	@Override
+	public String getCharacterEncoding() {
+		return null;
+	}
+
+	@Override
+	public String getContentType() {
+		return null;
+	}
+
+	@Override
+	public String getHeader(String s) {
+		return null;
+	}
+
+	@Override
+	public Collection<String> getHeaderNames() {
+		return null;
+	}
+
+	@Override
+	public Collection<String> getHeaders(String s) {
+		return null;
+	}
+
+	@Override
+	public Locale getLocale() {
+		return null;
+	}
+
+	@Override
+	public ServletOutputStream getOutputStream() throws IOException {
+		return null;
+	}
+
+	@Override
+	public int getStatus() {
+		return 0;
+	}
+
+	@Override
+	public PrintWriter getWriter() throws IOException {
+		return _unsyncPrintWriter;
+	}
+
+	@Override
+	public boolean isCommitted() {
+		return false;
+	}
+
+	@Override
+	public void reset() {
+	}
+
+	@Override
+	public void resetBuffer() {
+	}
+
+	@Override
+	public void sendError(int i) throws IOException {
+	}
+
+	@Override
+	public void sendError(int i, String s) throws IOException {
+	}
+
+	@Override
+	public void sendRedirect(String s) throws IOException {
+	}
+
+	@Override
+	public void setBufferSize(int i) {
+	}
+
+	@Override
+	public void setCharacterEncoding(String s) {
+	}
+
+	@Override
+	public void setContentLength(int i) {
+	}
+
+	@Override
+	public void setContentLengthLong(long l) {
+	}
+
+	@Override
+	public void setContentType(String s) {
+	}
+
+	@Override
+	public void setDateHeader(String s, long l) {
+	}
+
+	@Override
+	public void setHeader(String s, String s1) {
+	}
+
+	@Override
+	public void setIntHeader(String s, int i) {
+	}
+
+	@Override
+	public void setLocale(Locale locale) {
+	}
+
+	@Override
+	public void setStatus(int i) {
+	}
+
+	@Override
+	public void setStatus(int i, String s) {
+	}
+
+	private final UnsyncPrintWriter _unsyncPrintWriter = new UnsyncPrintWriter(
+		new UnsyncStringWriter());
+
+}


### PR DESCRIPTION
//cc @ealonso @pavel-savinov

After the changes in this PR:
- Searching behaves consistently after a Content Page is published and after Reindex takes place.
- Content of widgets is not longer indexed when the page is published as part of the Page (we assume that widgets are in nature dynamic, and the content rendered by the widget when the page is published or after a reindex, does not necessarily match the content that would be rendered when the search takes place, which could result in confusing behaviour)