### PR TITLE
LPS-91391 Add button role and tabIndex attributes to existing VerticalCards

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/CollectionProvidersVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/CollectionProvidersVerticalCard.java
@@ -109,6 +109,9 @@ public class CollectionProvidersVerticalCard extends BaseVerticalCard {
 			}
 		}
 
+		data.put("role", "button");
+		data.put("tabIndex", "0");
+
 		return data;
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/CollectionsVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/CollectionsVerticalCard.java
@@ -114,6 +114,9 @@ public class CollectionsVerticalCard extends BaseVerticalCard {
 			}
 		}
 
+		data.put("role", "button");
+		data.put("tabIndex", "0");
+
 		return data;
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/DefaultStylebookLayoutVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/DefaultStylebookLayoutVerticalCard.java
@@ -58,6 +58,10 @@ public class DefaultStylebookLayoutVerticalCard implements VerticalCard {
 			"data-name", _name
 		).put(
 			"data-styleBookEntryId", "0"
+		).put(
+			"role", "button"
+		).put(
+			"tabIndex", "0"
 		).build();
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectBasicTemplatesVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectBasicTemplatesVerticalCard.java
@@ -89,6 +89,9 @@ public class SelectBasicTemplatesVerticalCard implements VerticalCard {
 		catch (Exception exception) {
 		}
 
+		data.put("role", "button");
+		data.put("tabIndex", "0");
+
 		return data;
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectGlobalTemplatesVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectGlobalTemplatesVerticalCard.java
@@ -86,6 +86,9 @@ public class SelectGlobalTemplatesVerticalCard implements VerticalCard {
 		catch (Exception exception) {
 		}
 
+		data.put("role", "button");
+		data.put("tabIndex", "0");
+
 		return data;
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectLayoutMasterLayoutVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectLayoutMasterLayoutVerticalCard.java
@@ -106,6 +106,9 @@ public class SelectLayoutMasterLayoutVerticalCard implements VerticalCard {
 		catch (Exception exception) {
 		}
 
+		data.put("role", "button");
+		data.put("tabIndex", "0");
+
 		return data;
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectLayoutPageTemplateEntryVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectLayoutPageTemplateEntryVerticalCard.java
@@ -94,6 +94,9 @@ public class SelectLayoutPageTemplateEntryVerticalCard implements VerticalCard {
 		catch (Exception exception) {
 		}
 
+		data.put("role", "button");
+		data.put("tabIndex", "0");
+
 		return data;
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectMasterLayoutVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectMasterLayoutVerticalCard.java
@@ -51,6 +51,10 @@ public class SelectMasterLayoutVerticalCard implements VerticalCard {
 			"data-name", _layoutPageTemplateEntry.getName()
 		).put(
 			"data-plid", String.valueOf(_layoutPageTemplateEntry.getPlid())
+		).put(
+			"role", "button"
+		).put(
+			"tabIndex", "0"
 		).build();
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectStylebookLayoutVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectStylebookLayoutVerticalCard.java
@@ -51,6 +51,10 @@ public class SelectStylebookLayoutVerticalCard implements VerticalCard {
 		).put(
 			"data-styleBookEntryId",
 			String.valueOf(_styleBookEntry.getStyleBookEntryId())
+		).put(
+			"role", "button"
+		).put(
+			"tabIndex", "0"
 		).build();
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectThemeVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/clay/SelectThemeVerticalCard.java
@@ -50,6 +50,10 @@ public class SelectThemeVerticalCard implements VerticalCard {
 	public Map<String, String> getDynamicAttributes() {
 		return HashMapBuilder.put(
 			"data-themeid", _theme.getThemeId()
+		).put(
+			"role", "button"
+		).put(
+			"tabIndex", "0"
 		).build();
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_page_template_entry.jsp
@@ -184,8 +184,21 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 		}
 	);
 
+	var addLayoutActionOptionQueryKeyDownHandler = delegate(
+		layoutPageTemplateEntries,
+		'keydown',
+		'.add-layout-action-option',
+		function (event) {
+			if (event.code === 'Space' || event.code === 'Enter') {
+				event.preventDefault();
+				event.delegateTarget.click();
+			}
+		}
+	);
+
 	function handleDestroyPortlet() {
 		addLayoutActionOptionQueryClickHandler.dispose();
+		addLayoutActionOptionQueryKeyDownHandler.dispose();
 
 		Liferay.detach('destroyPortlet', handleDestroyPortlet);
 	}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/SelectDisplayPageMasterLayoutVerticalCardPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/SelectDisplayPageMasterLayoutVerticalCardPropsTransformer.js
@@ -32,5 +32,16 @@ export default function SelectDisplayPageMasterLayoutVerticalCardPropsTransforme
 				title,
 			});
 		},
+		onKeyDown: (event) => {
+			if (
+				event.nativeEvent.code === 'Enter' ||
+				event.nativeEvent.code === 'Space'
+			) {
+				event.preventDefault();
+				event.target.click();
+			}
+		},
+		role: 'button',
+		tabIndex: '0',
 	};
 }

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/SelectLayoutPageTemplateEntryMasterLayoutVerticalCardPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/SelectLayoutPageTemplateEntryMasterLayoutVerticalCardPropsTransformer.js
@@ -41,5 +41,16 @@ export default function SelectLayoutPageTemplateEntryMasterLayoutVerticalCardPro
 					'<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg',
 			});
 		},
+		onKeyDown: (event) => {
+			if (
+				event.nativeEvent.code === 'Enter' ||
+				event.nativeEvent.code === 'Space'
+			) {
+				event.preventDefault();
+				event.target.click();
+			}
+		},
+		role: 'button',
+		tabIndex: '0',
 	};
 }


### PR DESCRIPTION
I tried replacing this elements with a clay:navigation-card taglib, but it just uses a div with a tab-index attribute, so it's easier (and a bit more accessible) to add those attributes by ourselves.