### PR TITLE
LPS-120733 Reset orderByCol to null when Web Content Display is accessed

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -772,6 +772,11 @@ public class JournalDisplayContext {
 			return _orderByCol;
 		}
 
+		if (!isSearch()) {
+			_portalPreferences.setValue(
+				JournalPortletKeys.JOURNAL, "order-by-col", null);
+		}
+
 		_orderByCol = ParamUtil.getString(_httpServletRequest, "orderByCol");
 
 		if (Validator.isNull(_orderByCol)) {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
@@ -375,7 +375,6 @@ public class JournalManagementToolbarDisplayContext
 
 		portletURL.setParameter(
 			"folderId", String.valueOf(_journalDisplayContext.getFolderId()));
-		portletURL.setParameter("orderByCol", getOrderByCol());
 		portletURL.setParameter("orderByType", getOrderByType());
 		portletURL.setParameter(
 			"status", String.valueOf(_journalDisplayContext.getStatus()));


### PR DESCRIPTION
Notes from @noornajj
> https://issues.liferay.com/browse/LPS-120733
> 
> The issue here was that the value of the orderByCol preference was retaining the last selection the user made. Therefore, the default value is not always set correctly.
> To fix the issue, first I had to delete the line in getSearchActionURL() that sets the orderByCol parameter because it was preventing the preference from being assigned a default value. Next, I had to reset the orderByCol preference to null after the user is finished with search because, even after the default value is assigned, this line 
> `_orderByCol = _portalPreferences.getValue(
> 				JournalPortletKeys.JOURNAL, "order-by-col", defaultOrderByCol);`
> will override the default value with the previous value that was selected by the user.