### PR TITLE
LPS-121964 Update journal clay:vertical-card-v2 usages to clay:vertical-card. Highly recommended to update this usages to navigation-card once LPS-123370 is completed

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -206,9 +206,6 @@ public class DLViewDisplayContext {
 		renderURL.setParameter(
 			"mvcRenderCommandName", "/document_library/select_folder");
 		renderURL.setParameter(
-			"originFolderId",
-			String.valueOf(_dlAdminDisplayContext.getFolderId()));
-		renderURL.setParameter(
 			"folderId", String.valueOf(_dlAdminDisplayContext.getFolderId()));
 		renderURL.setWindowState(LiferayWindowState.POP_UP);
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLViewDisplayContext.java
@@ -206,6 +206,9 @@ public class DLViewDisplayContext {
 		renderURL.setParameter(
 			"mvcRenderCommandName", "/document_library/select_folder");
 		renderURL.setParameter(
+			"originFolderId",
+			String.valueOf(_dlAdminDisplayContext.getFolderId()));
+		renderURL.setParameter(
 			"folderId", String.valueOf(_dlAdminDisplayContext.getFolderId()));
 		renderURL.setWindowState(LiferayWindowState.POP_UP);
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLBreadcrumbUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLBreadcrumbUtil.java
@@ -237,7 +237,9 @@ public class DLBreadcrumbUtil {
 
 		long originFolderId = ParamUtil.getLong(
 			httpServletRequest, "originFolderId",
-			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+			ParamUtil.getLong(
+				httpServletRequest, "folderId",
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID));
 
 		portletURL.setParameter(
 			"originFolderId", String.valueOf(originFolderId));

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLBreadcrumbUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLBreadcrumbUtil.java
@@ -235,16 +235,16 @@ public class DLBreadcrumbUtil {
 
 		PortletURL portletURL = renderResponse.createRenderURL();
 
-		long originFolderId = ParamUtil.getLong(
-			httpServletRequest, "originFolderId",
-			ParamUtil.getLong(
-				httpServletRequest, "folderId",
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID));
-
-		portletURL.setParameter(
-			"originFolderId", String.valueOf(originFolderId));
-
 		if (mvcRenderCommandName.equals("/document_library/select_folder")) {
+			long originFolderId = ParamUtil.getLong(
+				httpServletRequest, "originFolderId",
+				ParamUtil.getLong(
+					httpServletRequest, "folderId",
+					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID));
+
+			portletURL.setParameter(
+				"originFolderId", String.valueOf(originFolderId));
+
 			long groupId = ParamUtil.getLong(httpServletRequest, "groupId");
 			boolean ignoreRootFolder = ParamUtil.getBoolean(
 				httpServletRequest, "ignoreRootFolder");

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLBreadcrumbUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLBreadcrumbUtil.java
@@ -235,6 +235,13 @@ public class DLBreadcrumbUtil {
 
 		PortletURL portletURL = renderResponse.createRenderURL();
 
+		long originFolderId = ParamUtil.getLong(
+			httpServletRequest, "originFolderId",
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		portletURL.setParameter(
+			"originFolderId", String.valueOf(originFolderId));
+
 		if (mvcRenderCommandName.equals("/document_library/select_folder")) {
 			long groupId = ParamUtil.getLong(httpServletRequest, "groupId");
 			boolean ignoreRootFolder = ParamUtil.getBoolean(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLBreadcrumbUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLBreadcrumbUtil.java
@@ -236,14 +236,14 @@ public class DLBreadcrumbUtil {
 		PortletURL portletURL = renderResponse.createRenderURL();
 
 		if (mvcRenderCommandName.equals("/document_library/select_folder")) {
-			long originFolderId = ParamUtil.getLong(
-				httpServletRequest, "originFolderId",
+			long selectedFolderId = ParamUtil.getLong(
+				httpServletRequest, "selectedFolderId",
 				ParamUtil.getLong(
 					httpServletRequest, "folderId",
 					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID));
 
 			portletURL.setParameter(
-				"originFolderId", String.valueOf(originFolderId));
+				"selectedFolderId", String.valueOf(selectedFolderId));
 
 			long groupId = ParamUtil.getLong(httpServletRequest, "groupId");
 			boolean ignoreRootFolder = ParamUtil.getBoolean(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLBreadcrumbUtil.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/util/DLBreadcrumbUtil.java
@@ -236,22 +236,20 @@ public class DLBreadcrumbUtil {
 		PortletURL portletURL = renderResponse.createRenderURL();
 
 		if (mvcRenderCommandName.equals("/document_library/select_folder")) {
+			long groupId = ParamUtil.getLong(httpServletRequest, "groupId");
+			boolean ignoreRootFolder = ParamUtil.getBoolean(
+				httpServletRequest, "ignoreRootFolder");
+
 			long selectedFolderId = ParamUtil.getLong(
 				httpServletRequest, "selectedFolderId",
 				ParamUtil.getLong(
 					httpServletRequest, "folderId",
 					DLFolderConstants.DEFAULT_PARENT_FOLDER_ID));
 
-			portletURL.setParameter(
-				"selectedFolderId", String.valueOf(selectedFolderId));
-
-			long groupId = ParamUtil.getLong(httpServletRequest, "groupId");
-			boolean ignoreRootFolder = ParamUtil.getBoolean(
-				httpServletRequest, "ignoreRootFolder");
-
 			_addPortletBreadcrumbEntry(
 				httpServletRequest, "mvcRenderCommandName",
-				mvcRenderCommandName, groupId, ignoreRootFolder, portletURL);
+				mvcRenderCommandName, groupId, ignoreRootFolder,
+				selectedFolderId, portletURL);
 		}
 		else {
 			long folderId = DLFolderConstants.DEFAULT_PARENT_FOLDER_ID;
@@ -293,7 +291,7 @@ public class DLBreadcrumbUtil {
 	private static void _addPortletBreadcrumbEntry(
 			HttpServletRequest httpServletRequest, String parameterName,
 			String parameterValue, long groupId, boolean ignoreRootFolder,
-			PortletURL portletURL)
+			long selectedFolderId, PortletURL portletURL)
 		throws Exception {
 
 		ThemeDisplay themeDisplay =
@@ -304,6 +302,8 @@ public class DLBreadcrumbUtil {
 		portletURL.setParameter("groupId", String.valueOf(groupId));
 		portletURL.setParameter(
 			"ignoreRootFolder", String.valueOf(ignoreRootFolder));
+		portletURL.setParameter(
+			"selectedFolderId", String.valueOf(selectedFolderId));
 		portletURL.setWindowState(LiferayWindowState.POP_UP);
 
 		PortalUtil.addPortletBreadcrumbEntry(

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -302,7 +302,7 @@ renderResponse.setTitle(headerTitle);
 
 											<liferay-portlet:renderURL var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 												<portlet:param name="mvcRenderCommandName" value="/document_library/select_folder" />
-												<portlet:param name="originFolderId" value="<%= String.valueOf(folderId) %>" />
+												<portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" />
 											</liferay-portlet:renderURL>
 
 											url: '<%= selectFolderURL.toString() %>',

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/edit_file_entry.jsp
@@ -302,6 +302,7 @@ renderResponse.setTitle(headerTitle);
 
 											<liferay-portlet:renderURL var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 												<portlet:param name="mvcRenderCommandName" value="/document_library/select_folder" />
+												<portlet:param name="originFolderId" value="<%= String.valueOf(folderId) %>" />
 											</liferay-portlet:renderURL>
 
 											url: '<%= selectFolderURL.toString() %>',

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
@@ -20,6 +20,7 @@
 Folder folder = (Folder)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FOLDER);
 
 long folderId = BeanParamUtil.getLong(folder, request, "folderId", DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+long originFolderId = ParamUtil.getLong(request, "originFolderId", DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
 
 long repositoryId = scopeGroupId;
 String folderName = LanguageUtil.get(request, "home");
@@ -69,6 +70,7 @@ DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlReques
 						"foldername", folderName
 					).build()
 				%>'
+				disabled="<%= folderId == originFolderId %>"
 				value="select-this-folder"
 			/>
 		</aui:button-row>
@@ -79,6 +81,7 @@ DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlReques
 		portletURL.setParameter("mvcRenderCommandName", "/document_library/select_folder");
 		portletURL.setParameter("folderId", String.valueOf(folderId));
 		portletURL.setParameter("ignoreRootFolder", Boolean.TRUE.toString());
+		portletURL.setParameter("originFolderId", String.valueOf(originFolderId));
 		portletURL.setParameter("showMountFolder", String.valueOf(dlVisualizationHelper.isMountFolderVisible()));
 		%>
 
@@ -100,6 +103,7 @@ DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlReques
 					<portlet:param name="mvcRenderCommandName" value="/document_library/select_folder" />
 					<portlet:param name="folderId" value="<%= String.valueOf(curFolder.getFolderId()) %>" />
 					<portlet:param name="ignoreRootFolder" value="<%= Boolean.TRUE.toString() %>" />
+					<portlet:param name="originFolderId" value="<%= String.valueOf(originFolderId) %>" />
 					<portlet:param name="showMountFolder" value="<%= String.valueOf(dlVisualizationHelper.isMountFolderVisible()) %>" />
 				</liferay-portlet:renderURL>
 
@@ -166,6 +170,7 @@ DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlReques
 									"foldername", curFolder.getName()
 								).build()
 							%>'
+							disabled="<%= curFolder.getFolderId() == originFolderId %>"
 							value="select"
 						/>
 					</c:if>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
@@ -20,7 +20,7 @@
 Folder folder = (Folder)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FOLDER);
 
 long folderId = BeanParamUtil.getLong(folder, request, "folderId", DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
-long originFolderId = ParamUtil.getLong(request, "originFolderId", DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+long originFolderId = ParamUtil.getLong(request, "originFolderId", folderId);
 
 long repositoryId = scopeGroupId;
 String folderName = LanguageUtil.get(request, "home");

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/select_folder.jsp
@@ -20,7 +20,7 @@
 Folder folder = (Folder)request.getAttribute(WebKeys.DOCUMENT_LIBRARY_FOLDER);
 
 long folderId = BeanParamUtil.getLong(folder, request, "folderId", DLFolderConstants.DEFAULT_PARENT_FOLDER_ID);
-long originFolderId = ParamUtil.getLong(request, "originFolderId", folderId);
+long selectedFolderId = ParamUtil.getLong(request, "selectedFolderId", folderId);
 
 long repositoryId = scopeGroupId;
 String folderName = LanguageUtil.get(request, "home");
@@ -70,7 +70,7 @@ DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlReques
 						"foldername", folderName
 					).build()
 				%>'
-				disabled="<%= folderId == originFolderId %>"
+				disabled="<%= folderId == selectedFolderId %>"
 				value="select-this-folder"
 			/>
 		</aui:button-row>
@@ -81,7 +81,7 @@ DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlReques
 		portletURL.setParameter("mvcRenderCommandName", "/document_library/select_folder");
 		portletURL.setParameter("folderId", String.valueOf(folderId));
 		portletURL.setParameter("ignoreRootFolder", Boolean.TRUE.toString());
-		portletURL.setParameter("originFolderId", String.valueOf(originFolderId));
+		portletURL.setParameter("selectedFolderId", String.valueOf(selectedFolderId));
 		portletURL.setParameter("showMountFolder", String.valueOf(dlVisualizationHelper.isMountFolderVisible()));
 		%>
 
@@ -103,7 +103,7 @@ DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlReques
 					<portlet:param name="mvcRenderCommandName" value="/document_library/select_folder" />
 					<portlet:param name="folderId" value="<%= String.valueOf(curFolder.getFolderId()) %>" />
 					<portlet:param name="ignoreRootFolder" value="<%= Boolean.TRUE.toString() %>" />
-					<portlet:param name="originFolderId" value="<%= String.valueOf(originFolderId) %>" />
+					<portlet:param name="selectedFolderId" value="<%= String.valueOf(selectedFolderId) %>" />
 					<portlet:param name="showMountFolder" value="<%= String.valueOf(dlVisualizationHelper.isMountFolderVisible()) %>" />
 				</liferay-portlet:renderURL>
 
@@ -170,7 +170,7 @@ DLVisualizationHelper dlVisualizationHelper = new DLVisualizationHelper(dlReques
 									"foldername", curFolder.getName()
 								).build()
 							%>'
-							disabled="<%= curFolder.getFolderId() == originFolderId %>"
+							disabled="<%= curFolder.getFolderId() == selectedFolderId %>"
 							value="select"
 						/>
 					</c:if>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -159,7 +159,6 @@ if (portletTitleBasedNavigation) {
 <portlet:renderURL var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 	<portlet:param name="mvcRenderCommandName" value="/document_library/select_folder" />
 	<portlet:param name="folderId" value="<%= String.valueOf(fileEntry.getFolderId()) %>" />
-	<portlet:param name="originFolderId" value="<%= String.valueOf(fileEntry.getFolderId()) %>" />
 </portlet:renderURL>
 
 <portlet:actionURL name="/document_library/edit_entry" var="editEntryURL" />

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/view_file_entry.jsp
@@ -156,7 +156,11 @@ if (portletTitleBasedNavigation) {
 	<liferay-util:include page="/document_library/version_details.jsp" servletContext="<%= application %>" />
 </c:if>
 
-<portlet:renderURL var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>"><portlet:param name="mvcRenderCommandName" value="/document_library/select_folder" /><portlet:param name="folderId" value="<%= String.valueOf(fileEntry.getFolderId()) %>" /></portlet:renderURL>
+<portlet:renderURL var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+	<portlet:param name="mvcRenderCommandName" value="/document_library/select_folder" />
+	<portlet:param name="folderId" value="<%= String.valueOf(fileEntry.getFolderId()) %>" />
+	<portlet:param name="originFolderId" value="<%= String.valueOf(fileEntry.getFolderId()) %>" />
+</portlet:renderURL>
 
 <portlet:actionURL name="/document_library/edit_entry" var="editEntryURL" />
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/package.json
@@ -5,6 +5,7 @@
 		"@clayui/layout": "3.2.0",
 		"@clayui/modal": "3.8.0",
 		"@clayui/table": "3.1.0",
+		"axios": "0.18.1",
 		"classnames": "2.2.6",
 		"clay-button": "2.21.4",
 		"clay-checkbox": "2.21.4",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributor.java
@@ -62,6 +62,9 @@ public class SelectDDMFormFieldTemplateContextContributor
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
 
 		Map<String, Object> parameters = HashMapBuilder.<String, Object>put(
+			"alphabeticalOrder",
+			GetterUtil.getBoolean(ddmFormField.getProperty("alphabeticalOrder"))
+		).put(
 			"dataSourceType", ddmFormField.getDataSourceType()
 		).put(
 			"multiple", getMultiple(ddmFormField, ddmFormFieldRenderingContext)
@@ -74,7 +77,8 @@ public class SelectDDMFormFieldTemplateContextContributor
 		parameters.put(
 			"options",
 			getOptions(
-				ddmFormFieldOptions, ddmFormFieldRenderingContext.getLocale(),
+				ddmFormField, ddmFormFieldOptions,
+				ddmFormFieldRenderingContext.getLocale(),
 				ddmFormFieldRenderingContext));
 
 		Locale displayLocale = LocaleThreadLocal.getThemeDisplayLocale();
@@ -137,11 +141,12 @@ public class SelectDDMFormFieldTemplateContextContributor
 		return ddmFormField.isMultiple();
 	}
 
-	protected List<Object> getOptions(
-		DDMFormFieldOptions ddmFormFieldOptions, Locale locale,
+	protected List<Map<String, String>> getOptions(
+		DDMFormField ddmFormField, DDMFormFieldOptions ddmFormFieldOptions,
+		Locale locale,
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext) {
 
-		List<Object> options = new ArrayList<>();
+		List<Map<String, String>> options = new ArrayList<>();
 
 		for (String optionValue : ddmFormFieldOptions.getOptionsValues()) {
 			if (optionValue == null) {
@@ -163,6 +168,19 @@ public class SelectDDMFormFieldTemplateContextContributor
 				).put(
 					"value", optionValue
 				).build());
+		}
+
+		boolean alphabeticalOrder = GetterUtil.getBoolean(
+			ddmFormField.getProperty("alphabeticalOrder"));
+
+		if (alphabeticalOrder) {
+			options.sort(
+				(map1, map2) -> {
+					String label1 = map1.get("label");
+					String label2 = map2.get("label");
+
+					return label1.compareTo(label2);
+				});
 		}
 
 		return options;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTypeSettings.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTypeSettings.java
@@ -90,7 +90,8 @@ import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 								"visibilityExpression", "validation",
 								"fieldNamespace", "indexType", "localizable",
 								"nativeField", "readOnly", "dataType", "type",
-								"showLabel", "repeatable", "multiple"
+								"showLabel", "repeatable", "multiple",
+								"alphabeticalOrder"
 							}
 						)
 					}
@@ -101,6 +102,12 @@ import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 )
 public interface SelectDDMFormFieldTypeSettings
 	extends DefaultDDMFormFieldTypeSettings {
+
+	@DDMFormField(
+		label = "%order-options-alphabetically",
+		properties = "showAsSwitcher=true"
+	)
+	public boolean alphabeticalOrder();
 
 	@DDMFormField(
 		label = "%create-list",

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributorTest.java
@@ -153,7 +153,46 @@ public class SelectDDMFormFieldTemplateContextContributorTest
 			DDMFormFieldOptionsTestUtil.createDDMFormFieldOptions();
 
 		List<Map<String, String>> actualOptions = _getActualOptions(
-			ddmFormFieldOptions, LocaleUtil.US);
+			new DDMFormField("field", "select"), ddmFormFieldOptions,
+			LocaleUtil.US);
+
+		Assert.assertEquals(expectedOptions, actualOptions);
+	}
+
+	@Test
+	public void testGetOptionsAlphabeticallyOrdered() {
+		List<Object> expectedOptions = new ArrayList<>();
+
+		expectedOptions.add(
+			DDMFormFieldOptionsTestUtil.createOption(
+				"Label 1", "Reference 1", "value 1"));
+		expectedOptions.add(
+			DDMFormFieldOptionsTestUtil.createOption(
+				"Label 2", "Reference 2", "value 2"));
+		expectedOptions.add(
+			DDMFormFieldOptionsTestUtil.createOption(
+				"Label 3", "Reference 3", "value 3"));
+
+		DDMFormField ddmFormField = new DDMFormField("field", "select");
+
+		DDMFormFieldOptions ddmFormFieldOptions = new DDMFormFieldOptions();
+
+		for (int i = 3; i > 0; i--) {
+			ddmFormFieldOptions.addOptionLabel(
+				"value " + i, LocaleUtil.US, "Label " + i);
+			ddmFormFieldOptions.addOptionReference(
+				"value " + i, "Reference " + i);
+		}
+
+		List<Map<String, String>> actualOptions = _getActualOptions(
+			ddmFormField, ddmFormFieldOptions, LocaleUtil.US);
+
+		Assert.assertNotEquals(expectedOptions, actualOptions);
+
+		ddmFormField.setProperty("alphabeticalOrder", "true");
+
+		actualOptions = _getActualOptions(
+			ddmFormField, ddmFormFieldOptions, LocaleUtil.US);
 
 		Assert.assertEquals(expectedOptions, actualOptions);
 	}
@@ -315,13 +354,14 @@ public class SelectDDMFormFieldTemplateContextContributorTest
 	}
 
 	private List<Map<String, String>> _getActualOptions(
-		DDMFormFieldOptions ddmFormFieldOptions, Locale locale) {
+		DDMFormField ddmFormField, DDMFormFieldOptions ddmFormFieldOptions,
+		Locale locale) {
 
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
 			new DDMFormFieldRenderingContext();
 
 		return _selectDDMFormFieldTemplateContextContributor.getOptions(
-			new DDMFormField("field", "select"), ddmFormFieldOptions, locale,
+			ddmFormField, ddmFormFieldOptions, locale,
 			ddmFormFieldRenderingContext);
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributorTest.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/test/java/com/liferay/dynamic/data/mapping/form/field/type/internal/select/SelectDDMFormFieldTemplateContextContributorTest.java
@@ -152,7 +152,7 @@ public class SelectDDMFormFieldTemplateContextContributorTest
 		DDMFormFieldOptions ddmFormFieldOptions =
 			DDMFormFieldOptionsTestUtil.createDDMFormFieldOptions();
 
-		List<Object> actualOptions = _getActualOptions(
+		List<Map<String, String>> actualOptions = _getActualOptions(
 			ddmFormFieldOptions, LocaleUtil.US);
 
 		Assert.assertEquals(expectedOptions, actualOptions);
@@ -314,14 +314,15 @@ public class SelectDDMFormFieldTemplateContextContributorTest
 		return spy;
 	}
 
-	private List<Object> _getActualOptions(
+	private List<Map<String, String>> _getActualOptions(
 		DDMFormFieldOptions ddmFormFieldOptions, Locale locale) {
 
 		DDMFormFieldRenderingContext ddmFormFieldRenderingContext =
 			new DDMFormFieldRenderingContext();
 
 		return _selectDDMFormFieldTemplateContextContributor.getOptions(
-			ddmFormFieldOptions, locale, ddmFormFieldRenderingContext);
+			new DDMFormField("field", "select"), ddmFormFieldOptions, locale,
+			ddmFormFieldRenderingContext);
 	}
 
 	private void _setUpDDMFormFieldOptionsFactory(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormTemplateContextProcessor.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormTemplateContextProcessor.java
@@ -102,6 +102,8 @@ public class DDMFormTemplateContextProcessor {
 
 		DDMFormField ddmFormField = new DDMFormField(name, type);
 
+		setDDMFormFieldAlphabeticalOrder(
+			jsonObject.getBoolean("alphabeticalOrder"), ddmFormField);
 		setDDMFormFieldCollapsible(
 			jsonObject.getBoolean("collapsible"), ddmFormField);
 		setDDMFormFieldDataProviderSettings(
@@ -240,6 +242,12 @@ public class DDMFormTemplateContextProcessor {
 
 	protected void setDDMFormDefaultLocale() {
 		_ddmForm.setDefaultLocale(_locale);
+	}
+
+	protected void setDDMFormFieldAlphabeticalOrder(
+		boolean alphabeticalOrder, DDMFormField ddmFormField) {
+
+		ddmFormField.setProperty("alphabeticalOrder", alphabeticalOrder);
 	}
 
 	protected void setDDMFormFieldCollapsible(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/css/main.scss
@@ -221,6 +221,25 @@ body .ddm-user-view-content {
 	a {
 		display: inline-block;
 	}
+
+	.clear-button-upload {
+		border-bottom-left-radius: 0;
+		border-top-left-radius: 0;
+	}
+
+	.clear-button-upload-on {
+		border-bottom-right-radius: 0;
+		border-top-right-radius: 0;
+	}
+
+	.input-file {
+		height: 0.1px;
+		opacity: 0;
+		overflow: hidden;
+		position: absolute;
+		width: 0.1px;
+		z-index: -1;
+	}
 }
 
 .liferay-ddm-form-field-paragraph,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/PaginatedVariant.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/PaginatedVariant.es.js
@@ -54,6 +54,7 @@ export const Container = ({
 				{!pages.length && showSubmitButton && (
 					<ClayButton
 						className="float-right lfr-ddm-form-submit"
+						id="ddm-form-submit"
 						type="submit"
 					>
 						{submitLabel}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/WizardVariant.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PageRenderer/WizardVariant.es.js
@@ -67,6 +67,7 @@ export const Container = ({
 				{!pages.length && showSubmitButton && (
 					<ClayButton
 						className="float-right lfr-ddm-form-submit"
+						id="ddm-form-submit"
 						type="submit"
 					>
 						{submitLabel}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PaginationControls.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/resources/META-INF/resources/js/components/PaginationControls.es.js
@@ -90,6 +90,7 @@ export const PaginationControls = ({
 			{activePage === total - 1 && !readOnly && showSubmitButton && (
 				<ClayButton
 					className="float-right lfr-ddm-form-submit"
+					id="ddm-form-submit"
 					type="submit"
 				>
 					{submitLabel}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option
 options-field-type-label=Options
 or=OR
+order-options-alphabetically=Order Options Alphabetically
 other-field=Other field
 output-parameters=Output Parameters
 page-options=Page Options

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ar.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=السماح بحذف الحق�
 option=الخيار
 options-field-type-label=الخيارات
 or=أو
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=حقل آخر
 output-parameters=معلمات الإخراج
 page-options=خيارات الصفحة

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_bg.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ca.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Permet que només es puguin eli
 option=Opció
 options-field-type-label=Opcions
 or=O
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Altre camp
 output-parameters=Paràmetres de sortida
 page-options=Opcions de la pàgina

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_cs.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Povolit mazání povinných pol
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_da.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_de.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Das Löschen von Pflichtfeldern
 option=Option
 options-field-type-label=Optionen
 or=ODER
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Anderes Feld
 output-parameters=Ausgabeparameter
 page-options=Seitenoptionen

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_el.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Να επιτραπεί η δι
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_en.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option
 options-field-type-label=Options
 or=OR
+order-options-alphabetically=Order Options Alphabetically
 other-field=Other field
 output-parameters=Output Parameters
 page-options=Page Options

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_en_AU.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_en_GB.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_es.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Sólo está permitido el borrad
 option=Opción
 options-field-type-label=Opciones
 or=O
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Otro campo
 output-parameters=Parámetros de salida
 page-options=Opciones de página

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_et.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_eu.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Derrigorrezko eremuak editatze 
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fa.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=تنها مجاز به حذف �
 option=گزینه
 options-field-type-label=گزینه‌ها
 or=یا
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=فیلد دیگر
 output-parameters=پارامترهای خروجی
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fi.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Vain muokkaustilassa on mahdoll
 option=Valinta
 options-field-type-label=Valinnat
 or=TAI
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Muu kenttä
 output-parameters=Lähtöparametrit
 page-options=Sivun Asetukset

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fr.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Autoriser seulement la suppress
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OU
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Autre champ
 output-parameters=Paramètres de sortie
 page-options=Options de la page

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_fr_CA.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_gl.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Opción
 options-field-type-label=Opcións
 or=OU
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Outro campo
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Opcións de páxina

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_hi_IN.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_hr.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Brisanje obveznih polja dozvoli
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_hu.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Csak a szükséges mezők törl
 option=Lehetőség
 options-field-type-label=Lehetőségek
 or=VAGY
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Más mező
 output-parameters=Kimenő paraméterek
 page-options=Oldal beállításai

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_in.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Hanya memungkinkan menghapus bi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_it.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Consenti solo la cancellazione 
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_iw.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=אפשר מחיקה של שדו
 option=אופציה
 options-field-type-label=אופציות
 or=או
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=שדה אחר
 output-parameters=פרמטרים של פלט
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ja.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=編集モードで必須フィ�
 option=オプション
 options-field-type-label=オプション
 or=または
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=他のフィールド
 output-parameters=出力パラメータ
 page-options=ページオプション

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_kk.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ko.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_lo.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=ອະນຸຍາດໃຫ້�
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_lt.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ms.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_nb.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Tillat bare sletting av påkrev
 option=Valg
 options-field-type-label=Valg
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Annet felt
 output-parameters=Utparametre
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_nl.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Verwijderen van verplichte veld
 option=Optie
 options-field-type-label=Opties
 or=OF
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Ander veld
 output-parameters=Outputparameters
 page-options=Paginaopties

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_nl_BE.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Verwijderen van velden alleen t
 option=Optie
 options-field-type-label=Opties
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_pl.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Pozwala na usunięcie tylko wyb
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_pt_BR.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Permitir apagar os campos obrig
 option=Opção
 options-field-type-label=Opções
 or=OU
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Outro campo
 output-parameters=Parâmetros de saída
 page-options=Opções de página

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_pt_PT.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Permitir apagar os campos obrig
 option=Opção
 options-field-type-label=Opções
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ro.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ru.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Разрешить удален
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sk.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Povoliť mazanie povinných pol
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sl.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sr_RS.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Само је дозвољен�
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Samo je dozvoljeno brisanje oba
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_sv.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Tillåt endast radering av obli
 option=Alternativ
 options-field-type-label=Alternativ
 or=ELLER
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Annat fält
 output-parameters=Utdataparametrar
 page-options=Sidalternativ

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_ta_IN.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=திருத்துதல�
 option=விருப்பம்
 options-field-type-label=விருப்பங்கள்
 or=அல்லது
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_th.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=อนุญาตให้ล�
 option=ตัวเลือก
 options-field-type-label=ตัวเลือก
 or=หรือ
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=ฟิลด์อื่น ๆ
 output-parameters=พารามิเตอร์เอาต์พุต
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_tr.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_uk.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Only allow deleting required fi
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_vi.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=Chỉ cho phép xóa trường 
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_zh_CN.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=只准许在编辑模式下删�
 option=选项
 options-field-type-label=选项
 or=或
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=其他字段
 output-parameters=输出参数
 page-options=页面选项

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-lang/src/main/resources/content/Language_zh_TW.properties
@@ -267,6 +267,7 @@ only-allow-deleting-required-fields-in-edit-mode=只允許在編輯模式刪除�
 option=Option (Automatic Copy)
 options-field-type-label=Options (Automatic Copy)
 or=OR (Automatic Copy)
+order-options-alphabetically=Order Options Alphabetically (Automatic Copy)
 other-field=Other field (Automatic Copy)
 output-parameters=Output Parameters (Automatic Copy)
 page-options=Page Options (Automatic Copy)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/resource-actions/default.xml
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/resources/resource-actions/default.xml
@@ -16,11 +16,7 @@
 				<action-key>ADD_FORM_INSTANCE</action-key>
 				<action-key>ADD_STRUCTURE</action-key>
 			</supports>
-			<site-member-defaults>
-				<action-key>ADD_DATA_PROVIDER_INSTANCE</action-key>
-				<action-key>ADD_FORM_INSTANCE</action-key>
-				<action-key>ADD_STRUCTURE</action-key>
-			</site-member-defaults>
+			<site-member-defaults />
 			<guest-defaults />
 			<guest-unsupported>
 				<action-key>ADD_DATA_PROVIDER_INSTANCE</action-key>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_contributed_fragment_entries.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_contributed_fragment_entries.jsp
@@ -39,7 +39,7 @@ ContributedFragmentManagementToolbarDisplayContext contributedFragmentManagement
 			%>
 
 			<liferay-ui:search-container-column-text>
-				<clay:vertical-card-v2
+				<clay:vertical-card
 					verticalCard="<%= new ContributedFragmentEntryVerticalCard(fragmentEntry, renderRequest, renderResponse, searchContainer.getRowChecker()) %>"
 				/>
 			</liferay-ui:search-container-column-text>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entries.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entries.jsp
@@ -51,12 +51,12 @@ FragmentManagementToolbarDisplayContext fragmentManagementToolbarDisplayContext 
 			<liferay-ui:search-container-column-text>
 				<c:choose>
 					<c:when test="<%= object instanceof FragmentComposition %>">
-						<clay:vertical-card-v2
+						<clay:vertical-card
 							verticalCard="<%= fragmentEntryVerticalCardFactory.getVerticalCard((FragmentComposition)object, renderRequest, renderResponse, searchContainer.getRowChecker(), fragmentDisplayContext.getFragmentType()) %>"
 						/>
 					</c:when>
 					<c:otherwise>
-						<clay:vertical-card-v2
+						<clay:vertical-card
 							verticalCard="<%= fragmentEntryVerticalCardFactory.getVerticalCard((FragmentEntry)object, renderRequest, renderResponse, searchContainer.getRowChecker(), fragmentDisplayContext.getFragmentType()) %>"
 						/>
 					</c:otherwise>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_resources.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_resources.jsp
@@ -54,7 +54,7 @@ FragmentCollectionResourcesManagementToolbarDisplayContext fragmentCollectionRes
 			%>
 
 			<liferay-ui:search-container-column-text>
-				<clay:vertical-card-v2
+				<clay:vertical-card
 					verticalCard="<%= new FragmentCollectionResourceVerticalCard(fileEntry, renderRequest, renderResponse, searchContainer.getRowChecker()) %>"
 				/>
 			</liferay-ui:search-container-column-text>

--- a/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleVerticalCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay-sample-web/src/main/java/com/liferay/frontend/taglib/clay/sample/web/internal/display/context/ClaySampleVerticalCard.java
@@ -20,8 +20,10 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuil
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder;
 import com.liferay.portal.kernel.security.RandomUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * @author Julien Castelain
@@ -80,6 +82,14 @@ public class ClaySampleVerticalCard implements VerticalCard {
 		}
 
 		return "custom-vertical-card-css-class";
+	}
+
+	public Map<String, String> getDynamicAttributes() {
+		return HashMapBuilder.put(
+			"data-id", getId()
+		).put(
+			"data-type", "vertical-card"
+		).build();
 	}
 
 	public String getHref() {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/VerticalCardTag.java
@@ -458,9 +458,14 @@ public class VerticalCardTag extends BaseCardTag {
 
 		StickerTag stickerTag = new StickerTag();
 
+		String stickerCssClass = getStickerCssClass();
 		String stickerIcon = getStickerIcon();
 		String stickerImageSrc = getStickerImageSrc();
 		String stickerLabel = getStickerLabel();
+
+		if (Validator.isNotNull(stickerCssClass)) {
+			stickerTag.setCssClass(stickerCssClass);
+		}
 
 		if (Validator.isNotNull(stickerIcon)) {
 			stickerTag.setIcon(stickerIcon);

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/BaseClayCard.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/soy/BaseClayCard.java
@@ -16,6 +16,7 @@ package com.liferay.frontend.taglib.clay.servlet.taglib.soy;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -49,7 +50,7 @@ public interface BaseClayCard {
 	}
 
 	public default Map<String, String> getDynamicAttributes() {
-		return null;
+		return Collections.emptyMap();
 	}
 
 	public default String getElementClasses() {

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/VerticalCard.js
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/resources/META-INF/resources/cards/VerticalCard.js
@@ -13,6 +13,8 @@
  */
 
 import {ClayCardWithInfo} from '@clayui/card';
+import ClayIcon from '@clayui/icon';
+import ClaySticker from '@clayui/sticker';
 import React, {useMemo, useState} from 'react';
 
 import getDataAttributes from './get_data_attributes';
@@ -51,26 +53,36 @@ export default function VerticalCard({
 }) {
 	const [selected, setSelected] = useState(initialSelected);
 
-	const stickerProps = useMemo(
-		() => ({
+	const stickerProps = useMemo(() => {
+		const stickerProps = {
 			className: stickerCssClass,
 			content: stickerLabel,
 			displayType: stickerStyle,
-			imageAlt: stickerImageAlt,
-			imageSrc: stickerImageSrc,
 			shape: stickerShape,
-			symbol: stickerIcon,
-		}),
-		[
-			stickerCssClass,
-			stickerIcon,
-			stickerImageAlt,
-			stickerImageSrc,
-			stickerLabel,
-			stickerShape,
-			stickerStyle,
-		]
-	);
+		};
+
+		if (stickerIcon) {
+			stickerProps.content = <ClayIcon symbol={stickerIcon} />;
+		}
+		else if (stickerImageSrc) {
+			stickerProps.content = (
+				<ClaySticker.Image
+					alt={stickerImageAlt}
+					src={stickerImageSrc}
+				/>
+			);
+		}
+
+		return stickerProps;
+	}, [
+		stickerCssClass,
+		stickerIcon,
+		stickerImageAlt,
+		stickerImageSrc,
+		stickerLabel,
+		stickerShape,
+		stickerStyle,
+	]);
 
 	return (
 		<ClayCardWithInfo

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -143,7 +143,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 							%>
 
 							<liferay-ui:search-container-column-text>
-								<clay:vertical-card-v2
+								<clay:vertical-card
 									verticalCard="<%= new JournalArticleItemSelectorVerticalCard(curArticle, renderRequest) %>"
 								/>
 							</liferay-ui:search-container-column-text>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_template.jsp
@@ -41,7 +41,7 @@ JournalSelectDDMTemplateDisplayContext journalSelectDDMTemplateDisplayContext = 
 					%>
 
 					<liferay-ui:search-container-column-text>
-						<clay:vertical-card-v2
+						<clay:vertical-card
 							verticalCard="<%= new JournalSelectDDMTemplateVerticalCard(ddmTemplate, renderRequest, journalSelectDDMTemplateDisplayContext) %>"
 						/>
 					</liferay-ui:search-container-column-text>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_article_history.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_article_history.jsp
@@ -119,7 +119,7 @@ JournalArticle article = journalDisplayContext.getArticle();
 							%>
 
 							<liferay-ui:search-container-column-text>
-								<clay:vertical-card-v2
+								<clay:vertical-card
 									verticalCard="<%= new JournalArticleHistoryVerticalCard(articleVersion, renderRequest, renderResponse, searchContainer.getRowChecker(), assetDisplayPageFriendlyURLProvider, trashHelper) %>"
 								/>
 							</liferay-ui:search-container-column-text>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_comments.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_comments.jsp
@@ -62,7 +62,7 @@
 				%>
 
 				<liferay-ui:search-container-column-text>
-					<clay:vertical-card-v2
+					<clay:vertical-card
 						verticalCard="<%= new JournalArticleCommentsVerticalCard(mbMessage, renderRequest) %>"
 					/>
 				</liferay-ui:search-container-column-text>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_templates.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_templates.jsp
@@ -89,7 +89,7 @@ if (ddmStructure != null) {
 					%>
 
 					<liferay-ui:search-container-column-text>
-						<clay:vertical-card-v2
+						<clay:vertical-card
 							verticalCard="<%= new JournalDDMTemplateVerticalCard(ddmTemplate, renderRequest, renderResponse, searchContainer.getRowChecker()) %>"
 						/>
 					</liferay-ui:search-container-column-text>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -331,7 +331,7 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 						<liferay-ui:search-container-column-text
 							colspan="<%= 2 %>"
 						>
-							<clay:horizontal-card-v2
+							<clay:horizontal-card
 								horizontalCard="<%= new JournalFolderHorizontalCard(curFolder, journalDisplayContext.getDisplayStyle(), renderRequest, renderResponse, searchContainer.getRowChecker(), trashHelper) %>"
 							/>
 						</liferay-ui:search-container-column-text>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -153,7 +153,7 @@ String referringPortletResource = ParamUtil.getString(request, "referringPortlet
 						%>
 
 						<liferay-ui:search-container-column-text>
-							<clay:vertical-card-v2
+							<clay:vertical-card
 								verticalCard="<%= new JournalArticleVerticalCard(curArticle, renderRequest, renderResponse, searchContainer.getRowChecker(), assetDisplayPageFriendlyURLProvider, trashHelper) %>"
 							/>
 						</liferay-ui:search-container-column-text>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_versions.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_versions.jsp
@@ -74,7 +74,7 @@
 				%>
 
 				<liferay-ui:search-container-column-text>
-					<clay:vertical-card-v2
+					<clay:vertical-card
 						verticalCard="<%= new JournalArticleVersionVerticalCard(articleVersion, renderRequest, renderResponse, searchContainer.getRowChecker(), assetDisplayPageFriendlyURLProvider, trashHelper) %>"
 					/>
 				</liferay-ui:search-container-column-text>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_columns.jspf
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_columns.jspf
@@ -34,7 +34,7 @@ names.addAll(ListUtil.toList(teams, Team.NAME_ACCESSOR));
 		%>
 
 		<liferay-ui:search-container-column-text>
-			<clay:user-card-v2
+			<clay:user-card
 				userCard="<%= new UsersUserCard(user2, !selectUsers, renderRequest, renderResponse, searchContainer.getRowChecker()) %>"
 				userColorClass='<%= "user-icon " + LexiconUtil.getUserColorCssClass(user2) %>'
 			/>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests_columns.jspf
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests_columns.jspf
@@ -88,7 +88,7 @@ previewURL.setParameter("membershipRequestId", String.valueOf(membershipRequest.
 		%>
 
 		<liferay-ui:search-container-column-text>
-			<clay:user-card-v2
+			<clay:user-card
 				userCard="<%= new ViewMembershipRequestsUserCard(membershipRequest, membershipRequestUser, renderRequest, renderResponse) %>"
 			/>
 		</liferay-ui:search-container-column-text>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests_pending_columns.jspf
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/view_membership_requests_pending_columns.jspf
@@ -53,7 +53,7 @@ User membershipRequestUser = UserLocalServiceUtil.fetchUserById(membershipReques
 		%>
 
 		<liferay-ui:search-container-column-text>
-			<clay:user-card-v2
+			<clay:user-card
 				userCard="<%= new ViewMembershipRequestsPendingUserCard(membershipRequest, membershipRequestUser, renderRequest, renderResponse) %>"
 			/>
 		</liferay-ui:search-container-column-text>

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/edit_team_assignments_users.jsp
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/edit_team_assignments_users.jsp
@@ -58,7 +58,7 @@ EditSiteTeamAssignmentsUsersManagementToolbarDisplayContext editSiteTeamAssignme
 					%>
 
 					<liferay-ui:search-container-column-text>
-						<clay:user-card-v2
+						<clay:user-card
 							userCard="<%= new UserUserCard(user2, editSiteTeamAssignmentsUsersDisplayContext.getTeamId(), renderRequest, renderResponse, searchContainer.getRowChecker()) %>"
 							userColorClass='<%= "user-icon " + LexiconUtil.getUserColorCssClass(user2) %>'
 						/>

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/select_users.jsp
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/select_users.jsp
@@ -45,7 +45,7 @@ SelectUsersDisplayContext selectUsersDisplayContext = new SelectUsersDisplayCont
 					%>
 
 					<liferay-ui:search-container-column-text>
-						<clay:user-card-v2
+						<clay:user-card
 							userCard="<%= new SelectUserUserCard(user2, renderRequest, searchContainer.getRowChecker()) %>"
 							userColorClass='<%= "user-icon " + LexiconUtil.getUserColorCssClass(user2) %>'
 						/>

--- a/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
@@ -136,10 +136,15 @@ definition {
 					imageFileName = "${imageFileName}",
 					navTab = "${navTab}");
 			}
-			else {
+			else if (isSet(currentSiteImage)) {
 				ItemSelector.selectDMImage(
-					imageFileName = "${webContentImage}",
+					imageFileName = "${imageFileName}",
 					navTab = "${navTab}");
+			}
+			else {
+				ItemSelector.uploadFile(
+					navTab = "${navTab}",
+					uploadFileName = "${uploadFileName}");
 			}
 		}
 		else {


### PR DESCRIPTION
On the usages where a `user-icon` is being used as sticker in the card you will see this result:

![image](https://user-images.githubusercontent.com/5803434/99989778-50078c80-2db3-11eb-94bf-86e8b1878de7.png)

As you can see there's no border and the icon color is always black. This will be fixed once a new release of clay lands in portal, so don't worry about it.

Please, take a special look to [the last commit](https://github.com/liferay-echo/liferay-portal/pull/2989/commits/f5e73bdadf5d4d3f813c0067e3e04693f57b7663). As we pointed in the commit message those two usages are candidates to use the new `clay:navigation-card` tag. We highly recommend you to update the usage once https://issues.liferay.com/browse/LPS-123370 is completed.