### PR TITLE
[TS] LPS-124622 master

### DIFF
--- a/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/asset/folder_full_content.jsp
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/resources/META-INF/resources/bookmarks/asset/folder_full_content.jsp
@@ -35,7 +35,7 @@ BookmarksFolder folder = (BookmarksFolder)request.getAttribute(BookmarksWebKeys.
 
 	<clay:row>
 		<clay:col
-			cssClass="lfr-asset-column lfr-asset-column-details"
+			cssClass="col lfr-asset-column lfr-asset-column-details"
 		>
 			<c:if test="<%= Validator.isNotNull(folder.getDescription()) %>">
 				<div class="lfr-asset-description">

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/asset/abstract.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/asset/abstract.jsp
@@ -26,7 +26,7 @@ request.setAttribute("view_user.jsp-user", user2);
 
 <clay:row>
 	<clay:col
-		cssClass="contacts-container"
+		cssClass="col contacts-container"
 	>
 		<div class="lfr-contact-thumb">
 			<img alt="<%= HtmlUtil.escapeAttribute(user2.getFullName()) %>" src="<%= user2.getPortraitURL(themeDisplay) %>" />

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/my_contacts/view.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/my_contacts/view.jsp
@@ -44,7 +44,7 @@
 			<c:otherwise>
 				<clay:row>
 					<clay:col
-						cssClass="my-contacts"
+						cssClass="col my-contacts"
 					>
 
 						<%
@@ -53,7 +53,7 @@
 
 							<clay:row>
 								<clay:col
-									cssClass="lfr-contact-grid-item"
+									cssClass="col lfr-contact-grid-item"
 								>
 									<div class="lfr-contact-thumb">
 										<a href="<%= user2.getDisplayURL(themeDisplay) %>"><img alt="<%= HtmlUtil.escapeAttribute(user2.getFullName()) %>" src="<%= user2.getPortraitURL(themeDisplay) %>" /></a>

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/profile/view.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/profile/view.jsp
@@ -27,7 +27,7 @@
 
 		<clay:row>
 			<clay:col
-				cssClass="contacts-container"
+				cssClass="col contacts-container"
 			>
 				<liferay-util:include page="/view_user.jsp" servletContext="<%= application %>" />
 			</clay:col>

--- a/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view_user.jsp
+++ b/modules/apps/contacts/contacts-web/src/main/resources/META-INF/resources/view_user.jsp
@@ -38,7 +38,7 @@ request.setAttribute("view_user.jsp-user", user2);
 		<c:if test="<%= (displayStyle == ContactsConstants.DISPLAY_STYLE_BASIC) || (displayStyle == ContactsConstants.DISPLAY_STYLE_FULL) %>">
 			<clay:row>
 				<clay:col
-					cssClass="social-relations"
+					cssClass="col social-relations"
 				>
 
 					<%
@@ -86,7 +86,7 @@ request.setAttribute("view_user.jsp-user", user2);
 
 					<clay:row>
 						<clay:col
-							cssClass="contacts-action"
+							cssClass="col contacts-action"
 						>
 							<c:choose>
 								<c:when test="<%= portletId.equals(ContactsPortletKeys.CONTACTS_CENTER) || portletId.equals(ContactsPortletKeys.MEMBERS) %>">

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ColTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/ColTag.java
@@ -106,7 +106,7 @@ public class ColTag extends BaseContainerTag {
 			cssClasses.add("col-xl-" + _xl);
 		}
 
-		if (cssClasses.isEmpty()) {
+		if (Validator.isNull(super.getCssClass()) && cssClasses.isEmpty()) {
 			cssClasses.add("col");
 		}
 

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/responsive/ResponsiveLayoutStructureUtil.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/responsive/ResponsiveLayoutStructureUtil.java
@@ -52,7 +52,9 @@ public class ResponsiveLayoutStructureUtil {
 			columnLayoutStructureItem.getViewportConfigurations();
 
 		for (ViewportSize viewportSize : ViewportSize.values()) {
-			if (Objects.equals(viewportSize, ViewportSize.DESKTOP)) {
+			if (Objects.equals(viewportSize, ViewportSize.DESKTOP) ||
+				Objects.equals(viewportSize, ViewportSize.PORTRAIT_MOBILE)) {
+				
 				continue;
 			}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/responsive/test/ResponsiveLayoutStructureUtilTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/responsive/test/ResponsiveLayoutStructureUtilTest.java
@@ -64,6 +64,7 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -188,7 +189,9 @@ public class ResponsiveLayoutStructureUtilTest {
 				WebKeys.LAYOUT_CONTENT));
 
 		for (ViewportSize viewportSize : ViewportSize.values()) {
-			if (viewportSize.equals(ViewportSize.DESKTOP)) {
+			if (Objects.equals(viewportSize, ViewportSize.DESKTOP) ||
+				Objects.equals(viewportSize, ViewportSize.PORTRAIT_MOBILE)) {
+
 				continue;
 			}
 


### PR DESCRIPTION
Hello @victorg1991 ,
The original PR is in closed status by now leaving it without response from TS side (my colleague Roland, Pakai is on PTO), so I re-send the PR and would like to continue the discussion in this current PR. The original PR: https://github.com/liferay-echo/liferay-portal/pull/3200 

"I think this is not a bug, it is how it works by default. You can modify the number of modules that are displayed per viewport in the "styles" tab of the grid fragment"

I think what you mentioned is a feature where you can select the number of columns (modules) to display per viewport and you can even adjust the width of modules to create a more custom layout. 
Displaying the columns with this feature, is creating a layout that is not responsive at all when you shrink the screen size, for example to mobile screen. When you choose the 3 columns layout and you shrink the screen size, ideally the modules should be displayed on top of each other, so the user easily can read it. Currently, it does not seem user friendly and responsiveness is the reason why the customer opened an LPP. Responsiveness works on 7.2.x. Can you please let me know your opinion and comment on this?

LPS: https://issues.liferay.com/browse/LPS-124622
Thank you,
Orsolya












