### PR TITLE
[TS] LPS-123800 fragment-service: Restore intended logic

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryLinkStagedModelDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryLinkStagedModelDataHandler.java
@@ -91,9 +91,11 @@ public class FragmentEntryLinkStagedModelDataHandler
 		String html = fragmentEntryLink.getHtml();
 
 		if (Validator.isNotNull(html)) {
-			_dlReferencesExportImportContentProcessor.
-				replaceExportContentReferences(
-					portletDataContext, fragmentEntryLink, html, true, false);
+			html =
+				_dlReferencesExportImportContentProcessor.
+					replaceExportContentReferences(
+						portletDataContext, fragmentEntryLink, html, true,
+						false);
 		}
 
 		fragmentEntryLink.setHtml(html);


### PR DESCRIPTION
**Notes**
The intended logic was altered due to: LPS-116999 Check for null (bb0519a4f2a5eb1ec7a04e21b71490613d52760e)

This commit also introduced the same issue for **editableValues**, which has already been resolved by: [LPS-122791](https://issues.liferay.com/browse/LPS-122791)
- Specific commit: https://github.com/liferay/liferay-portal/commit/915a6fcc80439636b3b4338d45e5d6dad183c0fa#diff-2c04ffe273193d9b2444f0bf4a3648a6cf00c2b3d8b3066eef005981fa681e89R104-R108