### PR TITLE
[TS] LPS-121823 Inconsistent Web Content with Image field type when referencing removed or renamed Document

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/ddm/image.ftl
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/com/liferay/dynamic/data/mapping/service/dependencies/ddm/image.ftl
@@ -10,6 +10,7 @@
 	alt = ""
 	imageData = ""
 	name = languageUtil.get(locale, "drag-file-here")
+	message = ""
 />
 
 <#if fieldRawValue?has_content>
@@ -19,6 +20,7 @@
 		alt = fileJSONObject.getString("alt")
 		imageData = fileJSONObject.getString("data")
 		name = fileJSONObject.getString("name")
+		message = fileJSONObject.getString("message")
 	/>
 </#if>
 
@@ -30,7 +32,7 @@
 	cssClass="form-builder-field"
 	data=data
 >
-	<div class="form-group">
+	<div class="form-group ${(message?has_content)?string('has-warning', '')}">
 		<div class="hide" id="${portletNamespace}${namespacedFieldName}UploadContainer"></div>
 
 		<div class="hide" id="${portletNamespace}${namespacedFieldName}PreviewContainer">
@@ -55,6 +57,10 @@
 			type="hidden"
 			value=fieldRawValue
 		/>
+
+		<#if validator.isNotNull(message)>
+			<div class="form-feedback-item" id="${portletNamespace}${namespacedFieldName}Message">${message}</div>
+		</#if>
 
 		<div class="button-holder">
 			<@liferay_aui.button

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -599,7 +599,9 @@ public class JournalConverterImpl implements JournalConverter {
 
 		Serializable serializable = null;
 
-		if (Objects.equals(DDMFormFieldType.DOCUMENT_LIBRARY, type)) {
+		if (Objects.equals(DDMFormFieldType.DOCUMENT_LIBRARY, type) ||
+			Objects.equals(DDMFormFieldType.IMAGE, type)) {
+
 			JSONObject jsonObject = null;
 
 			try {


### PR DESCRIPTION
Hi @liferay-echo, 

This solution resolves the same problem that LPS-92263 did with the Document and Media field type but with the Image field type. When you remove or rename a Document, the Web Contents referencing them with Image field type aren't updated. In the edit Web Content view, the old name is visualized. When the image is removed, no warning message is shown in the edit Web Content view.

In JournalConverterImpl.java class, I reuse the same method modified in LPS-92263. In the template "image.ftl" the solution the same too.