### PR TITLE
LPS-125552 Use window state pop_up so that only the content renders

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/util/LayoutCrawler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/util/LayoutCrawler.java
@@ -76,8 +76,13 @@ public class LayoutCrawler {
 			themeDisplay.setServerPort(_portal.getPortalServerPort(false));
 			themeDisplay.setSiteGroupId(layout.getGroupId());
 
-			HttpGet httpGet = new HttpGet(
-				_portal.getLayoutFullURL(layout, themeDisplay));
+			String layoutURL = _portal.getLayoutFullURL(layout, themeDisplay);
+
+			if (layout.isTypeContent()) {
+				layoutURL += "?p_p_state=pop_up";
+			}
+
+			HttpGet httpGet = new HttpGet(layoutURL);
 
 			HttpClientContext httpClientContext = new HttpClientContext();
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-125552

I wasn't sure if `p_p_state=pop_up` working the way it does with content pages is a bug, but it resolves the search issue. Please let me know if there are any questions.