### PR TITLE
[TS] LPS-122301 Use the SiteNavigationMenuItem's creator, not the Layout's

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/model/listener/LayoutModelListener.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/java/com/liferay/site/navigation/menu/item/layout/internal/model/listener/LayoutModelListener.java
@@ -134,8 +134,8 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 					layout.getParentPlid(), siteNavigationMenuId);
 
 			_siteNavigationMenuItemLocalService.addSiteNavigationMenuItem(
-				layout.getUserId(), layout.getGroupId(), siteNavigationMenuId,
-				parentSiteNavigationMenuItemId,
+				serviceContext.getUserId(), layout.getGroupId(),
+				siteNavigationMenuId, parentSiteNavigationMenuItemId,
 				SiteNavigationMenuItemTypeConstants.LAYOUT,
 				siteNavigationMenuItemType.getTypeSettingsFromLayout(layout),
 				serviceContext);


### PR DESCRIPTION
Hi Team,

layout.getUserId() can point to a deleted User, I think using serviceContext.getUserId() better reflects who actually created the siteNavigationMenuItem.

Can you please review?
https://issues.liferay.com/browse/LPS-122301

Thanks,
Balázs