### PR TITLE
LPS-121290 Prevent null pointer since _labelInfoLocalizedValue can be null, in this case return the name

### DIFF
--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/form/InfoForm.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/form/InfoForm.java
@@ -136,6 +136,10 @@ public class InfoForm {
 	}
 
 	public String getLabel(Locale locale) {
+		if (_builder._labelInfoLocalizedValue == null) {
+			return _builder._name;
+		}
+
 		return _builder._labelInfoLocalizedValue.getValue(locale);
 	}
 


### PR DESCRIPTION
forward