### PR TITLE
LPS-121579 Compute column style for non-divisible column widths

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/Collection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout-data-items/Collection.js
@@ -71,6 +71,9 @@ const Grid = ({
 		maxNumberOfItems / collectionConfig.numberOfColumns
 	);
 
+	const middleIndex = Math.floor(collectionConfig.numberOfColumns / 2);
+	const remaining = 12 % collectionConfig.numberOfColumns;
+
 	return Array.from({length: numberOfRows}).map((_, i) => (
 		<ClayLayout.Row key={`row-${i}`}>
 			{Array.from({length: collectionConfig.numberOfColumns}).map(
@@ -78,11 +81,16 @@ const Grid = ({
 					const key = `col-${i}-${j}`;
 					const index = i * collectionConfig.numberOfColumns + j;
 
+					let size = Math.floor(
+						12 / collectionConfig.numberOfColumns
+					);
+
+					if (remaining !== 0 && middleIndex === j) {
+						size += remaining;
+					}
+
 					return (
-						<ClayLayout.Col
-							key={key}
-							size={12 / collectionConfig.numberOfColumns}
-						>
+						<ClayLayout.Col key={key} size={size}>
 							{index < maxNumberOfItems && (
 								<ColumnContext
 									collectionConfig={collectionConfig}


### PR DESCRIPTION
If user chooses a number of columns that can't divide 12,
we compute the remaining of the division and add it to the
middle column