### PR TITLE
LPS-120537 Provide gogo shell commands to export page definitions of an existing page

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentCompositionMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentCompositionMVCActionCommand.java
@@ -115,7 +115,7 @@ public class AddFragmentCompositionMVCActionCommand
 			actionRequest, "segmentsExperienceId",
 			SegmentsExperienceConstants.ID_DEFAULT);
 
-		String layoutStructureJSON =
+		String layoutStructureItemJSON =
 			_layoutStructureItemJSONSerializer.toJSONString(
 				_layoutLocalService.getLayout(themeDisplay.getPlid()), itemId,
 				saveInlineContent, saveMappingConfiguration,
@@ -125,7 +125,7 @@ public class AddFragmentCompositionMVCActionCommand
 			_fragmentCompositionService.addFragmentComposition(
 				themeDisplay.getScopeGroupId(),
 				fragmentCollection.getFragmentCollectionId(), null, name,
-				description, layoutStructureJSON, 0,
+				description, layoutStructureItemJSON, 0,
 				WorkflowConstants.STATUS_APPROVED, serviceContext);
 
 		String previewImageURL = ParamUtil.getString(

--- a/modules/apps/layout/layout-impl/build.gradle
+++ b/modules/apps/layout/layout-impl/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-1"
+	compileOnly group: "com.liferay", name: "org.apache.felix.gogo.runtime", version: "1.1.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/osgi/commands/LayoutCommands.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/osgi/commands/LayoutCommands.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.internal.osgi.commands;
+
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.serializer.LayoutStructureItemJSONSerializer;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+
+import org.apache.felix.service.command.Descriptor;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jorge Ferrer
+ */
+@Component(
+	immediate = true,
+	property = {
+		"osgi.command.function=exportPageDefinition",
+		"osgi.command.scope=layout"
+	},
+	service = LayoutCommands.class
+)
+public class LayoutCommands {
+
+	@Descriptor("Get page definition for a given page specified by its plid")
+	public String exportPageDefinition(long plid) throws PortalException {
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		if (layout == null) {
+			return "Page with plid " + plid + " cannot be found";
+		}
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(layout.getGroupId(), plid);
+
+		if (layoutPageTemplateStructure == null) {
+			return "Page with plid " + plid + " does not have a structure";
+		}
+
+		long segmentsExperienceId = SegmentsExperienceConstants.ID_DEFAULT;
+
+		LayoutStructure layoutStructure = LayoutStructure.of(
+			layoutPageTemplateStructure.getData(segmentsExperienceId));
+
+		return _layoutStructureItemJSONSerializer.toJSONString(
+			layout, layoutStructure.getMainItemId(), false, false,
+			segmentsExperienceId);
+	}
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutPageTemplateStructureLocalService
+		_layoutPageTemplateStructureLocalService;
+
+	@Reference
+	private LayoutStructureItemJSONSerializer
+		_layoutStructureItemJSONSerializer;
+
+}

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/osgi/commands/LayoutOSGiCommands.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/osgi/commands/LayoutOSGiCommands.java
@@ -37,9 +37,9 @@ import org.osgi.service.component.annotations.Reference;
 		"osgi.command.function=exportPageDefinition",
 		"osgi.command.scope=layout"
 	},
-	service = LayoutCommands.class
+	service = LayoutOSGiCommands.class
 )
-public class LayoutCommands {
+public class LayoutOSGiCommands {
 
 	@Descriptor("Get page definition for a given page specified by its plid")
 	public String exportPageDefinition(long plid) throws PortalException {

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/osgi/commands/LayoutOSGiCommands.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/osgi/commands/LayoutOSGiCommands.java
@@ -34,19 +34,18 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = {
-		"osgi.command.function=exportPageDefinition",
-		"osgi.command.scope=layout"
+		"osgi.command.function=exportAsJSON", "osgi.command.scope=layout"
 	},
 	service = LayoutOSGiCommands.class
 )
 public class LayoutOSGiCommands {
 
-	@Descriptor("Get page definition for a given page specified by its plid")
-	public String exportPageDefinition(long plid) throws PortalException {
+	@Descriptor("Get Page Definition JSON for a given layout by its plid")
+	public String exportAsJSON(long plid) throws PortalException {
 		Layout layout = _layoutLocalService.fetchLayout(plid);
 
 		if (layout == null) {
-			return "Page with plid " + plid + " cannot be found";
+			return "Layout with plid " + plid + " cannot be found";
 		}
 
 		LayoutPageTemplateStructure layoutPageTemplateStructure =
@@ -54,7 +53,7 @@ public class LayoutOSGiCommands {
 				fetchLayoutPageTemplateStructure(layout.getGroupId(), plid);
 
 		if (layoutPageTemplateStructure == null) {
-			return "Page with plid " + plid + " does not have a structure";
+			return "Layout with plid " + plid + " does not have a structure";
 		}
 
 		long segmentsExperienceId = SegmentsExperienceConstants.ID_DEFAULT;


### PR DESCRIPTION
Hey Brian,
I've decided to make minimal changes to make the code of the OSGi Command class consistent. It'll be handy to have this command in 7.3 when creating solutions, but it's not worth doing a significant refactoring to generalize it around the concept of Page Definition. Let's do that for 7.4 instead.

cc: @ruben-pulido