### PR TITLE
LPS-123148 Add page comment fails after upgrade

### DIFF
--- a/modules/apps/layout/layout-service/bnd.bnd
+++ b/modules/apps/layout/layout-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Service
 Bundle-SymbolicName: com.liferay.layout.service
 Bundle-Version: 2.0.0
-Liferay-Require-SchemaVersion: 1.2.0
+Liferay-Require-SchemaVersion: 1.2.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/LayoutServiceUpgrade.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/LayoutServiceUpgrade.java
@@ -14,12 +14,16 @@
 
 package com.liferay.layout.internal.upgrade;
 
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.service.AssetEntryUsageLocalService;
 import com.liferay.layout.internal.upgrade.v1_0_0.UpgradeLayout;
 import com.liferay.layout.internal.upgrade.v1_0_0.UpgradeLayoutClassedModelUsage;
 import com.liferay.layout.internal.upgrade.v1_0_0.UpgradeLayoutPermissions;
 import com.liferay.layout.internal.upgrade.v1_1_0.UpgradeCompanyId;
+import com.liferay.layout.internal.upgrade.v1_2_1.UpgradeLayoutAsset;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeCTModel;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
@@ -46,12 +50,27 @@ public class LayoutServiceUpgrade implements UpgradeStepRegistrator {
 
 		registry.register(
 			"1.1.0", "1.2.0", new UpgradeCTModel("LayoutClassedModelUsage"));
+
+		registry.register(
+			"1.2.0", "1.2.1",
+			new UpgradeLayoutAsset(
+				_assetCategoryLocalService, _assetTagLocalService,
+				_layoutLocalService));
 	}
+
+	@Reference
+	private AssetCategoryLocalService _assetCategoryLocalService;
 
 	@Reference
 	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
 	private AssetEntryUsageLocalService _assetEntryUsageLocalService;
+
+	@Reference
+	private AssetTagLocalService _assetTagLocalService;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 }

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_2_1/UpgradeLayoutAsset.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_2_1/UpgradeLayoutAsset.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.internal.upgrade.v1_2_1;
+
+import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.util.List;
+
+/**
+ * @author István András Dézsi
+ */
+public class UpgradeLayoutAsset extends UpgradeProcess {
+
+	public UpgradeLayoutAsset(
+		AssetCategoryLocalService assetCategoryLocalService,
+		AssetTagLocalService assetTagLocalService,
+		LayoutLocalService layoutLocalService) {
+
+		_assetCategoryLocalService = assetCategoryLocalService;
+		_assetTagLocalService = assetTagLocalService;
+		_layoutLocalService = layoutLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		long[] assetCategoryIds = new long[0];
+
+		String[] assetTagNames = new String[0];
+
+		List<Layout> layouts = _layoutLocalService.getLayouts(
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		for (Layout layout : layouts) {
+			assetCategoryIds = _assetCategoryLocalService.getCategoryIds(
+				Layout.class.getName(), layout.getPlid());
+
+			assetTagNames = _assetTagLocalService.getTagNames(
+				Layout.class.getName(), layout.getPlid());
+
+			_layoutLocalService.updateAsset(
+				layout.getUserId(), layout, assetCategoryIds, assetTagNames);
+		}
+	}
+
+	private final AssetCategoryLocalService _assetCategoryLocalService;
+	private final AssetTagLocalService _assetTagLocalService;
+	private final LayoutLocalService _layoutLocalService;
+
+}


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

On DXP, all Pages (`Layouts`) have a corresponding `AssetEntry` that is fetched and used during the submission of a Page Comment
https://github.com/liferay/liferay-portal/blob/master/modules/apps/comment/comment-taglib/src/main/java/com/liferay/comment/taglib/internal/struts/EditDiscussionStrutsAction.java#L211

On 6.2, Pages don't have an `AssetEntry`, therefore, when upgrading 6.2 => DXP adding a Page Comment will fail due to the missing `AssetEntry`.

Therefore, I introduced a new upgrade process that calls `layoutLocalService.updateAsset()` for all `Layouts`, creating their `AssetEntries`.
 
Thank you and best regards,
István