### PR TITLE
LPS-126054 [$ASSET_ENTRIES$] associated with assets are duplicated in Asset Publisher's Email Subscription mail content | master 

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/messaging/AssetEntriesCheckerHelper.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/messaging/AssetEntriesCheckerHelper.java
@@ -63,6 +63,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import javax.portlet.PortletException;
 import javax.portlet.PortletPreferences;
@@ -128,6 +130,13 @@ public class AssetEntriesCheckerHelper {
 		if (assetEntries.isEmpty()) {
 			return;
 		}
+
+		Stream<AssetEntry> streamAssetEntries = assetEntries.stream();
+
+		assetEntries = streamAssetEntries.distinct(
+		).collect(
+			Collectors.toList()
+		);
 
 		long[] notifiedAssetEntryIds = GetterUtil.getLongValues(
 			portletPreferences.getValues("notifiedAssetEntryIds", null));


### PR DESCRIPTION
**Description:**
When user subscribes to Asset Publisher by email, it can happen that the list of the assets included in the body of the email are duplicated. This happens when an asset, i.e. web content, is updated some times and then checking of the assets for subscriptions runs.
[LPS-126054](https://issues.liferay.com/browse/LPS-126054)

**Steps to reproduce:**
1.  Setup outgoing emails in Liferay (see [LPS-104305](https://issues.liferay.com/browse/LPS-104305) to configure them)
2.  Change your Liferay user's email address so it isn't blacklisted.
3.  Add an Asset Publisher to a page.
4.  Enable the subscription in the the Asset Publisher configuration (from Display Settings - > Set and Enable).
5.  Enable Email Subscriptions from the Subcriptions configuration tab.
6.  Subscribe to the Asset Publisher.
7.  Create a web content. You can fill out only its title, i.e. 'Title 01'. Publish.
8.  Update some times the previous web content, i.e. 'Title 02' (publish), 'Title 03' (publish) and 'Title 04' (publish).
9.  Force the subscription check using following Groovy script:
   ```
 import com.liferay.registry.RegistryUtil

    try {
    	def registry = RegistryUtil.getRegistry()
    	def serviceReference = registry.getServiceReference("com.liferay.asset.publisher.web.internal.messaging.AssetEntriesCheckerHelper")
    	def assetEntriesCheckerHelper = registry.getService(serviceReference)
    	def checkEntriesMethod = assetEntriesCheckerHelper.getClass().getMethod("checkAssetEntries")

    	checkEntriesMethod.invoke(assetEntriesCheckerHelper) 
    }
    catch (Exception e) { e.printStackTrace(out) }
```

You can check the received email contains duplicated references to the web content. In our example four references:
`The following asset entries have been added to Asset Publisher: Title 04, Title 04, Title 04, Title 04. `

**Analysis:**
When the asset has some versions, the list of asset entries (entryid) recovered to be included in the email are also duplicated because of those versions of the asset (1:1).
So, removing duplicated elements of the list could resolve the issue. 

Best,
 Sergio.