### PR TITLE
[TS] LPS-119727

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/LayoutAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LayoutAction.java
@@ -169,8 +169,11 @@ public class LayoutAction implements Action {
 				plid = layout.getPlid();
 			}
 
-			return processLayout(
-				actionMapping, httpServletRequest, httpServletResponse, plid);
+			if (!layout.isTypeLinkToLayout()) {
+				return processLayout(
+					actionMapping, httpServletRequest, httpServletResponse,
+					plid);
+			}
 		}
 
 		try {


### PR DESCRIPTION
Hi team,

This fix tries to solve a corner case for those sites whose first visible/allowed page is a link-to-layout page pointing to the first of its child pages.

The solution prevents this kind of pages from being processed in order to force a redirect to the destination page.

Could you please review it?

Thanks in advance

\cc @hudakl