### PR TITLE
[TS] LPS-123387

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/configuration/JournalServiceConfiguration.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/configuration/JournalServiceConfiguration.java
@@ -144,6 +144,9 @@ public interface JournalServiceConfiguration {
 	)
 	public String journalArticleStorageType();
 
+	@Meta.AD(deflt = "0", name = "max-version-count", required = false)
+	public int maxVersionCount();
+
 	@Meta.AD(
 		deflt = "false",
 		description = "single-asset-publish-includes-version-history-help",

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/configuration/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/configuration/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language.properties
@@ -165,6 +165,7 @@ last-editor-profile-image=Last Editor Profile Image
 last-x-web-content=Last {0} Web Content
 manage-templates=Manage Templates
 max-add-menu-items=Maximum Add Menu Items
+max-version-count=Maximum Version Count
 maximum-file-size-small-image=Maximum File Size of Small Image
 menu-item-name=Menu Item Name
 model.resource.com.liferay.dynamic.data.mapping.model.DDMStructure-com.liferay.journal.model.JournalArticle=Web Content Structure

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6625,6 +6625,9 @@ public class JournalArticleLocalServiceImpl
 					article.getResourcePrimKey(), article.getDisplayDate(),
 					article.getExpirationDate(), isListable(article), true);
 
+				expireMaxVersionArticles(
+					article, user.getUserId(), serviceContext, articleURL);
+
 				// Social
 
 				JSONObject extraDataJSONObject = JSONUtil.put("title", title);
@@ -7392,6 +7395,35 @@ public class JournalArticleLocalServiceImpl
 		}
 	}
 
+	protected void expireMaxVersionArticles(
+			JournalArticle article, long userId, ServiceContext serviceContext,
+			String articleURL)
+		throws PortalException {
+
+		int maxVersionCount = getArticleMaxVersionCount();
+
+		if (maxVersionCount <= 0) {
+			return;
+		}
+
+		if (_log.isDebugEnabled()) {
+			_log.debug(
+				"Expiring oldest articles past the maximum version limit");
+		}
+
+		List<JournalArticle> articles = journalArticlePersistence.findByG_A_ST(
+			article.getGroupId(), article.getArticleId(),
+			WorkflowConstants.STATUS_APPROVED);
+
+		for (int i = maxVersionCount; i < articles.size(); i++) {
+			JournalArticle curArticle = articles.get(i);
+
+			expireArticle(
+				userId, curArticle.getGroupId(), curArticle.getArticleId(),
+				curArticle.getVersion(), articleURL, serviceContext);
+		}
+	}
+
 	protected JournalArticle fetchLatestLiveArticle(JournalArticle article)
 		throws PortalException {
 
@@ -7738,6 +7770,20 @@ public class JournalArticleLocalServiceImpl
 			article.isSmallImage(), article.getSmallImageId(),
 			article.getSmallImageURL(), numberOfPages, page, paginate,
 			cacheable);
+	}
+
+	protected int getArticleMaxVersionCount() {
+		try {
+			JournalServiceConfiguration journalServiceConfiguration =
+				configurationProvider.getCompanyConfiguration(
+					JournalServiceConfiguration.class,
+					CompanyThreadLocal.getCompanyId());
+
+			return journalServiceConfiguration.maxVersionCount();
+		}
+		catch (PortalException portalException) {
+			throw new RuntimeException(portalException);
+		}
 	}
 
 	protected List<ObjectValuePair<Long, Integer>> getArticleVersionStatuses(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-123387

Unfortunately, it seems the problem described in LPS-123387 cannot be resolved easily with a query.  This is because the query would need to return results within the given date ranges OR null values for displayDate/expirationDate.  Currently, it's only possible to retrieve a valid value or null, but not in the same query.

This specific query was achieved with a dynamic query as seen in https://github.com/liferay-echo/liferay-portal/pull/2873, however the dynamic query locked up the portal, killing performance when fetching multiple display articles at once.

So, in order to resolve any performance hits due to large amounts of journal article versions, I've added a configuration which allows for a max version cap.  Currently, this value is 0, meaning there is no upper-limit of versions.  However, changing this value to a valid int will put a cap on how many versions can exist for a given journal article.  This is done by expiring all article versions past this limit, starting with the lowest version numbers.

Also, I wasn't having any luck generating the language files; there were far too many translations trying to go through at once.

Please let me know if you have any questions, thanks!