### PR TITLE
[TS] LPS-124329 | Unable to reset to default display page after setting Layout display page

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -174,9 +174,7 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 		String layoutUuid = ParamUtil.getString(
 			uploadPortletRequest, "layoutUuid");
 
-		if ((displayPageType == AssetDisplayPageConstants.TYPE_DEFAULT) ||
-			(displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC)) {
-
+		if (displayPageType == AssetDisplayPageConstants.TYPE_SPECIFIC) {
 			Layout targetLayout = _journalHelper.getArticleLayout(
 				layoutUuid, groupId);
 


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?

https://issues.liferay.com/browse/LPS-124329

After [LPS-91475](https://github.com/brianchandotcom/liferay-portal/pull/71209/commits/baa1ec81718dd6db7e8489a049c573724d1c9d5b) removed the AssetDisplayPage related part for me this condition seems to be unnecessary. The condition causes a bug where the layoutUuid is kept even after changing the display template from a playout to the default display template. 

Can I get a second opinion related to this change while doing the review?


Best,
Attila