### PR TITLE
[TS] LPS-124622 Use md instead of cssClass for responsiveness

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_structure/init.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_structure/init.jsp
@@ -36,6 +36,7 @@ page import="com.liferay.layout.util.structure.LayoutStructure" %><%@
 page import="com.liferay.layout.util.structure.LayoutStructureItem" %><%@
 page import="com.liferay.layout.util.structure.RootLayoutStructureItem" %><%@
 page import="com.liferay.layout.util.structure.RowStyledLayoutStructureItem" %><%@
+page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.layoutconfiguration.util.RuntimePageUtil" %><%@
 page import="com.liferay.portal.kernel.model.LayoutTemplate" %><%@
 page import="com.liferay.portal.kernel.model.LayoutTemplateConstants" %><%@

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_structure/render_layout_structure.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_structure/render_layout_structure.jsp
@@ -109,7 +109,7 @@ for (String childrenItemId : childrenItemIds) {
 			%>
 
 			<clay:col
-				cssClass="<%= ResponsiveLayoutStructureUtil.getColumnCssClass(columnLayoutStructureItem) %>"
+				md="<%= (columnLayoutStructureItem.getSize() > 0) ? String.valueOf(columnLayoutStructureItem.getSize()) : StringPool.BLANK %>"
 			>
 
 				<%


### PR DESCRIPTION
Hi @liferay-echo 

could you plese check my changes and push it forward?

Thanks, Roland

https://issues.liferay.com/browse/LPS-124622

Based on my tests adding the col and col-4 classes breaks the responsivity

The col class is always added by the ColTag.processCssClasses method
the  col-lg-4 col-sm-4 col-4 col-md-4 are added by the ResponsiveLayoutStructureUtil.getColumnCssClass method

With the following commit https://github.com/liferay/liferay-portal/commit/a0bd4a81ffbce485d17045389d1dcc575cdbb3e0
the code was refactored from <div class> to <clay:col md >

And with the following commit https://github.com/liferay/liferay-portal/commit/7e122d46f77e43ba486f3b82821b7ec77cc40ac1
the md attribute was replaced with the cssClass attribute.