### PR TITLE
LPS-125765

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/application/list/AssetListPanelApp.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/application/list/AssetListPanelApp.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.staging.StagingGroupHelper;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -49,12 +48,6 @@ public class AssetListPanelApp extends BasePanelApp {
 	public boolean isShow(PermissionChecker permissionChecker, Group group)
 		throws PortalException {
 
-		if (_stagingGroupHelper.isLocalLiveGroup(group) ||
-			_stagingGroupHelper.isRemoteLiveGroup(group)) {
-
-			return false;
-		}
-
 		return super.isShow(permissionChecker, group);
 	}
 
@@ -66,8 +59,5 @@ public class AssetListPanelApp extends BasePanelApp {
 	public void setPortlet(Portlet portlet) {
 		super.setPortlet(portlet);
 	}
-
-	@Reference
-	private StagingGroupHelper _stagingGroupHelper;
 
 }

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListDisplayContext.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -47,6 +48,8 @@ import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.constants.SegmentsEntryConstants;
+import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
 
 import java.util.List;
 
@@ -367,6 +370,22 @@ public class AssetListDisplayContext {
 	}
 
 	public boolean isShowAddAssetListEntryAction() {
+		Group group = _themeDisplay.getScopeGroup();
+
+		if (group.isLayout()) {
+			group = group.getParentGroup();
+		}
+
+		StagingGroupHelper stagingGroupHelper =
+			StagingGroupHelperUtil.getStagingGroupHelper();
+
+		if (stagingGroupHelper.isLiveGroup(group) &&
+			stagingGroupHelper.isStagedPortlet(
+				group, AssetListPortletKeys.ASSET_LIST)) {
+
+			return false;
+		}
+
 		return AssetListPermission.contains(
 			_themeDisplay.getPermissionChecker(),
 			_themeDisplay.getScopeGroupId(),

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -84,6 +84,8 @@ import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.service.SegmentsEntryLocalServiceUtil;
 import com.liferay.segments.service.SegmentsEntryServiceUtil;
+import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -987,6 +989,34 @@ public class EditAssetListDisplayContext {
 		return GetterUtil.getBoolean(anyAssetType, true);
 	}
 
+	public boolean isLiveGroup() {
+		if (_liveGroup != null) {
+			return _liveGroup;
+		}
+
+		Group group = _themeDisplay.getScopeGroup();
+
+		if (group.isLayout()) {
+			group = group.getParentGroup();
+		}
+
+		StagingGroupHelper stagingGroupHelper =
+			StagingGroupHelperUtil.getStagingGroupHelper();
+
+		if (stagingGroupHelper.isLiveGroup(group) &&
+			stagingGroupHelper.isStagedPortlet(
+				group, AssetListPortletKeys.ASSET_LIST)) {
+
+			_liveGroup = true;
+
+			return _liveGroup;
+		}
+
+		_liveGroup = false;
+
+		return _liveGroup;
+	}
+
 	public Boolean isNoAssetTypeSelected() {
 		String anyAssetType = _unicodeProperties.getProperty("anyAssetType");
 
@@ -1211,6 +1241,7 @@ public class EditAssetListDisplayContext {
 	private String _ddmStructureFieldValue;
 	private final HttpServletRequest _httpServletRequest;
 	private final ItemSelector _itemSelector;
+	private Boolean _liveGroup;
 	private String _orderByColumn1;
 	private String _orderByColumn2;
 	private String _orderByType1;

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/AssetListControlPanelEntry.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/AssetListControlPanelEntry.java
@@ -20,10 +20,8 @@ import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.BaseControlPanelEntry;
 import com.liferay.portal.kernel.portlet.ControlPanelEntry;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
-import com.liferay.staging.StagingGroupHelper;
 
 import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Jürgen Kappler
@@ -40,17 +38,8 @@ public class AssetListControlPanelEntry extends BaseControlPanelEntry {
 			PermissionChecker permissionChecker, Group group, Portlet portlet)
 		throws Exception {
 
-		if (_stagingGroupHelper.isLocalLiveGroup(group) ||
-			_stagingGroupHelper.isRemoteLiveGroup(group)) {
-
-			return false;
-		}
-
 		return super.hasAccessPermissionDenied(
 			permissionChecker, group, portlet);
 	}
-
-	@Reference
-	private StagingGroupHelper _stagingGroupHelper;
 
 }

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/filter.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/filter.jsp
@@ -17,7 +17,9 @@
 <%@ include file="/init.jsp" %>
 
 <liferay-frontend:fieldset-group>
-	<liferay-frontend:fieldset>
+	<liferay-frontend:fieldset
+		disabled="<%= editAssetListDisplayContext.isLiveGroup() %>"
+	>
 		<liferay-asset:asset-tags-error />
 
 		<liferay-ui:error exception="<%= DuplicateQueryRuleException.class %>">
@@ -54,6 +56,8 @@
 				props='<%=
 					HashMapBuilder.<String, Object>put(
 						"categorySelectorURL", editAssetListDisplayContext.getCategorySelectorURL()
+					).put(
+						"disabled", editAssetListDisplayContext.isLiveGroup()
 					).put(
 						"groupIds", ListUtil.toList(editAssetListDisplayContext.getReferencedModelsGroupIds())
 					).put(

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/ordering.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/ordering.jsp
@@ -17,7 +17,9 @@
 <%@ include file="/init.jsp" %>
 
 <liferay-frontend:fieldset-group>
-	<liferay-frontend:fieldset>
+	<liferay-frontend:fieldset
+		disabled="<%= editAssetListDisplayContext.isLiveGroup() %>"
+	>
 		<clay:row
 			id='<%= liferayPortletResponse.getNamespace() + "ordering" %>'
 		>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/scope.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/scope.jsp
@@ -59,9 +59,11 @@ List<Group> selectedGroups = editAssetListDisplayContext.getSelectedGroups();
 			value="<%= LanguageUtil.get(request, group.getScopeLabel(themeDisplay)) %>"
 		/>
 
-		<liferay-ui:search-container-column-text>
-			<a class="modify-link" data-rowId="<%= group.getGroupId() %>" href="javascript:;"><%= removeLinkIcon %></a>
-		</liferay-ui:search-container-column-text>
+		<c:if test="<%= !editAssetListDisplayContext.isLiveGroup() %>">
+			<liferay-ui:search-container-column-text>
+				<a class="modify-link" data-rowId="<%= group.getGroupId() %>" href="javascript:;"><%= removeLinkIcon %></a>
+			</liferay-ui:search-container-column-text>
+		</c:if>
 	</liferay-ui:search-container-row>
 
 	<liferay-ui:search-iterator
@@ -70,41 +72,43 @@ List<Group> selectedGroups = editAssetListDisplayContext.getSelectedGroups();
 	/>
 </liferay-ui:search-container>
 
-<liferay-ui:icon-menu
-	cssClass="select-existing-selector"
-	direction="right"
-	message="select"
-	showArrow="<%= false %>"
-	showWhenSingleIcon="<%= true %>"
->
+<c:if test="<%= !editAssetListDisplayContext.isLiveGroup() %>">
+	<liferay-ui:icon-menu
+		cssClass="select-existing-selector"
+		direction="right"
+		message="select"
+		showArrow="<%= false %>"
+		showWhenSingleIcon="<%= true %>"
+	>
 
-	<%
-	for (Group group : editAssetListDisplayContext.getAvailableGroups()) {
-		if (selectedGroups.contains(group)) {
-			continue;
+		<%
+		for (Group group : editAssetListDisplayContext.getAvailableGroups()) {
+			if (selectedGroups.contains(group)) {
+				continue;
+			}
+
+			String taglibOnClick = liferayPortletResponse.getNamespace() + "addRow('" + group.getGroupId() + "', '" + HtmlUtil.escapeJS(HtmlUtil.escape(group.getDescriptiveName(themeDisplay.getLocale()))) + "', '" + LanguageUtil.get(request, group.getScopeLabel(themeDisplay)) + "');";
+		%>
+
+			<liferay-ui:icon
+				message="<%= group.getScopeDescriptiveName(themeDisplay) %>"
+				onClick="<%= taglibOnClick %>"
+				url="javascript:;"
+			/>
+
+		<%
 		}
-
-		String taglibOnClick = liferayPortletResponse.getNamespace() + "addRow('" + group.getGroupId() + "', '" + HtmlUtil.escapeJS(HtmlUtil.escape(group.getDescriptiveName(themeDisplay.getLocale()))) + "', '" + LanguageUtil.get(request, group.getScopeLabel(themeDisplay)) + "');";
-	%>
+		%>
 
 		<liferay-ui:icon
-			message="<%= group.getScopeDescriptiveName(themeDisplay) %>"
-			onClick="<%= taglibOnClick %>"
+			cssClass="highlited scope-selector"
+			id="selectManageableGroup"
+			message='<%= LanguageUtil.get(request, "other-site-or-asset-library") + StringPool.TRIPLE_PERIOD %>'
+			method="get"
 			url="javascript:;"
 		/>
-
-	<%
-	}
-	%>
-
-	<liferay-ui:icon
-		cssClass="highlited scope-selector"
-		id="selectManageableGroup"
-		message='<%= LanguageUtil.get(request, "other-site-or-asset-library") + StringPool.TRIPLE_PERIOD %>'
-		method="get"
-		url="javascript:;"
-	/>
-</liferay-ui:icon-menu>
+	</liferay-ui:icon-menu>
+</c:if>
 
 <aui:script use="liferay-search-container">
 	var searchContainer = Liferay.SearchContainer.get(

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -23,6 +23,7 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = new ArrayList<>
 <liferay-frontend:fieldset-group>
 	<liferay-frontend:fieldset
 		cssClass="source-container"
+		disabled="<%= editAssetListDisplayContext.isLiveGroup() %>"
 	>
 
 		<%

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list_entry_variation_action.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list_entry_variation_action.jsp
@@ -38,7 +38,7 @@
 		useDialog="<%= true %>"
 	/>
 
-	<c:if test="<%= editAssetListDisplayContext.getSegmentsEntryId() != SegmentsEntryConstants.ID_DEFAULT %>">
+	<c:if test="<%= (editAssetListDisplayContext.getSegmentsEntryId() != SegmentsEntryConstants.ID_DEFAULT) && !editAssetListDisplayContext.isLiveGroup() %>">
 		<portlet:actionURL name="/asset_list/delete_asset_list_entry_variation" var="deleteAssetListEntryVariationURL">
 			<portlet:param name="assetListEntryId" value="<%= String.valueOf(editAssetListDisplayContext.getAssetListEntryId()) %>" />
 			<portlet:param name="segmentsEntryId" value="<%= String.valueOf(editAssetListDisplayContext.getSegmentsEntryId()) %>" />

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/auto_field/index.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/auto_field/index.js
@@ -138,6 +138,7 @@ function Keywords({index, namespace, onChange, rule}) {
 
 function Rule({
 	categorySelectorURL,
+	disabled,
 	groupIds,
 	index,
 	namespace,
@@ -234,23 +235,26 @@ function Rule({
 				</div>
 			</div>
 
-			<div className="container-trash">
-				<ClayButton
-					className="condition-card-delete"
-					data-index={index}
-					monospaced
-					onClick={onDeleteRule}
-					small
-				>
-					<ClayIcon symbol="trash" />
-				</ClayButton>
-			</div>
+			{!disabled && (
+				<div className="container-trash">
+					<ClayButton
+						className="condition-card-delete"
+						data-index={index}
+						monospaced
+						onClick={onDeleteRule}
+						small
+					>
+						<ClayIcon symbol="trash" />
+					</ClayButton>
+				</div>
+			)}
 		</>
 	);
 }
 
 function AutoField({
 	categorySelectorURL,
+	disabled,
 	groupIds,
 	namespace,
 	rules,
@@ -319,6 +323,7 @@ function AutoField({
 					<li className="timeline-item" key={index}>
 						<Rule
 							categorySelectorURL={categorySelectorURL}
+							disabled={disabled}
 							groupIds={groupIds}
 							index={index}
 							namespace={namespace}
@@ -332,18 +337,20 @@ function AutoField({
 				))}
 			</ul>
 
-			<div className="addbutton-timeline-item">
-				<div className="add-condition timeline-increment-icon">
-					<ClayButton
-						className="form-builder-rule-add-condition form-builder-timeline-add-item"
-						monospaced
-						onClick={handleAddRule}
-						small
-					>
-						<ClayIcon symbol="plus" />
-					</ClayButton>
+			{!disabled && (
+				<div className="addbutton-timeline-item">
+					<div className="add-condition timeline-increment-icon">
+						<ClayButton
+							className="form-builder-rule-add-condition form-builder-timeline-add-item"
+							monospaced
+							onClick={handleAddRule}
+							small
+						>
+							<ClayIcon symbol="plus" />
+						</ClayButton>
+					</div>
 				</div>
-			</div>
+			)}
 		</>
 	);
 }

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -118,7 +118,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 								</p>
 
 								<liferay-frontend:empty-result-message
-									actionDropdownItems="<%= ((availableSegmentsEntries.size() > 0) && Validator.isNotNull(assetListEntry.getAssetEntryType())) ? editAssetListDisplayContext.getAssetListEntryVariationActionDropdownItems() : null %>"
+									actionDropdownItems="<%= ((availableSegmentsEntries.size() > 0) && Validator.isNotNull(assetListEntry.getAssetEntryType()) && !editAssetListDisplayContext.isLiveGroup()) ? editAssetListDisplayContext.getAssetListEntryVariationActionDropdownItems() : null %>"
 									animationType="<%= EmptyResultMessageKeys.AnimationType.NONE %>"
 									componentId='<%= liferayPortletResponse.getNamespace() + "emptyResultMessageComponent" %>'
 									description='<%= LanguageUtil.get(request, "no-personalized-variations-were-found") %>'

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_dynamic.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_dynamic.jsp
@@ -78,9 +78,11 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 		/>
 	</liferay-frontend:edit-form-body>
 
-	<liferay-frontend:edit-form-footer>
-		<aui:button disabled="<%= editAssetListDisplayContext.isNoAssetTypeSelected() %>" id="saveButton" onClick='<%= liferayPortletResponse.getNamespace() + "saveSelectBoxes();" %>' type="submit" />
+	<c:if test="<%= !editAssetListDisplayContext.isLiveGroup() %>">
+		<liferay-frontend:edit-form-footer>
+			<aui:button disabled="<%= editAssetListDisplayContext.isNoAssetTypeSelected() %>" id="saveButton" onClick='<%= liferayPortletResponse.getNamespace() + "saveSelectBoxes();" %>' type="submit" />
 
-		<aui:button href="<%= backURL %>" type="cancel" />
-	</liferay-frontend:edit-form-footer>
+			<aui:button href="<%= backURL %>" type="cancel" />
+		</liferay-frontend:edit-form-footer>
+	</c:if>
 </liferay-frontend:edit-form>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
@@ -55,11 +55,13 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 				<liferay-util:include page="/asset_list/source.jsp" servletContext="<%= application %>" />
 			</liferay-frontend:edit-form-body>
 
-			<liferay-frontend:edit-form-footer>
-				<aui:button disabled="<%= editAssetListDisplayContext.isNoAssetTypeSelected() %>" id="saveButton" onClick='<%= liferayPortletResponse.getNamespace() + "saveSelectBoxes();" %>' type="submit" />
+			<c:if test="<%= !editAssetListDisplayContext.isLiveGroup() %>">
+				<liferay-frontend:edit-form-footer>
+					<aui:button disabled="<%= editAssetListDisplayContext.isNoAssetTypeSelected() %>" id="saveButton" onClick='<%= liferayPortletResponse.getNamespace() + "saveSelectBoxes();" %>' type="submit" />
 
-				<aui:button href="<%= backURL %>" type="cancel" />
-			</liferay-frontend:edit-form-footer>
+					<aui:button href="<%= backURL %>" type="cancel" />
+				</liferay-frontend:edit-form-footer>
+			</c:if>
 		</liferay-frontend:edit-form>
 	</c:when>
 	<c:otherwise>
@@ -107,37 +109,39 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 					</span>
 						</clay:content-col>
 
-						<clay:content-col
-							containerElement="span"
-						>
-							<liferay-ui:icon-menu
-								direction="right"
-								message="select"
-								showArrow="<%= false %>"
-								showWhenSingleIcon="<%= true %>"
-								triggerCssClass="btn-sm"
+						<c:if test="<%= !editAssetListDisplayContext.isLiveGroup() %>">
+							<clay:content-col
+								containerElement="span"
 							>
+								<liferay-ui:icon-menu
+									direction="right"
+									message="select"
+									showArrow="<%= false %>"
+									showWhenSingleIcon="<%= true %>"
+									triggerCssClass="btn-sm"
+								>
 
-								<%
-								Map<String, Map<String, Object>> manualAddIconDataMap = editAssetListDisplayContext.getManualAddIconDataMap();
+									<%
+									Map<String, Map<String, Object>> manualAddIconDataMap = editAssetListDisplayContext.getManualAddIconDataMap();
 
-								for (Map.Entry<String, Map<String, Object>> entry : manualAddIconDataMap.entrySet()) {
-								%>
+									for (Map.Entry<String, Map<String, Object>> entry : manualAddIconDataMap.entrySet()) {
+									%>
 
-								<liferay-ui:icon
-									cssClass="asset-selector"
-									data="<%= entry.getValue() %>"
-									id="<%= themeDisplay.getScopeGroupId() + HtmlUtil.getAUICompatibleId(entry.getKey()) %>"
-									message="<%= HtmlUtil.escape(entry.getKey()) %>"
-									url="javascript:;"
-								/>
+									<liferay-ui:icon
+										cssClass="asset-selector"
+										data="<%= entry.getValue() %>"
+										id="<%= themeDisplay.getScopeGroupId() + HtmlUtil.getAUICompatibleId(entry.getKey()) %>"
+										message="<%= HtmlUtil.escape(entry.getKey()) %>"
+										url="javascript:;"
+									/>
 
-								<%
-								}
-								%>
+									<%
+									}
+									%>
 
-							</liferay-ui:icon-menu>
-						</clay:content-col>
+								</liferay-ui:icon-menu>
+							</clay:content-col>
+						</c:if>
 					</clay:content-row>
 				</h3>
 
@@ -189,17 +193,19 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 							value="<%= assetEntry.getModifiedDate() %>"
 						/>
 
-						<liferay-ui:search-container-column-jsp
-							path="/asset_list/asset_selection_order_up_action.jsp"
-						/>
+						<c:if test="<%= !editAssetListDisplayContext.isLiveGroup() %>">
+							<liferay-ui:search-container-column-jsp
+								path="/asset_list/asset_selection_order_up_action.jsp"
+							/>
 
-						<liferay-ui:search-container-column-jsp
-							path="/asset_list/asset_selection_order_down_action.jsp"
-						/>
+							<liferay-ui:search-container-column-jsp
+								path="/asset_list/asset_selection_order_down_action.jsp"
+							/>
 
-						<liferay-ui:search-container-column-jsp
-							path="/asset_list/asset_selection_action.jsp"
-						/>
+							<liferay-ui:search-container-column-jsp
+								path="/asset_list/asset_selection_action.jsp"
+							/>
+						</c:if>
 					</liferay-ui:search-container-row>
 
 					<liferay-ui:search-iterator

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view.jsp
@@ -53,7 +53,7 @@ AssetListManagementToolbarDisplayContext assetListManagementToolbarDisplayContex
 					<%
 					String editURL = StringPool.BLANK;
 
-					if (AssetListEntryPermission.contains(permissionChecker, assetListEntry, ActionKeys.UPDATE)) {
+					if (AssetListEntryPermission.contains(permissionChecker, assetListEntry, ActionKeys.VIEW) || AssetListEntryPermission.contains(permissionChecker, assetListEntry, ActionKeys.UPDATE)) {
 						PortletURL editAssetListEntryURL = liferayPortletResponse.createRenderURL();
 
 						editAssetListEntryURL.setParameter("mvcPath", "/edit_asset_list_entry.jsp");

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/FieldsetTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/FieldsetTag.java
@@ -68,6 +68,10 @@ public class FieldsetTag extends IncludeTag {
 		return _column;
 	}
 
+	public boolean isDisabled() {
+		return _disabled;
+	}
+
 	public boolean isLocalizeLabel() {
 		return _localizeLabel;
 	}
@@ -86,6 +90,10 @@ public class FieldsetTag extends IncludeTag {
 
 	public void setCssClass(String cssClass) {
 		_cssClass = cssClass;
+	}
+
+	public void setDisabled(boolean disabled) {
+		_disabled = disabled;
 	}
 
 	public void setHelpMessage(String helpMessage) {
@@ -119,6 +127,7 @@ public class FieldsetTag extends IncludeTag {
 		_collapsible = false;
 		_column = false;
 		_cssClass = null;
+		_disabled = false;
 		_helpMessage = null;
 		_id = null;
 		_label = null;
@@ -162,6 +171,8 @@ public class FieldsetTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-frontend:fieldset:cssClass", _cssClass);
 		httpServletRequest.setAttribute(
+			"liferay-frontend:fieldset:disabled", String.valueOf(_disabled));
+		httpServletRequest.setAttribute(
 			"liferay-frontend:fieldset:helpMessage", _helpMessage);
 		httpServletRequest.setAttribute("liferay-frontend:fieldset:id", _id);
 		httpServletRequest.setAttribute(
@@ -199,6 +210,7 @@ public class FieldsetTag extends IncludeTag {
 	private boolean _collapsible;
 	private boolean _column;
 	private String _cssClass;
+	private boolean _disabled;
 	private String _helpMessage;
 	private String _id;
 	private String _label;

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/liferay-frontend.tld
@@ -437,6 +437,12 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>disabled</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+			<type>boolean</type>
+		</attribute>
+		<attribute>
 			<description>Text to display as a help tooltip when mousing over the component's help icon.</description>
 			<name>helpMessage</name>
 			<required>false</required>

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/init.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/init.jsp
@@ -24,6 +24,7 @@ boolean collapsed = GetterUtil.getBoolean(String.valueOf(request.getAttribute("l
 boolean collapsible = GetterUtil.getBoolean(String.valueOf(request.getAttribute("liferay-frontend:fieldset:collapsible")));
 boolean column = GetterUtil.getBoolean(String.valueOf(request.getAttribute("liferay-frontend:fieldset:column")));
 String cssClass = GetterUtil.getString((java.lang.String)request.getAttribute("liferay-frontend:fieldset:cssClass"));
+boolean disabled = GetterUtil.getBoolean(String.valueOf(request.getAttribute("liferay-frontend:fieldset:disabled")));
 String helpMessage = GetterUtil.getString((java.lang.String)request.getAttribute("liferay-frontend:fieldset:helpMessage"));
 String id = GetterUtil.getString((java.lang.String)request.getAttribute("liferay-frontend:fieldset:id"));
 String label = GetterUtil.getString((java.lang.String)request.getAttribute("liferay-frontend:fieldset:label"));

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/fieldset/start.jsp
@@ -28,7 +28,7 @@ else if (collapsible) {
 }
 %>
 
-<fieldset aria-labelledby="<%= id %>Title" class="<%= collapsible ? "panel" : StringPool.BLANK %> <%= cssClass %>" <%= Validator.isNotNull(id) ? "id=\"" + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> role="group">
+<fieldset aria-labelledby="<%= id %>Title" class="<%= collapsible ? "panel" : StringPool.BLANK %> <%= cssClass %>" <%= disabled ? "disabled" : StringPool.BLANK %> <%= Validator.isNotNull(id) ? "id=\"" + id + "\"" : StringPool.BLANK %> <%= InlineUtil.buildDynamicAttributes(dynamicAttributes) %> role="group">
 	<c:if test="<%= Validator.isNotNull(label) %>">
 		<liferay-util:buffer
 			var="header"


### PR DESCRIPTION
Hello,

https://issues.liferay.com/browse/LPS-125765

The goal of this ticket is to show Collections / Content Sets on the Live site. This is done by removing the logic put in place by LPS-87470 in order to display the portlet in the menu as well as disable addition, edition, and all fields when viewing.

https://github.com/liferay-echo/liferay-portal/commit/fd8f47a5480ba808dcff5462ed7b40021cd5d8ac - This update to the taglib allows us to conditionally set whether or not a fieldset is disabled. The HTML tag only requires `disabled` to be present in the tag for it to be disabled so we needed a layer on top of that to exclude the keyword when necessary.

https://github.com/liferay-echo/liferay-portal/pull/3438/commits/5b6f9b19cb312f40d5cf32e7a99a2573e788a5bd - This reverts LPS-87470 and adds additional logic to remove action buttons and menus.

https://github.com/liferay-echo/liferay-portal/pull/3438/commits/4ad7e598a309f61e7072f2d13bb6f355cc5c9c89 - This uses the new taglib to disable the fields when viewing a Collection on a live site.

Please let me know your thoughts on these changes. If this is not how you would like to approach the solution I'd be happy to rework it. Additionally, if this isn't something the team wants or would rather inspect it more carefully as a Feature Request for 7.4 that is fine as well.

Thank you for your time.