### PR TITLE
[7.4-only] LPS-121968 Migrate v2 usages of clay:vertical-card in site-admin-web

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/servlet/taglib/clay/SelectSiteInitializerVerticalCard.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/servlet/taglib/clay/SelectSiteInitializerVerticalCard.java
@@ -54,9 +54,9 @@ public class SelectSiteInitializerVerticalCard implements VerticalCard {
 	}
 
 	@Override
-	public Map<String, String> getData() {
+	public Map<String, String> getDynamicAttributes() {
 		return HashMapBuilder.put(
-			"add-site-url",
+			"data-add-site-url",
 			() -> {
 				PortletURL addSiteURL = _renderResponse.createActionURL();
 
@@ -80,7 +80,7 @@ public class SelectSiteInitializerVerticalCard implements VerticalCard {
 				return addSiteURL.toString();
 			}
 		).put(
-			"checkbox-field-name",
+			"data-checkbox-field-name",
 			() -> {
 				if (Objects.equals(
 						_siteInitializerItem.getType(),
@@ -92,7 +92,7 @@ public class SelectSiteInitializerVerticalCard implements VerticalCard {
 				return StringPool.BLANK;
 			}
 		).put(
-			"layout-set-prototype-id",
+			"data-layout-set-prototype-id",
 			String.valueOf(_siteInitializerItem.getLayoutSetPrototypeId())
 		).build();
 	}

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/servlet/taglib/clay/SelectSiteInitializerVerticalCard.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/servlet/taglib/clay/SelectSiteInitializerVerticalCard.java
@@ -49,6 +49,11 @@ public class SelectSiteInitializerVerticalCard implements VerticalCard {
 	}
 
 	@Override
+	public String getCssClass() {
+		return "add-site-action-card mb-0";
+	}
+
+	@Override
 	public Map<String, String> getData() {
 		return HashMapBuilder.put(
 			"add-site-url",
@@ -90,12 +95,6 @@ public class SelectSiteInitializerVerticalCard implements VerticalCard {
 			"layout-set-prototype-id",
 			String.valueOf(_siteInitializerItem.getLayoutSetPrototypeId())
 		).build();
-	}
-
-	@Override
-	public String getElementClasses() {
-		return "add-site-action-option card-interactive " +
-			"card-interactive-secondary";
 	}
 
 	@Override

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
@@ -41,8 +41,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-site-template"));
 
 			<liferay-ui:search-container-column-text>
 				<button class="add-site-action-button btn btn-unstyled mb-4 w-100" type="button">
-					<clay:vertical-card-v2
-						elementClasses="add-site-action-card mb-0"
+					<clay:vertical-card
 						verticalCard="<%= new SelectSiteInitializerVerticalCard(siteInitializerItem, renderRequest, renderResponse) %>"
 					/>
 				</button>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -96,7 +96,7 @@
 				%>
 
 				<liferay-ui:search-container-column-text>
-					<clay:vertical-card-v2
+					<clay:vertical-card
 						verticalCard="<%= new SiteVerticalCard(curGroup, liferayPortletRequest, liferayPortletResponse, searchContainer.getRowChecker(), siteAdminDisplayContext) %>"
 					/>
 				</liferay-ui:search-container-column-text>


### PR DESCRIPTION
As seen with @p2kmgcl this is a good candidate for `<clay:navigation-card />` so we suggest changing it.
cc @carloslancha @markocikos
