### PR TITLE
[TS] LPS-123406

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/portlet/action/ApplicationsMenuPanelAppsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/portlet/action/ApplicationsMenuPanelAppsMVCResourceCommand.java
@@ -273,7 +273,8 @@ public class ApplicationsMenuPanelAppsMVCResourceCommand
 			sitesJSONObject.put(
 				"recentSites",
 				_getSitesJSONArray(
-					recentGroups, resourceRequest, themeDisplay));
+					ListUtil.subList(recentGroups, 0, max), resourceRequest,
+					themeDisplay));
 
 			max -= recentGroups.size();
 		}

--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/portlet/action/ApplicationsMenuPanelAppsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/portlet/action/ApplicationsMenuPanelAppsMVCResourceCommand.java
@@ -273,8 +273,7 @@ public class ApplicationsMenuPanelAppsMVCResourceCommand
 			sitesJSONObject.put(
 				"recentSites",
 				_getSitesJSONArray(
-					ListUtil.subList(recentGroups, 0, max), resourceRequest,
-					themeDisplay));
+					recentGroups, resourceRequest, themeDisplay));
 
 			max -= recentGroups.size();
 		}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -394,14 +394,19 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 
 	public boolean isShowSiteSelector() throws PortalException {
 		List<Group> mySites = getMySites();
+
+		if (!mySites.isEmpty()) {
+			return true;
+		}
+
 		List<Group> recentSites = _recentGroupManager.getRecentGroups(
 			PortalUtil.getHttpServletRequest(_portletRequest));
 
-		if (mySites.isEmpty() && recentSites.isEmpty()) {
-			return false;
+		if (!recentSites.isEmpty()) {
+			return true;
 		}
 
-		return true;
+		return false;
 	}
 
 	public boolean isShowStagingInfo() throws PortalException {

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/menu/MySitesPersonalMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/menu/MySitesPersonalMenuEntry.java
@@ -116,14 +116,18 @@ public class MySitesPersonalMenuEntry implements PersonalMenuEntry {
 			},
 			PropsValues.MY_SITES_MAX_ELEMENTS);
 
+		if (!mySiteGroups.isEmpty()) {
+			return true;
+		}
+
 		List<Group> recentGroups = _recentGroupManager.getRecentGroups(
 			_portal.getHttpServletRequest(portletRequest));
 
-		if (mySiteGroups.isEmpty() && recentGroups.isEmpty()) {
-			return false;
+		if (!recentGroups.isEmpty()) {
+			return true;
 		}
 
-		return true;
+		return false;
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SessionClicks;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsValues;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -80,7 +81,8 @@ public class RecentGroupManager {
 
 		groupIds.add(0, liveGroupId);
 
-		groupIds = ListUtil.subList(groupIds, 0, 8);
+		groupIds = ListUtil.subList(
+			groupIds, 0, PropsValues.RECENT_GROUPS_MAX_ELEMENTS);
 
 		_setRecentGroupsValue(httpServletRequest, StringUtil.merge(groupIds));
 	}

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/util/RecentGroupManager.java
@@ -80,6 +80,8 @@ public class RecentGroupManager {
 
 		groupIds.add(0, liveGroupId);
 
+		groupIds = ListUtil.subList(groupIds, 0, 8);
+
 		_setRecentGroupsValue(httpServletRequest, StringUtil.merge(groupIds));
 	}
 

--- a/portal-impl/src/com/liferay/portal/util/PropsValues.java
+++ b/portal-impl/src/com/liferay/portal/util/PropsValues.java
@@ -2391,6 +2391,9 @@ public class PropsValues {
 		GetterUtil.getInteger(
 			PropsUtil.get(PropsKeys.RECENT_CONTENT_MAX_DISPLAY_ITEMS));
 
+	public static final int RECENT_GROUPS_MAX_ELEMENTS = GetterUtil.getInteger(
+		PropsUtil.get(PropsKeys.RECENT_GROUPS_MAX_ELEMENTS));
+
 	public static final String[] REDIRECT_URL_DOMAINS_ALLOWED =
 		PropsUtil.getArray(PropsKeys.REDIRECT_URL_DOMAINS_ALLOWED);
 

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -11910,6 +11910,19 @@
     recent.content.max.display.items=5
 
 ##
+## Recent Groups
+##
+
+    #
+    # Set the maximum number of elements that will be retrieved when determining
+    # recent groups. For example, if the maximum is set to 8, then, at most, 8
+    # groups will be considered "recent" and displayed as such.
+    #
+    # Env: LIFERAY_RECENT_PERIOD_GROUPS_PERIOD_MAX_PERIOD_ELEMENTS
+    #
+    recent.groups.max.elements=8
+
+##
 ## My Sites Directory
 ##
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/PropsKeys.java
@@ -2650,6 +2650,9 @@ public interface PropsKeys {
 	public static final String RECENT_CONTENT_MAX_DISPLAY_ITEMS =
 		"recent.content.max.display.items";
 
+	public static final String RECENT_GROUPS_MAX_ELEMENTS =
+		"recent.groups.max.elements";
+
 	public static final String REDIRECT_URL_DOMAINS_ALLOWED =
 		"redirect.url.domains.allowed";
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-123406

Limiting the amount of "recent" groups we retrieve from the DB will give us a performance boost in situations where there are hundred of entries.  This PR also includes other minor performance improvements.

@Preston-crary, I'm sending this PR directly to the echo  team, since it mostly deals with business logic and the performance boosts are more obvious.  Please let me know if you have questions/concerns with the solution though.
