### PR TITLE
LPS-122566 Update checkboxNames input value when changing the theme

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_edit.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_edit.jsp
@@ -85,6 +85,24 @@ else {
 
 							themeContainer.setContent(responseData);
 
+							var newCheckboxNames = [];
+							var checkboxInputs = themeContainer.all(
+								'input[type=checkbox]'
+							);
+
+							checkboxInputs.each(function (item, index) {
+								var checkboxName = item.attr('name');
+								newCheckboxNames.push(
+									checkboxName.substring(
+										'<portlet:namespace />'.length
+									)
+								);
+							});
+
+							document.querySelector(
+								'#<portlet:namespace />checkboxNames'
+							).value = newCheckboxNames.join(',');
+
 							selThemeId = selectedItem;
 						});
 				}


### PR DESCRIPTION
Notes from @noornajj :

https://issues.liferay.com/browse/LPS-122566

> 
> The issue here was that theme settings changes were not being saved the first time when changing the theme.
> This was caused by the checkboxNames input value to be holding the settings for the previous theme. To fix this issue, I updated this value to the new theme settings at the time of the theme change.