### PR TITLE
LPS-124564 Adding a mask on top of video (only in edit mode) so in case the user click on the fragment it prevents to play the video and behaves the same than any other fragment

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/video/index.css
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/video/index.css
@@ -35,3 +35,11 @@
 	top: 0;
 	width: 100%;
 }
+
+.video-mask {
+	height: 100%;
+	left: 0;
+	position: absolute;
+	top: 0;
+	width: 100%;
+}

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/video/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/video/index.html
@@ -7,5 +7,6 @@
 
 		<div aria-hidden="true" class="loading-animation"></div>
 		<div aria-hidden="true" class="video-container"></div>
+		<div aria-hidden="true" class="video-mask"></div>
 	</div>
 </div>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/video/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/video/index.js
@@ -2,6 +2,7 @@ let content = null;
 let videoContainer = null;
 let errorMessage = null;
 let loadingIndicator = null;
+let videoMask = null;
 
 const height = configuration.videoHeight
 	? configuration.videoHeight.replace('px', '')
@@ -35,6 +36,10 @@ function showVideo() {
 	videoContainer.removeAttribute('aria-hidden');
 	errorMessage.parentElement.removeChild(errorMessage);
 	loadingIndicator.parentElement.removeChild(loadingIndicator);
+
+	if (!document.body.classList.contains('has-edit-mode-menu')) {
+		videoMask.parentElement.removeChild(videoMask);
+	}
 
 	window.addEventListener('resize', resize);
 
@@ -169,6 +174,7 @@ function main() {
 	videoContainer = content.querySelector('.video-container');
 	errorMessage = content.querySelector('.error-message');
 	loadingIndicator = content.querySelector('.loading-animation');
+	videoMask = content.querySelector('.video-mask');
 
 	window.removeEventListener('resize', resize);
 


### PR DESCRIPTION
Hi guys,

Can you review this pull request, please?

You can get more information in [LPS-124564](https://issues.liferay.com/browse/LPS-124654) and [PTR-2134](https://issues.liferay.com/browse/PTR-2134).

Thanks.

Regards.