### PR TITLE
LPS-124706 Preserve existing fragment configurations

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/EditableValuesTransformerUtil.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/EditableValuesTransformerUtil.java
@@ -166,7 +166,7 @@ public class EditableValuesTransformerUtil {
 		JSONObject jsonObject, long segmentsExperienceId) {
 
 		if (!jsonObject.has(_ID_PREFIX + segmentsExperienceId)) {
-			return JSONFactoryUtil.createJSONObject();
+			return jsonObject;
 		}
 
 		return jsonObject.getJSONObject(_ID_PREFIX + segmentsExperienceId);

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/EditableValuesTransformerUtil.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/EditableValuesTransformerUtil.java
@@ -166,7 +166,19 @@ public class EditableValuesTransformerUtil {
 		JSONObject jsonObject, long segmentsExperienceId) {
 
 		if (!jsonObject.has(_ID_PREFIX + segmentsExperienceId)) {
-			return jsonObject;
+			JSONObject newJSONObject = JSONFactoryUtil.createJSONObject();
+
+			Iterator<String> valueKeysIterator = jsonObject.keys();
+
+			while (valueKeysIterator.hasNext()) {
+				String valueKey = valueKeysIterator.next();
+
+				if (!valueKey.startsWith(_ID_PREFIX)) {
+					newJSONObject.put(valueKey, jsonObject.get(valueKey));
+				}
+			}
+
+			return newJSONObject;
 		}
 
 		return jsonObject.getJSONObject(_ID_PREFIX + segmentsExperienceId);

--- a/modules/apps/layout/layout-page-template-service/src/test/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/EditableValuesTransformerUtilTest.java
+++ b/modules/apps/layout/layout-page-template-service/src/test/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/EditableValuesTransformerUtilTest.java
@@ -133,6 +133,18 @@ public class EditableValuesTransformerUtilTest {
 	}
 
 	@Test
+	public void testGetEditableValuesWithoutExperience() throws Exception {
+		String editableValues = _read(
+			"fragment_entry_link_editable_values_without_experience.json");
+
+		Assert.assertEquals(
+			_objectMapper.readTree(editableValues),
+			_objectMapper.readTree(
+				EditableValuesTransformerUtil.getEditableValues(
+					editableValues, 0)));
+	}
+
+	@Test
 	public void testGetFreeMarkerEditableValues() throws Exception {
 		String editableValues = _read(
 			"fragment_entry_link_free_marker_editable_values.json");

--- a/modules/apps/layout/layout-page-template-service/src/test/resources/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/dependencies/fragment_entry_link_editable_values_without_experience.json
+++ b/modules/apps/layout/layout-page-template-service/src/test/resources/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/dependencies/fragment_entry_link_editable_values_without_experience.json
@@ -1,0 +1,14 @@
+{
+	"com.liferay.fragment.entry.processor.background.image.BackgroundImageFragmentEntryProcessor": {
+	},
+	"com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor": {
+		"link": {
+			"config": {
+			},
+			"defaultValue": "Go Somewhere"
+		}
+	},
+	"com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor": {
+		"buttonType": "secondary"
+	}
+}


### PR DESCRIPTION
We've been seeing a number of fragment styling configs getting lost after upgrading to 7.3, for example cases like the following:
```
  {
    "com.liferay.fragment.entry.processor.background.image.BackgroundImageFragmentEntryProcessor": {},
    "com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor": {
      "link": { "defaultValue": "Go Somewhere", "config": {} }
    },
    "com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor": {
      "buttonType": "secondary"
    }
  }
```
will get changed to

```
 {
    "com.liferay.fragment.entry.processor.background.image.BackgroundImageFragmentEntryProcessor": {},
    "com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor": {
      "link": { "defaultValue": "Go Somewhere", "config": {} }
    },
    "com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor": {}
  }
```
This is because the upgrade step only includes settings from com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor that have an experience. But there are cases (e.g. display page templates) where we have configurations without experiences and the upgrade step is just removing these.

I made this fix which solves a lot of styling issues for us. Can you please take a look?