### PR TITLE
[TS] LPS-124827 Replace content references recursively inside editableValues

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/FragmentEntryLinkExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/FragmentEntryLinkExportImportContentProcessor.java
@@ -191,6 +191,62 @@ public class FragmentEntryLinkExportImportContentProcessor
 		}
 	}
 
+	private void _replaceAllEditableExportContentReferences(
+			JSONObject editableValuesJSONObject,
+			boolean exportReferencedContent,
+			PortletDataContext portletDataContext, StagedModel stagedModel)
+		throws Exception {
+
+		if ((editableValuesJSONObject == null) ||
+			(editableValuesJSONObject.length() <= 0)) {
+
+			return;
+		}
+
+		_replaceMappedFieldExportContentReferences(
+			portletDataContext, stagedModel, editableValuesJSONObject,
+			exportReferencedContent);
+
+		Iterator<String> editableKeysIterator = editableValuesJSONObject.keys();
+
+		while (editableKeysIterator.hasNext()) {
+			String editableKey = editableKeysIterator.next();
+
+			JSONObject editableJSONObject =
+				editableValuesJSONObject.getJSONObject(editableKey);
+
+			_replaceAllEditableExportContentReferences(
+				editableJSONObject, exportReferencedContent, portletDataContext,
+				stagedModel);
+		}
+	}
+
+	private void _replaceAllEditableImportContentReferences(
+		JSONObject editableValuesJSONObject,
+		PortletDataContext portletDataContext) {
+
+		if ((editableValuesJSONObject == null) ||
+			(editableValuesJSONObject.length() <= 0)) {
+
+			return;
+		}
+
+		_replaceMappedFieldImportContentReferences(
+			portletDataContext, editableValuesJSONObject);
+
+		Iterator<String> editableKeysIterator = editableValuesJSONObject.keys();
+
+		while (editableKeysIterator.hasNext()) {
+			String editableKey = editableKeysIterator.next();
+
+			JSONObject editableJSONObject =
+				editableValuesJSONObject.getJSONObject(editableKey);
+
+			_replaceAllEditableImportContentReferences(
+				editableJSONObject, portletDataContext);
+		}
+	}
+
 	private void _replaceConfigurationExportContentReferences(
 			JSONObject editableValuesJSONObject,
 			boolean exportReferencedContent,
@@ -265,25 +321,9 @@ public class FragmentEntryLinkExportImportContentProcessor
 			editableValuesJSONObject.getJSONObject(
 				_KEY_EDITABLE_FRAGMENT_ENTRY_PROCESSOR);
 
-		if ((editableProcessorJSONObject == null) ||
-			(editableProcessorJSONObject.length() <= 0)) {
-
-			return;
-		}
-
-		Iterator<String> editableKeysIterator =
-			editableProcessorJSONObject.keys();
-
-		while (editableKeysIterator.hasNext()) {
-			String editableKey = editableKeysIterator.next();
-
-			JSONObject editableJSONObject =
-				editableProcessorJSONObject.getJSONObject(editableKey);
-
-			_replaceMappedFieldExportContentReferences(
-				portletDataContext, stagedModel, editableJSONObject,
-				exportReferencedContent);
-		}
+		_replaceAllEditableExportContentReferences(
+			editableProcessorJSONObject, exportReferencedContent,
+			portletDataContext, stagedModel);
 	}
 
 	private void _replaceEditableImportContentReferences(
@@ -294,24 +334,8 @@ public class FragmentEntryLinkExportImportContentProcessor
 			editableValuesJSONObject.getJSONObject(
 				_KEY_EDITABLE_FRAGMENT_ENTRY_PROCESSOR);
 
-		if ((editableProcessorJSONObject == null) ||
-			(editableProcessorJSONObject.length() <= 0)) {
-
-			return;
-		}
-
-		Iterator<String> editableKeysIterator =
-			editableProcessorJSONObject.keys();
-
-		while (editableKeysIterator.hasNext()) {
-			String editableKey = editableKeysIterator.next();
-
-			JSONObject editableJSONObject =
-				editableProcessorJSONObject.getJSONObject(editableKey);
-
-			_replaceMappedFieldImportContentReferences(
-				portletDataContext, editableJSONObject);
-		}
+		_replaceAllEditableImportContentReferences(
+			editableProcessorJSONObject, portletDataContext);
 	}
 
 	private void _replaceMappedFieldExportContentReferences(


### PR DESCRIPTION
Hi @liferay-echo team,

To fix the case of [LPS-124827](https://issues.liferay.com/browse/LPS-124827), I've implemented a recursive solution: it will replace all content references inside the JSON content of `editableValues`, under the `"EditableFragmentEntryProcessor"` nodes.

In this case, the actual content reference is stored under `"config"` / `"en_US"` node, while the original implementation only looked at the `"03-link"` node
```
{
	"com.liferay.fragment.entry.processor.background.image.BackgroundImageFragmentEntryProcessor":{"banner-center":{}},
	"com.liferay.fragment.entry.processor.editable.EditableFragmentEntryProcessor":{
		"02-subtitle":{"defaultValue":"...This is a simple banner component...","config":{}},
		"01-title":{"defaultValue":"\n\t\t\t\t\tBanner Title Example\n\t\t\t\t","config":{}},
		"03-link":{
			"defaultValue":"\n\t\t\t\t\tGo Somewhere\n\t\t\t\t",
			"config":{
				"en_US":{
					"className":"com.liferay.journal.model.JournalArticle","classNameId":"20133","classPK":"39543","fieldId":"title"
				}
			}
		}
	},
	"com.liferay.fragment.entry.processor.freemarker.FreeMarkerFragmentEntryProcessor":{}
}
```

My guess was that every single fragment implementation can store their references under arbitrary nodes.

Please review my changes.

Thanks,
Vendel