### PR TITLE
LPS-124926 Make more robust ControlMenu bar, since when a ProductNavigationControlMenuEntry implementation fails, it takes down the whole ControlMenu bar

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-impl/src/main/java/com/liferay/product/navigation/control/menu/internal/util/ProductNavigationControlMenuEntryRegistryImpl.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-impl/src/main/java/com/liferay/product/navigation/control/menu/internal/util/ProductNavigationControlMenuEntryRegistryImpl.java
@@ -17,7 +17,6 @@ package com.liferay.product.navigation.control.menu.internal.util;
 import com.liferay.osgi.service.tracker.collections.ServiceTrackerMapBuilder;
 import com.liferay.osgi.service.tracker.collections.map.PropertyServiceReferenceComparator;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
-import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -84,8 +83,10 @@ public class ProductNavigationControlMenuEntryRegistryImpl
 					return productNavigationControlMenuEntry.isShow(
 						httpServletRequest);
 				}
-				catch (PortalException portalException) {
-					_log.error(portalException, portalException);
+				catch (Exception exception) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(exception, exception);
+					}
 				}
 
 				return false;


### PR DESCRIPTION
forward