### PR TITLE
LPS-125922 Add external reference code to JournalArticle

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/exception/DuplicateExternalReferenceCodeException.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/exception/DuplicateExternalReferenceCodeException.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Javier de Arcos
+ */
+public class DuplicateExternalReferenceCodeException extends PortalException {
+
+	public DuplicateExternalReferenceCodeException() {
+	}
+
+	public DuplicateExternalReferenceCodeException(String msg) {
+		super(msg);
+	}
+
+	public DuplicateExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateExternalReferenceCodeException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticle.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticle.java
@@ -76,6 +76,26 @@ public interface JournalArticle
 			}
 
 		};
+	public static final Accessor<JournalArticle, String>
+		EXTERNAL_REFERENCE_CODE_ACCESSOR =
+			new Accessor<JournalArticle, String>() {
+
+				@Override
+				public String get(JournalArticle journalArticle) {
+					return journalArticle.getExternalReferenceCode();
+				}
+
+				@Override
+				public Class<String> getAttributeClass() {
+					return String.class;
+				}
+
+				@Override
+				public Class<JournalArticle> getTypeClass() {
+					return JournalArticle.class;
+				}
+
+			};
 
 	public com.liferay.portal.kernel.repository.model.Folder addImagesFolder()
 		throws com.liferay.portal.kernel.exception.PortalException;

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleModel.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleModel.java
@@ -351,6 +351,21 @@ public interface JournalArticleModel
 	public void setArticleId(String articleId);
 
 	/**
+	 * Returns the external reference code of this journal article.
+	 *
+	 * @return the external reference code of this journal article
+	 */
+	@AutoEscape
+	public String getExternalReferenceCode();
+
+	/**
+	 * Sets the external reference code of this journal article.
+	 *
+	 * @param externalReferenceCode the external reference code of this journal article
+	 */
+	public void setExternalReferenceCode(String externalReferenceCode);
+
+	/**
 	 * Returns the version of this journal article.
 	 *
 	 * @return the version of this journal article

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleSoap.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleSoap.java
@@ -49,6 +49,7 @@ public class JournalArticleSoap implements Serializable {
 		soapModel.setClassPK(model.getClassPK());
 		soapModel.setTreePath(model.getTreePath());
 		soapModel.setArticleId(model.getArticleId());
+		soapModel.setExternalReferenceCode(model.getExternalReferenceCode());
 		soapModel.setVersion(model.getVersion());
 		soapModel.setUrlTitle(model.getUrlTitle());
 		soapModel.setContent(model.getContent());
@@ -254,6 +255,14 @@ public class JournalArticleSoap implements Serializable {
 		_articleId = articleId;
 	}
 
+	public String getExternalReferenceCode() {
+		return _externalReferenceCode;
+	}
+
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		_externalReferenceCode = externalReferenceCode;
+	}
+
 	public double getVersion() {
 		return _version;
 	}
@@ -430,6 +439,7 @@ public class JournalArticleSoap implements Serializable {
 	private long _classPK;
 	private String _treePath;
 	private String _articleId;
+	private String _externalReferenceCode;
 	private double _version;
 	private String _urlTitle;
 	private String _content;

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleTable.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleTable.java
@@ -68,6 +68,10 @@ public class JournalArticleTable extends BaseTable<JournalArticleTable> {
 		"treePath", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<JournalArticleTable, String> articleId = createColumn(
 		"articleId", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<JournalArticleTable, String> externalReferenceCode =
+		createColumn(
+			"externalReferenceCode", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
 	public final Column<JournalArticleTable, Double> version = createColumn(
 		"version", Double.class, Types.DOUBLE, Column.FLAG_DEFAULT);
 	public final Column<JournalArticleTable, String> urlTitle = createColumn(

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleWrapper.java
@@ -61,6 +61,7 @@ public class JournalArticleWrapper
 		attributes.put("classPK", getClassPK());
 		attributes.put("treePath", getTreePath());
 		attributes.put("articleId", getArticleId());
+		attributes.put("externalReferenceCode", getExternalReferenceCode());
 		attributes.put("version", getVersion());
 		attributes.put("urlTitle", getUrlTitle());
 		attributes.put("content", getContent());
@@ -180,6 +181,13 @@ public class JournalArticleWrapper
 
 		if (articleId != null) {
 			setArticleId(articleId);
+		}
+
+		String externalReferenceCode = (String)attributes.get(
+			"externalReferenceCode");
+
+		if (externalReferenceCode != null) {
+			setExternalReferenceCode(externalReferenceCode);
 		}
 
 		Double version = (Double)attributes.get("version");
@@ -532,6 +540,16 @@ public class JournalArticleWrapper
 	@Override
 	public Date getExpirationDate() {
 		return model.getExpirationDate();
+	}
+
+	/**
+	 * Returns the external reference code of this journal article.
+	 *
+	 * @return the external reference code of this journal article
+	 */
+	@Override
+	public String getExternalReferenceCode() {
+		return model.getExternalReferenceCode();
 	}
 
 	@Override
@@ -1284,6 +1302,16 @@ public class JournalArticleWrapper
 	@Override
 	public void setExpirationDate(Date expirationDate) {
 		model.setExpirationDate(expirationDate);
+	}
+
+	/**
+	 * Sets the external reference code of this journal article.
+	 *
+	 * @param externalReferenceCode the external reference code of this journal article
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		model.setExternalReferenceCode(externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
@@ -319,6 +319,126 @@ public interface JournalArticleLocalService
 		throws PortalException;
 
 	/**
+	 * Adds a web content article with additional parameters. All scheduling
+	 * parameters (display date, expiration date, and review date) use the
+	 * current user's timezone.
+	 *
+	 * <p>
+	 * The web content articles hold HTML content wrapped in XML. The XML lets
+	 * you specify the article's default locale and available locales. Here is a
+	 * content example:
+	 * </p>
+	 *
+	 * <p>
+	 * <pre>
+	 * <code>
+	 * &lt;?xml version='1.0' encoding='UTF-8'?&gt;
+	 * &lt;root default-locale="en_US" available-locales="en_US"&gt;
+	 * 	&lt;static-content language-id="en_US"&gt;
+	 * 		&lt;![CDATA[&lt;p&gt;&lt;b&gt;&lt;i&gt;test&lt;i&gt; content&lt;b&gt;&lt;/p&gt;]]&gt;
+	 * 	&lt;/static-content&gt;
+	 * &lt;/root&gt;
+	 * </code>
+	 * </pre></p>
+	 *
+	 * @param userId the primary key of the web content article's creator/owner
+	 * @param groupId the primary key of the web content article's group
+	 * @param folderId the primary key of the web content article folder
+	 * @param classNameId the primary key of the DDMStructure class if the web
+	 content article is related to a DDM structure, the primary key of
+	 the class name associated with the article, or
+	 JournalArticleConstants.CLASS_NAME_ID_DEFAULT in the journal-api
+	 module otherwise
+	 * @param classPK the primary key of the DDM structure, if the primary key
+	 of the DDMStructure class is given as the
+	 <code>classNameId</code> parameter, the primary key of the class
+	 associated with the web content article, or <code>0</code>
+	 otherwise
+	 * @param articleId the primary key of the web content article
+	 * @param autoArticleId whether to auto generate the web content article ID
+	 * @param externalReferenceCode the external reference code of the web
+	 content article
+	 * @param version the web content article's version
+	 * @param titleMap the web content article's locales and localized titles
+	 * @param descriptionMap the web content article's locales and localized
+	 descriptions
+	 * @param friendlyURLMap the web content article's locales and localized
+	 friendly URLs
+	 * @param content the HTML content wrapped in XML
+	 * @param ddmStructureKey the primary key of the web content article's DDM
+	 structure, if the article is related to a DDM structure, or
+	 <code>null</code> otherwise
+	 * @param ddmTemplateKey the primary key of the web content article's DDM
+	 template
+	 * @param layoutUuid the unique string identifying the web content
+	 article's display page
+	 * @param displayDateMonth the month the web content article is set to
+	 display
+	 * @param displayDateDay the calendar day the web content article is set to
+	 display
+	 * @param displayDateYear the year the web content article is set to
+	 display
+	 * @param displayDateHour the hour the web content article is set to
+	 display
+	 * @param displayDateMinute the minute the web content article is set to
+	 display
+	 * @param expirationDateMonth the month the web content article is set to
+	 expire
+	 * @param expirationDateDay the calendar day the web content article is set
+	 to expire
+	 * @param expirationDateYear the year the web content article is set to
+	 expire
+	 * @param expirationDateHour the hour the web content article is set to
+	 expire
+	 * @param expirationDateMinute the minute the web content article is set to
+	 expire
+	 * @param neverExpire whether the web content article is not set to auto
+	 expire
+	 * @param reviewDateMonth the month the web content article is set for
+	 review
+	 * @param reviewDateDay the calendar day the web content article is set for
+	 review
+	 * @param reviewDateYear the year the web content article is set for review
+	 * @param reviewDateHour the hour the web content article is set for review
+	 * @param reviewDateMinute the minute the web content article is set for
+	 review
+	 * @param neverReview whether the web content article is not set for review
+	 * @param indexable whether the web content article is searchable
+	 * @param smallImage whether the web content article has a small image
+	 * @param smallImageURL the web content article's small image URL
+	 * @param smallImageFile the web content article's small image file
+	 * @param images the web content's images
+	 * @param articleURL the web content article's accessible URL
+	 * @param serviceContext the service context to be applied. Can set the
+	 UUID, creation date, modification date, expando bridge
+	 attributes, guest permissions, group permissions, asset category
+	 IDs, asset tag names, asset link entry IDs, URL title, and
+	 workflow actions for the web content article. Can also set
+	 whether to add the default guest and group permissions.
+	 * @return the web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Indexable(type = IndexableType.REINDEX)
+	public JournalArticle addArticle(
+			long userId, long groupId, long folderId, long classNameId,
+			long classPK, String articleId, boolean autoArticleId,
+			String externalReferenceCode, double version,
+			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			String ddmStructureKey, String ddmTemplateKey, String layoutUuid,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, int expirationDateMonth,
+			int expirationDateDay, int expirationDateYear,
+			int expirationDateHour, int expirationDateMinute,
+			boolean neverExpire, int reviewDateMonth, int reviewDateDay,
+			int reviewDateYear, int reviewDateHour, int reviewDateMinute,
+			boolean neverReview, boolean indexable, boolean smallImage,
+			String smallImageURL, File smallImageFile,
+			Map<String, byte[]> images, String articleURL,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	/**
 	 * Adds a web content article.
 	 *
 	 * @param userId the primary key of the web content article's creator/owner
@@ -888,6 +1008,19 @@ public interface JournalArticleLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public JournalArticle fetchLatestArticle(
 		long groupId, String articleId, int status);
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code, and
+	 * workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the web content article's external reference code
+	 * @return the latest matching web content article, or <code>null</code> if
+	 no matching web content article could be found
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public JournalArticle fetchLatestArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public JournalArticle fetchLatestArticleByUrlTitle(
@@ -1835,6 +1968,20 @@ public interface JournalArticleLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public JournalArticle getLatestArticle(
 			long groupId, String className, long classPK)
+		throws PortalException;
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code, and
+	 * workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the web content article's external reference code
+	 * @return the latest matching web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public JournalArticle getLatestArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
 		throws PortalException;
 
 	/**
@@ -3381,6 +3528,112 @@ public interface JournalArticleLocalService
 	public JournalArticle updateArticle(
 			long userId, long groupId, long folderId, String articleId,
 			double version, String content, ServiceContext serviceContext)
+		throws PortalException;
+
+	/**
+	 * Updates the web content article with additional parameters. All
+	 * scheduling parameters (display date, expiration date, and review date)
+	 * use the current user's timezone.
+	 *
+	 * @param userId the primary key of the user updating the web content
+	 article
+	 * @param groupId the primary key of the web content article's group
+	 * @param folderId the primary key of the web content article folder
+	 * @param articleId the primary key of the web content article
+	 * @param externalReferenceCode the external reference code of the web
+	 content article
+	 * @param version the web content article's version
+	 * @param titleMap the web content article's locales and localized titles
+	 * @param descriptionMap the web content article's locales and localized
+	 descriptions
+	 * @param friendlyURLMap the web content article's locales and localized
+	 friendly URLs
+	 * @param content the HTML content wrapped in XML. For more information,
+	 see the content example in the {@link #addArticle(long, long,
+	 long, long, long, String, boolean, double, Map, Map, String,
+	 String, String, String, int, int, int, int, int, int, int, int,
+	 int, int, boolean, int, int, int, int, int, boolean, boolean,
+	 boolean, String, File, Map, String, ServiceContext)} description.
+	 * @param ddmStructureKey the primary key of the web content article's DDM
+	 structure, if the article is related to a DDM structure, or
+	 <code>null</code> otherwise
+	 * @param ddmTemplateKey the primary key of the web content article's DDM
+	 template
+	 * @param layoutUuid the unique string identifying the web content
+	 article's display page
+	 * @param displayDateMonth the month the web content article is set to
+	 display
+	 * @param displayDateDay the calendar day the web content article is set to
+	 display
+	 * @param displayDateYear the year the web content article is set to
+	 display
+	 * @param displayDateHour the hour the web content article is set to
+	 display
+	 * @param displayDateMinute the minute the web content article is set to
+	 display
+	 * @param expirationDateMonth the month the web content article is set to
+	 expire
+	 * @param expirationDateDay the calendar day the web content article is set
+	 to expire
+	 * @param expirationDateYear the year the web content article is set to
+	 expire
+	 * @param expirationDateHour the hour the web content article is set to
+	 expire
+	 * @param expirationDateMinute the minute the web content article is set to
+	 expire
+	 * @param neverExpire whether the web content article is not set to auto
+	 expire
+	 * @param reviewDateMonth the month the web content article is set for
+	 review
+	 * @param reviewDateDay the calendar day the web content article is set for
+	 review
+	 * @param reviewDateYear the year the web content article is set for review
+	 * @param reviewDateHour the hour the web content article is set for review
+	 * @param reviewDateMinute the minute the web content article is set for
+	 review
+	 * @param neverReview whether the web content article is not set for review
+	 * @param indexable whether the web content is searchable
+	 * @param smallImage whether to update web content article's a small image.
+	 A file must be passed in as <code>smallImageFile</code> value,
+	 otherwise the current small image is deleted.
+	 * @param smallImageURL the web content article's small image URL
+	 (optionally <code>null</code>)
+	 * @param smallImageFile the web content article's new small image file
+	 (optionally <code>null</code>). Must pass in
+	 <code>smallImage</code> value of <code>true</code> to replace the
+	 article's small image file.
+	 * @param images the web content's images (optionally <code>null</code>)
+	 * @param articleURL the web content article's accessible URL (optionally
+	 <code>null</code>)
+	 * @param serviceContext the service context to be applied. Can set the
+	 modification date, expando bridge attributes, asset category IDs,
+	 asset tag names, asset link entry IDs, asset priority, workflow
+	 actions, URL title , and can set whether to add the default
+	 command update for the web content article. With respect to
+	 social activities, by setting the service context's command to
+	 {@link Constants#UPDATE}, the invocation is considered a web
+	 content update activity; otherwise it is considered a web content
+	 add activity.
+	 * @return the updated web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Indexable(type = IndexableType.REINDEX)
+	public JournalArticle updateArticle(
+			long userId, long groupId, long folderId, String articleId,
+			String externalReferenceCode, double version,
+			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			String ddmStructureKey, String ddmTemplateKey, String layoutUuid,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, int expirationDateMonth,
+			int expirationDateDay, int expirationDateYear,
+			int expirationDateHour, int expirationDateMinute,
+			boolean neverExpire, int reviewDateMonth, int reviewDateDay,
+			int reviewDateYear, int reviewDateHour, int reviewDateMinute,
+			boolean neverReview, boolean indexable, boolean smallImage,
+			String smallImageURL, File smallImageFile,
+			Map<String, byte[]> images, String articleURL,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
@@ -297,6 +297,140 @@ public class JournalArticleLocalServiceUtil {
 	}
 
 	/**
+	 * Adds a web content article with additional parameters. All scheduling
+	 * parameters (display date, expiration date, and review date) use the
+	 * current user's timezone.
+	 *
+	 * <p>
+	 * The web content articles hold HTML content wrapped in XML. The XML lets
+	 * you specify the article's default locale and available locales. Here is a
+	 * content example:
+	 * </p>
+	 *
+	 * <p>
+	 * <pre>
+	 * <code>
+	 * &lt;?xml version='1.0' encoding='UTF-8'?&gt;
+	 * &lt;root default-locale="en_US" available-locales="en_US"&gt;
+	 * 	&lt;static-content language-id="en_US"&gt;
+	 * 		&lt;![CDATA[&lt;p&gt;&lt;b&gt;&lt;i&gt;test&lt;i&gt; content&lt;b&gt;&lt;/p&gt;]]&gt;
+	 * 	&lt;/static-content&gt;
+	 * &lt;/root&gt;
+	 * </code>
+	 * </pre></p>
+	 *
+	 * @param userId the primary key of the web content article's creator/owner
+	 * @param groupId the primary key of the web content article's group
+	 * @param folderId the primary key of the web content article folder
+	 * @param classNameId the primary key of the DDMStructure class if the web
+	 content article is related to a DDM structure, the primary key of
+	 the class name associated with the article, or
+	 JournalArticleConstants.CLASS_NAME_ID_DEFAULT in the journal-api
+	 module otherwise
+	 * @param classPK the primary key of the DDM structure, if the primary key
+	 of the DDMStructure class is given as the
+	 <code>classNameId</code> parameter, the primary key of the class
+	 associated with the web content article, or <code>0</code>
+	 otherwise
+	 * @param articleId the primary key of the web content article
+	 * @param autoArticleId whether to auto generate the web content article ID
+	 * @param externalReferenceCode the external reference code of the web
+	 content article
+	 * @param version the web content article's version
+	 * @param titleMap the web content article's locales and localized titles
+	 * @param descriptionMap the web content article's locales and localized
+	 descriptions
+	 * @param friendlyURLMap the web content article's locales and localized
+	 friendly URLs
+	 * @param content the HTML content wrapped in XML
+	 * @param ddmStructureKey the primary key of the web content article's DDM
+	 structure, if the article is related to a DDM structure, or
+	 <code>null</code> otherwise
+	 * @param ddmTemplateKey the primary key of the web content article's DDM
+	 template
+	 * @param layoutUuid the unique string identifying the web content
+	 article's display page
+	 * @param displayDateMonth the month the web content article is set to
+	 display
+	 * @param displayDateDay the calendar day the web content article is set to
+	 display
+	 * @param displayDateYear the year the web content article is set to
+	 display
+	 * @param displayDateHour the hour the web content article is set to
+	 display
+	 * @param displayDateMinute the minute the web content article is set to
+	 display
+	 * @param expirationDateMonth the month the web content article is set to
+	 expire
+	 * @param expirationDateDay the calendar day the web content article is set
+	 to expire
+	 * @param expirationDateYear the year the web content article is set to
+	 expire
+	 * @param expirationDateHour the hour the web content article is set to
+	 expire
+	 * @param expirationDateMinute the minute the web content article is set to
+	 expire
+	 * @param neverExpire whether the web content article is not set to auto
+	 expire
+	 * @param reviewDateMonth the month the web content article is set for
+	 review
+	 * @param reviewDateDay the calendar day the web content article is set for
+	 review
+	 * @param reviewDateYear the year the web content article is set for review
+	 * @param reviewDateHour the hour the web content article is set for review
+	 * @param reviewDateMinute the minute the web content article is set for
+	 review
+	 * @param neverReview whether the web content article is not set for review
+	 * @param indexable whether the web content article is searchable
+	 * @param smallImage whether the web content article has a small image
+	 * @param smallImageURL the web content article's small image URL
+	 * @param smallImageFile the web content article's small image file
+	 * @param images the web content's images
+	 * @param articleURL the web content article's accessible URL
+	 * @param serviceContext the service context to be applied. Can set the
+	 UUID, creation date, modification date, expando bridge
+	 attributes, guest permissions, group permissions, asset category
+	 IDs, asset tag names, asset link entry IDs, URL title, and
+	 workflow actions for the web content article. Can also set
+	 whether to add the default guest and group permissions.
+	 * @return the web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static com.liferay.journal.model.JournalArticle addArticle(
+			long userId, long groupId, long folderId, long classNameId,
+			long classPK, String articleId, boolean autoArticleId,
+			String externalReferenceCode, double version,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmStructureKey, String ddmTemplateKey,
+			String layoutUuid, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			int expirationDateMonth, int expirationDateDay,
+			int expirationDateYear, int expirationDateHour,
+			int expirationDateMinute, boolean neverExpire, int reviewDateMonth,
+			int reviewDateDay, int reviewDateYear, int reviewDateHour,
+			int reviewDateMinute, boolean neverReview, boolean indexable,
+			boolean smallImage, String smallImageURL,
+			java.io.File smallImageFile, java.util.Map<String, byte[]> images,
+			String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addArticle(
+			userId, groupId, folderId, classNameId, classPK, articleId,
+			autoArticleId, externalReferenceCode, version, titleMap,
+			descriptionMap, friendlyURLMap, content, ddmStructureKey,
+			ddmTemplateKey, layoutUuid, displayDateMonth, displayDateDay,
+			displayDateYear, displayDateHour, displayDateMinute,
+			expirationDateMonth, expirationDateDay, expirationDateYear,
+			expirationDateHour, expirationDateMinute, neverExpire,
+			reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
+			reviewDateMinute, neverReview, indexable, smallImage, smallImageURL,
+			smallImageFile, images, articleURL, serviceContext);
+	}
+
+	/**
 	 * Adds a web content article.
 	 *
 	 * @param userId the primary key of the web content article's creator/owner
@@ -1026,6 +1160,23 @@ public class JournalArticleLocalServiceUtil {
 		long groupId, String articleId, int status) {
 
 		return getService().fetchLatestArticle(groupId, articleId, status);
+	}
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code, and
+	 * workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the web content article's external reference code
+	 * @return the latest matching web content article, or <code>null</code> if
+	 no matching web content article could be found
+	 */
+	public static com.liferay.journal.model.JournalArticle
+		fetchLatestArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode) {
+
+		return getService().fetchLatestArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	public static com.liferay.journal.model.JournalArticle
@@ -2221,6 +2372,24 @@ public class JournalArticleLocalServiceUtil {
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return getService().getLatestArticle(groupId, className, classPK);
+	}
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code, and
+	 * workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the web content article's external reference code
+	 * @return the latest matching web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static com.liferay.journal.model.JournalArticle
+			getLatestArticleByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().getLatestArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	/**
@@ -3995,6 +4164,125 @@ public class JournalArticleLocalServiceUtil {
 		return getService().updateArticle(
 			userId, groupId, folderId, articleId, version, content,
 			serviceContext);
+	}
+
+	/**
+	 * Updates the web content article with additional parameters. All
+	 * scheduling parameters (display date, expiration date, and review date)
+	 * use the current user's timezone.
+	 *
+	 * @param userId the primary key of the user updating the web content
+	 article
+	 * @param groupId the primary key of the web content article's group
+	 * @param folderId the primary key of the web content article folder
+	 * @param articleId the primary key of the web content article
+	 * @param externalReferenceCode the external reference code of the web
+	 content article
+	 * @param version the web content article's version
+	 * @param titleMap the web content article's locales and localized titles
+	 * @param descriptionMap the web content article's locales and localized
+	 descriptions
+	 * @param friendlyURLMap the web content article's locales and localized
+	 friendly URLs
+	 * @param content the HTML content wrapped in XML. For more information,
+	 see the content example in the {@link #addArticle(long, long,
+	 long, long, long, String, boolean, double, Map, Map, String,
+	 String, String, String, int, int, int, int, int, int, int, int,
+	 int, int, boolean, int, int, int, int, int, boolean, boolean,
+	 boolean, String, File, Map, String, ServiceContext)} description.
+	 * @param ddmStructureKey the primary key of the web content article's DDM
+	 structure, if the article is related to a DDM structure, or
+	 <code>null</code> otherwise
+	 * @param ddmTemplateKey the primary key of the web content article's DDM
+	 template
+	 * @param layoutUuid the unique string identifying the web content
+	 article's display page
+	 * @param displayDateMonth the month the web content article is set to
+	 display
+	 * @param displayDateDay the calendar day the web content article is set to
+	 display
+	 * @param displayDateYear the year the web content article is set to
+	 display
+	 * @param displayDateHour the hour the web content article is set to
+	 display
+	 * @param displayDateMinute the minute the web content article is set to
+	 display
+	 * @param expirationDateMonth the month the web content article is set to
+	 expire
+	 * @param expirationDateDay the calendar day the web content article is set
+	 to expire
+	 * @param expirationDateYear the year the web content article is set to
+	 expire
+	 * @param expirationDateHour the hour the web content article is set to
+	 expire
+	 * @param expirationDateMinute the minute the web content article is set to
+	 expire
+	 * @param neverExpire whether the web content article is not set to auto
+	 expire
+	 * @param reviewDateMonth the month the web content article is set for
+	 review
+	 * @param reviewDateDay the calendar day the web content article is set for
+	 review
+	 * @param reviewDateYear the year the web content article is set for review
+	 * @param reviewDateHour the hour the web content article is set for review
+	 * @param reviewDateMinute the minute the web content article is set for
+	 review
+	 * @param neverReview whether the web content article is not set for review
+	 * @param indexable whether the web content is searchable
+	 * @param smallImage whether to update web content article's a small image.
+	 A file must be passed in as <code>smallImageFile</code> value,
+	 otherwise the current small image is deleted.
+	 * @param smallImageURL the web content article's small image URL
+	 (optionally <code>null</code>)
+	 * @param smallImageFile the web content article's new small image file
+	 (optionally <code>null</code>). Must pass in
+	 <code>smallImage</code> value of <code>true</code> to replace the
+	 article's small image file.
+	 * @param images the web content's images (optionally <code>null</code>)
+	 * @param articleURL the web content article's accessible URL (optionally
+	 <code>null</code>)
+	 * @param serviceContext the service context to be applied. Can set the
+	 modification date, expando bridge attributes, asset category IDs,
+	 asset tag names, asset link entry IDs, asset priority, workflow
+	 actions, URL title , and can set whether to add the default
+	 command update for the web content article. With respect to
+	 social activities, by setting the service context's command to
+	 {@link Constants#UPDATE}, the invocation is considered a web
+	 content update activity; otherwise it is considered a web content
+	 add activity.
+	 * @return the updated web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static com.liferay.journal.model.JournalArticle updateArticle(
+			long userId, long groupId, long folderId, String articleId,
+			String externalReferenceCode, double version,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmStructureKey, String ddmTemplateKey,
+			String layoutUuid, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			int expirationDateMonth, int expirationDateDay,
+			int expirationDateYear, int expirationDateHour,
+			int expirationDateMinute, boolean neverExpire, int reviewDateMonth,
+			int reviewDateDay, int reviewDateYear, int reviewDateHour,
+			int reviewDateMinute, boolean neverReview, boolean indexable,
+			boolean smallImage, String smallImageURL,
+			java.io.File smallImageFile, java.util.Map<String, byte[]> images,
+			String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().updateArticle(
+			userId, groupId, folderId, articleId, externalReferenceCode,
+			version, titleMap, descriptionMap, friendlyURLMap, content,
+			ddmStructureKey, ddmTemplateKey, layoutUuid, displayDateMonth,
+			displayDateDay, displayDateYear, displayDateHour, displayDateMinute,
+			expirationDateMonth, expirationDateDay, expirationDateYear,
+			expirationDateHour, expirationDateMinute, neverExpire,
+			reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
+			reviewDateMinute, neverReview, indexable, smallImage, smallImageURL,
+			smallImageFile, images, articleURL, serviceContext);
 	}
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
@@ -297,6 +297,141 @@ public class JournalArticleLocalServiceWrapper
 	}
 
 	/**
+	 * Adds a web content article with additional parameters. All scheduling
+	 * parameters (display date, expiration date, and review date) use the
+	 * current user's timezone.
+	 *
+	 * <p>
+	 * The web content articles hold HTML content wrapped in XML. The XML lets
+	 * you specify the article's default locale and available locales. Here is a
+	 * content example:
+	 * </p>
+	 *
+	 * <p>
+	 * <pre>
+	 * <code>
+	 * &lt;?xml version='1.0' encoding='UTF-8'?&gt;
+	 * &lt;root default-locale="en_US" available-locales="en_US"&gt;
+	 * 	&lt;static-content language-id="en_US"&gt;
+	 * 		&lt;![CDATA[&lt;p&gt;&lt;b&gt;&lt;i&gt;test&lt;i&gt; content&lt;b&gt;&lt;/p&gt;]]&gt;
+	 * 	&lt;/static-content&gt;
+	 * &lt;/root&gt;
+	 * </code>
+	 * </pre></p>
+	 *
+	 * @param userId the primary key of the web content article's creator/owner
+	 * @param groupId the primary key of the web content article's group
+	 * @param folderId the primary key of the web content article folder
+	 * @param classNameId the primary key of the DDMStructure class if the web
+	 content article is related to a DDM structure, the primary key of
+	 the class name associated with the article, or
+	 JournalArticleConstants.CLASS_NAME_ID_DEFAULT in the journal-api
+	 module otherwise
+	 * @param classPK the primary key of the DDM structure, if the primary key
+	 of the DDMStructure class is given as the
+	 <code>classNameId</code> parameter, the primary key of the class
+	 associated with the web content article, or <code>0</code>
+	 otherwise
+	 * @param articleId the primary key of the web content article
+	 * @param autoArticleId whether to auto generate the web content article ID
+	 * @param externalReferenceCode the external reference code of the web
+	 content article
+	 * @param version the web content article's version
+	 * @param titleMap the web content article's locales and localized titles
+	 * @param descriptionMap the web content article's locales and localized
+	 descriptions
+	 * @param friendlyURLMap the web content article's locales and localized
+	 friendly URLs
+	 * @param content the HTML content wrapped in XML
+	 * @param ddmStructureKey the primary key of the web content article's DDM
+	 structure, if the article is related to a DDM structure, or
+	 <code>null</code> otherwise
+	 * @param ddmTemplateKey the primary key of the web content article's DDM
+	 template
+	 * @param layoutUuid the unique string identifying the web content
+	 article's display page
+	 * @param displayDateMonth the month the web content article is set to
+	 display
+	 * @param displayDateDay the calendar day the web content article is set to
+	 display
+	 * @param displayDateYear the year the web content article is set to
+	 display
+	 * @param displayDateHour the hour the web content article is set to
+	 display
+	 * @param displayDateMinute the minute the web content article is set to
+	 display
+	 * @param expirationDateMonth the month the web content article is set to
+	 expire
+	 * @param expirationDateDay the calendar day the web content article is set
+	 to expire
+	 * @param expirationDateYear the year the web content article is set to
+	 expire
+	 * @param expirationDateHour the hour the web content article is set to
+	 expire
+	 * @param expirationDateMinute the minute the web content article is set to
+	 expire
+	 * @param neverExpire whether the web content article is not set to auto
+	 expire
+	 * @param reviewDateMonth the month the web content article is set for
+	 review
+	 * @param reviewDateDay the calendar day the web content article is set for
+	 review
+	 * @param reviewDateYear the year the web content article is set for review
+	 * @param reviewDateHour the hour the web content article is set for review
+	 * @param reviewDateMinute the minute the web content article is set for
+	 review
+	 * @param neverReview whether the web content article is not set for review
+	 * @param indexable whether the web content article is searchable
+	 * @param smallImage whether the web content article has a small image
+	 * @param smallImageURL the web content article's small image URL
+	 * @param smallImageFile the web content article's small image file
+	 * @param images the web content's images
+	 * @param articleURL the web content article's accessible URL
+	 * @param serviceContext the service context to be applied. Can set the
+	 UUID, creation date, modification date, expando bridge
+	 attributes, guest permissions, group permissions, asset category
+	 IDs, asset tag names, asset link entry IDs, URL title, and
+	 workflow actions for the web content article. Can also set
+	 whether to add the default guest and group permissions.
+	 * @return the web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public JournalArticle addArticle(
+			long userId, long groupId, long folderId, long classNameId,
+			long classPK, String articleId, boolean autoArticleId,
+			String externalReferenceCode, double version,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmStructureKey, String ddmTemplateKey,
+			String layoutUuid, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			int expirationDateMonth, int expirationDateDay,
+			int expirationDateYear, int expirationDateHour,
+			int expirationDateMinute, boolean neverExpire, int reviewDateMonth,
+			int reviewDateDay, int reviewDateYear, int reviewDateHour,
+			int reviewDateMinute, boolean neverReview, boolean indexable,
+			boolean smallImage, String smallImageURL,
+			java.io.File smallImageFile, java.util.Map<String, byte[]> images,
+			String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleLocalService.addArticle(
+			userId, groupId, folderId, classNameId, classPK, articleId,
+			autoArticleId, externalReferenceCode, version, titleMap,
+			descriptionMap, friendlyURLMap, content, ddmStructureKey,
+			ddmTemplateKey, layoutUuid, displayDateMonth, displayDateDay,
+			displayDateYear, displayDateHour, displayDateMinute,
+			expirationDateMonth, expirationDateDay, expirationDateYear,
+			expirationDateHour, expirationDateMinute, neverExpire,
+			reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
+			reviewDateMinute, neverReview, indexable, smallImage, smallImageURL,
+			smallImageFile, images, articleURL, serviceContext);
+	}
+
+	/**
 	 * Adds a web content article.
 	 *
 	 * @param userId the primary key of the web content article's creator/owner
@@ -1057,6 +1192,24 @@ public class JournalArticleLocalServiceWrapper
 
 		return _journalArticleLocalService.fetchLatestArticle(
 			groupId, articleId, status);
+	}
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code, and
+	 * workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the web content article's external reference code
+	 * @return the latest matching web content article, or <code>null</code> if
+	 no matching web content article could be found
+	 */
+	@Override
+	public JournalArticle fetchLatestArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		return _journalArticleLocalService.
+			fetchLatestArticleByExternalReferenceCode(
+				groupId, externalReferenceCode);
 	}
 
 	@Override
@@ -2300,6 +2453,25 @@ public class JournalArticleLocalServiceWrapper
 
 		return _journalArticleLocalService.getLatestArticle(
 			groupId, className, classPK);
+	}
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code, and
+	 * workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the web content article's external reference code
+	 * @return the latest matching web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public JournalArticle getLatestArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleLocalService.
+			getLatestArticleByExternalReferenceCode(
+				groupId, externalReferenceCode);
 	}
 
 	/**
@@ -4123,6 +4295,126 @@ public class JournalArticleLocalServiceWrapper
 		return _journalArticleLocalService.updateArticle(
 			userId, groupId, folderId, articleId, version, content,
 			serviceContext);
+	}
+
+	/**
+	 * Updates the web content article with additional parameters. All
+	 * scheduling parameters (display date, expiration date, and review date)
+	 * use the current user's timezone.
+	 *
+	 * @param userId the primary key of the user updating the web content
+	 article
+	 * @param groupId the primary key of the web content article's group
+	 * @param folderId the primary key of the web content article folder
+	 * @param articleId the primary key of the web content article
+	 * @param externalReferenceCode the external reference code of the web
+	 content article
+	 * @param version the web content article's version
+	 * @param titleMap the web content article's locales and localized titles
+	 * @param descriptionMap the web content article's locales and localized
+	 descriptions
+	 * @param friendlyURLMap the web content article's locales and localized
+	 friendly URLs
+	 * @param content the HTML content wrapped in XML. For more information,
+	 see the content example in the {@link #addArticle(long, long,
+	 long, long, long, String, boolean, double, Map, Map, String,
+	 String, String, String, int, int, int, int, int, int, int, int,
+	 int, int, boolean, int, int, int, int, int, boolean, boolean,
+	 boolean, String, File, Map, String, ServiceContext)} description.
+	 * @param ddmStructureKey the primary key of the web content article's DDM
+	 structure, if the article is related to a DDM structure, or
+	 <code>null</code> otherwise
+	 * @param ddmTemplateKey the primary key of the web content article's DDM
+	 template
+	 * @param layoutUuid the unique string identifying the web content
+	 article's display page
+	 * @param displayDateMonth the month the web content article is set to
+	 display
+	 * @param displayDateDay the calendar day the web content article is set to
+	 display
+	 * @param displayDateYear the year the web content article is set to
+	 display
+	 * @param displayDateHour the hour the web content article is set to
+	 display
+	 * @param displayDateMinute the minute the web content article is set to
+	 display
+	 * @param expirationDateMonth the month the web content article is set to
+	 expire
+	 * @param expirationDateDay the calendar day the web content article is set
+	 to expire
+	 * @param expirationDateYear the year the web content article is set to
+	 expire
+	 * @param expirationDateHour the hour the web content article is set to
+	 expire
+	 * @param expirationDateMinute the minute the web content article is set to
+	 expire
+	 * @param neverExpire whether the web content article is not set to auto
+	 expire
+	 * @param reviewDateMonth the month the web content article is set for
+	 review
+	 * @param reviewDateDay the calendar day the web content article is set for
+	 review
+	 * @param reviewDateYear the year the web content article is set for review
+	 * @param reviewDateHour the hour the web content article is set for review
+	 * @param reviewDateMinute the minute the web content article is set for
+	 review
+	 * @param neverReview whether the web content article is not set for review
+	 * @param indexable whether the web content is searchable
+	 * @param smallImage whether to update web content article's a small image.
+	 A file must be passed in as <code>smallImageFile</code> value,
+	 otherwise the current small image is deleted.
+	 * @param smallImageURL the web content article's small image URL
+	 (optionally <code>null</code>)
+	 * @param smallImageFile the web content article's new small image file
+	 (optionally <code>null</code>). Must pass in
+	 <code>smallImage</code> value of <code>true</code> to replace the
+	 article's small image file.
+	 * @param images the web content's images (optionally <code>null</code>)
+	 * @param articleURL the web content article's accessible URL (optionally
+	 <code>null</code>)
+	 * @param serviceContext the service context to be applied. Can set the
+	 modification date, expando bridge attributes, asset category IDs,
+	 asset tag names, asset link entry IDs, asset priority, workflow
+	 actions, URL title , and can set whether to add the default
+	 command update for the web content article. With respect to
+	 social activities, by setting the service context's command to
+	 {@link Constants#UPDATE}, the invocation is considered a web
+	 content update activity; otherwise it is considered a web content
+	 add activity.
+	 * @return the updated web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public JournalArticle updateArticle(
+			long userId, long groupId, long folderId, String articleId,
+			String externalReferenceCode, double version,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmStructureKey, String ddmTemplateKey,
+			String layoutUuid, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			int expirationDateMonth, int expirationDateDay,
+			int expirationDateYear, int expirationDateHour,
+			int expirationDateMinute, boolean neverExpire, int reviewDateMonth,
+			int reviewDateDay, int reviewDateYear, int reviewDateHour,
+			int reviewDateMinute, boolean neverReview, boolean indexable,
+			boolean smallImage, String smallImageURL,
+			java.io.File smallImageFile, java.util.Map<String, byte[]> images,
+			String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleLocalService.updateArticle(
+			userId, groupId, folderId, articleId, externalReferenceCode,
+			version, titleMap, descriptionMap, friendlyURLMap, content,
+			ddmStructureKey, ddmTemplateKey, layoutUuid, displayDateMonth,
+			displayDateDay, displayDateYear, displayDateHour, displayDateMinute,
+			expirationDateMonth, expirationDateDay, expirationDateYear,
+			expirationDateHour, expirationDateMinute, neverExpire,
+			reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
+			reviewDateMinute, neverReview, indexable, smallImage, smallImageURL,
+			smallImageFile, images, articleURL, serviceContext);
 	}
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleService.java
@@ -344,6 +344,106 @@ public interface JournalArticleService extends BaseService {
 		throws PortalException;
 
 	/**
+	 * Adds a web content article with additional parameters. All scheduling
+	 * parameters (display date, expiration date, and review date) use the
+	 * current user's timezone.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param folderId the primary key of the web content article folder
+	 * @param classNameId the primary key of the DDMStructure class if the web
+	 content article is related to a DDM structure, the primary key of
+	 the class name associated with the article, or
+	 JournalArticleConstants.CLASS_NAME_ID_DEFAULT in the journal-api
+	 module otherwise
+	 * @param classPK the primary key of the DDM structure, if the primary key
+	 of the DDMStructure class is given as the
+	 <code>classNameId</code> parameter, the primary key of the class
+	 associated with the web content article, or <code>0</code>
+	 otherwise
+	 * @param articleId the primary key of the web content article
+	 * @param autoArticleId whether to auto generate the web content article ID
+	 * @param titleMap the web content article's locales and localized titles
+	 * @param descriptionMap the web content article's locales and localized
+	 descriptions
+	 * @param friendlyURLMap the web content article's locales and localized
+	 friendly URLs
+	 * @param content the HTML content wrapped in XML. For more information,
+	 see the content example in the {@link #updateArticle(long, long,
+	 String, double, String, ServiceContext)} description.
+	 * @param ddmStructureKey the primary key of the web content article's DDM
+	 structure, if the article is related to a DDM structure, or
+	 <code>null</code> otherwise
+	 * @param ddmTemplateKey the primary key of the web content article's DDM
+	 template
+	 * @param externalReferenceCode the external reference code of the web
+	 content article
+	 * @param layoutUuid the unique string identifying the web content
+	 article's display page
+	 * @param displayDateMonth the month the web content article is set to
+	 display
+	 * @param displayDateDay the calendar day the web content article is set to
+	 display
+	 * @param displayDateYear the year the web content article is set to
+	 display
+	 * @param displayDateHour the hour the web content article is set to
+	 display
+	 * @param displayDateMinute the minute the web content article is set to
+	 display
+	 * @param expirationDateMonth the month the web content article is set to
+	 expire
+	 * @param expirationDateDay the calendar day the web content article is set
+	 to expire
+	 * @param expirationDateYear the year the web content article is set to
+	 expire
+	 * @param expirationDateHour the hour the web content article is set to
+	 expire
+	 * @param expirationDateMinute the minute the web content article is set to
+	 expire
+	 * @param neverExpire whether the web content article is not set to auto
+	 expire
+	 * @param reviewDateMonth the month the web content article is set for
+	 review
+	 * @param reviewDateDay the calendar day the web content article is set for
+	 review
+	 * @param reviewDateYear the year the web content article is set for review
+	 * @param reviewDateHour the hour the web content article is set for review
+	 * @param reviewDateMinute the minute the web content article is set for
+	 review
+	 * @param neverReview whether the web content article is not set for review
+	 * @param indexable whether the web content article is searchable
+	 * @param smallImage whether the web content article has a small image
+	 * @param smallImageURL the web content article's small image URL
+	 * @param smallFile the web content article's small image file
+	 * @param images the web content's images
+	 * @param articleURL the web content article's accessible URL
+	 * @param serviceContext the service context to be applied. Can set the
+	 UUID, creation date, modification date, expando bridge
+	 attributes, guest permissions, group permissions, asset category
+	 IDs, asset tag names, asset link entry IDs, asset priority, URL
+	 title, and workflow actions for the web content article. Can also
+	 set whether to add the default guest and group permissions.
+	 * @return the web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public JournalArticle addArticle(
+			long groupId, long folderId, long classNameId, long classPK,
+			String articleId, boolean autoArticleId,
+			String externalReferenceCode, Map<Locale, String> titleMap,
+			Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			String ddmStructureKey, String ddmTemplateKey, String layoutUuid,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, int expirationDateMonth,
+			int expirationDateDay, int expirationDateYear,
+			int expirationDateHour, int expirationDateMinute,
+			boolean neverExpire, int reviewDateMonth, int reviewDateDay,
+			int reviewDateYear, int reviewDateHour, int reviewDateMinute,
+			boolean neverReview, boolean indexable, boolean smallImage,
+			String smallImageURL, File smallFile, Map<String, byte[]> images,
+			String articleURL, ServiceContext serviceContext)
+		throws PortalException;
+
+	/**
 	 * Adds a web content article.
 	 *
 	 * @param groupId the primary key of the web content article's group
@@ -493,6 +593,20 @@ public interface JournalArticleService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public JournalArticle fetchArticle(long groupId, String articleId)
+		throws PortalException;
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code,
+	 * and workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the external reference code of the web content article
+	 * @return the latest matching web content article, or <code>null</code> if
+	 no matching web content article could be found
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public JournalArticle fetchLatestArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
 		throws PortalException;
 
 	/**
@@ -1227,6 +1341,20 @@ public interface JournalArticleService extends BaseService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public JournalArticle getLatestArticle(
 			long groupId, String className, long classPK)
+		throws PortalException;
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code,
+	 * and workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the external reference code of the web content article
+	 * @return the latest matching web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public JournalArticle getLatestArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -2121,6 +2249,105 @@ public interface JournalArticleService extends BaseService {
 	public JournalArticle updateArticle(
 			long groupId, long folderId, String articleId, double version,
 			String content, ServiceContext serviceContext)
+		throws PortalException;
+
+	/**
+	 * Updates the web content article with additional parameters. All
+	 * scheduling parameters (display date, expiration date, and review date)
+	 * use the current user's timezone.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param folderId the primary key of the web content article folder
+	 * @param articleId the primary key of the web content article
+	 * @param externalReferenCode the external reference code of the web
+	 content article
+	 * @param version the web content article's version
+	 * @param titleMap the web content article's locales and localized titles
+	 * @param descriptionMap the web content article's locales and localized
+	 descriptions
+	 * @param friendlyURLMap the web content article's locales and localized
+	 friendly URLs
+	 * @param content the HTML content wrapped in XML. For more information,
+	 see the content example in the {@link #updateArticle(long, long,
+	 String, double, String, ServiceContext)} description.
+	 * @param ddmStructureKey the primary key of the web content article's DDM
+	 structure, if the article is related to a DDM structure, or
+	 <code>null</code> otherwise
+	 * @param ddmTemplateKey the primary key of the web content article's DDM
+	 template
+	 * @param layoutUuid the unique string identifying the web content
+	 article's display page
+	 * @param displayDateMonth the month the web content article is set to
+	 display
+	 * @param displayDateDay the calendar day the web content article is set to
+	 display
+	 * @param displayDateYear the year the web content article is set to
+	 display
+	 * @param displayDateHour the hour the web content article is set to
+	 display
+	 * @param displayDateMinute the minute the web content article is set to
+	 display
+	 * @param expirationDateMonth the month the web content article is set to
+	 expire
+	 * @param expirationDateDay the calendar day the web content article is set
+	 to expire
+	 * @param expirationDateYear the year the web content article is set to
+	 expire
+	 * @param expirationDateHour the hour the web content article is set to
+	 expire
+	 * @param expirationDateMinute the minute the web content article is set to
+	 expire
+	 * @param neverExpire whether the web content article is not set to auto
+	 expire
+	 * @param reviewDateMonth the month the web content article is set for
+	 review
+	 * @param reviewDateDay the calendar day the web content article is set for
+	 review
+	 * @param reviewDateYear the year the web content article is set for review
+	 * @param reviewDateHour the hour the web content article is set for review
+	 * @param reviewDateMinute the minute the web content article is set for
+	 review
+	 * @param neverReview whether the web content article is not set for review
+	 * @param indexable whether the web content is searchable
+	 * @param smallImage whether to update web content article's a small image.
+	 A file must be passed in as <code>smallImageFile</code> value,
+	 otherwise the current small image is deleted.
+	 * @param smallImageURL the web content article's small image URL
+	 (optionally <code>null</code>)
+	 * @param smallFile the web content article's new small image file
+	 (optionally <code>null</code>). Must pass in
+	 <code>smallImage</code> value of <code>true</code> to replace the
+	 article's small image file.
+	 * @param images the web content's images (optionally <code>null</code>)
+	 * @param articleURL the web content article's accessible URL (optionally
+	 <code>null</code>)
+	 * @param serviceContext the service context to be applied. Can set the
+	 modification date, expando bridge attributes, asset category IDs,
+	 asset tag names, asset link entry IDs, asset priority, workflow
+	 actions, URL title, and can set whether to add the default
+	 command update for the web content article. With respect to
+	 social activities, by setting the service context's command to
+	 {@link com.liferay.portal.kernel.util.Constants#UPDATE}, the
+	 invocation is considered a web content update activity; otherwise
+	 it is considered a web content add activity.
+	 * @return the updated web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public JournalArticle updateArticle(
+			long groupId, long folderId, String articleId,
+			String externalReferenceCode, double version,
+			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			String ddmStructureKey, String ddmTemplateKey, String layoutUuid,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, int expirationDateMonth,
+			int expirationDateDay, int expirationDateYear,
+			int expirationDateHour, int expirationDateMinute,
+			boolean neverExpire, int reviewDateMonth, int reviewDateDay,
+			int reviewDateYear, int reviewDateHour, int reviewDateMinute,
+			boolean neverReview, boolean indexable, boolean smallImage,
+			String smallImageURL, File smallFile, Map<String, byte[]> images,
+			String articleURL, ServiceContext serviceContext)
 		throws PortalException;
 
 	public JournalArticle updateArticleDefaultValues(

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceUtil.java
@@ -358,6 +358,121 @@ public class JournalArticleServiceUtil {
 	}
 
 	/**
+	 * Adds a web content article with additional parameters. All scheduling
+	 * parameters (display date, expiration date, and review date) use the
+	 * current user's timezone.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param folderId the primary key of the web content article folder
+	 * @param classNameId the primary key of the DDMStructure class if the web
+	 content article is related to a DDM structure, the primary key of
+	 the class name associated with the article, or
+	 JournalArticleConstants.CLASS_NAME_ID_DEFAULT in the journal-api
+	 module otherwise
+	 * @param classPK the primary key of the DDM structure, if the primary key
+	 of the DDMStructure class is given as the
+	 <code>classNameId</code> parameter, the primary key of the class
+	 associated with the web content article, or <code>0</code>
+	 otherwise
+	 * @param articleId the primary key of the web content article
+	 * @param autoArticleId whether to auto generate the web content article ID
+	 * @param titleMap the web content article's locales and localized titles
+	 * @param descriptionMap the web content article's locales and localized
+	 descriptions
+	 * @param friendlyURLMap the web content article's locales and localized
+	 friendly URLs
+	 * @param content the HTML content wrapped in XML. For more information,
+	 see the content example in the {@link #updateArticle(long, long,
+	 String, double, String, ServiceContext)} description.
+	 * @param ddmStructureKey the primary key of the web content article's DDM
+	 structure, if the article is related to a DDM structure, or
+	 <code>null</code> otherwise
+	 * @param ddmTemplateKey the primary key of the web content article's DDM
+	 template
+	 * @param externalReferenceCode the external reference code of the web
+	 content article
+	 * @param layoutUuid the unique string identifying the web content
+	 article's display page
+	 * @param displayDateMonth the month the web content article is set to
+	 display
+	 * @param displayDateDay the calendar day the web content article is set to
+	 display
+	 * @param displayDateYear the year the web content article is set to
+	 display
+	 * @param displayDateHour the hour the web content article is set to
+	 display
+	 * @param displayDateMinute the minute the web content article is set to
+	 display
+	 * @param expirationDateMonth the month the web content article is set to
+	 expire
+	 * @param expirationDateDay the calendar day the web content article is set
+	 to expire
+	 * @param expirationDateYear the year the web content article is set to
+	 expire
+	 * @param expirationDateHour the hour the web content article is set to
+	 expire
+	 * @param expirationDateMinute the minute the web content article is set to
+	 expire
+	 * @param neverExpire whether the web content article is not set to auto
+	 expire
+	 * @param reviewDateMonth the month the web content article is set for
+	 review
+	 * @param reviewDateDay the calendar day the web content article is set for
+	 review
+	 * @param reviewDateYear the year the web content article is set for review
+	 * @param reviewDateHour the hour the web content article is set for review
+	 * @param reviewDateMinute the minute the web content article is set for
+	 review
+	 * @param neverReview whether the web content article is not set for review
+	 * @param indexable whether the web content article is searchable
+	 * @param smallImage whether the web content article has a small image
+	 * @param smallImageURL the web content article's small image URL
+	 * @param smallFile the web content article's small image file
+	 * @param images the web content's images
+	 * @param articleURL the web content article's accessible URL
+	 * @param serviceContext the service context to be applied. Can set the
+	 UUID, creation date, modification date, expando bridge
+	 attributes, guest permissions, group permissions, asset category
+	 IDs, asset tag names, asset link entry IDs, asset priority, URL
+	 title, and workflow actions for the web content article. Can also
+	 set whether to add the default guest and group permissions.
+	 * @return the web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static com.liferay.journal.model.JournalArticle addArticle(
+			long groupId, long folderId, long classNameId, long classPK,
+			String articleId, boolean autoArticleId,
+			String externalReferenceCode,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmStructureKey, String ddmTemplateKey,
+			String layoutUuid, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			int expirationDateMonth, int expirationDateDay,
+			int expirationDateYear, int expirationDateHour,
+			int expirationDateMinute, boolean neverExpire, int reviewDateMonth,
+			int reviewDateDay, int reviewDateYear, int reviewDateHour,
+			int reviewDateMinute, boolean neverReview, boolean indexable,
+			boolean smallImage, String smallImageURL, java.io.File smallFile,
+			java.util.Map<String, byte[]> images, String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addArticle(
+			groupId, folderId, classNameId, classPK, articleId, autoArticleId,
+			externalReferenceCode, titleMap, descriptionMap, friendlyURLMap,
+			content, ddmStructureKey, ddmTemplateKey, layoutUuid,
+			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
+			displayDateMinute, expirationDateMonth, expirationDateDay,
+			expirationDateYear, expirationDateHour, expirationDateMinute,
+			neverExpire, reviewDateMonth, reviewDateDay, reviewDateYear,
+			reviewDateHour, reviewDateMinute, neverReview, indexable,
+			smallImage, smallImageURL, smallFile, images, articleURL,
+			serviceContext);
+	}
+
+	/**
 	 * Adds a web content article.
 	 *
 	 * @param groupId the primary key of the web content article's group
@@ -548,6 +663,24 @@ public class JournalArticleServiceUtil {
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return getService().fetchArticle(groupId, articleId);
+	}
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code,
+	 * and workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the external reference code of the web content article
+	 * @return the latest matching web content article, or <code>null</code> if
+	 no matching web content article could be found
+	 */
+	public static com.liferay.journal.model.JournalArticle
+			fetchLatestArticleByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().fetchLatestArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	/**
@@ -1424,6 +1557,24 @@ public class JournalArticleServiceUtil {
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return getService().getLatestArticle(groupId, className, classPK);
+	}
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code,
+	 * and workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the external reference code of the web content article
+	 * @return the latest matching web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static com.liferay.journal.model.JournalArticle
+			getLatestArticleByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().getLatestArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	public static java.util.List<com.liferay.journal.model.JournalArticle>
@@ -2458,6 +2609,119 @@ public class JournalArticleServiceUtil {
 
 		return getService().updateArticle(
 			groupId, folderId, articleId, version, content, serviceContext);
+	}
+
+	/**
+	 * Updates the web content article with additional parameters. All
+	 * scheduling parameters (display date, expiration date, and review date)
+	 * use the current user's timezone.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param folderId the primary key of the web content article folder
+	 * @param articleId the primary key of the web content article
+	 * @param externalReferenCode the external reference code of the web
+	 content article
+	 * @param version the web content article's version
+	 * @param titleMap the web content article's locales and localized titles
+	 * @param descriptionMap the web content article's locales and localized
+	 descriptions
+	 * @param friendlyURLMap the web content article's locales and localized
+	 friendly URLs
+	 * @param content the HTML content wrapped in XML. For more information,
+	 see the content example in the {@link #updateArticle(long, long,
+	 String, double, String, ServiceContext)} description.
+	 * @param ddmStructureKey the primary key of the web content article's DDM
+	 structure, if the article is related to a DDM structure, or
+	 <code>null</code> otherwise
+	 * @param ddmTemplateKey the primary key of the web content article's DDM
+	 template
+	 * @param layoutUuid the unique string identifying the web content
+	 article's display page
+	 * @param displayDateMonth the month the web content article is set to
+	 display
+	 * @param displayDateDay the calendar day the web content article is set to
+	 display
+	 * @param displayDateYear the year the web content article is set to
+	 display
+	 * @param displayDateHour the hour the web content article is set to
+	 display
+	 * @param displayDateMinute the minute the web content article is set to
+	 display
+	 * @param expirationDateMonth the month the web content article is set to
+	 expire
+	 * @param expirationDateDay the calendar day the web content article is set
+	 to expire
+	 * @param expirationDateYear the year the web content article is set to
+	 expire
+	 * @param expirationDateHour the hour the web content article is set to
+	 expire
+	 * @param expirationDateMinute the minute the web content article is set to
+	 expire
+	 * @param neverExpire whether the web content article is not set to auto
+	 expire
+	 * @param reviewDateMonth the month the web content article is set for
+	 review
+	 * @param reviewDateDay the calendar day the web content article is set for
+	 review
+	 * @param reviewDateYear the year the web content article is set for review
+	 * @param reviewDateHour the hour the web content article is set for review
+	 * @param reviewDateMinute the minute the web content article is set for
+	 review
+	 * @param neverReview whether the web content article is not set for review
+	 * @param indexable whether the web content is searchable
+	 * @param smallImage whether to update web content article's a small image.
+	 A file must be passed in as <code>smallImageFile</code> value,
+	 otherwise the current small image is deleted.
+	 * @param smallImageURL the web content article's small image URL
+	 (optionally <code>null</code>)
+	 * @param smallFile the web content article's new small image file
+	 (optionally <code>null</code>). Must pass in
+	 <code>smallImage</code> value of <code>true</code> to replace the
+	 article's small image file.
+	 * @param images the web content's images (optionally <code>null</code>)
+	 * @param articleURL the web content article's accessible URL (optionally
+	 <code>null</code>)
+	 * @param serviceContext the service context to be applied. Can set the
+	 modification date, expando bridge attributes, asset category IDs,
+	 asset tag names, asset link entry IDs, asset priority, workflow
+	 actions, URL title, and can set whether to add the default
+	 command update for the web content article. With respect to
+	 social activities, by setting the service context's command to
+	 {@link com.liferay.portal.kernel.util.Constants#UPDATE}, the
+	 invocation is considered a web content update activity; otherwise
+	 it is considered a web content add activity.
+	 * @return the updated web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static com.liferay.journal.model.JournalArticle updateArticle(
+			long groupId, long folderId, String articleId,
+			String externalReferenceCode, double version,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmStructureKey, String ddmTemplateKey,
+			String layoutUuid, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			int expirationDateMonth, int expirationDateDay,
+			int expirationDateYear, int expirationDateHour,
+			int expirationDateMinute, boolean neverExpire, int reviewDateMonth,
+			int reviewDateDay, int reviewDateYear, int reviewDateHour,
+			int reviewDateMinute, boolean neverReview, boolean indexable,
+			boolean smallImage, String smallImageURL, java.io.File smallFile,
+			java.util.Map<String, byte[]> images, String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().updateArticle(
+			groupId, folderId, articleId, externalReferenceCode, version,
+			titleMap, descriptionMap, friendlyURLMap, content, ddmStructureKey,
+			ddmTemplateKey, layoutUuid, displayDateMonth, displayDateDay,
+			displayDateYear, displayDateHour, displayDateMinute,
+			expirationDateMonth, expirationDateDay, expirationDateYear,
+			expirationDateHour, expirationDateMinute, neverExpire,
+			reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
+			reviewDateMinute, neverReview, indexable, smallImage, smallImageURL,
+			smallFile, images, articleURL, serviceContext);
 	}
 
 	public static com.liferay.journal.model.JournalArticle

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceWrapper.java
@@ -356,6 +356,122 @@ public class JournalArticleServiceWrapper
 	}
 
 	/**
+	 * Adds a web content article with additional parameters. All scheduling
+	 * parameters (display date, expiration date, and review date) use the
+	 * current user's timezone.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param folderId the primary key of the web content article folder
+	 * @param classNameId the primary key of the DDMStructure class if the web
+	 content article is related to a DDM structure, the primary key of
+	 the class name associated with the article, or
+	 JournalArticleConstants.CLASS_NAME_ID_DEFAULT in the journal-api
+	 module otherwise
+	 * @param classPK the primary key of the DDM structure, if the primary key
+	 of the DDMStructure class is given as the
+	 <code>classNameId</code> parameter, the primary key of the class
+	 associated with the web content article, or <code>0</code>
+	 otherwise
+	 * @param articleId the primary key of the web content article
+	 * @param autoArticleId whether to auto generate the web content article ID
+	 * @param titleMap the web content article's locales and localized titles
+	 * @param descriptionMap the web content article's locales and localized
+	 descriptions
+	 * @param friendlyURLMap the web content article's locales and localized
+	 friendly URLs
+	 * @param content the HTML content wrapped in XML. For more information,
+	 see the content example in the {@link #updateArticle(long, long,
+	 String, double, String, ServiceContext)} description.
+	 * @param ddmStructureKey the primary key of the web content article's DDM
+	 structure, if the article is related to a DDM structure, or
+	 <code>null</code> otherwise
+	 * @param ddmTemplateKey the primary key of the web content article's DDM
+	 template
+	 * @param externalReferenceCode the external reference code of the web
+	 content article
+	 * @param layoutUuid the unique string identifying the web content
+	 article's display page
+	 * @param displayDateMonth the month the web content article is set to
+	 display
+	 * @param displayDateDay the calendar day the web content article is set to
+	 display
+	 * @param displayDateYear the year the web content article is set to
+	 display
+	 * @param displayDateHour the hour the web content article is set to
+	 display
+	 * @param displayDateMinute the minute the web content article is set to
+	 display
+	 * @param expirationDateMonth the month the web content article is set to
+	 expire
+	 * @param expirationDateDay the calendar day the web content article is set
+	 to expire
+	 * @param expirationDateYear the year the web content article is set to
+	 expire
+	 * @param expirationDateHour the hour the web content article is set to
+	 expire
+	 * @param expirationDateMinute the minute the web content article is set to
+	 expire
+	 * @param neverExpire whether the web content article is not set to auto
+	 expire
+	 * @param reviewDateMonth the month the web content article is set for
+	 review
+	 * @param reviewDateDay the calendar day the web content article is set for
+	 review
+	 * @param reviewDateYear the year the web content article is set for review
+	 * @param reviewDateHour the hour the web content article is set for review
+	 * @param reviewDateMinute the minute the web content article is set for
+	 review
+	 * @param neverReview whether the web content article is not set for review
+	 * @param indexable whether the web content article is searchable
+	 * @param smallImage whether the web content article has a small image
+	 * @param smallImageURL the web content article's small image URL
+	 * @param smallFile the web content article's small image file
+	 * @param images the web content's images
+	 * @param articleURL the web content article's accessible URL
+	 * @param serviceContext the service context to be applied. Can set the
+	 UUID, creation date, modification date, expando bridge
+	 attributes, guest permissions, group permissions, asset category
+	 IDs, asset tag names, asset link entry IDs, asset priority, URL
+	 title, and workflow actions for the web content article. Can also
+	 set whether to add the default guest and group permissions.
+	 * @return the web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public JournalArticle addArticle(
+			long groupId, long folderId, long classNameId, long classPK,
+			String articleId, boolean autoArticleId,
+			String externalReferenceCode,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmStructureKey, String ddmTemplateKey,
+			String layoutUuid, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			int expirationDateMonth, int expirationDateDay,
+			int expirationDateYear, int expirationDateHour,
+			int expirationDateMinute, boolean neverExpire, int reviewDateMonth,
+			int reviewDateDay, int reviewDateYear, int reviewDateHour,
+			int reviewDateMinute, boolean neverReview, boolean indexable,
+			boolean smallImage, String smallImageURL, java.io.File smallFile,
+			java.util.Map<String, byte[]> images, String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleService.addArticle(
+			groupId, folderId, classNameId, classPK, articleId, autoArticleId,
+			externalReferenceCode, titleMap, descriptionMap, friendlyURLMap,
+			content, ddmStructureKey, ddmTemplateKey, layoutUuid,
+			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
+			displayDateMinute, expirationDateMonth, expirationDateDay,
+			expirationDateYear, expirationDateHour, expirationDateMinute,
+			neverExpire, reviewDateMonth, reviewDateDay, reviewDateYear,
+			reviewDateHour, reviewDateMinute, neverReview, indexable,
+			smallImage, smallImageURL, smallFile, images, articleURL,
+			serviceContext);
+	}
+
+	/**
 	 * Adds a web content article.
 	 *
 	 * @param groupId the primary key of the web content article's group
@@ -553,6 +669,24 @@ public class JournalArticleServiceWrapper
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _journalArticleService.fetchArticle(groupId, articleId);
+	}
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code,
+	 * and workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the external reference code of the web content article
+	 * @return the latest matching web content article, or <code>null</code> if
+	 no matching web content article could be found
+	 */
+	@Override
+	public JournalArticle fetchLatestArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleService.fetchLatestArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	/**
@@ -1445,6 +1579,24 @@ public class JournalArticleServiceWrapper
 
 		return _journalArticleService.getLatestArticle(
 			groupId, className, classPK);
+	}
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code,
+	 * and workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the external reference code of the web content article
+	 * @return the latest matching web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public JournalArticle getLatestArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleService.getLatestArticleByExternalReferenceCode(
+			groupId, externalReferenceCode);
 	}
 
 	@Override
@@ -2504,6 +2656,120 @@ public class JournalArticleServiceWrapper
 
 		return _journalArticleService.updateArticle(
 			groupId, folderId, articleId, version, content, serviceContext);
+	}
+
+	/**
+	 * Updates the web content article with additional parameters. All
+	 * scheduling parameters (display date, expiration date, and review date)
+	 * use the current user's timezone.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param folderId the primary key of the web content article folder
+	 * @param articleId the primary key of the web content article
+	 * @param externalReferenCode the external reference code of the web
+	 content article
+	 * @param version the web content article's version
+	 * @param titleMap the web content article's locales and localized titles
+	 * @param descriptionMap the web content article's locales and localized
+	 descriptions
+	 * @param friendlyURLMap the web content article's locales and localized
+	 friendly URLs
+	 * @param content the HTML content wrapped in XML. For more information,
+	 see the content example in the {@link #updateArticle(long, long,
+	 String, double, String, ServiceContext)} description.
+	 * @param ddmStructureKey the primary key of the web content article's DDM
+	 structure, if the article is related to a DDM structure, or
+	 <code>null</code> otherwise
+	 * @param ddmTemplateKey the primary key of the web content article's DDM
+	 template
+	 * @param layoutUuid the unique string identifying the web content
+	 article's display page
+	 * @param displayDateMonth the month the web content article is set to
+	 display
+	 * @param displayDateDay the calendar day the web content article is set to
+	 display
+	 * @param displayDateYear the year the web content article is set to
+	 display
+	 * @param displayDateHour the hour the web content article is set to
+	 display
+	 * @param displayDateMinute the minute the web content article is set to
+	 display
+	 * @param expirationDateMonth the month the web content article is set to
+	 expire
+	 * @param expirationDateDay the calendar day the web content article is set
+	 to expire
+	 * @param expirationDateYear the year the web content article is set to
+	 expire
+	 * @param expirationDateHour the hour the web content article is set to
+	 expire
+	 * @param expirationDateMinute the minute the web content article is set to
+	 expire
+	 * @param neverExpire whether the web content article is not set to auto
+	 expire
+	 * @param reviewDateMonth the month the web content article is set for
+	 review
+	 * @param reviewDateDay the calendar day the web content article is set for
+	 review
+	 * @param reviewDateYear the year the web content article is set for review
+	 * @param reviewDateHour the hour the web content article is set for review
+	 * @param reviewDateMinute the minute the web content article is set for
+	 review
+	 * @param neverReview whether the web content article is not set for review
+	 * @param indexable whether the web content is searchable
+	 * @param smallImage whether to update web content article's a small image.
+	 A file must be passed in as <code>smallImageFile</code> value,
+	 otherwise the current small image is deleted.
+	 * @param smallImageURL the web content article's small image URL
+	 (optionally <code>null</code>)
+	 * @param smallFile the web content article's new small image file
+	 (optionally <code>null</code>). Must pass in
+	 <code>smallImage</code> value of <code>true</code> to replace the
+	 article's small image file.
+	 * @param images the web content's images (optionally <code>null</code>)
+	 * @param articleURL the web content article's accessible URL (optionally
+	 <code>null</code>)
+	 * @param serviceContext the service context to be applied. Can set the
+	 modification date, expando bridge attributes, asset category IDs,
+	 asset tag names, asset link entry IDs, asset priority, workflow
+	 actions, URL title, and can set whether to add the default
+	 command update for the web content article. With respect to
+	 social activities, by setting the service context's command to
+	 {@link com.liferay.portal.kernel.util.Constants#UPDATE}, the
+	 invocation is considered a web content update activity; otherwise
+	 it is considered a web content add activity.
+	 * @return the updated web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public JournalArticle updateArticle(
+			long groupId, long folderId, String articleId,
+			String externalReferenceCode, double version,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmStructureKey, String ddmTemplateKey,
+			String layoutUuid, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			int expirationDateMonth, int expirationDateDay,
+			int expirationDateYear, int expirationDateHour,
+			int expirationDateMinute, boolean neverExpire, int reviewDateMonth,
+			int reviewDateDay, int reviewDateYear, int reviewDateHour,
+			int reviewDateMinute, boolean neverReview, boolean indexable,
+			boolean smallImage, String smallImageURL, java.io.File smallFile,
+			java.util.Map<String, byte[]> images, String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleService.updateArticle(
+			groupId, folderId, articleId, externalReferenceCode, version,
+			titleMap, descriptionMap, friendlyURLMap, content, ddmStructureKey,
+			ddmTemplateKey, layoutUuid, displayDateMonth, displayDateDay,
+			displayDateYear, displayDateHour, displayDateMinute,
+			expirationDateMonth, expirationDateDay, expirationDateYear,
+			expirationDateHour, expirationDateMinute, neverExpire,
+			reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
+			reviewDateMinute, neverReview, indexable, smallImage, smallImageURL,
+			smallFile, images, articleURL, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticlePersistence.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticlePersistence.java
@@ -2731,6 +2731,231 @@ public interface JournalArticlePersistence
 	public int filterCountByG_A(long groupId, String articleId);
 
 	/**
+	 * Returns all the journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching journal articles
+	 */
+	public java.util.List<JournalArticle> findByG_ERC(
+		long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns a range of all the journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @return the range of matching journal articles
+	 */
+	public java.util.List<JournalArticle> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching journal articles
+	 */
+	public java.util.List<JournalArticle> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<JournalArticle>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching journal articles
+	 */
+	public java.util.List<JournalArticle> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<JournalArticle>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching journal article
+	 * @throws NoSuchArticleException if a matching journal article could not be found
+	 */
+	public JournalArticle findByG_ERC_First(
+			long groupId, String externalReferenceCode,
+			com.liferay.portal.kernel.util.OrderByComparator<JournalArticle>
+				orderByComparator)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns the first journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
+	 */
+	public JournalArticle fetchByG_ERC_First(
+		long groupId, String externalReferenceCode,
+		com.liferay.portal.kernel.util.OrderByComparator<JournalArticle>
+			orderByComparator);
+
+	/**
+	 * Returns the last journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching journal article
+	 * @throws NoSuchArticleException if a matching journal article could not be found
+	 */
+	public JournalArticle findByG_ERC_Last(
+			long groupId, String externalReferenceCode,
+			com.liferay.portal.kernel.util.OrderByComparator<JournalArticle>
+				orderByComparator)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns the last journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
+	 */
+	public JournalArticle fetchByG_ERC_Last(
+		long groupId, String externalReferenceCode,
+		com.liferay.portal.kernel.util.OrderByComparator<JournalArticle>
+			orderByComparator);
+
+	/**
+	 * Returns the journal articles before and after the current journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param id the primary key of the current journal article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next journal article
+	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
+	 */
+	public JournalArticle[] findByG_ERC_PrevAndNext(
+			long id, long groupId, String externalReferenceCode,
+			com.liferay.portal.kernel.util.OrderByComparator<JournalArticle>
+				orderByComparator)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns all the journal articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching journal articles that the user has permission to view
+	 */
+	public java.util.List<JournalArticle> filterFindByG_ERC(
+		long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns a range of all the journal articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @return the range of matching journal articles that the user has permission to view
+	 */
+	public java.util.List<JournalArticle> filterFindByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the journal articles that the user has permissions to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching journal articles that the user has permission to view
+	 */
+	public java.util.List<JournalArticle> filterFindByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<JournalArticle>
+			orderByComparator);
+
+	/**
+	 * Returns the journal articles before and after the current journal article in the ordered set of journal articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param id the primary key of the current journal article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next journal article
+	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
+	 */
+	public JournalArticle[] filterFindByG_ERC_PrevAndNext(
+			long id, long groupId, String externalReferenceCode,
+			com.liferay.portal.kernel.util.OrderByComparator<JournalArticle>
+				orderByComparator)
+		throws NoSuchArticleException;
+
+	/**
+	 * Removes all the journal articles where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 */
+	public void removeByG_ERC(long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns the number of journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching journal articles
+	 */
+	public int countByG_ERC(long groupId, String externalReferenceCode);
+
+	/**
+	 * Returns the number of journal articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching journal articles that the user has permission to view
+	 */
+	public int filterCountByG_ERC(long groupId, String externalReferenceCode);
+
+	/**
 	 * Returns all the journal articles where groupId = &#63; and urlTitle = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -7189,6 +7414,66 @@ public interface JournalArticlePersistence
 	 */
 	public int filterCountByG_A_NotST(
 		long groupId, String articleId, int status);
+
+	/**
+	 * Returns the journal article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or throws a <code>NoSuchArticleException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching journal article
+	 * @throws NoSuchArticleException if a matching journal article could not be found
+	 */
+	public JournalArticle findByG_ERC_V(
+			long groupId, String externalReferenceCode, double version)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns the journal article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching journal article, or <code>null</code> if a matching journal article could not be found
+	 */
+	public JournalArticle fetchByG_ERC_V(
+		long groupId, String externalReferenceCode, double version);
+
+	/**
+	 * Returns the journal article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching journal article, or <code>null</code> if a matching journal article could not be found
+	 */
+	public JournalArticle fetchByG_ERC_V(
+		long groupId, String externalReferenceCode, double version,
+		boolean useFinderCache);
+
+	/**
+	 * Removes the journal article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the journal article that was removed
+	 */
+	public JournalArticle removeByG_ERC_V(
+			long groupId, String externalReferenceCode, double version)
+		throws NoSuchArticleException;
+
+	/**
+	 * Returns the number of journal articles where groupId = &#63; and externalReferenceCode = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the number of matching journal articles
+	 */
+	public int countByG_ERC_V(
+		long groupId, String externalReferenceCode, double version);
 
 	/**
 	 * Returns all the journal articles where groupId = &#63; and urlTitle = &#63; and status = &#63;.

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/persistence/JournalArticleUtil.java
@@ -3347,6 +3347,285 @@ public class JournalArticleUtil {
 	}
 
 	/**
+	 * Returns all the journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching journal articles
+	 */
+	public static List<JournalArticle> findByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return getPersistence().findByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns a range of all the journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @return the range of matching journal articles
+	 */
+	public static List<JournalArticle> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end) {
+
+		return getPersistence().findByG_ERC(
+			groupId, externalReferenceCode, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching journal articles
+	 */
+	public static List<JournalArticle> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<JournalArticle> orderByComparator) {
+
+		return getPersistence().findByG_ERC(
+			groupId, externalReferenceCode, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching journal articles
+	 */
+	public static List<JournalArticle> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<JournalArticle> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_ERC(
+			groupId, externalReferenceCode, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching journal article
+	 * @throws NoSuchArticleException if a matching journal article could not be found
+	 */
+	public static JournalArticle findByG_ERC_First(
+			long groupId, String externalReferenceCode,
+			OrderByComparator<JournalArticle> orderByComparator)
+		throws com.liferay.journal.exception.NoSuchArticleException {
+
+		return getPersistence().findByG_ERC_First(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns the first journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
+	 */
+	public static JournalArticle fetchByG_ERC_First(
+		long groupId, String externalReferenceCode,
+		OrderByComparator<JournalArticle> orderByComparator) {
+
+		return getPersistence().fetchByG_ERC_First(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns the last journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching journal article
+	 * @throws NoSuchArticleException if a matching journal article could not be found
+	 */
+	public static JournalArticle findByG_ERC_Last(
+			long groupId, String externalReferenceCode,
+			OrderByComparator<JournalArticle> orderByComparator)
+		throws com.liferay.journal.exception.NoSuchArticleException {
+
+		return getPersistence().findByG_ERC_Last(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns the last journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
+	 */
+	public static JournalArticle fetchByG_ERC_Last(
+		long groupId, String externalReferenceCode,
+		OrderByComparator<JournalArticle> orderByComparator) {
+
+		return getPersistence().fetchByG_ERC_Last(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns the journal articles before and after the current journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param id the primary key of the current journal article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next journal article
+	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
+	 */
+	public static JournalArticle[] findByG_ERC_PrevAndNext(
+			long id, long groupId, String externalReferenceCode,
+			OrderByComparator<JournalArticle> orderByComparator)
+		throws com.liferay.journal.exception.NoSuchArticleException {
+
+		return getPersistence().findByG_ERC_PrevAndNext(
+			id, groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Returns all the journal articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching journal articles that the user has permission to view
+	 */
+	public static List<JournalArticle> filterFindByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return getPersistence().filterFindByG_ERC(
+			groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns a range of all the journal articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @return the range of matching journal articles that the user has permission to view
+	 */
+	public static List<JournalArticle> filterFindByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end) {
+
+		return getPersistence().filterFindByG_ERC(
+			groupId, externalReferenceCode, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the journal articles that the user has permissions to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching journal articles that the user has permission to view
+	 */
+	public static List<JournalArticle> filterFindByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<JournalArticle> orderByComparator) {
+
+		return getPersistence().filterFindByG_ERC(
+			groupId, externalReferenceCode, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns the journal articles before and after the current journal article in the ordered set of journal articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param id the primary key of the current journal article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next journal article
+	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
+	 */
+	public static JournalArticle[] filterFindByG_ERC_PrevAndNext(
+			long id, long groupId, String externalReferenceCode,
+			OrderByComparator<JournalArticle> orderByComparator)
+		throws com.liferay.journal.exception.NoSuchArticleException {
+
+		return getPersistence().filterFindByG_ERC_PrevAndNext(
+			id, groupId, externalReferenceCode, orderByComparator);
+	}
+
+	/**
+	 * Removes all the journal articles where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 */
+	public static void removeByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		getPersistence().removeByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the number of journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching journal articles
+	 */
+	public static int countByG_ERC(long groupId, String externalReferenceCode) {
+		return getPersistence().countByG_ERC(groupId, externalReferenceCode);
+	}
+
+	/**
+	 * Returns the number of journal articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching journal articles that the user has permission to view
+	 */
+	public static int filterCountByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return getPersistence().filterCountByG_ERC(
+			groupId, externalReferenceCode);
+	}
+
+	/**
 	 * Returns all the journal articles where groupId = &#63; and urlTitle = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -8771,6 +9050,86 @@ public class JournalArticleUtil {
 
 		return getPersistence().filterCountByG_A_NotST(
 			groupId, articleId, status);
+	}
+
+	/**
+	 * Returns the journal article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or throws a <code>NoSuchArticleException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching journal article
+	 * @throws NoSuchArticleException if a matching journal article could not be found
+	 */
+	public static JournalArticle findByG_ERC_V(
+			long groupId, String externalReferenceCode, double version)
+		throws com.liferay.journal.exception.NoSuchArticleException {
+
+		return getPersistence().findByG_ERC_V(
+			groupId, externalReferenceCode, version);
+	}
+
+	/**
+	 * Returns the journal article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching journal article, or <code>null</code> if a matching journal article could not be found
+	 */
+	public static JournalArticle fetchByG_ERC_V(
+		long groupId, String externalReferenceCode, double version) {
+
+		return getPersistence().fetchByG_ERC_V(
+			groupId, externalReferenceCode, version);
+	}
+
+	/**
+	 * Returns the journal article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching journal article, or <code>null</code> if a matching journal article could not be found
+	 */
+	public static JournalArticle fetchByG_ERC_V(
+		long groupId, String externalReferenceCode, double version,
+		boolean useFinderCache) {
+
+		return getPersistence().fetchByG_ERC_V(
+			groupId, externalReferenceCode, version, useFinderCache);
+	}
+
+	/**
+	 * Removes the journal article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the journal article that was removed
+	 */
+	public static JournalArticle removeByG_ERC_V(
+			long groupId, String externalReferenceCode, double version)
+		throws com.liferay.journal.exception.NoSuchArticleException {
+
+		return getPersistence().removeByG_ERC_V(
+			groupId, externalReferenceCode, version);
+	}
+
+	/**
+	 * Returns the number of journal articles where groupId = &#63; and externalReferenceCode = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the number of matching journal articles
+	 */
+	public static int countByG_ERC_V(
+		long groupId, String externalReferenceCode, double version) {
+
+		return getPersistence().countByG_ERC_V(
+			groupId, externalReferenceCode, version);
 	}
 
 	/**

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/exception/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/exception/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/model/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.2.0
+version 4.3.0

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.5.0
+version 3.6.0

--- a/modules/apps/journal/journal-service/bnd.bnd
+++ b/modules/apps/journal/journal-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal Service
 Bundle-SymbolicName: com.liferay.journal.service
 Bundle-Version: 7.0.0
-Liferay-Require-SchemaVersion: 3.4.1
+Liferay-Require-SchemaVersion: 3.5.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/journal/journal-service/service.xml
+++ b/modules/apps/journal/journal-service/service.xml
@@ -32,6 +32,7 @@
 		<column name="classPK" type="long" />
 		<column name="treePath" type="String" />
 		<column accessor="true" name="articleId" type="String" />
+		<column accessor="true" name="externalReferenceCode" type="String" />
 		<column name="version" type="double" />
 		<column name="urlTitle" type="String" uad-nonanonymizable="true" />
 		<column name="content" type="String" uad-nonanonymizable="true" />
@@ -98,6 +99,10 @@
 		<finder name="G_A" return-type="Collection">
 			<finder-column name="groupId" />
 			<finder-column name="articleId" />
+		</finder>
+		<finder name="G_ERC" return-type="Collection">
+			<finder-column name="groupId" />
+			<finder-column name="externalReferenceCode" />
 		</finder>
 		<finder name="G_UT" return-type="Collection">
 			<finder-column name="groupId" />
@@ -188,6 +193,11 @@
 			<finder-column name="groupId" />
 			<finder-column name="articleId" />
 			<finder-column comparator="!=" name="status" />
+		</finder>
+		<finder name="G_ERC_V" return-type="JournalArticle" unique="true">
+			<finder-column name="groupId" />
+			<finder-column name="externalReferenceCode" />
+			<finder-column name="version" />
 		</finder>
 		<finder name="G_UT_ST" return-type="Collection">
 			<finder-column name="groupId" />

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -650,6 +650,18 @@ public class JournalArticleStagedModelDataHandler
 			autoArticleId = false;
 		}
 
+		String externalReferenceCode = article.getExternalReferenceCode();
+
+		JournalArticle articleByERC =
+			_journalArticleLocalService.
+				fetchLatestArticleByExternalReferenceCode(
+					portletDataContext.getScopeGroupId(),
+					externalReferenceCode);
+
+		if (articleByERC != null) {
+			externalReferenceCode = newArticleId;
+		}
+
 		String content = article.getContent();
 
 		content =
@@ -941,13 +953,13 @@ public class JournalArticleStagedModelDataHandler
 					importedArticle = _journalArticleLocalService.addArticle(
 						userId, portletDataContext.getScopeGroupId(), folderId,
 						article.getClassNameId(), ddmStructureId, articleId,
-						autoArticleId, article.getVersion(),
-						article.getTitleMap(), article.getDescriptionMap(),
-						friendlyURLMap, article.getContent(),
-						parentDDMStructureKey, parentDDMTemplateKey,
-						article.getLayoutUuid(), displayDateMonth,
-						displayDateDay, displayDateYear, displayDateHour,
-						displayDateMinute, expirationDateMonth,
+						autoArticleId, externalReferenceCode,
+						article.getVersion(), article.getTitleMap(),
+						article.getDescriptionMap(), friendlyURLMap,
+						article.getContent(), parentDDMStructureKey,
+						parentDDMTemplateKey, article.getLayoutUuid(),
+						displayDateMonth, displayDateDay, displayDateYear,
+						displayDateHour, displayDateMinute, expirationDateMonth,
 						expirationDateDay, expirationDateYear,
 						expirationDateHour, expirationDateMinute, neverExpire,
 						reviewDateMonth, reviewDateDay, reviewDateYear,
@@ -959,13 +971,14 @@ public class JournalArticleStagedModelDataHandler
 				else {
 					importedArticle = _journalArticleLocalService.updateArticle(
 						userId, existingArticle.getGroupId(), folderId,
-						existingArticle.getArticleId(), article.getVersion(),
-						article.getTitleMap(), article.getDescriptionMap(),
-						friendlyURLMap, article.getContent(),
-						parentDDMStructureKey, parentDDMTemplateKey,
-						article.getLayoutUuid(), displayDateMonth,
-						displayDateDay, displayDateYear, displayDateHour,
-						displayDateMinute, expirationDateMonth,
+						existingArticle.getArticleId(),
+						existingArticleVersion.getExternalReferenceCode(),
+						article.getVersion(), article.getTitleMap(),
+						article.getDescriptionMap(), friendlyURLMap,
+						article.getContent(), parentDDMStructureKey,
+						parentDDMTemplateKey, article.getLayoutUuid(),
+						displayDateMonth, displayDateDay, displayDateYear,
+						displayDateHour, displayDateMinute, expirationDateMonth,
 						expirationDateDay, expirationDateYear,
 						expirationDateHour, expirationDateMinute, neverExpire,
 						reviewDateMonth, reviewDateDay, reviewDateYear,
@@ -989,9 +1002,9 @@ public class JournalArticleStagedModelDataHandler
 				importedArticle = _journalArticleLocalService.addArticle(
 					userId, portletDataContext.getScopeGroupId(), folderId,
 					article.getClassNameId(), ddmStructureId, articleId,
-					autoArticleId, article.getVersion(), article.getTitleMap(),
-					article.getDescriptionMap(), friendlyURLMap,
-					article.getContent(), parentDDMStructureKey,
+					autoArticleId, externalReferenceCode, article.getVersion(),
+					article.getTitleMap(), article.getDescriptionMap(),
+					friendlyURLMap, article.getContent(), parentDDMStructureKey,
 					parentDDMTemplateKey, article.getLayoutUuid(),
 					displayDateMonth, displayDateDay, displayDateYear,
 					displayDateHour, displayDateMinute, expirationDateMonth,

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalServiceUpgrade.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/JournalServiceUpgrade.java
@@ -279,6 +279,11 @@ public class JournalServiceUpgrade implements UpgradeStepRegistrator {
 			"3.4.0", "3.4.1",
 			new com.liferay.journal.internal.upgrade.v3_4_1.
 				UpgradeJournalArticleLocalization());
+
+		registry.register(
+			"3.4.1", "3.5.0",
+			new com.liferay.journal.internal.upgrade.v3_5_0.
+				UpgradeJournalArticle());
 	}
 
 	protected void deleteTempImages() throws Exception {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v3_5_0/UpgradeJournalArticle.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v3_5_0/UpgradeJournalArticle.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.internal.upgrade.v3_5_0;
+
+import com.liferay.journal.internal.upgrade.v3_5_0.util.JournalArticleTable;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Javier de Arcos
+ */
+public class UpgradeJournalArticle extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		if (hasColumn("JournalArticle", "externalReferenceCode")) {
+			return;
+		}
+
+		alter(
+			JournalArticleTable.class,
+			new AlterTableAddColumn("externalReferenceCode", "VARCHAR(75)"));
+
+		runSQL("update JournalArticle set externalReferenceCode = articleId");
+	}
+
+}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v3_5_0/util/JournalArticleTable.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v3_5_0/util/JournalArticleTable.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.internal.upgrade.v3_5_0.util;
+
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Javier de Arcos
+ * @generated
+ */
+public class JournalArticleTable {
+
+	public static final String TABLE_NAME = "JournalArticle";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
+		{"uuid_", Types.VARCHAR}, {"id_", Types.BIGINT},
+		{"resourcePrimKey", Types.BIGINT}, {"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP}, {"folderId", Types.BIGINT},
+		{"classNameId", Types.BIGINT}, {"classPK", Types.BIGINT},
+		{"treePath", Types.VARCHAR}, {"articleId", Types.VARCHAR},
+		{"externalReferenceCode", Types.VARCHAR}, {"version", Types.DOUBLE},
+		{"urlTitle", Types.VARCHAR}, {"content", Types.CLOB},
+		{"DDMStructureKey", Types.VARCHAR}, {"DDMTemplateKey", Types.VARCHAR},
+		{"defaultLanguageId", Types.VARCHAR}, {"layoutUuid", Types.VARCHAR},
+		{"displayDate", Types.TIMESTAMP}, {"expirationDate", Types.TIMESTAMP},
+		{"reviewDate", Types.TIMESTAMP}, {"indexable", Types.BOOLEAN},
+		{"smallImage", Types.BOOLEAN}, {"smallImageId", Types.BIGINT},
+		{"smallImageURL", Types.VARCHAR}, {"lastPublishDate", Types.TIMESTAMP},
+		{"status", Types.INTEGER}, {"statusByUserId", Types.BIGINT},
+		{"statusByUserName", Types.VARCHAR}, {"statusDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
+new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("id_", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("resourcePrimKey", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("folderId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("classNameId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("treePath", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("articleId", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("version", Types.DOUBLE);
+
+TABLE_COLUMNS_MAP.put("urlTitle", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("content", Types.CLOB);
+
+TABLE_COLUMNS_MAP.put("DDMStructureKey", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("DDMTemplateKey", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("defaultLanguageId", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("layoutUuid", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("displayDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("expirationDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("reviewDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("indexable", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("smallImage", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("smallImageId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("smallImageURL", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("status", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("statusByUserId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("statusByUserName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("statusDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE =
+"create table JournalArticle (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,id_ LONG not null,resourcePrimKey LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,folderId LONG,classNameId LONG,classPK LONG,treePath STRING null,articleId VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,version DOUBLE,urlTitle VARCHAR(255) null,content TEXT null,DDMStructureKey VARCHAR(75) null,DDMTemplateKey VARCHAR(75) null,defaultLanguageId VARCHAR(75) null,layoutUuid VARCHAR(75) null,displayDate DATE null,expirationDate DATE null,reviewDate DATE null,indexable BOOLEAN,smallImage BOOLEAN,smallImageId LONG,smallImageURL STRING null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (id_, ctCollectionId))";
+
+	public static final String TABLE_SQL_DROP = "drop table JournalArticle";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_F1C2B662 on JournalArticle (DDMStructureKey[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_A01DB92F on JournalArticle (DDMTemplateKey[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_AAF3B581 on JournalArticle (companyId, ctCollectionId)",
+		"create index IX_6D9F9567 on JournalArticle (companyId, status, ctCollectionId)",
+		"create index IX_F12AB4A3 on JournalArticle (companyId, version, ctCollectionId)",
+		"create index IX_F97E5289 on JournalArticle (companyId, version, status, ctCollectionId)",
+		"create index IX_62EBBA43 on JournalArticle (ctCollectionId)",
+		"create index IX_55CADE3F on JournalArticle (displayDate, status, ctCollectionId)",
+		"create index IX_70325BE2 on JournalArticle (groupId, DDMStructureKey[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_6A6363AF on JournalArticle (groupId, DDMTemplateKey[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_E10314FA on JournalArticle (groupId, articleId[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_9E386BE0 on JournalArticle (groupId, articleId[$COLUMN_LENGTH:75$], status, ctCollectionId)",
+		"create unique index IX_D3ACAD4A on JournalArticle (groupId, articleId[$COLUMN_LENGTH:75$], version, ctCollectionId)",
+		"create index IX_8A0FEBBE on JournalArticle (groupId, classNameId, DDMStructureKey[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_20E66853 on JournalArticle (groupId, classNameId, DDMTemplateKey[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_E748358 on JournalArticle (groupId, classNameId, classPK, ctCollectionId)",
+		"create index IX_6CA45D20 on JournalArticle (groupId, classNameId, layoutUuid[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_1ED664C3 on JournalArticle (groupId, ctCollectionId)",
+		"create index IX_DB98B996 on JournalArticle (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create unique index IX_D9F0782E on JournalArticle (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], version, ctCollectionId)",
+		"create index IX_8868DCD0 on JournalArticle (groupId, folderId, classNameId, status, ctCollectionId)",
+		"create index IX_74060760 on JournalArticle (groupId, folderId, ctCollectionId)",
+		"create index IX_D36D9846 on JournalArticle (groupId, folderId, status, ctCollectionId)",
+		"create index IX_E6BD667C on JournalArticle (groupId, layoutUuid[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_E107E2A9 on JournalArticle (groupId, status, ctCollectionId)",
+		"create index IX_254CBF60 on JournalArticle (groupId, urlTitle[$COLUMN_LENGTH:255$], ctCollectionId)",
+		"create index IX_E7C5046 on JournalArticle (groupId, urlTitle[$COLUMN_LENGTH:255$], status, ctCollectionId)",
+		"create index IX_E20FD06D on JournalArticle (groupId, userId, classNameId, ctCollectionId)",
+		"create index IX_B2F1D3FD on JournalArticle (groupId, userId, ctCollectionId)",
+		"create index IX_75FE7BFC on JournalArticle (layoutUuid[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_7D1E8774 on JournalArticle (resourcePrimKey, ctCollectionId)",
+		"create index IX_60EF9564 on JournalArticle (resourcePrimKey, indexable, ctCollectionId)",
+		"create index IX_DFAE24A on JournalArticle (resourcePrimKey, indexable, status, ctCollectionId)",
+		"create index IX_115EC45A on JournalArticle (resourcePrimKey, status, ctCollectionId)",
+		"create index IX_DAB0F686 on JournalArticle (smallImageId, ctCollectionId)",
+		"create index IX_584284F7 on JournalArticle (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId)",
+		"create index IX_9603F88D on JournalArticle (uuid_[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create unique index IX_4D5E99B9 on JournalArticle (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId)"
+	};
+
+}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
@@ -39,6 +39,7 @@ import com.liferay.journal.exception.ArticleSmallImageNameException;
 import com.liferay.journal.exception.ArticleSmallImageSizeException;
 import com.liferay.journal.exception.ArticleTitleException;
 import com.liferay.journal.exception.DuplicateArticleIdException;
+import com.liferay.journal.exception.DuplicateExternalReferenceCodeException;
 import com.liferay.journal.exception.InvalidDDMStructureException;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleLocalization;
@@ -224,10 +225,11 @@ public class JournalArticleModelValidator
 
 	public void validate(
 			long companyId, long groupId, long classNameId, String articleId,
-			boolean autoArticleId, double version, Map<Locale, String> titleMap,
-			String content, String ddmStructureKey, String ddmTemplateKey,
-			Date displayDate, Date expirationDate, boolean smallImage,
-			String smallImageURL, File smallImageFile, byte[] smallImageBytes,
+			boolean autoArticleId, String externalReferenceCode, double version,
+			Map<Locale, String> titleMap, String content,
+			String ddmStructureKey, String ddmTemplateKey, Date displayDate,
+			Date expirationDate, boolean smallImage, String smallImageURL,
+			File smallImageFile, byte[] smallImageBytes,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -252,6 +254,23 @@ public class JournalArticleModelValidator
 
 				throw new DuplicateArticleIdException(sb.toString());
 			}
+		}
+
+		List<JournalArticle> articles = _journalArticlePersistence.findByG_ERC(
+			groupId, externalReferenceCode);
+
+		if (!articles.isEmpty()) {
+			StringBundler sb = new StringBundler(7);
+
+			sb.append("{groupId=");
+			sb.append(groupId);
+			sb.append(", externalReferenceCode=");
+			sb.append(externalReferenceCode);
+			sb.append(", version=");
+			sb.append(version);
+			sb.append("}");
+
+			throw new DuplicateExternalReferenceCodeException(sb.toString());
 		}
 
 		validate(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleCacheModel.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleCacheModel.java
@@ -77,7 +77,7 @@ public class JournalArticleCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(71);
+		StringBundler sb = new StringBundler(73);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -111,6 +111,8 @@ public class JournalArticleCacheModel
 		sb.append(treePath);
 		sb.append(", articleId=");
 		sb.append(articleId);
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
 		sb.append(", version=");
 		sb.append(version);
 		sb.append(", urlTitle=");
@@ -211,6 +213,13 @@ public class JournalArticleCacheModel
 		}
 		else {
 			journalArticleImpl.setArticleId(articleId);
+		}
+
+		if (externalReferenceCode == null) {
+			journalArticleImpl.setExternalReferenceCode("");
+		}
+		else {
+			journalArticleImpl.setExternalReferenceCode(externalReferenceCode);
 		}
 
 		journalArticleImpl.setVersion(version);
@@ -349,6 +358,7 @@ public class JournalArticleCacheModel
 		classPK = objectInput.readLong();
 		treePath = objectInput.readUTF();
 		articleId = objectInput.readUTF();
+		externalReferenceCode = objectInput.readUTF();
 
 		version = objectInput.readDouble();
 		urlTitle = objectInput.readUTF();
@@ -430,6 +440,13 @@ public class JournalArticleCacheModel
 		}
 		else {
 			objectOutput.writeUTF(articleId);
+		}
+
+		if (externalReferenceCode == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(externalReferenceCode);
 		}
 
 		objectOutput.writeDouble(version);
@@ -527,6 +544,7 @@ public class JournalArticleCacheModel
 	public long classPK;
 	public String treePath;
 	public String articleId;
+	public String externalReferenceCode;
 	public double version;
 	public String urlTitle;
 	public String content;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleModelImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleModelImpl.java
@@ -87,16 +87,16 @@ public class JournalArticleModelImpl
 		{"modifiedDate", Types.TIMESTAMP}, {"folderId", Types.BIGINT},
 		{"classNameId", Types.BIGINT}, {"classPK", Types.BIGINT},
 		{"treePath", Types.VARCHAR}, {"articleId", Types.VARCHAR},
-		{"version", Types.DOUBLE}, {"urlTitle", Types.VARCHAR},
-		{"content", Types.CLOB}, {"DDMStructureKey", Types.VARCHAR},
-		{"DDMTemplateKey", Types.VARCHAR}, {"defaultLanguageId", Types.VARCHAR},
-		{"layoutUuid", Types.VARCHAR}, {"displayDate", Types.TIMESTAMP},
-		{"expirationDate", Types.TIMESTAMP}, {"reviewDate", Types.TIMESTAMP},
-		{"indexable", Types.BOOLEAN}, {"smallImage", Types.BOOLEAN},
-		{"smallImageId", Types.BIGINT}, {"smallImageURL", Types.VARCHAR},
-		{"lastPublishDate", Types.TIMESTAMP}, {"status", Types.INTEGER},
-		{"statusByUserId", Types.BIGINT}, {"statusByUserName", Types.VARCHAR},
-		{"statusDate", Types.TIMESTAMP}
+		{"externalReferenceCode", Types.VARCHAR}, {"version", Types.DOUBLE},
+		{"urlTitle", Types.VARCHAR}, {"content", Types.CLOB},
+		{"DDMStructureKey", Types.VARCHAR}, {"DDMTemplateKey", Types.VARCHAR},
+		{"defaultLanguageId", Types.VARCHAR}, {"layoutUuid", Types.VARCHAR},
+		{"displayDate", Types.TIMESTAMP}, {"expirationDate", Types.TIMESTAMP},
+		{"reviewDate", Types.TIMESTAMP}, {"indexable", Types.BOOLEAN},
+		{"smallImage", Types.BOOLEAN}, {"smallImageId", Types.BIGINT},
+		{"smallImageURL", Types.VARCHAR}, {"lastPublishDate", Types.TIMESTAMP},
+		{"status", Types.INTEGER}, {"statusByUserId", Types.BIGINT},
+		{"statusByUserName", Types.VARCHAR}, {"statusDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -119,6 +119,7 @@ public class JournalArticleModelImpl
 		TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("treePath", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("articleId", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("version", Types.DOUBLE);
 		TABLE_COLUMNS_MAP.put("urlTitle", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("content", Types.CLOB);
@@ -141,7 +142,7 @@ public class JournalArticleModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table JournalArticle (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,id_ LONG not null,resourcePrimKey LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,folderId LONG,classNameId LONG,classPK LONG,treePath STRING null,articleId VARCHAR(75) null,version DOUBLE,urlTitle VARCHAR(255) null,content TEXT null,DDMStructureKey VARCHAR(75) null,DDMTemplateKey VARCHAR(75) null,defaultLanguageId VARCHAR(75) null,layoutUuid VARCHAR(75) null,displayDate DATE null,expirationDate DATE null,reviewDate DATE null,indexable BOOLEAN,smallImage BOOLEAN,smallImageId LONG,smallImageURL STRING null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (id_, ctCollectionId))";
+		"create table JournalArticle (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,id_ LONG not null,resourcePrimKey LONG,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,folderId LONG,classNameId LONG,classPK LONG,treePath STRING null,articleId VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,version DOUBLE,urlTitle VARCHAR(255) null,content TEXT null,DDMStructureKey VARCHAR(75) null,DDMTemplateKey VARCHAR(75) null,defaultLanguageId VARCHAR(75) null,layoutUuid VARCHAR(75) null,displayDate DATE null,expirationDate DATE null,reviewDate DATE null,indexable BOOLEAN,smallImage BOOLEAN,smallImageId LONG,smallImageURL STRING null,lastPublishDate DATE null,status INTEGER,statusByUserId LONG,statusByUserName VARCHAR(75) null,statusDate DATE null,primary key (id_, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table JournalArticle";
 
@@ -203,67 +204,73 @@ public class JournalArticleModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long FOLDERID_COLUMN_BITMASK = 128L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 128L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 256L;
+	public static final long FOLDERID_COLUMN_BITMASK = 256L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long INDEXABLE_COLUMN_BITMASK = 512L;
+	public static final long GROUPID_COLUMN_BITMASK = 512L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long LAYOUTUUID_COLUMN_BITMASK = 1024L;
+	public static final long INDEXABLE_COLUMN_BITMASK = 1024L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long RESOURCEPRIMKEY_COLUMN_BITMASK = 2048L;
+	public static final long LAYOUTUUID_COLUMN_BITMASK = 2048L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long SMALLIMAGEID_COLUMN_BITMASK = 4096L;
+	public static final long RESOURCEPRIMKEY_COLUMN_BITMASK = 4096L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long STATUS_COLUMN_BITMASK = 8192L;
+	public static final long SMALLIMAGEID_COLUMN_BITMASK = 8192L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long URLTITLE_COLUMN_BITMASK = 16384L;
+	public static final long STATUS_COLUMN_BITMASK = 16384L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long USERID_COLUMN_BITMASK = 32768L;
+	public static final long URLTITLE_COLUMN_BITMASK = 32768L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 65536L;
+	public static final long USERID_COLUMN_BITMASK = 65536L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
 	 */
 	@Deprecated
-	public static final long VERSION_COLUMN_BITMASK = 131072L;
+	public static final long UUID_COLUMN_BITMASK = 131072L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)
+	 */
+	@Deprecated
+	public static final long VERSION_COLUMN_BITMASK = 262144L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -310,6 +317,7 @@ public class JournalArticleModelImpl
 		model.setClassPK(soapModel.getClassPK());
 		model.setTreePath(soapModel.getTreePath());
 		model.setArticleId(soapModel.getArticleId());
+		model.setExternalReferenceCode(soapModel.getExternalReferenceCode());
 		model.setVersion(soapModel.getVersion());
 		model.setUrlTitle(soapModel.getUrlTitle());
 		model.setContent(soapModel.getContent());
@@ -553,6 +561,12 @@ public class JournalArticleModelImpl
 		attributeSetterBiConsumers.put(
 			"articleId",
 			(BiConsumer<JournalArticle, String>)JournalArticle::setArticleId);
+		attributeGetterFunctions.put(
+			"externalReferenceCode", JournalArticle::getExternalReferenceCode);
+		attributeSetterBiConsumers.put(
+			"externalReferenceCode",
+			(BiConsumer<JournalArticle, String>)
+				JournalArticle::setExternalReferenceCode);
 		attributeGetterFunctions.put("version", JournalArticle::getVersion);
 		attributeSetterBiConsumers.put(
 			"version",
@@ -1048,6 +1062,35 @@ public class JournalArticleModelImpl
 	@Deprecated
 	public String getOriginalArticleId() {
 		return getColumnOriginalValue("articleId");
+	}
+
+	@JSON
+	@Override
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCode == null) {
+			return "";
+		}
+		else {
+			return _externalReferenceCode;
+		}
+	}
+
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalExternalReferenceCode() {
+		return getColumnOriginalValue("externalReferenceCode");
 	}
 
 	@JSON
@@ -1797,6 +1840,7 @@ public class JournalArticleModelImpl
 		journalArticleImpl.setClassPK(getClassPK());
 		journalArticleImpl.setTreePath(getTreePath());
 		journalArticleImpl.setArticleId(getArticleId());
+		journalArticleImpl.setExternalReferenceCode(getExternalReferenceCode());
 		journalArticleImpl.setVersion(getVersion());
 		journalArticleImpl.setUrlTitle(getUrlTitle());
 		journalArticleImpl.setContent(getContent());
@@ -1980,6 +2024,18 @@ public class JournalArticleModelImpl
 
 		if ((articleId != null) && (articleId.length() == 0)) {
 			journalArticleCacheModel.articleId = null;
+		}
+
+		journalArticleCacheModel.externalReferenceCode =
+			getExternalReferenceCode();
+
+		String externalReferenceCode =
+			journalArticleCacheModel.externalReferenceCode;
+
+		if ((externalReferenceCode != null) &&
+			(externalReferenceCode.length() == 0)) {
+
+			journalArticleCacheModel.externalReferenceCode = null;
 		}
 
 		journalArticleCacheModel.version = getVersion();
@@ -2196,6 +2252,7 @@ public class JournalArticleModelImpl
 	private long _classPK;
 	private String _treePath;
 	private String _articleId;
+	private String _externalReferenceCode;
 	private double _version;
 	private String _urlTitle;
 	private String _content;
@@ -2261,6 +2318,8 @@ public class JournalArticleModelImpl
 		_columnOriginalValues.put("classPK", _classPK);
 		_columnOriginalValues.put("treePath", _treePath);
 		_columnOriginalValues.put("articleId", _articleId);
+		_columnOriginalValues.put(
+			"externalReferenceCode", _externalReferenceCode);
 		_columnOriginalValues.put("version", _version);
 		_columnOriginalValues.put("urlTitle", _urlTitle);
 		_columnOriginalValues.put("content", _content);
@@ -2336,43 +2395,45 @@ public class JournalArticleModelImpl
 
 		columnBitmasks.put("articleId", 32768L);
 
-		columnBitmasks.put("version", 65536L);
+		columnBitmasks.put("externalReferenceCode", 65536L);
 
-		columnBitmasks.put("urlTitle", 131072L);
+		columnBitmasks.put("version", 131072L);
 
-		columnBitmasks.put("content", 262144L);
+		columnBitmasks.put("urlTitle", 262144L);
 
-		columnBitmasks.put("DDMStructureKey", 524288L);
+		columnBitmasks.put("content", 524288L);
 
-		columnBitmasks.put("DDMTemplateKey", 1048576L);
+		columnBitmasks.put("DDMStructureKey", 1048576L);
 
-		columnBitmasks.put("defaultLanguageId", 2097152L);
+		columnBitmasks.put("DDMTemplateKey", 2097152L);
 
-		columnBitmasks.put("layoutUuid", 4194304L);
+		columnBitmasks.put("defaultLanguageId", 4194304L);
 
-		columnBitmasks.put("displayDate", 8388608L);
+		columnBitmasks.put("layoutUuid", 8388608L);
 
-		columnBitmasks.put("expirationDate", 16777216L);
+		columnBitmasks.put("displayDate", 16777216L);
 
-		columnBitmasks.put("reviewDate", 33554432L);
+		columnBitmasks.put("expirationDate", 33554432L);
 
-		columnBitmasks.put("indexable", 67108864L);
+		columnBitmasks.put("reviewDate", 67108864L);
 
-		columnBitmasks.put("smallImage", 134217728L);
+		columnBitmasks.put("indexable", 134217728L);
 
-		columnBitmasks.put("smallImageId", 268435456L);
+		columnBitmasks.put("smallImage", 268435456L);
 
-		columnBitmasks.put("smallImageURL", 536870912L);
+		columnBitmasks.put("smallImageId", 536870912L);
 
-		columnBitmasks.put("lastPublishDate", 1073741824L);
+		columnBitmasks.put("smallImageURL", 1073741824L);
 
-		columnBitmasks.put("status", 2147483648L);
+		columnBitmasks.put("lastPublishDate", 2147483648L);
 
-		columnBitmasks.put("statusByUserId", 4294967296L);
+		columnBitmasks.put("status", 4294967296L);
 
-		columnBitmasks.put("statusByUserName", 8589934592L);
+		columnBitmasks.put("statusByUserId", 8589934592L);
 
-		columnBitmasks.put("statusDate", 17179869184L);
+		columnBitmasks.put("statusByUserName", 17179869184L);
+
+		columnBitmasks.put("statusDate", 34359738368L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceHttp.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceHttp.java
@@ -244,6 +244,71 @@ public class JournalArticleServiceHttp {
 
 	public static com.liferay.journal.model.JournalArticle addArticle(
 			HttpPrincipal httpPrincipal, long groupId, long folderId,
+			long classNameId, long classPK, String articleId,
+			boolean autoArticleId, String externalReferenceCode,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmStructureKey, String ddmTemplateKey,
+			String layoutUuid, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			int expirationDateMonth, int expirationDateDay,
+			int expirationDateYear, int expirationDateHour,
+			int expirationDateMinute, boolean neverExpire, int reviewDateMonth,
+			int reviewDateDay, int reviewDateYear, int reviewDateHour,
+			int reviewDateMinute, boolean neverReview, boolean indexable,
+			boolean smallImage, String smallImageURL, java.io.File smallFile,
+			java.util.Map<String, byte[]> images, String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				JournalArticleServiceUtil.class, "addArticle",
+				_addArticleParameterTypes3);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, folderId, classNameId, classPK, articleId,
+				autoArticleId, externalReferenceCode, titleMap, descriptionMap,
+				friendlyURLMap, content, ddmStructureKey, ddmTemplateKey,
+				layoutUuid, displayDateMonth, displayDateDay, displayDateYear,
+				displayDateHour, displayDateMinute, expirationDateMonth,
+				expirationDateDay, expirationDateYear, expirationDateHour,
+				expirationDateMinute, neverExpire, reviewDateMonth,
+				reviewDateDay, reviewDateYear, reviewDateHour, reviewDateMinute,
+				neverReview, indexable, smallImage, smallImageURL, smallFile,
+				images, articleURL, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.journal.model.JournalArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.journal.model.JournalArticle addArticle(
+			HttpPrincipal httpPrincipal, long groupId, long folderId,
 			java.util.Map<java.util.Locale, String> titleMap,
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			String content, String ddmStructureKey, String ddmTemplateKey,
@@ -253,7 +318,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "addArticle",
-				_addArticleParameterTypes3);
+				_addArticleParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, titleMap, descriptionMap, content,
@@ -301,7 +366,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "addArticleDefaultValues",
-				_addArticleDefaultValuesParameterTypes4);
+				_addArticleDefaultValuesParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classPK, titleMap,
@@ -345,7 +410,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "copyArticle",
-				_copyArticleParameterTypes5);
+				_copyArticleParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, oldArticleId, newArticleId, autoArticleId,
@@ -388,7 +453,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "deleteArticle",
-				_deleteArticleParameterTypes6);
+				_deleteArticleParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, articleURL,
@@ -427,7 +492,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "deleteArticle",
-				_deleteArticleParameterTypes7);
+				_deleteArticleParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, articleURL, serviceContext);
@@ -464,7 +529,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "deleteArticleDefaultValues",
-				_deleteArticleDefaultValuesParameterTypes8);
+				_deleteArticleDefaultValuesParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, ddmStructureKey);
@@ -502,7 +567,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "expireArticle",
-				_expireArticleParameterTypes9);
+				_expireArticleParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, articleURL,
@@ -545,7 +610,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "expireArticle",
-				_expireArticleParameterTypes10);
+				_expireArticleParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, articleURL, serviceContext);
@@ -581,10 +646,53 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "fetchArticle",
-				_fetchArticleParameterTypes11);
+				_fetchArticleParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.journal.model.JournalArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.journal.model.JournalArticle
+			fetchLatestArticleByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long groupId,
+				String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				JournalArticleServiceUtil.class,
+				"fetchLatestArticleByExternalReferenceCode",
+				_fetchLatestArticleByExternalReferenceCodeParameterTypes13);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, externalReferenceCode);
 
 			Object returnObj = null;
 
@@ -621,7 +729,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticle",
-				_getArticleParameterTypes12);
+				_getArticleParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, id);
 
@@ -660,7 +768,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticle",
-				_getArticleParameterTypes13);
+				_getArticleParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -701,7 +809,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticle",
-				_getArticleParameterTypes14);
+				_getArticleParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version);
@@ -742,7 +850,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticle",
-				_getArticleParameterTypes15);
+				_getArticleParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, className, classPK);
@@ -782,7 +890,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticleByUrlTitle",
-				_getArticleByUrlTitleParameterTypes16);
+				_getArticleByUrlTitleParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, urlTitle);
@@ -826,7 +934,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticleContent",
-				_getArticleContentParameterTypes17);
+				_getArticleContentParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, languageId,
@@ -871,7 +979,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticleContent",
-				_getArticleContentParameterTypes18);
+				_getArticleContentParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, languageId, portletRequestModel,
@@ -913,7 +1021,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticles",
-				_getArticlesParameterTypes19);
+				_getArticlesParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, locale);
@@ -950,7 +1058,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticles",
-				_getArticlesParameterTypes20);
+				_getArticlesParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, locale, start, end,
@@ -988,7 +1096,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByArticleId",
-				_getArticlesByArticleIdParameterTypes21);
+				_getArticlesByArticleIdParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, start, end, orderByComparator);
@@ -1022,7 +1130,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByLayoutUuid",
-				_getArticlesByLayoutUuidParameterTypes22);
+				_getArticlesByLayoutUuidParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutUuid);
@@ -1057,7 +1165,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByLayoutUuid",
-				_getArticlesByLayoutUuidParameterTypes23);
+				_getArticlesByLayoutUuidParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutUuid, start, end);
@@ -1090,7 +1198,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByLayoutUuidCount",
-				_getArticlesByLayoutUuidCountParameterTypes24);
+				_getArticlesByLayoutUuidCountParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutUuid);
@@ -1126,7 +1234,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByStructureId",
-				_getArticlesByStructureIdParameterTypes25);
+				_getArticlesByStructureIdParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, ddmStructureKey, status, start,
@@ -1165,7 +1273,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByStructureId",
-				_getArticlesByStructureIdParameterTypes26);
+				_getArticlesByStructureIdParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, ddmStructureKey, locale,
@@ -1203,7 +1311,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByStructureId",
-				_getArticlesByStructureIdParameterTypes27);
+				_getArticlesByStructureIdParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructureKey, status, start, end,
@@ -1241,7 +1349,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByStructureId",
-				_getArticlesByStructureIdParameterTypes28);
+				_getArticlesByStructureIdParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructureKey, start, end,
@@ -1279,7 +1387,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByStructureId",
-				_getArticlesByStructureIdParameterTypes29);
+				_getArticlesByStructureIdParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructureKey, locale, status, start, end,
@@ -1313,7 +1421,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesCount",
-				_getArticlesCountParameterTypes30);
+				_getArticlesCountParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -1345,7 +1453,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesCount",
-				_getArticlesCountParameterTypes31);
+				_getArticlesCountParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, status);
@@ -1377,7 +1485,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesCountByArticleId",
-				_getArticlesCountByArticleIdParameterTypes32);
+				_getArticlesCountByArticleIdParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -1411,7 +1519,7 @@ public class JournalArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class,
 				"getArticlesCountByStructureId",
-				_getArticlesCountByStructureIdParameterTypes33);
+				_getArticlesCountByStructureIdParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, ddmStructureKey, status);
@@ -1444,7 +1552,7 @@ public class JournalArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class,
 				"getArticlesCountByStructureId",
-				_getArticlesCountByStructureIdParameterTypes34);
+				_getArticlesCountByStructureIdParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructureKey);
@@ -1478,7 +1586,7 @@ public class JournalArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class,
 				"getArticlesCountByStructureId",
-				_getArticlesCountByStructureIdParameterTypes35);
+				_getArticlesCountByStructureIdParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructureKey, status);
@@ -1512,7 +1620,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getDisplayArticleByUrlTitle",
-				_getDisplayArticleByUrlTitleParameterTypes36);
+				_getDisplayArticleByUrlTitleParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, urlTitle);
@@ -1552,7 +1660,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getFoldersAndArticlesCount",
-				_getFoldersAndArticlesCountParameterTypes37);
+				_getFoldersAndArticlesCountParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderIds);
@@ -1591,7 +1699,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticles",
-				_getGroupArticlesParameterTypes38);
+				_getGroupArticlesParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, status, includeOwner,
@@ -1639,7 +1747,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticles",
-				_getGroupArticlesParameterTypes39);
+				_getGroupArticlesParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, status, includeOwner,
@@ -1686,7 +1794,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticles",
-				_getGroupArticlesParameterTypes40);
+				_getGroupArticlesParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, status, start, end,
@@ -1733,7 +1841,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticles",
-				_getGroupArticlesParameterTypes41);
+				_getGroupArticlesParameterTypes43);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, start, end,
@@ -1776,7 +1884,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticlesCount",
-				_getGroupArticlesCountParameterTypes42);
+				_getGroupArticlesCountParameterTypes44);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId);
@@ -1817,7 +1925,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticlesCount",
-				_getGroupArticlesCountParameterTypes43);
+				_getGroupArticlesCountParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, status);
@@ -1858,7 +1966,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticlesCount",
-				_getGroupArticlesCountParameterTypes44);
+				_getGroupArticlesCountParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, status, includeOwner);
@@ -1898,7 +2006,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLatestArticle",
-				_getLatestArticleParameterTypes45);
+				_getLatestArticleParameterTypes47);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey);
@@ -1939,7 +2047,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLatestArticle",
-				_getLatestArticleParameterTypes46);
+				_getLatestArticleParameterTypes48);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, status);
@@ -1980,10 +2088,53 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLatestArticle",
-				_getLatestArticleParameterTypes47);
+				_getLatestArticleParameterTypes49);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, className, classPK);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.journal.model.JournalArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.journal.model.JournalArticle
+			getLatestArticleByExternalReferenceCode(
+				HttpPrincipal httpPrincipal, long groupId,
+				String externalReferenceCode)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				JournalArticleServiceUtil.class,
+				"getLatestArticleByExternalReferenceCode",
+				_getLatestArticleByExternalReferenceCodeParameterTypes50);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, externalReferenceCode);
 
 			Object returnObj = null;
 
@@ -2023,7 +2174,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLatestArticles",
-				_getLatestArticlesParameterTypes48);
+				_getLatestArticlesParameterTypes51);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, start, end, orderByComparator);
@@ -2056,7 +2207,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLatestArticlesCount",
-				_getLatestArticlesCountParameterTypes49);
+				_getLatestArticlesCountParameterTypes52);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status);
@@ -2088,7 +2239,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLayoutArticles",
-				_getLayoutArticlesParameterTypes50);
+				_getLayoutArticlesParameterTypes53);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -2121,7 +2272,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLayoutArticles",
-				_getLayoutArticlesParameterTypes51);
+				_getLayoutArticlesParameterTypes54);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, start, end);
@@ -2154,7 +2305,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLayoutArticlesCount",
-				_getLayoutArticlesCountParameterTypes52);
+				_getLayoutArticlesCountParameterTypes55);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -2188,7 +2339,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "moveArticle",
-				_moveArticleParameterTypes53);
+				_moveArticleParameterTypes56);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, newFolderId, serviceContext);
@@ -2226,7 +2377,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "moveArticleFromTrash",
-				_moveArticleFromTrashParameterTypes54);
+				_moveArticleFromTrashParameterTypes57);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey, newFolderId,
@@ -2269,7 +2420,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "moveArticleFromTrash",
-				_moveArticleFromTrashParameterTypes55);
+				_moveArticleFromTrashParameterTypes58);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, newFolderId, serviceContext);
@@ -2309,7 +2460,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "moveArticleToTrash",
-				_moveArticleToTrashParameterTypes56);
+				_moveArticleToTrashParameterTypes59);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -2349,7 +2500,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "removeArticleLocale",
-				_removeArticleLocaleParameterTypes57);
+				_removeArticleLocaleParameterTypes60);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, languageId);
@@ -2386,7 +2537,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "removeArticleLocale",
-				_removeArticleLocaleParameterTypes58);
+				_removeArticleLocaleParameterTypes61);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, languageId);
@@ -2426,7 +2577,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "restoreArticleFromTrash",
-				_restoreArticleFromTrashParameterTypes59);
+				_restoreArticleFromTrashParameterTypes62);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey);
@@ -2462,7 +2613,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "restoreArticleFromTrash",
-				_restoreArticleFromTrashParameterTypes60);
+				_restoreArticleFromTrashParameterTypes63);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -2499,7 +2650,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "search",
-				_searchParameterTypes61);
+				_searchParameterTypes64);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, creatorUserId, status, start, end);
@@ -2545,7 +2696,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "search",
-				_searchParameterTypes62);
+				_searchParameterTypes65);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, folderIds, classNameId, keywords,
@@ -2590,7 +2741,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "search",
-				_searchParameterTypes63);
+				_searchParameterTypes66);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, folderIds, classNameId,
@@ -2635,7 +2786,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "search",
-				_searchParameterTypes64);
+				_searchParameterTypes67);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, folderIds, classNameId,
@@ -2675,7 +2826,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "searchCount",
-				_searchCountParameterTypes65);
+				_searchCountParameterTypes68);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, folderIds, classNameId, keywords,
@@ -2714,7 +2865,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "searchCount",
-				_searchCountParameterTypes66);
+				_searchCountParameterTypes69);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, folderIds, classNameId,
@@ -2754,7 +2905,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "searchCount",
-				_searchCountParameterTypes67);
+				_searchCountParameterTypes70);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, folderIds, classNameId,
@@ -2790,7 +2941,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "subscribe",
-				_subscribeParameterTypes68);
+				_subscribeParameterTypes71);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -2827,7 +2978,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "subscribeStructure",
-				_subscribeStructureParameterTypes69);
+				_subscribeStructureParameterTypes72);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, ddmStructureId);
@@ -2863,7 +3014,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "unsubscribe",
-				_unsubscribeParameterTypes70);
+				_unsubscribeParameterTypes73);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -2900,7 +3051,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "unsubscribeStructure",
-				_unsubscribeStructureParameterTypes71);
+				_unsubscribeStructureParameterTypes74);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, ddmStructureId);
@@ -2941,7 +3092,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticle",
-				_updateArticleParameterTypes72);
+				_updateArticleParameterTypes75);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, userId, groupId, folderId, articleId, version,
@@ -2997,7 +3148,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticle",
-				_updateArticleParameterTypes73);
+				_updateArticleParameterTypes76);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, articleId, version, titleMap,
@@ -3059,7 +3210,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticle",
-				_updateArticleParameterTypes74);
+				_updateArticleParameterTypes77);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, articleId, version, titleMap,
@@ -3109,10 +3260,74 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticle",
-				_updateArticleParameterTypes75);
+				_updateArticleParameterTypes78);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, articleId, version, content,
+				serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.journal.model.JournalArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.journal.model.JournalArticle updateArticle(
+			HttpPrincipal httpPrincipal, long groupId, long folderId,
+			String articleId, String externalReferenceCode, double version,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmStructureKey, String ddmTemplateKey,
+			String layoutUuid, int displayDateMonth, int displayDateDay,
+			int displayDateYear, int displayDateHour, int displayDateMinute,
+			int expirationDateMonth, int expirationDateDay,
+			int expirationDateYear, int expirationDateHour,
+			int expirationDateMinute, boolean neverExpire, int reviewDateMonth,
+			int reviewDateDay, int reviewDateYear, int reviewDateHour,
+			int reviewDateMinute, boolean neverReview, boolean indexable,
+			boolean smallImage, String smallImageURL, java.io.File smallFile,
+			java.util.Map<String, byte[]> images, String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				JournalArticleServiceUtil.class, "updateArticle",
+				_updateArticleParameterTypes79);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, folderId, articleId, externalReferenceCode,
+				version, titleMap, descriptionMap, friendlyURLMap, content,
+				ddmStructureKey, ddmTemplateKey, layoutUuid, displayDateMonth,
+				displayDateDay, displayDateYear, displayDateHour,
+				displayDateMinute, expirationDateMonth, expirationDateDay,
+				expirationDateYear, expirationDateHour, expirationDateMinute,
+				neverExpire, reviewDateMonth, reviewDateDay, reviewDateYear,
+				reviewDateHour, reviewDateMinute, neverReview, indexable,
+				smallImage, smallImageURL, smallFile, images, articleURL,
 				serviceContext);
 
 			Object returnObj = null;
@@ -3157,7 +3372,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticleDefaultValues",
-				_updateArticleDefaultValuesParameterTypes76);
+				_updateArticleDefaultValuesParameterTypes80);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, titleMap, descriptionMap,
@@ -3204,7 +3419,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticleTranslation",
-				_updateArticleTranslationParameterTypes77);
+				_updateArticleTranslationParameterTypes81);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, locale, title,
@@ -3246,7 +3461,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateContent",
-				_updateContentParameterTypes78);
+				_updateContentParameterTypes82);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, content);
@@ -3288,7 +3503,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateStatus",
-				_updateStatusParameterTypes79);
+				_updateStatusParameterTypes83);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, status, articleURL,
@@ -3356,11 +3571,22 @@ public class JournalArticleServiceHttp {
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
 	private static final Class<?>[] _addArticleParameterTypes3 = new Class[] {
+		long.class, long.class, long.class, long.class, String.class,
+		boolean.class, String.class, java.util.Map.class, java.util.Map.class,
+		java.util.Map.class, String.class, String.class, String.class,
+		String.class, int.class, int.class, int.class, int.class, int.class,
+		int.class, int.class, int.class, int.class, int.class, boolean.class,
+		int.class, int.class, int.class, int.class, int.class, boolean.class,
+		boolean.class, boolean.class, String.class, java.io.File.class,
+		java.util.Map.class, String.class,
+		com.liferay.portal.kernel.service.ServiceContext.class
+	};
+	private static final Class<?>[] _addArticleParameterTypes4 = new Class[] {
 		long.class, long.class, java.util.Map.class, java.util.Map.class,
 		String.class, String.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _addArticleDefaultValuesParameterTypes4 =
+	private static final Class<?>[] _addArticleDefaultValuesParameterTypes5 =
 		new Class[] {
 			long.class, long.class, long.class, java.util.Map.class,
 			java.util.Map.class, String.class, String.class, String.class,
@@ -3368,264 +3594,271 @@ public class JournalArticleServiceHttp {
 			java.io.File.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _copyArticleParameterTypes5 = new Class[] {
+	private static final Class<?>[] _copyArticleParameterTypes6 = new Class[] {
 		long.class, String.class, String.class, boolean.class, double.class
 	};
-	private static final Class<?>[] _deleteArticleParameterTypes6 =
-		new Class[] {
-			long.class, String.class, double.class, String.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
-		};
 	private static final Class<?>[] _deleteArticleParameterTypes7 =
 		new Class[] {
-			long.class, String.class, String.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
-		};
-	private static final Class<?>[] _deleteArticleDefaultValuesParameterTypes8 =
-		new Class[] {long.class, String.class, String.class};
-	private static final Class<?>[] _expireArticleParameterTypes9 =
-		new Class[] {
 			long.class, String.class, double.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
+	private static final Class<?>[] _deleteArticleParameterTypes8 =
+		new Class[] {
+			long.class, String.class, String.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _deleteArticleDefaultValuesParameterTypes9 =
+		new Class[] {long.class, String.class, String.class};
 	private static final Class<?>[] _expireArticleParameterTypes10 =
 		new Class[] {
+			long.class, String.class, double.class, String.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _expireArticleParameterTypes11 =
+		new Class[] {
 			long.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _fetchArticleParameterTypes11 =
+	private static final Class<?>[] _fetchArticleParameterTypes12 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _getArticleParameterTypes12 = new Class[] {
+	private static final Class<?>[]
+		_fetchLatestArticleByExternalReferenceCodeParameterTypes13 =
+			new Class[] {long.class, String.class};
+	private static final Class<?>[] _getArticleParameterTypes14 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getArticleParameterTypes13 = new Class[] {
+	private static final Class<?>[] _getArticleParameterTypes15 = new Class[] {
 		long.class, String.class
 	};
-	private static final Class<?>[] _getArticleParameterTypes14 = new Class[] {
+	private static final Class<?>[] _getArticleParameterTypes16 = new Class[] {
 		long.class, String.class, double.class
 	};
-	private static final Class<?>[] _getArticleParameterTypes15 = new Class[] {
+	private static final Class<?>[] _getArticleParameterTypes17 = new Class[] {
 		long.class, String.class, long.class
 	};
-	private static final Class<?>[] _getArticleByUrlTitleParameterTypes16 =
+	private static final Class<?>[] _getArticleByUrlTitleParameterTypes18 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _getArticleContentParameterTypes17 =
+	private static final Class<?>[] _getArticleContentParameterTypes19 =
 		new Class[] {
 			long.class, String.class, double.class, String.class,
 			com.liferay.portal.kernel.portlet.PortletRequestModel.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getArticleContentParameterTypes18 =
+	private static final Class<?>[] _getArticleContentParameterTypes20 =
 		new Class[] {
 			long.class, String.class, String.class,
 			com.liferay.portal.kernel.portlet.PortletRequestModel.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getArticlesParameterTypes19 = new Class[] {
+	private static final Class<?>[] _getArticlesParameterTypes21 = new Class[] {
 		long.class, long.class, java.util.Locale.class
 	};
-	private static final Class<?>[] _getArticlesParameterTypes20 = new Class[] {
+	private static final Class<?>[] _getArticlesParameterTypes22 = new Class[] {
 		long.class, long.class, java.util.Locale.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _getArticlesByArticleIdParameterTypes21 =
+	private static final Class<?>[] _getArticlesByArticleIdParameterTypes23 =
 		new Class[] {
 			long.class, String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByLayoutUuidParameterTypes22 =
+	private static final Class<?>[] _getArticlesByLayoutUuidParameterTypes24 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _getArticlesByLayoutUuidParameterTypes23 =
+	private static final Class<?>[] _getArticlesByLayoutUuidParameterTypes25 =
 		new Class[] {long.class, String.class, int.class, int.class};
 	private static final Class<?>[]
-		_getArticlesByLayoutUuidCountParameterTypes24 = new Class[] {
+		_getArticlesByLayoutUuidCountParameterTypes26 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes25 =
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes27 =
 		new Class[] {
 			long.class, long.class, String.class, int.class, int.class,
 			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes26 =
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes28 =
 		new Class[] {
 			long.class, long.class, String.class, java.util.Locale.class,
 			int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes27 =
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes29 =
 		new Class[] {
 			long.class, String.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes28 =
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes30 =
 		new Class[] {
 			long.class, String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes29 =
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes31 =
 		new Class[] {
 			long.class, String.class, java.util.Locale.class, int.class,
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesCountParameterTypes30 =
+	private static final Class<?>[] _getArticlesCountParameterTypes32 =
 		new Class[] {long.class, long.class};
-	private static final Class<?>[] _getArticlesCountParameterTypes31 =
+	private static final Class<?>[] _getArticlesCountParameterTypes33 =
 		new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[]
-		_getArticlesCountByArticleIdParameterTypes32 = new Class[] {
-			long.class, String.class
-		};
-	private static final Class<?>[]
-		_getArticlesCountByStructureIdParameterTypes33 = new Class[] {
-			long.class, long.class, String.class, int.class
-		};
-	private static final Class<?>[]
-		_getArticlesCountByStructureIdParameterTypes34 = new Class[] {
+		_getArticlesCountByArticleIdParameterTypes34 = new Class[] {
 			long.class, String.class
 		};
 	private static final Class<?>[]
 		_getArticlesCountByStructureIdParameterTypes35 = new Class[] {
-			long.class, String.class, int.class
+			long.class, long.class, String.class, int.class
 		};
 	private static final Class<?>[]
-		_getDisplayArticleByUrlTitleParameterTypes36 = new Class[] {
+		_getArticlesCountByStructureIdParameterTypes36 = new Class[] {
 			long.class, String.class
 		};
 	private static final Class<?>[]
-		_getFoldersAndArticlesCountParameterTypes37 = new Class[] {
+		_getArticlesCountByStructureIdParameterTypes37 = new Class[] {
+			long.class, String.class, int.class
+		};
+	private static final Class<?>[]
+		_getDisplayArticleByUrlTitleParameterTypes38 = new Class[] {
+			long.class, String.class
+		};
+	private static final Class<?>[]
+		_getFoldersAndArticlesCountParameterTypes39 = new Class[] {
 			long.class, java.util.List.class
 		};
-	private static final Class<?>[] _getGroupArticlesParameterTypes38 =
+	private static final Class<?>[] _getGroupArticlesParameterTypes40 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, boolean.class,
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupArticlesParameterTypes39 =
+	private static final Class<?>[] _getGroupArticlesParameterTypes41 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, boolean.class,
 			java.util.Locale.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupArticlesParameterTypes40 =
+	private static final Class<?>[] _getGroupArticlesParameterTypes42 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupArticlesParameterTypes41 =
+	private static final Class<?>[] _getGroupArticlesParameterTypes43 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupArticlesCountParameterTypes42 =
-		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _getGroupArticlesCountParameterTypes43 =
-		new Class[] {long.class, long.class, long.class, int.class};
 	private static final Class<?>[] _getGroupArticlesCountParameterTypes44 =
+		new Class[] {long.class, long.class, long.class};
+	private static final Class<?>[] _getGroupArticlesCountParameterTypes45 =
+		new Class[] {long.class, long.class, long.class, int.class};
+	private static final Class<?>[] _getGroupArticlesCountParameterTypes46 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, boolean.class
 		};
-	private static final Class<?>[] _getLatestArticleParameterTypes45 =
-		new Class[] {long.class};
-	private static final Class<?>[] _getLatestArticleParameterTypes46 =
-		new Class[] {long.class, String.class, int.class};
 	private static final Class<?>[] _getLatestArticleParameterTypes47 =
+		new Class[] {long.class};
+	private static final Class<?>[] _getLatestArticleParameterTypes48 =
+		new Class[] {long.class, String.class, int.class};
+	private static final Class<?>[] _getLatestArticleParameterTypes49 =
 		new Class[] {long.class, String.class, long.class};
-	private static final Class<?>[] _getLatestArticlesParameterTypes48 =
+	private static final Class<?>[]
+		_getLatestArticleByExternalReferenceCodeParameterTypes50 = new Class[] {
+			long.class, String.class
+		};
+	private static final Class<?>[] _getLatestArticlesParameterTypes51 =
 		new Class[] {
 			long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getLatestArticlesCountParameterTypes49 =
+	private static final Class<?>[] _getLatestArticlesCountParameterTypes52 =
 		new Class[] {long.class, int.class};
-	private static final Class<?>[] _getLayoutArticlesParameterTypes50 =
+	private static final Class<?>[] _getLayoutArticlesParameterTypes53 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getLayoutArticlesParameterTypes51 =
+	private static final Class<?>[] _getLayoutArticlesParameterTypes54 =
 		new Class[] {long.class, int.class, int.class};
-	private static final Class<?>[] _getLayoutArticlesCountParameterTypes52 =
+	private static final Class<?>[] _getLayoutArticlesCountParameterTypes55 =
 		new Class[] {long.class};
-	private static final Class<?>[] _moveArticleParameterTypes53 = new Class[] {
+	private static final Class<?>[] _moveArticleParameterTypes56 = new Class[] {
 		long.class, String.class, long.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _moveArticleFromTrashParameterTypes54 =
+	private static final Class<?>[] _moveArticleFromTrashParameterTypes57 =
 		new Class[] {
 			long.class, long.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveArticleFromTrashParameterTypes55 =
+	private static final Class<?>[] _moveArticleFromTrashParameterTypes58 =
 		new Class[] {
 			long.class, String.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveArticleToTrashParameterTypes56 =
+	private static final Class<?>[] _moveArticleToTrashParameterTypes59 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _removeArticleLocaleParameterTypes57 =
+	private static final Class<?>[] _removeArticleLocaleParameterTypes60 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _removeArticleLocaleParameterTypes58 =
+	private static final Class<?>[] _removeArticleLocaleParameterTypes61 =
 		new Class[] {long.class, String.class, double.class, String.class};
-	private static final Class<?>[] _restoreArticleFromTrashParameterTypes59 =
+	private static final Class<?>[] _restoreArticleFromTrashParameterTypes62 =
 		new Class[] {long.class};
-	private static final Class<?>[] _restoreArticleFromTrashParameterTypes60 =
+	private static final Class<?>[] _restoreArticleFromTrashParameterTypes63 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _searchParameterTypes61 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes64 = new Class[] {
 		long.class, long.class, int.class, int.class, int.class
 	};
-	private static final Class<?>[] _searchParameterTypes62 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes65 = new Class[] {
 		long.class, long.class, java.util.List.class, long.class, String.class,
 		Double.class, String.class, String.class, java.util.Date.class,
 		java.util.Date.class, int.class, java.util.Date.class, int.class,
 		int.class, com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _searchParameterTypes63 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes66 = new Class[] {
 		long.class, long.class, java.util.List.class, long.class, String.class,
 		Double.class, String.class, String.class, String.class, String.class,
 		String.class, java.util.Date.class, java.util.Date.class, int.class,
 		java.util.Date.class, boolean.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _searchParameterTypes64 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes67 = new Class[] {
 		long.class, long.class, java.util.List.class, long.class, String.class,
 		Double.class, String.class, String.class, String.class, String[].class,
 		String[].class, java.util.Date.class, java.util.Date.class, int.class,
 		java.util.Date.class, boolean.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes65 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes68 = new Class[] {
 		long.class, long.class, java.util.List.class, long.class, String.class,
 		Double.class, String.class, String.class, java.util.Date.class,
 		java.util.Date.class, int.class, java.util.Date.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes66 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes69 = new Class[] {
 		long.class, long.class, java.util.List.class, long.class, String.class,
 		Double.class, String.class, String.class, String.class, String.class,
 		String.class, java.util.Date.class, java.util.Date.class, int.class,
 		java.util.Date.class, boolean.class
 	};
-	private static final Class<?>[] _searchCountParameterTypes67 = new Class[] {
+	private static final Class<?>[] _searchCountParameterTypes70 = new Class[] {
 		long.class, long.class, java.util.List.class, long.class, String.class,
 		Double.class, String.class, String.class, String.class, String[].class,
 		String[].class, java.util.Date.class, java.util.Date.class, int.class,
 		java.util.Date.class, boolean.class
 	};
-	private static final Class<?>[] _subscribeParameterTypes68 = new Class[] {
+	private static final Class<?>[] _subscribeParameterTypes71 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _subscribeStructureParameterTypes69 =
+	private static final Class<?>[] _subscribeStructureParameterTypes72 =
 		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _unsubscribeParameterTypes70 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes73 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _unsubscribeStructureParameterTypes71 =
+	private static final Class<?>[] _unsubscribeStructureParameterTypes74 =
 		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _updateArticleParameterTypes72 =
+	private static final Class<?>[] _updateArticleParameterTypes75 =
 		new Class[] {
 			long.class, long.class, long.class, String.class, double.class,
 			java.util.Map.class, java.util.Map.class, String.class,
 			String.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleParameterTypes73 =
+	private static final Class<?>[] _updateArticleParameterTypes76 =
 		new Class[] {
 			long.class, long.class, String.class, double.class,
 			java.util.Map.class, java.util.Map.class, java.util.Map.class,
@@ -3637,7 +3870,7 @@ public class JournalArticleServiceHttp {
 			java.util.Map.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleParameterTypes74 =
+	private static final Class<?>[] _updateArticleParameterTypes77 =
 		new Class[] {
 			long.class, long.class, String.class, double.class,
 			java.util.Map.class, java.util.Map.class, String.class,
@@ -3649,27 +3882,39 @@ public class JournalArticleServiceHttp {
 			java.util.Map.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleParameterTypes75 =
+	private static final Class<?>[] _updateArticleParameterTypes78 =
 		new Class[] {
 			long.class, long.class, String.class, double.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
+	private static final Class<?>[] _updateArticleParameterTypes79 =
+		new Class[] {
+			long.class, long.class, String.class, String.class, double.class,
+			java.util.Map.class, java.util.Map.class, java.util.Map.class,
+			String.class, String.class, String.class, String.class, int.class,
+			int.class, int.class, int.class, int.class, int.class, int.class,
+			int.class, int.class, int.class, boolean.class, int.class,
+			int.class, int.class, int.class, int.class, boolean.class,
+			boolean.class, boolean.class, String.class, java.io.File.class,
+			java.util.Map.class, String.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
 	private static final Class<?>[]
-		_updateArticleDefaultValuesParameterTypes76 = new Class[] {
+		_updateArticleDefaultValuesParameterTypes80 = new Class[] {
 			long.class, String.class, java.util.Map.class, java.util.Map.class,
 			String.class, String.class, String.class, String.class,
 			boolean.class, boolean.class, String.class, java.io.File.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleTranslationParameterTypes77 =
+	private static final Class<?>[] _updateArticleTranslationParameterTypes81 =
 		new Class[] {
 			long.class, String.class, double.class, java.util.Locale.class,
 			String.class, String.class, String.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateContentParameterTypes78 =
+	private static final Class<?>[] _updateContentParameterTypes82 =
 		new Class[] {long.class, String.class, double.class, String.class};
-	private static final Class<?>[] _updateStatusParameterTypes79 =
+	private static final Class<?>[] _updateStatusParameterTypes83 =
 		new Class[] {
 			long.class, String.class, double.class, int.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceSoap.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceSoap.java
@@ -444,6 +444,36 @@ public class JournalArticleServiceSoap {
 	}
 
 	/**
+	 * Returns the latest web content article matching the group, external reference code,
+	 * and workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the external reference code of the web content article
+	 * @return the latest matching web content article, or <code>null</code> if
+	 no matching web content article could be found
+	 */
+	public static com.liferay.journal.model.JournalArticleSoap
+			fetchLatestArticleByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws RemoteException {
+
+		try {
+			com.liferay.journal.model.JournalArticle returnValue =
+				JournalArticleServiceUtil.
+					fetchLatestArticleByExternalReferenceCode(
+						groupId, externalReferenceCode);
+
+			return com.liferay.journal.model.JournalArticleSoap.toSoapModel(
+				returnValue);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
+	/**
 	 * Returns the web content article with the ID.
 	 *
 	 * @param id the primary key of the web content article
@@ -1664,6 +1694,36 @@ public class JournalArticleServiceSoap {
 			com.liferay.journal.model.JournalArticle returnValue =
 				JournalArticleServiceUtil.getLatestArticle(
 					groupId, className, classPK);
+
+			return com.liferay.journal.model.JournalArticleSoap.toSoapModel(
+				returnValue);
+		}
+		catch (Exception exception) {
+			_log.error(exception, exception);
+
+			throw new RemoteException(exception.getMessage());
+		}
+	}
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code,
+	 * and workflow status.
+	 *
+	 * @param groupId the primary key of the web content article's group
+	 * @param externalReferenceCode the external reference code of the web content article
+	 * @return the latest matching web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	public static com.liferay.journal.model.JournalArticleSoap
+			getLatestArticleByExternalReferenceCode(
+				long groupId, String externalReferenceCode)
+		throws RemoteException {
+
+		try {
+			com.liferay.journal.model.JournalArticle returnValue =
+				JournalArticleServiceUtil.
+					getLatestArticleByExternalReferenceCode(
+						groupId, externalReferenceCode);
 
 			return com.liferay.journal.model.JournalArticleSoap.toSoapModel(
 				returnValue);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -343,204 +343,17 @@ public class JournalArticleLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		// Article
-
-		User user = userLocalService.getUser(userId);
-		articleId = StringUtil.toUpperCase(StringUtil.trim(articleId));
-
-		Date displayDate = _portal.getDate(
+		return journalArticleLocalService.addArticle(
+			userId, groupId, folderId, classNameId, classPK, articleId,
+			autoArticleId, null, version, titleMap, descriptionMap, titleMap,
+			content, ddmStructureKey, ddmTemplateKey, layoutUuid,
 			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
-			displayDateMinute, user.getTimeZone(), null);
-
-		Date expirationDate = null;
-		Date reviewDate = null;
-
-		if (!neverExpire) {
-			expirationDate = _portal.getDate(
-				expirationDateMonth, expirationDateDay, expirationDateYear,
-				expirationDateHour, expirationDateMinute, user.getTimeZone(),
-				ArticleExpirationDateException.class);
-		}
-
-		if (!neverReview) {
-			reviewDate = _portal.getDate(
-				reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
-				reviewDateMinute, user.getTimeZone(),
-				ArticleReviewDateException.class);
-		}
-
-		byte[] smallImageBytes = null;
-
-		try {
-			smallImageBytes = FileUtil.getBytes(smallImageFile);
-		}
-		catch (IOException ioException) {
-		}
-
-		boolean validate = !ExportImportThreadLocal.isImportInProcess();
-
-		if (validate) {
-			validateDDMStructureId(groupId, folderId, ddmStructureKey);
-		}
-
-		if (autoArticleId) {
-			articleId = String.valueOf(counterLocalService.increment());
-		}
-
-		sanitize(user.getCompanyId(), groupId, userId, classPK, descriptionMap);
-
-		if (validate) {
-			validate(
-				user.getCompanyId(), groupId, classNameId, articleId,
-				autoArticleId, version, titleMap, content, ddmStructureKey,
-				ddmTemplateKey, displayDate, expirationDate, smallImage,
-				smallImageURL, smallImageFile, smallImageBytes, serviceContext);
-
-			try {
-				validateReferences(
-					groupId, ddmStructureKey, ddmTemplateKey, layoutUuid,
-					smallImage, smallImageURL, smallImageBytes, 0, content);
-			}
-			catch (ExportImportContentValidationException
-						exportImportContentValidationException) {
-
-				exportImportContentValidationException.setStagedModelClassName(
-					JournalArticle.class.getName());
-				exportImportContentValidationException.
-					setStagedModelPrimaryKeyObj(articleId);
-
-				throw exportImportContentValidationException;
-			}
-		}
-
-		serviceContext.setAttribute("articleId", articleId);
-
-		long id = counterLocalService.increment();
-
-		String articleResourceUuid = GetterUtil.getString(
-			serviceContext.getAttribute("articleResourceUuid"));
-
-		long resourcePrimKey =
-			_journalArticleResourceLocalService.getArticleResourcePrimKey(
-				articleResourceUuid, groupId, articleId);
-
-		JournalArticle article = journalArticlePersistence.create(id);
-
-		Locale locale = getArticleDefaultLocale(content);
-
-		friendlyURLMap = _checkFriendlyURLMap(locale, friendlyURLMap, titleMap);
-
-		Map<String, String> urlTitleMap = _getURLTitleMap(
-			groupId, resourcePrimKey, friendlyURLMap, titleMap);
-
-		article.setUuid(serviceContext.getUuid());
-		article.setResourcePrimKey(resourcePrimKey);
-		article.setGroupId(groupId);
-		article.setCompanyId(user.getCompanyId());
-		article.setUserId(user.getUserId());
-		article.setUserName(user.getFullName());
-		article.setFolderId(folderId);
-		article.setClassNameId(classNameId);
-		article.setClassPK(classPK);
-		article.setTreePath(article.buildTreePath());
-		article.setArticleId(articleId);
-		article.setExternalReferenceCode(articleId);
-		article.setVersion(version);
-		article.setUrlTitle(urlTitleMap.get(LocaleUtil.toLanguageId(locale)));
-
-		content = format(user, groupId, article, content);
-		content = _replaceTempImages(article, content);
-
-		article.setContent(content);
-
-		article.setDDMStructureKey(ddmStructureKey);
-		article.setDDMTemplateKey(ddmTemplateKey);
-		article.setDefaultLanguageId(LocaleUtil.toLanguageId(locale));
-		article.setLayoutUuid(layoutUuid);
-		article.setDisplayDate(displayDate);
-		article.setExpirationDate(expirationDate);
-		article.setReviewDate(reviewDate);
-		article.setIndexable(indexable);
-		article.setSmallImage(smallImage);
-		article.setSmallImageId(counterLocalService.increment());
-		article.setSmallImageURL(smallImageURL);
-
-		Date now = new Date();
-
-		if ((expirationDate == null) || expirationDate.after(now)) {
-			article.setStatus(WorkflowConstants.STATUS_DRAFT);
-		}
-		else {
-			article.setStatus(WorkflowConstants.STATUS_EXPIRED);
-		}
-
-		article.setStatusByUserId(userId);
-		article.setStatusDate(serviceContext.getModifiedDate(now));
-		article.setExpandoBridgeAttributes(serviceContext);
-
-		article = journalArticlePersistence.update(article);
-
-		// Friendly URLs
-
-		updateFriendlyURLs(article, urlTitleMap, serviceContext);
-
-		// Article localization
-
-		_addArticleLocalizedFields(
-			user.getCompanyId(), article.getId(), titleMap, descriptionMap);
-
-		// Resources
-
-		if (serviceContext.isAddGroupPermissions() ||
-			serviceContext.isAddGuestPermissions()) {
-
-			addArticleResources(
-				article, serviceContext.isAddGroupPermissions(),
-				serviceContext.isAddGuestPermissions());
-		}
-		else {
-			addArticleResources(article, serviceContext.getModelPermissions());
-		}
-
-		// Small image
-
-		saveImages(
-			smallImage, article.getSmallImageId(), smallImageFile,
-			smallImageBytes);
-
-		// Asset
-
-		updateAsset(
-			userId, article, serviceContext.getAssetCategoryIds(),
-			serviceContext.getAssetTagNames(),
-			serviceContext.getAssetLinkEntryIds(),
-			serviceContext.getAssetPriority());
-
-		// Dynamic data mapping
-
-		if (classNameLocalService.getClassNameId(DDMStructure.class) ==
-				classNameId) {
-
-			updateDDMStructurePredefinedValues(
-				classPK, content, serviceContext);
-		}
-		else {
-			updateDDMLinks(id, groupId, ddmStructureKey, ddmTemplateKey, true);
-		}
-
-		// Email
-
-		articleURL = buildArticleURL(articleURL, groupId, folderId, articleId);
-
-		serviceContext.setAttribute("articleURL", articleURL);
-
-		sendEmail(article, articleURL, "requested", serviceContext);
-
-		// Workflow
-
-		startWorkflowInstance(userId, article, serviceContext);
-
-		return article;
+			displayDateMinute, expirationDateMonth, expirationDateDay,
+			expirationDateYear, expirationDateHour, expirationDateMinute,
+			neverExpire, reviewDateMonth, reviewDateDay, reviewDateYear,
+			reviewDateHour, reviewDateMinute, neverReview, indexable,
+			smallImage, smallImageURL, smallImageFile, images, articleURL,
+			serviceContext);
 	}
 
 	/**
@@ -671,6 +484,332 @@ public class JournalArticleLocalServiceImpl
 	}
 
 	/**
+	 * Adds a web content article with additional parameters. All scheduling
+	 * parameters (display date, expiration date, and review date) use the
+	 * current user's timezone.
+	 *
+	 * <p>
+	 * The web content articles hold HTML content wrapped in XML. The XML lets
+	 * you specify the article's default locale and available locales. Here is a
+	 * content example:
+	 * </p>
+	 *
+	 * <p>
+	 * <pre>
+	 * <code>
+	 * &lt;?xml version='1.0' encoding='UTF-8'?&gt;
+	 * &lt;root default-locale="en_US" available-locales="en_US"&gt;
+	 * 	&lt;static-content language-id="en_US"&gt;
+	 * 		&lt;![CDATA[&lt;p&gt;&lt;b&gt;&lt;i&gt;test&lt;i&gt; content&lt;b&gt;&lt;/p&gt;]]&gt;
+	 * 	&lt;/static-content&gt;
+	 * &lt;/root&gt;
+	 * </code>
+	 * </pre></p>
+	 *
+	 * @param  userId the primary key of the web content article's creator/owner
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  folderId the primary key of the web content article folder
+	 * @param  classNameId the primary key of the DDMStructure class if the web
+	 *         content article is related to a DDM structure, the primary key of
+	 *         the class name associated with the article, or
+	 *         JournalArticleConstants.CLASS_NAME_ID_DEFAULT in the journal-api
+	 *         module otherwise
+	 * @param  classPK the primary key of the DDM structure, if the primary key
+	 *         of the DDMStructure class is given as the
+	 *         <code>classNameId</code> parameter, the primary key of the class
+	 *         associated with the web content article, or <code>0</code>
+	 *         otherwise
+	 * @param  articleId the primary key of the web content article
+	 * @param  autoArticleId whether to auto generate the web content article ID
+	 * @param  externalReferenceCode the external reference code of the web
+	 *         content article
+	 * @param  version the web content article's version
+	 * @param  titleMap the web content article's locales and localized titles
+	 * @param  descriptionMap the web content article's locales and localized
+	 *         descriptions
+	 * @param  friendlyURLMap the web content article's locales and localized
+	 *         friendly URLs
+	 * @param  content the HTML content wrapped in XML
+	 * @param  ddmStructureKey the primary key of the web content article's DDM
+	 *         structure, if the article is related to a DDM structure, or
+	 *         <code>null</code> otherwise
+	 * @param  ddmTemplateKey the primary key of the web content article's DDM
+	 *         template
+	 * @param  layoutUuid the unique string identifying the web content
+	 *         article's display page
+	 * @param  displayDateMonth the month the web content article is set to
+	 *         display
+	 * @param  displayDateDay the calendar day the web content article is set to
+	 *         display
+	 * @param  displayDateYear the year the web content article is set to
+	 *         display
+	 * @param  displayDateHour the hour the web content article is set to
+	 *         display
+	 * @param  displayDateMinute the minute the web content article is set to
+	 *         display
+	 * @param  expirationDateMonth the month the web content article is set to
+	 *         expire
+	 * @param  expirationDateDay the calendar day the web content article is set
+	 *         to expire
+	 * @param  expirationDateYear the year the web content article is set to
+	 *         expire
+	 * @param  expirationDateHour the hour the web content article is set to
+	 *         expire
+	 * @param  expirationDateMinute the minute the web content article is set to
+	 *         expire
+	 * @param  neverExpire whether the web content article is not set to auto
+	 *         expire
+	 * @param  reviewDateMonth the month the web content article is set for
+	 *         review
+	 * @param  reviewDateDay the calendar day the web content article is set for
+	 *         review
+	 * @param  reviewDateYear the year the web content article is set for review
+	 * @param  reviewDateHour the hour the web content article is set for review
+	 * @param  reviewDateMinute the minute the web content article is set for
+	 *         review
+	 * @param  neverReview whether the web content article is not set for review
+	 * @param  indexable whether the web content article is searchable
+	 * @param  smallImage whether the web content article has a small image
+	 * @param  smallImageURL the web content article's small image URL
+	 * @param  smallImageFile the web content article's small image file
+	 * @param  images the web content's images
+	 * @param  articleURL the web content article's accessible URL
+	 * @param  serviceContext the service context to be applied. Can set the
+	 *         UUID, creation date, modification date, expando bridge
+	 *         attributes, guest permissions, group permissions, asset category
+	 *         IDs, asset tag names, asset link entry IDs, URL title, and
+	 *         workflow actions for the web content article. Can also set
+	 *         whether to add the default guest and group permissions.
+	 * @return the web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Indexable(type = IndexableType.REINDEX)
+	@Override
+	public JournalArticle addArticle(
+			long userId, long groupId, long folderId, long classNameId,
+			long classPK, String articleId, boolean autoArticleId,
+			String externalReferenceCode, double version,
+			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			String ddmStructureKey, String ddmTemplateKey, String layoutUuid,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, int expirationDateMonth,
+			int expirationDateDay, int expirationDateYear,
+			int expirationDateHour, int expirationDateMinute,
+			boolean neverExpire, int reviewDateMonth, int reviewDateDay,
+			int reviewDateYear, int reviewDateHour, int reviewDateMinute,
+			boolean neverReview, boolean indexable, boolean smallImage,
+			String smallImageURL, File smallImageFile,
+			Map<String, byte[]> images, String articleURL,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		// Article
+
+		User user = userLocalService.getUser(userId);
+		articleId = StringUtil.toUpperCase(StringUtil.trim(articleId));
+
+		Date displayDate = _portal.getDate(
+			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
+			displayDateMinute, user.getTimeZone(), null);
+
+		Date expirationDate = null;
+		Date reviewDate = null;
+
+		if (!neverExpire) {
+			expirationDate = _portal.getDate(
+				expirationDateMonth, expirationDateDay, expirationDateYear,
+				expirationDateHour, expirationDateMinute, user.getTimeZone(),
+				ArticleExpirationDateException.class);
+		}
+
+		if (!neverReview) {
+			reviewDate = _portal.getDate(
+				reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
+				reviewDateMinute, user.getTimeZone(),
+				ArticleReviewDateException.class);
+		}
+
+		byte[] smallImageBytes = null;
+
+		try {
+			smallImageBytes = FileUtil.getBytes(smallImageFile);
+		}
+		catch (IOException ioException) {
+		}
+
+		boolean validate = !ExportImportThreadLocal.isImportInProcess();
+
+		if (validate) {
+			validateDDMStructureId(groupId, folderId, ddmStructureKey);
+		}
+
+		if (autoArticleId) {
+			articleId = String.valueOf(counterLocalService.increment());
+		}
+
+		if (externalReferenceCode == null) {
+			externalReferenceCode = articleId;
+		}
+
+		sanitize(user.getCompanyId(), groupId, userId, classPK, descriptionMap);
+
+		if (validate) {
+			validate(
+				user.getCompanyId(), groupId, classNameId, articleId,
+				autoArticleId, externalReferenceCode, version, titleMap,
+				content, ddmStructureKey, ddmTemplateKey, displayDate,
+				expirationDate, smallImage, smallImageURL, smallImageFile,
+				smallImageBytes, serviceContext);
+
+			try {
+				validateReferences(
+					groupId, ddmStructureKey, ddmTemplateKey, layoutUuid,
+					smallImage, smallImageURL, smallImageBytes, 0, content);
+			}
+			catch (ExportImportContentValidationException
+						exportImportContentValidationException) {
+
+				exportImportContentValidationException.setStagedModelClassName(
+					JournalArticle.class.getName());
+				exportImportContentValidationException.
+					setStagedModelPrimaryKeyObj(articleId);
+
+				throw exportImportContentValidationException;
+			}
+		}
+
+		serviceContext.setAttribute("articleId", articleId);
+
+		long id = counterLocalService.increment();
+
+		String articleResourceUuid = GetterUtil.getString(
+			serviceContext.getAttribute("articleResourceUuid"));
+
+		long resourcePrimKey =
+			_journalArticleResourceLocalService.getArticleResourcePrimKey(
+				articleResourceUuid, groupId, articleId);
+
+		JournalArticle article = journalArticlePersistence.create(id);
+
+		Locale locale = getArticleDefaultLocale(content);
+
+		friendlyURLMap = _checkFriendlyURLMap(locale, friendlyURLMap, titleMap);
+
+		Map<String, String> urlTitleMap = _getURLTitleMap(
+			groupId, resourcePrimKey, friendlyURLMap, titleMap);
+
+		article.setUuid(serviceContext.getUuid());
+		article.setResourcePrimKey(resourcePrimKey);
+		article.setGroupId(groupId);
+		article.setCompanyId(user.getCompanyId());
+		article.setUserId(user.getUserId());
+		article.setUserName(user.getFullName());
+		article.setFolderId(folderId);
+		article.setClassNameId(classNameId);
+		article.setClassPK(classPK);
+		article.setTreePath(article.buildTreePath());
+		article.setArticleId(articleId);
+		article.setExternalReferenceCode(externalReferenceCode);
+		article.setVersion(version);
+		article.setUrlTitle(urlTitleMap.get(LocaleUtil.toLanguageId(locale)));
+
+		content = format(user, groupId, article, content);
+		content = _replaceTempImages(article, content);
+
+		article.setContent(content);
+
+		article.setDDMStructureKey(ddmStructureKey);
+		article.setDDMTemplateKey(ddmTemplateKey);
+		article.setDefaultLanguageId(LocaleUtil.toLanguageId(locale));
+		article.setLayoutUuid(layoutUuid);
+		article.setDisplayDate(displayDate);
+		article.setExpirationDate(expirationDate);
+		article.setReviewDate(reviewDate);
+		article.setIndexable(indexable);
+		article.setSmallImage(smallImage);
+		article.setSmallImageId(counterLocalService.increment());
+		article.setSmallImageURL(smallImageURL);
+
+		Date now = new Date();
+
+		if ((expirationDate == null) || expirationDate.after(now)) {
+			article.setStatus(WorkflowConstants.STATUS_DRAFT);
+		}
+		else {
+			article.setStatus(WorkflowConstants.STATUS_EXPIRED);
+		}
+
+		article.setStatusByUserId(userId);
+		article.setStatusDate(serviceContext.getModifiedDate(now));
+		article.setExpandoBridgeAttributes(serviceContext);
+
+		article = journalArticlePersistence.update(article);
+
+		// Friendly URLs
+
+		updateFriendlyURLs(article, urlTitleMap, serviceContext);
+
+		// Article localization
+
+		_addArticleLocalizedFields(
+			user.getCompanyId(), article.getId(), titleMap, descriptionMap);
+
+		// Resources
+
+		if (serviceContext.isAddGroupPermissions() ||
+			serviceContext.isAddGuestPermissions()) {
+
+			addArticleResources(
+				article, serviceContext.isAddGroupPermissions(),
+				serviceContext.isAddGuestPermissions());
+		}
+		else {
+			addArticleResources(article, serviceContext.getModelPermissions());
+		}
+
+		// Small image
+
+		saveImages(
+			smallImage, article.getSmallImageId(), smallImageFile,
+			smallImageBytes);
+
+		// Asset
+
+		updateAsset(
+			userId, article, serviceContext.getAssetCategoryIds(),
+			serviceContext.getAssetTagNames(),
+			serviceContext.getAssetLinkEntryIds(),
+			serviceContext.getAssetPriority());
+
+		// Dynamic data mapping
+
+		if (classNameLocalService.getClassNameId(DDMStructure.class) ==
+				classNameId) {
+
+			updateDDMStructurePredefinedValues(
+				classPK, content, serviceContext);
+		}
+		else {
+			updateDDMLinks(id, groupId, ddmStructureKey, ddmTemplateKey, true);
+		}
+
+		// Email
+
+		articleURL = buildArticleURL(articleURL, groupId, folderId, articleId);
+
+		serviceContext.setAttribute("articleURL", articleURL);
+
+		sendEmail(article, articleURL, "requested", serviceContext);
+
+		// Workflow
+
+		startWorkflowInstance(userId, article, serviceContext);
+
+		return article;
+	}
+
+	/**
 	 * Adds a web content article.
 	 *
 	 * @param  userId the primary key of the web content article's creator/owner
@@ -754,10 +893,10 @@ public class JournalArticleLocalServiceImpl
 		sanitize(user.getCompanyId(), groupId, userId, classPK, descriptionMap);
 
 		validate(
-			user.getCompanyId(), groupId, classNameId, articleId, true, 0,
-			titleMap, content, ddmStructureKey, ddmTemplateKey, null, null,
-			smallImage, smallImageURL, smallImageFile, smallImageBytes,
-			serviceContext);
+			user.getCompanyId(), groupId, classNameId, articleId, true,
+			articleId, 0, titleMap, content, ddmStructureKey, ddmTemplateKey,
+			null, null, smallImage, smallImageURL, smallImageFile,
+			smallImageBytes, serviceContext);
 
 		serviceContext.setAttribute("articleId", articleId);
 
@@ -8802,18 +8941,19 @@ public class JournalArticleLocalServiceImpl
 
 	protected void validate(
 			long companyId, long groupId, long classNameId, String articleId,
-			boolean autoArticleId, double version, Map<Locale, String> titleMap,
-			String content, String ddmStructureKey, String ddmTemplateKey,
-			Date displayDate, Date expirationDate, boolean smallImage,
-			String smallImageURL, File smallImageFile, byte[] smallImageBytes,
+			boolean autoArticleId, String externalReferenceCode, double version,
+			Map<Locale, String> titleMap, String content,
+			String ddmStructureKey, String ddmTemplateKey, Date displayDate,
+			Date expirationDate, boolean smallImage, String smallImageURL,
+			File smallImageFile, byte[] smallImageBytes,
 			ServiceContext serviceContext)
 		throws PortalException {
 
 		_getModelValidator().validate(
-			companyId, groupId, classNameId, articleId, autoArticleId, version,
-			titleMap, content, ddmStructureKey, ddmTemplateKey, displayDate,
-			expirationDate, smallImage, smallImageURL, smallImageFile,
-			smallImageBytes, serviceContext);
+			companyId, groupId, classNameId, articleId, autoArticleId,
+			externalReferenceCode, version, titleMap, content, ddmStructureKey,
+			ddmTemplateKey, displayDate, expirationDate, smallImage,
+			smallImageURL, smallImageFile, smallImageBytes, serviceContext);
 	}
 
 	protected void validate(String articleId) throws PortalException {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1978,6 +1978,26 @@ public class JournalArticleLocalServiceImpl
 			groupId, articleId, status, orderByComparator);
 	}
 
+	/**
+	 * Returns the latest web content article matching the group, external reference code, and
+	 * workflow status.
+	 *
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  externalReferenceCode the web content article's external reference code
+	 * @return the latest matching web content article, or <code>null</code> if
+	 *         no matching web content article could be found
+	 */
+	@Override
+	public JournalArticle fetchLatestArticleByExternalReferenceCode(
+		long groupId, String externalReferenceCode) {
+
+		OrderByComparator<JournalArticle> orderByComparator =
+			new ArticleVersionComparator();
+
+		return journalArticlePersistence.fetchByG_ERC_First(
+			groupId, externalReferenceCode, orderByComparator);
+	}
+
 	@Override
 	public JournalArticle fetchLatestArticleByUrlTitle(
 		long groupId, String urlTitle, int status) {
@@ -3417,6 +3437,27 @@ public class JournalArticleLocalServiceImpl
 		}
 
 		return articles.get(0);
+	}
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code, and
+	 * workflow status.
+	 *
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  externalReferenceCode the web content article's external reference code
+	 * @return the latest matching web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public JournalArticle getLatestArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		OrderByComparator<JournalArticle> orderByComparator =
+			new ArticleVersionComparator();
+
+		return journalArticlePersistence.findByG_ERC_First(
+			groupId, externalReferenceCode, orderByComparator);
 	}
 
 	/**

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -648,7 +648,9 @@ public class JournalArticleLocalServiceImpl
 			articleId = String.valueOf(counterLocalService.increment());
 		}
 
-		if (externalReferenceCode == null) {
+		if ((externalReferenceCode == null) ||
+			StringUtil.equals(externalReferenceCode, StringPool.BLANK)) {
+
 			externalReferenceCode = articleId;
 		}
 
@@ -5706,264 +5708,16 @@ public class JournalArticleLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		// Article
-
-		User user = userLocalService.getUser(userId);
-		articleId = StringUtil.toUpperCase(StringUtil.trim(articleId));
-
-		byte[] smallImageBytes = null;
-
-		try {
-			smallImageBytes = FileUtil.getBytes(smallImageFile);
-		}
-		catch (IOException ioException) {
-		}
-
-		JournalArticle latestArticle = getLatestArticle(
-			groupId, articleId, WorkflowConstants.STATUS_ANY);
-
-		JournalArticle article = latestArticle;
-
-		boolean imported = ExportImportThreadLocal.isImportInProcess();
-
-		boolean addNewVersion = false;
-
-		if (imported) {
-			article = getArticle(groupId, articleId, version);
-		}
-		else {
-			double latestArticleVersion = latestArticle.getVersion();
-
-			if ((version > 0) && (version != latestArticleVersion)) {
-				StringBundler sb = new StringBundler(4);
-
-				sb.append("Version ");
-				sb.append(version);
-				sb.append(" is not the same as ");
-				sb.append(latestArticleVersion);
-
-				throw new ArticleVersionException(sb.toString());
-			}
-
-			serviceContext.validateModifiedDate(
-				latestArticle, ArticleVersionException.class);
-
-			if (latestArticle.isApproved() || latestArticle.isExpired() ||
-				latestArticle.isScheduled()) {
-
-				addNewVersion = true;
-
-				version = getNextVersion(article);
-			}
-		}
-
-		Date displayDate = _portal.getDate(
-			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
-			displayDateMinute, user.getTimeZone(), null);
-
-		Date expirationDate = null;
-		Date reviewDate = null;
-
-		if (!neverExpire) {
-			expirationDate = _portal.getDate(
-				expirationDateMonth, expirationDateDay, expirationDateYear,
-				expirationDateHour, expirationDateMinute, user.getTimeZone(),
-				ArticleExpirationDateException.class);
-		}
-
-		if (!neverReview) {
-			reviewDate = _portal.getDate(
-				reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
-				reviewDateMinute, user.getTimeZone(),
-				ArticleReviewDateException.class);
-		}
-
-		Date now = new Date();
-
-		boolean expired = false;
-
-		if ((expirationDate != null) && expirationDate.before(now)) {
-			expired = true;
-		}
-
-		sanitize(
-			user.getCompanyId(), groupId, userId, article.getClassPK(),
-			descriptionMap);
-
-		boolean validate = !ExportImportThreadLocal.isImportInProcess();
-
-		if (validate) {
-			validate(
-				user.getCompanyId(), groupId, latestArticle.getClassNameId(),
-				titleMap, content, ddmStructureKey, ddmTemplateKey, displayDate,
-				expirationDate, smallImage, smallImageURL, smallImageFile,
-				smallImageBytes, serviceContext);
-
-			try {
-				validateReferences(
-					groupId, ddmStructureKey, ddmTemplateKey, layoutUuid,
-					smallImage, smallImageURL, smallImageBytes,
-					latestArticle.getSmallImageId(), content);
-			}
-			catch (ExportImportContentValidationException
-						exportImportContentValidationException) {
-
-				exportImportContentValidationException.setStagedModelClassName(
-					JournalArticle.class.getName());
-				exportImportContentValidationException.
-					setStagedModelPrimaryKeyObj(articleId);
-
-				throw exportImportContentValidationException;
-			}
-		}
-
-		if (addNewVersion) {
-			long id = counterLocalService.increment();
-
-			article = journalArticlePersistence.create(id);
-
-			article.setResourcePrimKey(latestArticle.getResourcePrimKey());
-			article.setGroupId(latestArticle.getGroupId());
-			article.setCompanyId(latestArticle.getCompanyId());
-			article.setUserId(user.getUserId());
-			article.setUserName(user.getFullName());
-			article.setCreateDate(latestArticle.getCreateDate());
-			article.setModifiedDate(serviceContext.getModifiedDate(now));
-			article.setClassNameId(latestArticle.getClassNameId());
-			article.setClassPK(latestArticle.getClassPK());
-			article.setArticleId(articleId);
-			article.setExternalReferenceCode(
-				latestArticle.getExternalReferenceCode());
-			article.setVersion(version);
-			article.setSmallImageId(latestArticle.getSmallImageId());
-			article.setStatusByUserId(user.getUserId());
-			article.setStatusByUserName(user.getFullName());
-			article.setStatusDate(serviceContext.getModifiedDate(now));
-
-			serviceContext.setAttribute("version", version);
-
-			_addArticleLocalizedFields(
-				article.getCompanyId(), article.getId(), titleMap,
-				descriptionMap);
-		}
-		else {
-			_updateArticleLocalizedFields(
-				article.getCompanyId(), article.getId(), titleMap,
-				descriptionMap);
-		}
-
-		Locale locale = getArticleDefaultLocale(content);
-
-		Map<String, String> urlTitleMap = _getURLTitleMap(
-			groupId, article.getResourcePrimKey(), friendlyURLMap, titleMap);
-
-		String urlTitle = urlTitleMap.get(LocaleUtil.toLanguageId(locale));
-
-		if (Validator.isNull(urlTitle) &&
-			(classNameLocalService.getClassNameId(DDMStructure.class) !=
-				article.getClassNameId())) {
-
-			throw new ArticleFriendlyURLException();
-		}
-
-		content = format(user, groupId, article, content);
-		content = _replaceTempImages(article, content);
-
-		article.setFolderId(folderId);
-		article.setTreePath(article.buildTreePath());
-		article.setUrlTitle(urlTitle);
-		article.setContent(content);
-		article.setDDMStructureKey(ddmStructureKey);
-		article.setDDMTemplateKey(ddmTemplateKey);
-		article.setDefaultLanguageId(LocaleUtil.toLanguageId(locale));
-		article.setLayoutUuid(layoutUuid);
-		article.setDisplayDate(displayDate);
-		article.setExpirationDate(expirationDate);
-		article.setReviewDate(reviewDate);
-		article.setIndexable(indexable);
-		article.setSmallImage(smallImage);
-
-		if (smallImage) {
-			if ((smallImageFile != null) && (smallImageBytes != null) &&
-				(article.getSmallImageId() <= 0)) {
-
-				article.setSmallImageId(counterLocalService.increment());
-			}
-		}
-		else {
-			article.setSmallImageId(0);
-		}
-
-		article.setSmallImageURL(smallImageURL);
-
-		if (latestArticle.isPending()) {
-			article.setStatus(latestArticle.getStatus());
-		}
-		else if (!expired) {
-			article.setStatus(WorkflowConstants.STATUS_DRAFT);
-		}
-		else {
-			article.setStatus(WorkflowConstants.STATUS_EXPIRED);
-		}
-
-		ExpandoBridgeUtil.setExpandoBridgeAttributes(
-			latestArticle.getExpandoBridge(), article.getExpandoBridge(),
-			serviceContext);
-
-		article = journalArticlePersistence.update(article);
-
-		// Friendly URLs
-
-		updateFriendlyURLs(article, urlTitleMap, serviceContext);
-
-		// Asset
-
-		if (hasModifiedLatestApprovedVersion(groupId, articleId, version)) {
-			updateAsset(
-				userId, article, serviceContext.getAssetCategoryIds(),
-				serviceContext.getAssetTagNames(),
-				serviceContext.getAssetLinkEntryIds(),
-				serviceContext.getAssetPriority());
-		}
-
-		// Dynamic data mapping
-
-		if (classNameLocalService.getClassNameId(DDMStructure.class) !=
-				article.getClassNameId()) {
-
-			updateDDMLinks(
-				article.getId(), groupId, ddmStructureKey, ddmTemplateKey,
-				addNewVersion);
-		}
-
-		// Small image
-
-		saveImages(
-			smallImage, article.getSmallImageId(), smallImageFile,
-			smallImageBytes);
-
-		// Email and workflow
-
-		if (expired && imported) {
-			article = updateStatus(
-				userId, article, article.getStatus(), articleURL,
-				serviceContext, new HashMap<>());
-		}
-
-		if (serviceContext.getWorkflowAction() ==
-				WorkflowConstants.ACTION_PUBLISH) {
-
-			articleURL = buildArticleURL(
-				articleURL, groupId, folderId, articleId);
-
-			serviceContext.setAttribute("articleURL", articleURL);
-
-			sendEmail(article, articleURL, "requested", serviceContext);
-
-			startWorkflowInstance(userId, article, serviceContext);
-		}
-
-		return article;
+		return journalArticleLocalService.updateArticle(
+			userId, groupId, folderId, articleId, null, version, titleMap,
+			descriptionMap, titleMap, content, ddmStructureKey, ddmTemplateKey,
+			layoutUuid, displayDateMonth, displayDateDay, displayDateYear,
+			displayDateHour, displayDateMinute, expirationDateMonth,
+			expirationDateDay, expirationDateYear, expirationDateHour,
+			expirationDateMinute, neverExpire, reviewDateMonth, reviewDateDay,
+			reviewDateYear, reviewDateHour, reviewDateMinute, neverReview,
+			indexable, smallImage, smallImageURL, smallImageFile, images,
+			articleURL, serviceContext);
 	}
 
 	/**
@@ -6281,6 +6035,378 @@ public class JournalArticleLocalServiceImpl
 			userId, groupId, folderId, articleId, version,
 			article.getTitleMap(), article.getDescriptionMap(), content,
 			article.getLayoutUuid(), serviceContext);
+	}
+
+	/**
+	 * Updates the web content article with additional parameters. All
+	 * scheduling parameters (display date, expiration date, and review date)
+	 * use the current user's timezone.
+	 *
+	 * @param  userId the primary key of the user updating the web content
+	 *         article
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  folderId the primary key of the web content article folder
+	 * @param  articleId the primary key of the web content article
+	 * @param  externalReferenceCode the external reference code of the web
+	 *         content article
+	 * @param  version the web content article's version
+	 * @param  titleMap the web content article's locales and localized titles
+	 * @param  descriptionMap the web content article's locales and localized
+	 *         descriptions
+	 * @param  friendlyURLMap the web content article's locales and localized
+	 *         friendly URLs
+	 * @param  content the HTML content wrapped in XML. For more information,
+	 *         see the content example in the {@link #addArticle(long, long,
+	 *         long, long, long, String, boolean, double, Map, Map, String,
+	 *         String, String, String, int, int, int, int, int, int, int, int,
+	 *         int, int, boolean, int, int, int, int, int, boolean, boolean,
+	 *         boolean, String, File, Map, String, ServiceContext)} description.
+	 * @param  ddmStructureKey the primary key of the web content article's DDM
+	 *         structure, if the article is related to a DDM structure, or
+	 *         <code>null</code> otherwise
+	 * @param  ddmTemplateKey the primary key of the web content article's DDM
+	 *         template
+	 * @param  layoutUuid the unique string identifying the web content
+	 *         article's display page
+	 * @param  displayDateMonth the month the web content article is set to
+	 *         display
+	 * @param  displayDateDay the calendar day the web content article is set to
+	 *         display
+	 * @param  displayDateYear the year the web content article is set to
+	 *         display
+	 * @param  displayDateHour the hour the web content article is set to
+	 *         display
+	 * @param  displayDateMinute the minute the web content article is set to
+	 *         display
+	 * @param  expirationDateMonth the month the web content article is set to
+	 *         expire
+	 * @param  expirationDateDay the calendar day the web content article is set
+	 *         to expire
+	 * @param  expirationDateYear the year the web content article is set to
+	 *         expire
+	 * @param  expirationDateHour the hour the web content article is set to
+	 *         expire
+	 * @param  expirationDateMinute the minute the web content article is set to
+	 *         expire
+	 * @param  neverExpire whether the web content article is not set to auto
+	 *         expire
+	 * @param  reviewDateMonth the month the web content article is set for
+	 *         review
+	 * @param  reviewDateDay the calendar day the web content article is set for
+	 *         review
+	 * @param  reviewDateYear the year the web content article is set for review
+	 * @param  reviewDateHour the hour the web content article is set for review
+	 * @param  reviewDateMinute the minute the web content article is set for
+	 *         review
+	 * @param  neverReview whether the web content article is not set for review
+	 * @param  indexable whether the web content is searchable
+	 * @param  smallImage whether to update web content article's a small image.
+	 *         A file must be passed in as <code>smallImageFile</code> value,
+	 *         otherwise the current small image is deleted.
+	 * @param  smallImageURL the web content article's small image URL
+	 *         (optionally <code>null</code>)
+	 * @param  smallImageFile the web content article's new small image file
+	 *         (optionally <code>null</code>). Must pass in
+	 *         <code>smallImage</code> value of <code>true</code> to replace the
+	 *         article's small image file.
+	 * @param  images the web content's images (optionally <code>null</code>)
+	 * @param  articleURL the web content article's accessible URL (optionally
+	 *         <code>null</code>)
+	 * @param  serviceContext the service context to be applied. Can set the
+	 *         modification date, expando bridge attributes, asset category IDs,
+	 *         asset tag names, asset link entry IDs, asset priority, workflow
+	 *         actions, URL title , and can set whether to add the default
+	 *         command update for the web content article. With respect to
+	 *         social activities, by setting the service context's command to
+	 *         {@link Constants#UPDATE}, the invocation is considered a web
+	 *         content update activity; otherwise it is considered a web content
+	 *         add activity.
+	 * @return the updated web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Indexable(type = IndexableType.REINDEX)
+	@Override
+	public JournalArticle updateArticle(
+			long userId, long groupId, long folderId, String articleId,
+			String externalReferenceCode, double version,
+			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			String ddmStructureKey, String ddmTemplateKey, String layoutUuid,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, int expirationDateMonth,
+			int expirationDateDay, int expirationDateYear,
+			int expirationDateHour, int expirationDateMinute,
+			boolean neverExpire, int reviewDateMonth, int reviewDateDay,
+			int reviewDateYear, int reviewDateHour, int reviewDateMinute,
+			boolean neverReview, boolean indexable, boolean smallImage,
+			String smallImageURL, File smallImageFile,
+			Map<String, byte[]> images, String articleURL,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		// Article
+
+		User user = userLocalService.getUser(userId);
+		articleId = StringUtil.toUpperCase(StringUtil.trim(articleId));
+
+		byte[] smallImageBytes = null;
+
+		try {
+			smallImageBytes = FileUtil.getBytes(smallImageFile);
+		}
+		catch (IOException ioException) {
+		}
+
+		JournalArticle latestArticle = getLatestArticle(
+			groupId, articleId, WorkflowConstants.STATUS_ANY);
+
+		JournalArticle article = latestArticle;
+
+		if ((externalReferenceCode == null) ||
+			StringUtil.equals(externalReferenceCode, StringPool.BLANK)) {
+
+			externalReferenceCode = latestArticle.getExternalReferenceCode();
+		}
+
+		boolean imported = ExportImportThreadLocal.isImportInProcess();
+
+		boolean addNewVersion = false;
+
+		if (imported) {
+			article = getArticle(groupId, articleId, version);
+		}
+		else {
+			double latestArticleVersion = latestArticle.getVersion();
+
+			if ((version > 0) && (version != latestArticleVersion)) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append("Version ");
+				sb.append(version);
+				sb.append(" is not the same as ");
+				sb.append(latestArticleVersion);
+
+				throw new ArticleVersionException(sb.toString());
+			}
+
+			serviceContext.validateModifiedDate(
+				latestArticle, ArticleVersionException.class);
+
+			if (latestArticle.isApproved() || latestArticle.isExpired() ||
+				latestArticle.isScheduled()) {
+
+				addNewVersion = true;
+
+				version = getNextVersion(article);
+			}
+		}
+
+		Date displayDate = _portal.getDate(
+			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
+			displayDateMinute, user.getTimeZone(), null);
+
+		Date expirationDate = null;
+		Date reviewDate = null;
+
+		if (!neverExpire) {
+			expirationDate = _portal.getDate(
+				expirationDateMonth, expirationDateDay, expirationDateYear,
+				expirationDateHour, expirationDateMinute, user.getTimeZone(),
+				ArticleExpirationDateException.class);
+		}
+
+		if (!neverReview) {
+			reviewDate = _portal.getDate(
+				reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
+				reviewDateMinute, user.getTimeZone(),
+				ArticleReviewDateException.class);
+		}
+
+		Date now = new Date();
+
+		boolean expired = false;
+
+		if ((expirationDate != null) && expirationDate.before(now)) {
+			expired = true;
+		}
+
+		sanitize(
+			user.getCompanyId(), groupId, userId, article.getClassPK(),
+			descriptionMap);
+
+		boolean validate = !ExportImportThreadLocal.isImportInProcess();
+
+		if (validate) {
+			validate(
+				user.getCompanyId(), groupId, latestArticle.getClassNameId(),
+				titleMap, content, ddmStructureKey, ddmTemplateKey, displayDate,
+				expirationDate, smallImage, smallImageURL, smallImageFile,
+				smallImageBytes, serviceContext);
+
+			try {
+				validateReferences(
+					groupId, ddmStructureKey, ddmTemplateKey, layoutUuid,
+					smallImage, smallImageURL, smallImageBytes,
+					latestArticle.getSmallImageId(), content);
+			}
+			catch (ExportImportContentValidationException
+						exportImportContentValidationException) {
+
+				exportImportContentValidationException.setStagedModelClassName(
+					JournalArticle.class.getName());
+				exportImportContentValidationException.
+					setStagedModelPrimaryKeyObj(articleId);
+
+				throw exportImportContentValidationException;
+			}
+		}
+
+		if (addNewVersion) {
+			long id = counterLocalService.increment();
+
+			article = journalArticlePersistence.create(id);
+
+			article.setResourcePrimKey(latestArticle.getResourcePrimKey());
+			article.setGroupId(latestArticle.getGroupId());
+			article.setCompanyId(latestArticle.getCompanyId());
+			article.setUserId(user.getUserId());
+			article.setUserName(user.getFullName());
+			article.setCreateDate(latestArticle.getCreateDate());
+			article.setModifiedDate(serviceContext.getModifiedDate(now));
+			article.setClassNameId(latestArticle.getClassNameId());
+			article.setClassPK(latestArticle.getClassPK());
+			article.setArticleId(articleId);
+			article.setExternalReferenceCode(externalReferenceCode);
+			article.setVersion(version);
+			article.setSmallImageId(latestArticle.getSmallImageId());
+			article.setStatusByUserId(user.getUserId());
+			article.setStatusByUserName(user.getFullName());
+			article.setStatusDate(serviceContext.getModifiedDate(now));
+
+			serviceContext.setAttribute("version", version);
+
+			_addArticleLocalizedFields(
+				article.getCompanyId(), article.getId(), titleMap,
+				descriptionMap);
+		}
+		else {
+			_updateArticleLocalizedFields(
+				article.getCompanyId(), article.getId(), titleMap,
+				descriptionMap);
+		}
+
+		Locale locale = getArticleDefaultLocale(content);
+
+		Map<String, String> urlTitleMap = _getURLTitleMap(
+			groupId, article.getResourcePrimKey(), friendlyURLMap, titleMap);
+
+		String urlTitle = urlTitleMap.get(LocaleUtil.toLanguageId(locale));
+
+		if (Validator.isNull(urlTitle) &&
+			(classNameLocalService.getClassNameId(DDMStructure.class) !=
+				article.getClassNameId())) {
+
+			throw new ArticleFriendlyURLException();
+		}
+
+		content = format(user, groupId, article, content);
+		content = _replaceTempImages(article, content);
+
+		article.setFolderId(folderId);
+		article.setTreePath(article.buildTreePath());
+		article.setUrlTitle(urlTitle);
+		article.setContent(content);
+		article.setDDMStructureKey(ddmStructureKey);
+		article.setDDMTemplateKey(ddmTemplateKey);
+		article.setDefaultLanguageId(LocaleUtil.toLanguageId(locale));
+		article.setLayoutUuid(layoutUuid);
+		article.setDisplayDate(displayDate);
+		article.setExpirationDate(expirationDate);
+		article.setReviewDate(reviewDate);
+		article.setIndexable(indexable);
+		article.setSmallImage(smallImage);
+
+		if (smallImage) {
+			if ((smallImageFile != null) && (smallImageBytes != null) &&
+				(article.getSmallImageId() <= 0)) {
+
+				article.setSmallImageId(counterLocalService.increment());
+			}
+		}
+		else {
+			article.setSmallImageId(0);
+		}
+
+		article.setSmallImageURL(smallImageURL);
+
+		if (latestArticle.isPending()) {
+			article.setStatus(latestArticle.getStatus());
+		}
+		else if (!expired) {
+			article.setStatus(WorkflowConstants.STATUS_DRAFT);
+		}
+		else {
+			article.setStatus(WorkflowConstants.STATUS_EXPIRED);
+		}
+
+		ExpandoBridgeUtil.setExpandoBridgeAttributes(
+			latestArticle.getExpandoBridge(), article.getExpandoBridge(),
+			serviceContext);
+
+		article = journalArticlePersistence.update(article);
+
+		// Friendly URLs
+
+		updateFriendlyURLs(article, urlTitleMap, serviceContext);
+
+		// Asset
+
+		if (hasModifiedLatestApprovedVersion(groupId, articleId, version)) {
+			updateAsset(
+				userId, article, serviceContext.getAssetCategoryIds(),
+				serviceContext.getAssetTagNames(),
+				serviceContext.getAssetLinkEntryIds(),
+				serviceContext.getAssetPriority());
+		}
+
+		// Dynamic data mapping
+
+		if (classNameLocalService.getClassNameId(DDMStructure.class) !=
+				article.getClassNameId()) {
+
+			updateDDMLinks(
+				article.getId(), groupId, ddmStructureKey, ddmTemplateKey,
+				addNewVersion);
+		}
+
+		// Small image
+
+		saveImages(
+			smallImage, article.getSmallImageId(), smallImageFile,
+			smallImageBytes);
+
+		// Email and workflow
+
+		if (expired && imported) {
+			article = updateStatus(
+				userId, article, article.getStatus(), articleURL,
+				serviceContext, new HashMap<>());
+		}
+
+		if (serviceContext.getWorkflowAction() ==
+				WorkflowConstants.ACTION_PUBLISH) {
+
+			articleURL = buildArticleURL(
+				articleURL, groupId, folderId, articleId);
+
+			serviceContext.setAttribute("articleURL", articleURL);
+
+			sendEmail(article, articleURL, "requested", serviceContext);
+
+			startWorkflowInstance(userId, article, serviceContext);
+		}
+
+		return article;
 	}
 
 	/**

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -444,6 +444,7 @@ public class JournalArticleLocalServiceImpl
 		article.setClassPK(classPK);
 		article.setTreePath(article.buildTreePath());
 		article.setArticleId(articleId);
+		article.setExternalReferenceCode(articleId);
 		article.setVersion(version);
 		article.setUrlTitle(urlTitleMap.get(LocaleUtil.toLanguageId(locale)));
 
@@ -782,6 +783,7 @@ public class JournalArticleLocalServiceImpl
 		article.setClassNameId(classNameId);
 		article.setClassPK(classPK);
 		article.setArticleId(articleId);
+		article.setExternalReferenceCode(articleId);
 
 		content = format(user, groupId, article, content);
 		content = _replaceTempImages(article, content);
@@ -1073,6 +1075,7 @@ public class JournalArticleLocalServiceImpl
 		newArticle.setFolderId(oldArticle.getFolderId());
 		newArticle.setTreePath(oldArticle.getTreePath());
 		newArticle.setArticleId(newArticleId);
+		newArticle.setExternalReferenceCode(newArticleId);
 		newArticle.setVersion(JournalArticleConstants.VERSION_DEFAULT);
 		newArticle.setUrlTitle(
 			getUniqueUrlTitle(
@@ -5690,6 +5693,8 @@ public class JournalArticleLocalServiceImpl
 			article.setClassNameId(latestArticle.getClassNameId());
 			article.setClassPK(latestArticle.getClassPK());
 			article.setArticleId(articleId);
+			article.setExternalReferenceCode(
+				latestArticle.getExternalReferenceCode());
 			article.setVersion(version);
 			article.setSmallImageId(latestArticle.getSmallImageId());
 			article.setStatusByUserId(user.getUserId());
@@ -6340,6 +6345,8 @@ public class JournalArticleLocalServiceImpl
 			article.setClassNameId(oldArticle.getClassNameId());
 			article.setClassPK(oldArticle.getClassPK());
 			article.setArticleId(articleId);
+			article.setExternalReferenceCode(
+				oldArticle.getExternalReferenceCode());
 			article.setVersion(newVersion);
 			article.setUrlTitle(
 				getUniqueUrlTitle(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
@@ -2969,6 +2969,124 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 			serviceContext);
 	}
 
+	/**
+	 * Updates the web content article with additional parameters. All
+	 * scheduling parameters (display date, expiration date, and review date)
+	 * use the current user's timezone.
+	 *
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  folderId the primary key of the web content article folder
+	 * @param  articleId the primary key of the web content article
+	 * @param  externalReferenCode the external reference code of the web
+	 *         content article
+	 * @param  version the web content article's version
+	 * @param  titleMap the web content article's locales and localized titles
+	 * @param  descriptionMap the web content article's locales and localized
+	 *         descriptions
+	 * @param  friendlyURLMap the web content article's locales and localized
+	 *         friendly URLs
+	 * @param  content the HTML content wrapped in XML. For more information,
+	 *         see the content example in the {@link #updateArticle(long, long,
+	 *         String, double, String, ServiceContext)} description.
+	 * @param  ddmStructureKey the primary key of the web content article's DDM
+	 *         structure, if the article is related to a DDM structure, or
+	 *         <code>null</code> otherwise
+	 * @param  ddmTemplateKey the primary key of the web content article's DDM
+	 *         template
+	 * @param  layoutUuid the unique string identifying the web content
+	 *         article's display page
+	 * @param  displayDateMonth the month the web content article is set to
+	 *         display
+	 * @param  displayDateDay the calendar day the web content article is set to
+	 *         display
+	 * @param  displayDateYear the year the web content article is set to
+	 *         display
+	 * @param  displayDateHour the hour the web content article is set to
+	 *         display
+	 * @param  displayDateMinute the minute the web content article is set to
+	 *         display
+	 * @param  expirationDateMonth the month the web content article is set to
+	 *         expire
+	 * @param  expirationDateDay the calendar day the web content article is set
+	 *         to expire
+	 * @param  expirationDateYear the year the web content article is set to
+	 *         expire
+	 * @param  expirationDateHour the hour the web content article is set to
+	 *         expire
+	 * @param  expirationDateMinute the minute the web content article is set to
+	 *         expire
+	 * @param  neverExpire whether the web content article is not set to auto
+	 *         expire
+	 * @param  reviewDateMonth the month the web content article is set for
+	 *         review
+	 * @param  reviewDateDay the calendar day the web content article is set for
+	 *         review
+	 * @param  reviewDateYear the year the web content article is set for review
+	 * @param  reviewDateHour the hour the web content article is set for review
+	 * @param  reviewDateMinute the minute the web content article is set for
+	 *         review
+	 * @param  neverReview whether the web content article is not set for review
+	 * @param  indexable whether the web content is searchable
+	 * @param  smallImage whether to update web content article's a small image.
+	 *         A file must be passed in as <code>smallImageFile</code> value,
+	 *         otherwise the current small image is deleted.
+	 * @param  smallImageURL the web content article's small image URL
+	 *         (optionally <code>null</code>)
+	 * @param  smallFile the web content article's new small image file
+	 *         (optionally <code>null</code>). Must pass in
+	 *         <code>smallImage</code> value of <code>true</code> to replace the
+	 *         article's small image file.
+	 * @param  images the web content's images (optionally <code>null</code>)
+	 * @param  articleURL the web content article's accessible URL (optionally
+	 *         <code>null</code>)
+	 * @param  serviceContext the service context to be applied. Can set the
+	 *         modification date, expando bridge attributes, asset category IDs,
+	 *         asset tag names, asset link entry IDs, asset priority, workflow
+	 *         actions, URL title, and can set whether to add the default
+	 *         command update for the web content article. With respect to
+	 *         social activities, by setting the service context's command to
+	 *         {@link com.liferay.portal.kernel.util.Constants#UPDATE}, the
+	 *         invocation is considered a web content update activity; otherwise
+	 *         it is considered a web content add activity.
+	 * @return the updated web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public JournalArticle updateArticle(
+			long groupId, long folderId, String articleId,
+			String externalReferenceCode, double version,
+			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			String ddmStructureKey, String ddmTemplateKey, String layoutUuid,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, int expirationDateMonth,
+			int expirationDateDay, int expirationDateYear,
+			int expirationDateHour, int expirationDateMinute,
+			boolean neverExpire, int reviewDateMonth, int reviewDateDay,
+			int reviewDateYear, int reviewDateHour, int reviewDateMinute,
+			boolean neverReview, boolean indexable, boolean smallImage,
+			String smallImageURL, File smallFile, Map<String, byte[]> images,
+			String articleURL, ServiceContext serviceContext)
+		throws PortalException {
+
+		JournalArticle article = journalArticlePersistence.findByG_A_V(
+			groupId, articleId, version);
+
+		_journalArticleModelResourcePermission.check(
+			getPermissionChecker(), article, ActionKeys.UPDATE);
+
+		return journalArticleLocalService.updateArticle(
+			getUserId(), groupId, folderId, articleId, externalReferenceCode,
+			version, titleMap, descriptionMap, friendlyURLMap, content,
+			ddmStructureKey, ddmTemplateKey, layoutUuid, displayDateMonth,
+			displayDateDay, displayDateYear, displayDateHour, displayDateMinute,
+			expirationDateMonth, expirationDateDay, expirationDateYear,
+			expirationDateHour, expirationDateMinute, neverExpire,
+			reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
+			reviewDateMinute, neverReview, indexable, smallImage, smallImageURL,
+			smallFile, images, articleURL, serviceContext);
+	}
+
 	@Override
 	public JournalArticle updateArticleDefaultValues(
 			long groupId, String articleId, Map<Locale, String> titleMap,

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
@@ -404,6 +404,125 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	}
 
 	/**
+	 * Adds a web content article with additional parameters. All scheduling
+	 * parameters (display date, expiration date, and review date) use the
+	 * current user's timezone.
+	 *
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  folderId the primary key of the web content article folder
+	 * @param  classNameId the primary key of the DDMStructure class if the web
+	 *         content article is related to a DDM structure, the primary key of
+	 *         the class name associated with the article, or
+	 *         JournalArticleConstants.CLASS_NAME_ID_DEFAULT in the journal-api
+	 *         module otherwise
+	 * @param  classPK the primary key of the DDM structure, if the primary key
+	 *         of the DDMStructure class is given as the
+	 *         <code>classNameId</code> parameter, the primary key of the class
+	 *         associated with the web content article, or <code>0</code>
+	 *         otherwise
+	 * @param  articleId the primary key of the web content article
+	 * @param  autoArticleId whether to auto generate the web content article ID
+	 * @param  titleMap the web content article's locales and localized titles
+	 * @param  descriptionMap the web content article's locales and localized
+	 *         descriptions
+	 * @param  friendlyURLMap the web content article's locales and localized
+	 *         friendly URLs
+	 * @param  content the HTML content wrapped in XML. For more information,
+	 *         see the content example in the {@link #updateArticle(long, long,
+	 *         String, double, String, ServiceContext)} description.
+	 * @param  ddmStructureKey the primary key of the web content article's DDM
+	 *         structure, if the article is related to a DDM structure, or
+	 *         <code>null</code> otherwise
+	 * @param  ddmTemplateKey the primary key of the web content article's DDM
+	 *         template
+	 * @param  externalReferenceCode the external reference code of the web
+	 *         content article
+	 * @param  layoutUuid the unique string identifying the web content
+	 *         article's display page
+	 * @param  displayDateMonth the month the web content article is set to
+	 *         display
+	 * @param  displayDateDay the calendar day the web content article is set to
+	 *         display
+	 * @param  displayDateYear the year the web content article is set to
+	 *         display
+	 * @param  displayDateHour the hour the web content article is set to
+	 *         display
+	 * @param  displayDateMinute the minute the web content article is set to
+	 *         display
+	 * @param  expirationDateMonth the month the web content article is set to
+	 *         expire
+	 * @param  expirationDateDay the calendar day the web content article is set
+	 *         to expire
+	 * @param  expirationDateYear the year the web content article is set to
+	 *         expire
+	 * @param  expirationDateHour the hour the web content article is set to
+	 *         expire
+	 * @param  expirationDateMinute the minute the web content article is set to
+	 *         expire
+	 * @param  neverExpire whether the web content article is not set to auto
+	 *         expire
+	 * @param  reviewDateMonth the month the web content article is set for
+	 *         review
+	 * @param  reviewDateDay the calendar day the web content article is set for
+	 *         review
+	 * @param  reviewDateYear the year the web content article is set for review
+	 * @param  reviewDateHour the hour the web content article is set for review
+	 * @param  reviewDateMinute the minute the web content article is set for
+	 *         review
+	 * @param  neverReview whether the web content article is not set for review
+	 * @param  indexable whether the web content article is searchable
+	 * @param  smallImage whether the web content article has a small image
+	 * @param  smallImageURL the web content article's small image URL
+	 * @param  smallFile the web content article's small image file
+	 * @param  images the web content's images
+	 * @param  articleURL the web content article's accessible URL
+	 * @param  serviceContext the service context to be applied. Can set the
+	 *         UUID, creation date, modification date, expando bridge
+	 *         attributes, guest permissions, group permissions, asset category
+	 *         IDs, asset tag names, asset link entry IDs, asset priority, URL
+	 *         title, and workflow actions for the web content article. Can also
+	 *         set whether to add the default guest and group permissions.
+	 * @return the web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public JournalArticle addArticle(
+			long groupId, long folderId, long classNameId, long classPK,
+			String articleId, boolean autoArticleId,
+			String externalReferenceCode, Map<Locale, String> titleMap,
+			Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			String ddmStructureKey, String ddmTemplateKey, String layoutUuid,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, int expirationDateMonth,
+			int expirationDateDay, int expirationDateYear,
+			int expirationDateHour, int expirationDateMinute,
+			boolean neverExpire, int reviewDateMonth, int reviewDateDay,
+			int reviewDateYear, int reviewDateHour, int reviewDateMinute,
+			boolean neverReview, boolean indexable, boolean smallImage,
+			String smallImageURL, File smallFile, Map<String, byte[]> images,
+			String articleURL, ServiceContext serviceContext)
+		throws PortalException {
+
+		ModelResourcePermissionUtil.check(
+			_journalFolderModelResourcePermission, getPermissionChecker(),
+			groupId, folderId, ActionKeys.ADD_ARTICLE);
+
+		return journalArticleLocalService.addArticle(
+			getUserId(), groupId, folderId, classNameId, classPK, articleId,
+			autoArticleId, externalReferenceCode,
+			JournalArticleConstants.VERSION_DEFAULT, titleMap, descriptionMap,
+			friendlyURLMap, content, ddmStructureKey, ddmTemplateKey,
+			layoutUuid, displayDateMonth, displayDateDay, displayDateYear,
+			displayDateHour, displayDateMinute, expirationDateMonth,
+			expirationDateDay, expirationDateYear, expirationDateHour,
+			expirationDateMinute, neverExpire, reviewDateMonth, reviewDateDay,
+			reviewDateYear, reviewDateHour, reviewDateMinute, neverReview,
+			indexable, smallImage, smallImageURL, smallFile, images, articleURL,
+			serviceContext);
+	}
+
+	/**
 	 * Adds a web content article.
 	 *
 	 * @param  groupId the primary key of the web content article's group

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
@@ -661,6 +661,33 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	}
 
 	/**
+	 * Returns the latest web content article matching the group, external reference code,
+	 * and workflow status.
+	 *
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  externalReferenceCode the external reference code of the web content article
+	 * @return the latest matching web content article, or <code>null</code> if
+	 *         no matching web content article could be found
+	 */
+	@Override
+	public JournalArticle fetchLatestArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		JournalArticle article =
+			journalArticleLocalService.
+				fetchLatestArticleByExternalReferenceCode(
+					groupId, externalReferenceCode);
+
+		if (article != null) {
+			_journalArticleModelResourcePermission.check(
+				getPermissionChecker(), article, ActionKeys.VIEW);
+		}
+
+		return article;
+	}
+
+	/**
 	 * Returns the web content article with the ID.
 	 *
 	 * @param  id the primary key of the web content article
@@ -1653,6 +1680,30 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 
 		JournalArticle article = journalArticleLocalService.getLatestArticle(
 			groupId, className, classPK);
+
+		_journalArticleModelResourcePermission.check(
+			getPermissionChecker(), article, ActionKeys.VIEW);
+
+		return article;
+	}
+
+	/**
+	 * Returns the latest web content article matching the group, external reference code,
+	 * and workflow status.
+	 *
+	 * @param  groupId the primary key of the web content article's group
+	 * @param  externalReferenceCode the external reference code of the web content article
+	 * @return the latest matching web content article
+	 * @throws PortalException if a portal exception occurred
+	 */
+	@Override
+	public JournalArticle getLatestArticleByExternalReferenceCode(
+			long groupId, String externalReferenceCode)
+		throws PortalException {
+
+		JournalArticle article =
+			journalArticleLocalService.getLatestArticleByExternalReferenceCode(
+				groupId, externalReferenceCode);
 
 		_journalArticleModelResourcePermission.check(
 			getPermissionChecker(), article, ActionKeys.VIEW);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticlePersistenceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticlePersistenceImpl.java
@@ -10826,6 +10826,1052 @@ public class JournalArticlePersistenceImpl
 	private static final String _FINDER_COLUMN_G_A_ARTICLEID_3 =
 		"(journalArticle.articleId IS NULL OR journalArticle.articleId = '')";
 
+	private FinderPath _finderPathWithPaginationFindByG_ERC;
+	private FinderPath _finderPathWithoutPaginationFindByG_ERC;
+	private FinderPath _finderPathCountByG_ERC;
+
+	/**
+	 * Returns all the journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching journal articles
+	 */
+	@Override
+	public List<JournalArticle> findByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return findByG_ERC(
+			groupId, externalReferenceCode, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @return the range of matching journal articles
+	 */
+	@Override
+	public List<JournalArticle> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end) {
+
+		return findByG_ERC(groupId, externalReferenceCode, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching journal articles
+	 */
+	@Override
+	public List<JournalArticle> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<JournalArticle> orderByComparator) {
+
+		return findByG_ERC(
+			groupId, externalReferenceCode, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching journal articles
+	 */
+	@Override
+	public List<JournalArticle> findByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<JournalArticle> orderByComparator,
+		boolean useFinderCache) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			JournalArticle.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache && productionMode) {
+				finderPath = _finderPathWithoutPaginationFindByG_ERC;
+				finderArgs = new Object[] {groupId, externalReferenceCode};
+			}
+		}
+		else if (useFinderCache && productionMode) {
+			finderPath = _finderPathWithPaginationFindByG_ERC;
+			finderArgs = new Object[] {
+				groupId, externalReferenceCode, start, end, orderByComparator
+			};
+		}
+
+		List<JournalArticle> list = null;
+
+		if (useFinderCache && productionMode) {
+			list = (List<JournalArticle>)finderCache.getResult(
+				finderPath, finderArgs);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (JournalArticle journalArticle : list) {
+					if ((groupId != journalArticle.getGroupId()) ||
+						!externalReferenceCode.equals(
+							journalArticle.getExternalReferenceCode())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					4 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(4);
+			}
+
+			sb.append(_SQL_SELECT_JOURNALARTICLE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+			}
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(JournalArticleModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				list = (List<JournalArticle>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache && productionMode) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching journal article
+	 * @throws NoSuchArticleException if a matching journal article could not be found
+	 */
+	@Override
+	public JournalArticle findByG_ERC_First(
+			long groupId, String externalReferenceCode,
+			OrderByComparator<JournalArticle> orderByComparator)
+		throws NoSuchArticleException {
+
+		JournalArticle journalArticle = fetchByG_ERC_First(
+			groupId, externalReferenceCode, orderByComparator);
+
+		if (journalArticle != null) {
+			return journalArticle;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
+
+		sb.append("}");
+
+		throw new NoSuchArticleException(sb.toString());
+	}
+
+	/**
+	 * Returns the first journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching journal article, or <code>null</code> if a matching journal article could not be found
+	 */
+	@Override
+	public JournalArticle fetchByG_ERC_First(
+		long groupId, String externalReferenceCode,
+		OrderByComparator<JournalArticle> orderByComparator) {
+
+		List<JournalArticle> list = findByG_ERC(
+			groupId, externalReferenceCode, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching journal article
+	 * @throws NoSuchArticleException if a matching journal article could not be found
+	 */
+	@Override
+	public JournalArticle findByG_ERC_Last(
+			long groupId, String externalReferenceCode,
+			OrderByComparator<JournalArticle> orderByComparator)
+		throws NoSuchArticleException {
+
+		JournalArticle journalArticle = fetchByG_ERC_Last(
+			groupId, externalReferenceCode, orderByComparator);
+
+		if (journalArticle != null) {
+			return journalArticle;
+		}
+
+		StringBundler sb = new StringBundler(6);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
+
+		sb.append("}");
+
+		throw new NoSuchArticleException(sb.toString());
+	}
+
+	/**
+	 * Returns the last journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching journal article, or <code>null</code> if a matching journal article could not be found
+	 */
+	@Override
+	public JournalArticle fetchByG_ERC_Last(
+		long groupId, String externalReferenceCode,
+		OrderByComparator<JournalArticle> orderByComparator) {
+
+		int count = countByG_ERC(groupId, externalReferenceCode);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<JournalArticle> list = findByG_ERC(
+			groupId, externalReferenceCode, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the journal articles before and after the current journal article in the ordered set where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param id the primary key of the current journal article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next journal article
+	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
+	 */
+	@Override
+	public JournalArticle[] findByG_ERC_PrevAndNext(
+			long id, long groupId, String externalReferenceCode,
+			OrderByComparator<JournalArticle> orderByComparator)
+		throws NoSuchArticleException {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		JournalArticle journalArticle = findByPrimaryKey(id);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			JournalArticle[] array = new JournalArticleImpl[3];
+
+			array[0] = getByG_ERC_PrevAndNext(
+				session, journalArticle, groupId, externalReferenceCode,
+				orderByComparator, true);
+
+			array[1] = journalArticle;
+
+			array[2] = getByG_ERC_PrevAndNext(
+				session, journalArticle, groupId, externalReferenceCode,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected JournalArticle getByG_ERC_PrevAndNext(
+		Session session, JournalArticle journalArticle, long groupId,
+		String externalReferenceCode,
+		OrderByComparator<JournalArticle> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				5 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(4);
+		}
+
+		sb.append(_SQL_SELECT_JOURNALARTICLE_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(JournalArticleModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		if (bindExternalReferenceCode) {
+			queryPos.add(externalReferenceCode);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						journalArticle)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<JournalArticle> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Returns all the journal articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the matching journal articles that the user has permission to view
+	 */
+	@Override
+	public List<JournalArticle> filterFindByG_ERC(
+		long groupId, String externalReferenceCode) {
+
+		return filterFindByG_ERC(
+			groupId, externalReferenceCode, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the journal articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @return the range of matching journal articles that the user has permission to view
+	 */
+	@Override
+	public List<JournalArticle> filterFindByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end) {
+
+		return filterFindByG_ERC(
+			groupId, externalReferenceCode, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the journal articles that the user has permissions to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>JournalArticleModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param start the lower bound of the range of journal articles
+	 * @param end the upper bound of the range of journal articles (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching journal articles that the user has permission to view
+	 */
+	@Override
+	public List<JournalArticle> filterFindByG_ERC(
+		long groupId, String externalReferenceCode, int start, int end,
+		OrderByComparator<JournalArticle> orderByComparator) {
+
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return findByG_ERC(
+				groupId, externalReferenceCode, start, end, orderByComparator);
+		}
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				4 + (orderByComparator.getOrderByFields().length * 2));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_JOURNALARTICLE_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_JOURNALARTICLE_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+		}
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_JOURNALARTICLE_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			if (getDB().isSupportsInlineDistinct()) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator, true);
+			}
+			else {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_TABLE, orderByComparator, true);
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(JournalArticleModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(JournalArticleModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), JournalArticle.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			if (getDB().isSupportsInlineDistinct()) {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_ALIAS, JournalArticleImpl.class);
+			}
+			else {
+				sqlQuery.addEntity(
+					_FILTER_ENTITY_TABLE, JournalArticleImpl.class);
+			}
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(groupId);
+
+			if (bindExternalReferenceCode) {
+				queryPos.add(externalReferenceCode);
+			}
+
+			return (List<JournalArticle>)QueryUtil.list(
+				sqlQuery, getDialect(), start, end);
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	/**
+	 * Returns the journal articles before and after the current journal article in the ordered set of journal articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param id the primary key of the current journal article
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next journal article
+	 * @throws NoSuchArticleException if a journal article with the primary key could not be found
+	 */
+	@Override
+	public JournalArticle[] filterFindByG_ERC_PrevAndNext(
+			long id, long groupId, String externalReferenceCode,
+			OrderByComparator<JournalArticle> orderByComparator)
+		throws NoSuchArticleException {
+
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return findByG_ERC_PrevAndNext(
+				id, groupId, externalReferenceCode, orderByComparator);
+		}
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		JournalArticle journalArticle = findByPrimaryKey(id);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			JournalArticle[] array = new JournalArticleImpl[3];
+
+			array[0] = filterGetByG_ERC_PrevAndNext(
+				session, journalArticle, groupId, externalReferenceCode,
+				orderByComparator, true);
+
+			array[1] = journalArticle;
+
+			array[2] = filterGetByG_ERC_PrevAndNext(
+				session, journalArticle, groupId, externalReferenceCode,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected JournalArticle filterGetByG_ERC_PrevAndNext(
+		Session session, JournalArticle journalArticle, long groupId,
+		String externalReferenceCode,
+		OrderByComparator<JournalArticle> orderByComparator, boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sb.append(_FILTER_SQL_SELECT_JOURNALARTICLE_WHERE);
+		}
+		else {
+			sb.append(
+				_FILTER_SQL_SELECT_JOURNALARTICLE_NO_INLINE_DISTINCT_WHERE_1);
+		}
+
+		sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+		}
+
+		if (!getDB().isSupportsInlineDistinct()) {
+			sb.append(
+				_FILTER_SQL_SELECT_JOURNALARTICLE_NO_INLINE_DISTINCT_WHERE_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByConditionFields[i],
+							true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByConditionFields[i],
+							true));
+				}
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				if (getDB().isSupportsInlineDistinct()) {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_ALIAS, orderByFields[i], true));
+				}
+				else {
+					sb.append(
+						getColumnName(
+							_ORDER_BY_ENTITY_TABLE, orderByFields[i], true));
+				}
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			if (getDB().isSupportsInlineDistinct()) {
+				sb.append(JournalArticleModelImpl.ORDER_BY_JPQL);
+			}
+			else {
+				sb.append(JournalArticleModelImpl.ORDER_BY_SQL);
+			}
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), JournalArticle.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+		sqlQuery.setFirstResult(0);
+		sqlQuery.setMaxResults(2);
+
+		if (getDB().isSupportsInlineDistinct()) {
+			sqlQuery.addEntity(_FILTER_ENTITY_ALIAS, JournalArticleImpl.class);
+		}
+		else {
+			sqlQuery.addEntity(_FILTER_ENTITY_TABLE, JournalArticleImpl.class);
+		}
+
+		QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+		queryPos.add(groupId);
+
+		if (bindExternalReferenceCode) {
+			queryPos.add(externalReferenceCode);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						journalArticle)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<JournalArticle> list = sqlQuery.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the journal articles where groupId = &#63; and externalReferenceCode = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 */
+	@Override
+	public void removeByG_ERC(long groupId, String externalReferenceCode) {
+		for (JournalArticle journalArticle :
+				findByG_ERC(
+					groupId, externalReferenceCode, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(journalArticle);
+		}
+	}
+
+	/**
+	 * Returns the number of journal articles where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching journal articles
+	 */
+	@Override
+	public int countByG_ERC(long groupId, String externalReferenceCode) {
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			JournalArticle.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByG_ERC;
+
+			finderArgs = new Object[] {groupId, externalReferenceCode};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(_SQL_COUNT_JOURNALARTICLE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				count = (Long)query.uniqueResult();
+
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	/**
+	 * Returns the number of journal articles that the user has permission to view where groupId = &#63; and externalReferenceCode = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @return the number of matching journal articles that the user has permission to view
+	 */
+	@Override
+	public int filterCountByG_ERC(long groupId, String externalReferenceCode) {
+		if (!InlineSQLHelperUtil.isEnabled(groupId)) {
+			return countByG_ERC(groupId, externalReferenceCode);
+		}
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(_FILTER_SQL_COUNT_JOURNALARTICLE_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_ERC_GROUPID_2);
+
+		boolean bindExternalReferenceCode = false;
+
+		if (externalReferenceCode.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3);
+		}
+		else {
+			bindExternalReferenceCode = true;
+
+			sb.append(_FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2);
+		}
+
+		String sql = InlineSQLHelperUtil.replacePermissionCheck(
+			sb.toString(), JournalArticle.class.getName(),
+			_FILTER_ENTITY_TABLE_FILTER_PK_COLUMN, groupId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			SQLQuery sqlQuery = session.createSynchronizedSQLQuery(sql);
+
+			sqlQuery.addScalar(
+				COUNT_COLUMN_NAME, com.liferay.portal.kernel.dao.orm.Type.LONG);
+
+			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			queryPos.add(groupId);
+
+			if (bindExternalReferenceCode) {
+				queryPos.add(externalReferenceCode);
+			}
+
+			Long count = (Long)sqlQuery.uniqueResult();
+
+			return count.intValue();
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	private static final String _FINDER_COLUMN_G_ERC_GROUPID_2 =
+		"journalArticle.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_2 =
+		"journalArticle.externalReferenceCode = ?";
+
+	private static final String _FINDER_COLUMN_G_ERC_EXTERNALREFERENCECODE_3 =
+		"(journalArticle.externalReferenceCode IS NULL OR journalArticle.externalReferenceCode = '')";
+
 	private FinderPath _finderPathWithPaginationFindByG_UT;
 	private FinderPath _finderPathWithoutPaginationFindByG_UT;
 	private FinderPath _finderPathCountByG_UT;
@@ -29862,6 +30908,300 @@ public class JournalArticlePersistenceImpl
 	private static final String _FINDER_COLUMN_G_A_NOTST_STATUS_2 =
 		"journalArticle.status != ?";
 
+	private FinderPath _finderPathFetchByG_ERC_V;
+	private FinderPath _finderPathCountByG_ERC_V;
+
+	/**
+	 * Returns the journal article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or throws a <code>NoSuchArticleException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching journal article
+	 * @throws NoSuchArticleException if a matching journal article could not be found
+	 */
+	@Override
+	public JournalArticle findByG_ERC_V(
+			long groupId, String externalReferenceCode, double version)
+		throws NoSuchArticleException {
+
+		JournalArticle journalArticle = fetchByG_ERC_V(
+			groupId, externalReferenceCode, version);
+
+		if (journalArticle == null) {
+			StringBundler sb = new StringBundler(8);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("groupId=");
+			sb.append(groupId);
+
+			sb.append(", externalReferenceCode=");
+			sb.append(externalReferenceCode);
+
+			sb.append(", version=");
+			sb.append(version);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchArticleException(sb.toString());
+		}
+
+		return journalArticle;
+	}
+
+	/**
+	 * Returns the journal article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the matching journal article, or <code>null</code> if a matching journal article could not be found
+	 */
+	@Override
+	public JournalArticle fetchByG_ERC_V(
+		long groupId, String externalReferenceCode, double version) {
+
+		return fetchByG_ERC_V(groupId, externalReferenceCode, version, true);
+	}
+
+	/**
+	 * Returns the journal article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching journal article, or <code>null</code> if a matching journal article could not be found
+	 */
+	@Override
+	public JournalArticle fetchByG_ERC_V(
+		long groupId, String externalReferenceCode, double version,
+		boolean useFinderCache) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			JournalArticle.class);
+
+		Object[] finderArgs = null;
+
+		if (useFinderCache && productionMode) {
+			finderArgs = new Object[] {groupId, externalReferenceCode, version};
+		}
+
+		Object result = null;
+
+		if (useFinderCache && productionMode) {
+			result = finderCache.getResult(
+				_finderPathFetchByG_ERC_V, finderArgs);
+		}
+
+		if (result instanceof JournalArticle) {
+			JournalArticle journalArticle = (JournalArticle)result;
+
+			if ((groupId != journalArticle.getGroupId()) ||
+				!Objects.equals(
+					externalReferenceCode,
+					journalArticle.getExternalReferenceCode()) ||
+				(version != journalArticle.getVersion())) {
+
+				result = null;
+			}
+		}
+
+		if (result == null) {
+			StringBundler sb = new StringBundler(5);
+
+			sb.append(_SQL_SELECT_JOURNALARTICLE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_V_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_V_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_V_EXTERNALREFERENCECODE_2);
+			}
+
+			sb.append(_FINDER_COLUMN_G_ERC_V_VERSION_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				queryPos.add(version);
+
+				List<JournalArticle> list = query.list();
+
+				if (list.isEmpty()) {
+					if (useFinderCache && productionMode) {
+						finderCache.putResult(
+							_finderPathFetchByG_ERC_V, finderArgs, list);
+					}
+				}
+				else {
+					JournalArticle journalArticle = list.get(0);
+
+					result = journalArticle;
+
+					cacheResult(journalArticle);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		if (result instanceof List<?>) {
+			return null;
+		}
+		else {
+			return (JournalArticle)result;
+		}
+	}
+
+	/**
+	 * Removes the journal article where groupId = &#63; and externalReferenceCode = &#63; and version = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the journal article that was removed
+	 */
+	@Override
+	public JournalArticle removeByG_ERC_V(
+			long groupId, String externalReferenceCode, double version)
+		throws NoSuchArticleException {
+
+		JournalArticle journalArticle = findByG_ERC_V(
+			groupId, externalReferenceCode, version);
+
+		return remove(journalArticle);
+	}
+
+	/**
+	 * Returns the number of journal articles where groupId = &#63; and externalReferenceCode = &#63; and version = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param externalReferenceCode the external reference code
+	 * @param version the version
+	 * @return the number of matching journal articles
+	 */
+	@Override
+	public int countByG_ERC_V(
+		long groupId, String externalReferenceCode, double version) {
+
+		externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			JournalArticle.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByG_ERC_V;
+
+			finderArgs = new Object[] {groupId, externalReferenceCode, version};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_SQL_COUNT_JOURNALARTICLE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_ERC_V_GROUPID_2);
+
+			boolean bindExternalReferenceCode = false;
+
+			if (externalReferenceCode.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_ERC_V_EXTERNALREFERENCECODE_3);
+			}
+			else {
+				bindExternalReferenceCode = true;
+
+				sb.append(_FINDER_COLUMN_G_ERC_V_EXTERNALREFERENCECODE_2);
+			}
+
+			sb.append(_FINDER_COLUMN_G_ERC_V_VERSION_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				if (bindExternalReferenceCode) {
+					queryPos.add(externalReferenceCode);
+				}
+
+				queryPos.add(version);
+
+				count = (Long)query.uniqueResult();
+
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_G_ERC_V_GROUPID_2 =
+		"journalArticle.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_ERC_V_EXTERNALREFERENCECODE_2 =
+		"journalArticle.externalReferenceCode = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_ERC_V_EXTERNALREFERENCECODE_3 =
+		"(journalArticle.externalReferenceCode IS NULL OR journalArticle.externalReferenceCode = '') AND ";
+
+	private static final String _FINDER_COLUMN_G_ERC_V_VERSION_2 =
+		"journalArticle.version = ?";
+
 	private FinderPath _finderPathWithPaginationFindByG_UT_ST;
 	private FinderPath _finderPathWithoutPaginationFindByG_UT_ST;
 	private FinderPath _finderPathCountByG_UT_ST;
@@ -32662,6 +34002,15 @@ public class JournalArticlePersistenceImpl
 				journalArticle.getVersion()
 			},
 			journalArticle);
+
+		finderCache.putResult(
+			_finderPathFetchByG_ERC_V,
+			new Object[] {
+				journalArticle.getGroupId(),
+				journalArticle.getExternalReferenceCode(),
+				journalArticle.getVersion()
+			},
+			journalArticle);
 	}
 
 	/**
@@ -32759,6 +34108,16 @@ public class JournalArticlePersistenceImpl
 		finderCache.putResult(_finderPathCountByG_A_V, args, Long.valueOf(1));
 		finderCache.putResult(
 			_finderPathFetchByG_A_V, args, journalArticleModelImpl);
+
+		args = new Object[] {
+			journalArticleModelImpl.getGroupId(),
+			journalArticleModelImpl.getExternalReferenceCode(),
+			journalArticleModelImpl.getVersion()
+		};
+
+		finderCache.putResult(_finderPathCountByG_ERC_V, args, Long.valueOf(1));
+		finderCache.putResult(
+			_finderPathFetchByG_ERC_V, args, journalArticleModelImpl);
 	}
 
 	/**
@@ -33399,6 +34758,7 @@ public class JournalArticlePersistenceImpl
 		ctStrictColumnNames.add("classPK");
 		ctStrictColumnNames.add("treePath");
 		ctStrictColumnNames.add("articleId");
+		ctStrictColumnNames.add("externalReferenceCode");
 		ctStrictColumnNames.add("version");
 		ctStrictColumnNames.add("urlTitle");
 		ctStrictColumnNames.add("content");
@@ -33433,6 +34793,9 @@ public class JournalArticlePersistenceImpl
 
 		_uniqueIndexColumnNames.add(
 			new String[] {"groupId", "articleId", "version"});
+
+		_uniqueIndexColumnNames.add(
+			new String[] {"groupId", "externalReferenceCode", "version"});
 	}
 
 	/**
@@ -33740,6 +35103,25 @@ public class JournalArticlePersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_A",
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"groupId", "articleId"}, false);
+
+		_finderPathWithPaginationFindByG_ERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_ERC",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "externalReferenceCode"}, true);
+
+		_finderPathWithoutPaginationFindByG_ERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_ERC",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "externalReferenceCode"}, true);
+
+		_finderPathCountByG_ERC = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC",
+			new String[] {Long.class.getName(), String.class.getName()},
+			new String[] {"groupId", "externalReferenceCode"}, false);
 
 		_finderPathWithPaginationFindByG_UT = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_UT",
@@ -34159,6 +35541,23 @@ public class JournalArticlePersistenceImpl
 				Integer.class.getName()
 			},
 			new String[] {"groupId", "articleId", "status"}, false);
+
+		_finderPathFetchByG_ERC_V = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_ERC_V",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Double.class.getName()
+			},
+			new String[] {"groupId", "externalReferenceCode", "version"}, true);
+
+		_finderPathCountByG_ERC_V = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_ERC_V",
+			new String[] {
+				Long.class.getName(), String.class.getName(),
+				Double.class.getName()
+			},
+			new String[] {"groupId", "externalReferenceCode", "version"},
+			false);
 
 		_finderPathWithPaginationFindByG_UT_ST = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_UT_ST",

--- a/modules/apps/journal/journal-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/journal/journal-service/src/main/resources/META-INF/module-hbm.xml
@@ -27,6 +27,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="classPK" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="treePath" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="articleId" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="externalReferenceCode" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="version" type="com.liferay.portal.dao.orm.hibernate.DoubleType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="urlTitle" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="content" type="com.liferay.portal.dao.orm.hibernate.StringClobType" />

--- a/modules/apps/journal/journal-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/journal/journal-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -22,6 +22,7 @@
 		<field name="articleId" type="String">
 			<hint name="upper-case">true</hint>
 		</field>
+		<field name="externalReferenceCode" type="String" />
 		<field name="version" type="double" />
 		<field name="urlTitle" type="String">
 			<hint name="max-length">255</hint>

--- a/modules/apps/journal/journal-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/journal/journal-service/src/main/resources/META-INF/sql/indexes.sql
@@ -16,6 +16,8 @@ create index IX_20E66853 on JournalArticle (groupId, classNameId, DDMTemplateKey
 create index IX_E748358 on JournalArticle (groupId, classNameId, classPK, ctCollectionId);
 create index IX_6CA45D20 on JournalArticle (groupId, classNameId, layoutUuid[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_1ED664C3 on JournalArticle (groupId, ctCollectionId);
+create index IX_DB98B996 on JournalArticle (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], ctCollectionId);
+create unique index IX_D9F0782E on JournalArticle (groupId, externalReferenceCode[$COLUMN_LENGTH:75$], version, ctCollectionId);
 create index IX_8868DCD0 on JournalArticle (groupId, folderId, classNameId, status, ctCollectionId);
 create index IX_74060760 on JournalArticle (groupId, folderId, ctCollectionId);
 create index IX_D36D9846 on JournalArticle (groupId, folderId, status, ctCollectionId);

--- a/modules/apps/journal/journal-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/journal/journal-service/src/main/resources/META-INF/sql/tables.sql
@@ -15,6 +15,7 @@ create table JournalArticle (
 	classPK LONG,
 	treePath STRING null,
 	articleId VARCHAR(75) null,
+	externalReferenceCode VARCHAR(75) null,
 	version DOUBLE,
 	urlTitle VARCHAR(255) null,
 	content TEXT null,

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -173,6 +173,23 @@ public class JournalTestUtil {
 			ServiceContext serviceContext)
 		throws Exception {
 
+		return addArticle(
+			groupId, folderId, classNameId, articleId, autoArticleId, null,
+			titleMap, descriptionMap, contentMap, layoutUuid, defaultLocale,
+			displayDate, expirationDate, workflowEnabled, approved,
+			serviceContext);
+	}
+
+	public static JournalArticle addArticle(
+			long groupId, long folderId, long classNameId, String articleId,
+			boolean autoArticleId, String externalReferenceCode,
+			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
+			Map<Locale, String> contentMap, String layoutUuid,
+			Locale defaultLocale, Date displayDate, Date expirationDate,
+			boolean workflowEnabled, boolean approved,
+			ServiceContext serviceContext)
+		throws Exception {
+
 		String content = DDMStructureTestUtil.getSampleStructuredContent(
 			contentMap, LocaleUtil.toLanguageId(defaultLocale));
 
@@ -242,8 +259,9 @@ public class JournalTestUtil {
 
 		return JournalArticleLocalServiceUtil.addArticle(
 			serviceContext.getUserId(), groupId, folderId, classNameId, 0,
-			articleId, autoArticleId, JournalArticleConstants.VERSION_DEFAULT,
-			titleMap, descriptionMap, content, ddmStructure.getStructureKey(),
+			articleId, autoArticleId, externalReferenceCode,
+			JournalArticleConstants.VERSION_DEFAULT, titleMap, descriptionMap,
+			titleMap, content, ddmStructure.getStructureKey(),
 			ddmTemplate.getTemplateKey(), layoutUuid, displayDateMonth,
 			displayDateDay, displayDateYear, displayDateHour, displayDateMinute,
 			expirationDateMonth, expirationDateDay, expirationDateYear,
@@ -317,6 +335,38 @@ public class JournalTestUtil {
 			_getLocalizedMap(RandomTestUtil.randomString()),
 			_getLocalizedMap(RandomTestUtil.randomString()), null,
 			LocaleUtil.getSiteDefault(), null, false, false, serviceContext);
+	}
+
+	public static JournalArticle addArticle(
+			long groupId, long folderId, String articleId,
+			boolean autoArticleId, String externalReferenceCode)
+		throws Exception {
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(groupId);
+
+		serviceContext.setCommand(Constants.ADD);
+		serviceContext.setLayoutFullURL("http://localhost");
+
+		return addArticle(
+			groupId, folderId, articleId, autoArticleId, externalReferenceCode,
+			serviceContext);
+	}
+
+	public static JournalArticle addArticle(
+			long groupId, long folderId, String articleId,
+			boolean autoArticleId, String externalReferenceCode,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		return addArticle(
+			groupId, folderId, JournalArticleConstants.CLASS_NAME_ID_DEFAULT,
+			articleId, autoArticleId, externalReferenceCode,
+			_getLocalizedMap(RandomTestUtil.randomString()),
+			_getLocalizedMap(RandomTestUtil.randomString()),
+			_getLocalizedMap(RandomTestUtil.randomString()), null,
+			LocaleUtil.getSiteDefault(), null, null, false, false,
+			serviceContext);
 	}
 
 	public static JournalArticle addArticle(
@@ -945,8 +995,9 @@ public class JournalTestUtil {
 
 		return JournalArticleLocalServiceUtil.updateArticle(
 			userId, article.getGroupId(), article.getFolderId(),
-			article.getArticleId(), article.getVersion(), titleMap,
-			article.getDescriptionMap(), content, article.getDDMStructureKey(),
+			article.getArticleId(), article.getExternalReferenceCode(),
+			article.getVersion(), titleMap, article.getDescriptionMap(),
+			titleMap, content, article.getDDMStructureKey(),
 			article.getDDMTemplateKey(), article.getLayoutUuid(),
 			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
 			displayDateMinute, 0, 0, 0, 0, 0, true, 0, 0, 0, 0, 0, true,

--- a/modules/apps/journal/journal-test-util/src/main/resources/com/liferay/journal/test/util/packageinfo
+++ b/modules/apps/journal/journal-test-util/src/main/resources/com/liferay/journal/test/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 3.2.0

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticlePersistenceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalArticlePersistenceTest.java
@@ -155,6 +155,9 @@ public class JournalArticlePersistenceTest {
 
 		newJournalArticle.setArticleId(RandomTestUtil.randomString());
 
+		newJournalArticle.setExternalReferenceCode(
+			RandomTestUtil.randomString());
+
 		newJournalArticle.setVersion(RandomTestUtil.nextDouble());
 
 		newJournalArticle.setUrlTitle(RandomTestUtil.randomString());
@@ -243,6 +246,9 @@ public class JournalArticlePersistenceTest {
 		Assert.assertEquals(
 			existingJournalArticle.getArticleId(),
 			newJournalArticle.getArticleId());
+		Assert.assertEquals(
+			existingJournalArticle.getExternalReferenceCode(),
+			newJournalArticle.getExternalReferenceCode());
 		AssertUtils.assertEquals(
 			existingJournalArticle.getVersion(),
 			newJournalArticle.getVersion());
@@ -443,6 +449,15 @@ public class JournalArticlePersistenceTest {
 		_persistence.countByG_A(0L, "null");
 
 		_persistence.countByG_A(0L, (String)null);
+	}
+
+	@Test
+	public void testCountByG_ERC() throws Exception {
+		_persistence.countByG_ERC(RandomTestUtil.nextLong(), "");
+
+		_persistence.countByG_ERC(0L, "null");
+
+		_persistence.countByG_ERC(0L, (String)null);
 	}
 
 	@Test
@@ -657,6 +672,16 @@ public class JournalArticlePersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_ERC_V() throws Exception {
+		_persistence.countByG_ERC_V(
+			RandomTestUtil.nextLong(), "", RandomTestUtil.nextDouble());
+
+		_persistence.countByG_ERC_V(0L, "null", 0D);
+
+		_persistence.countByG_ERC_V(0L, (String)null, 0D);
+	}
+
+	@Test
 	public void testCountByG_UT_ST() throws Exception {
 		_persistence.countByG_UT_ST(
 			RandomTestUtil.nextLong(), "", RandomTestUtil.nextInt());
@@ -719,10 +744,11 @@ public class JournalArticlePersistenceTest {
 			"uuid", true, "id", true, "resourcePrimKey", true, "groupId", true,
 			"companyId", true, "userId", true, "userName", true, "createDate",
 			true, "modifiedDate", true, "folderId", true, "classNameId", true,
-			"classPK", true, "treePath", true, "articleId", true, "version",
-			true, "urlTitle", true, "DDMStructureKey", true, "DDMTemplateKey",
-			true, "defaultLanguageId", true, "layoutUuid", true, "displayDate",
-			true, "expirationDate", true, "reviewDate", true, "indexable", true,
+			"classPK", true, "treePath", true, "articleId", true,
+			"externalReferenceCode", true, "version", true, "urlTitle", true,
+			"DDMStructureKey", true, "DDMTemplateKey", true,
+			"defaultLanguageId", true, "layoutUuid", true, "displayDate", true,
+			"expirationDate", true, "reviewDate", true, "indexable", true,
 			"smallImage", true, "smallImageId", true, "smallImageURL", true,
 			"lastPublishDate", true, "status", true, "statusByUserId", true,
 			"statusByUserName", true, "statusDate", true);
@@ -1029,6 +1055,22 @@ public class JournalArticlePersistenceTest {
 			ReflectionTestUtil.<Double>invoke(
 				journalArticle, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "version"));
+
+		Assert.assertEquals(
+			Long.valueOf(journalArticle.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				journalArticle, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
+		Assert.assertEquals(
+			journalArticle.getExternalReferenceCode(),
+			ReflectionTestUtil.invoke(
+				journalArticle, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "externalReferenceCode"));
+		AssertUtils.assertEquals(
+			journalArticle.getVersion(),
+			ReflectionTestUtil.<Double>invoke(
+				journalArticle, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "version"));
 	}
 
 	protected JournalArticle addJournalArticle() throws Exception {
@@ -1065,6 +1107,8 @@ public class JournalArticlePersistenceTest {
 		journalArticle.setTreePath(RandomTestUtil.randomString());
 
 		journalArticle.setArticleId(RandomTestUtil.randomString());
+
+		journalArticle.setExternalReferenceCode(RandomTestUtil.randomString());
 
 		journalArticle.setVersion(RandomTestUtil.nextDouble());
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -31,6 +31,7 @@ import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.exception.DuplicateArticleIdException;
+import com.liferay.journal.exception.DuplicateExternalReferenceCodeException;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleDisplay;
 import com.liferay.journal.service.JournalArticleLocalService;
@@ -263,6 +264,18 @@ public class JournalArticleLocalServiceTest {
 			_group.getGroupId(),
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			article.getArticleId(), true);
+	}
+
+	@Test(expected = DuplicateExternalReferenceCodeException.class)
+	public void testDuplicatedExternalReferenceCode() throws Exception {
+		JournalArticle article = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			article.getArticleId(), true, article.getExternalReferenceCode());
 	}
 
 	@Test

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleServiceTest.java
@@ -30,12 +30,14 @@ import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
 import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalFolderConstants;
+import com.liferay.journal.exception.NoSuchArticleException;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.journal.service.JournalArticleServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.PortalPreferences;
@@ -169,6 +171,28 @@ public class JournalArticleServiceTest {
 	}
 
 	@Test
+	public void testAddArticleWithExternalReferenceCode() throws Exception {
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		_article = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, StringPool.BLANK,
+			true, externalReferenceCode);
+
+		Assert.assertNotNull(_article);
+		Assert.assertEquals(
+			externalReferenceCode, _article.getExternalReferenceCode());
+
+		_latestArticle =
+			JournalArticleServiceUtil.fetchLatestArticleByExternalReferenceCode(
+				_group.getGroupId(), externalReferenceCode);
+
+		Assert.assertNotNull(_latestArticle);
+		Assert.assertEquals(
+			externalReferenceCode, _latestArticle.getExternalReferenceCode());
+	}
+
+	@Test
 	public void testAddArticleWithNotEmptyRequiredHTMLField() throws Exception {
 		testAddArticleRequiredFields(
 			"test-ddm-structure-html-required-field.xml",
@@ -176,6 +200,28 @@ public class JournalArticleServiceTest {
 			HashMapBuilder.put(
 				"HTML2030", "<p>Hello.</p>"
 			).build());
+	}
+
+	@Test
+	public void testAddArticleWithoutExternalReferenceCode() throws Exception {
+		String articleId = StringUtil.toUpperCase(
+			RandomTestUtil.randomString());
+
+		_article = JournalTestUtil.addArticle(
+			_group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID, articleId, false);
+
+		Assert.assertNotNull(_article);
+		Assert.assertEquals(articleId, _article.getArticleId());
+		Assert.assertEquals(articleId, _article.getExternalReferenceCode());
+
+		_latestArticle =
+			JournalArticleServiceUtil.fetchLatestArticleByExternalReferenceCode(
+				_group.getGroupId(), articleId);
+
+		Assert.assertNotNull(_latestArticle);
+		Assert.assertEquals(
+			articleId, _latestArticle.getExternalReferenceCode());
 	}
 
 	@Test(expected = StructureDefinitionException.class)
@@ -306,6 +352,37 @@ public class JournalArticleServiceTest {
 		_article = JournalTestUtil.updateArticle(_article, "Version 2");
 
 		_latestArticle = fetchLatestArticle(WorkflowConstants.STATUS_DRAFT);
+
+		Assert.assertNull(_latestArticle);
+	}
+
+	@Test
+	public void testFetchLatestArticleByExternalReferenceCode()
+		throws Exception {
+
+		long groupId = _article.getGroupId();
+		String externalReferenceCode = _article.getExternalReferenceCode();
+
+		_article = JournalTestUtil.updateArticle(_article, "Version 2");
+
+		_latestArticle =
+			JournalArticleServiceUtil.fetchLatestArticleByExternalReferenceCode(
+				groupId, externalReferenceCode);
+
+		Assert.assertEquals(
+			"Version 2", _latestArticle.getTitle(LocaleUtil.getDefault()));
+		Assert.assertEquals(1.1, _latestArticle.getVersion(), 0);
+		Assert.assertEquals(
+			externalReferenceCode, _latestArticle.getExternalReferenceCode());
+	}
+
+	@Test
+	public void testFetchLatestArticleByNonexistentExternalReferenceCode()
+		throws Exception {
+
+		_latestArticle =
+			JournalArticleServiceUtil.fetchLatestArticleByExternalReferenceCode(
+				_article.getGroupId(), RandomTestUtil.randomString());
 
 		Assert.assertNull(_latestArticle);
 	}
@@ -508,6 +585,32 @@ public class JournalArticleServiceTest {
 	}
 
 	@Test
+	public void testGetLatestArticleByExternalReferenceCode() throws Exception {
+		long groupId = _article.getGroupId();
+		String externalReferenceCode = _article.getExternalReferenceCode();
+
+		_article = JournalTestUtil.updateArticle(_article, "Version 2");
+
+		_latestArticle =
+			JournalArticleServiceUtil.getLatestArticleByExternalReferenceCode(
+				groupId, externalReferenceCode);
+
+		Assert.assertEquals(
+			"Version 2", _latestArticle.getTitle(LocaleUtil.getDefault()));
+		Assert.assertEquals(1.1, _latestArticle.getVersion(), 0);
+		Assert.assertEquals(
+			externalReferenceCode, _latestArticle.getExternalReferenceCode());
+	}
+
+	@Test(expected = NoSuchArticleException.class)
+	public void testGetLatestArticleByNonexistentExternalReferenceCode()
+		throws Exception {
+
+		JournalArticleServiceUtil.getLatestArticleByExternalReferenceCode(
+			_article.getGroupId(), RandomTestUtil.randomString());
+	}
+
+	@Test
 	public void testGetLatestArticlesByStatus() throws Exception {
 		List<JournalArticle> articles = addArticles(
 			1, RandomTestUtil.randomString());
@@ -614,6 +717,58 @@ public class JournalArticleServiceTest {
 
 		Assert.assertEquals(
 			_article.getDisplayDate(), assetEntry.getPublishDate());
+	}
+
+	@Test
+	public void testUpdateWithExternalReferenceCode() throws Exception {
+		long groupId = _article.getGroupId();
+
+		String externalReferenceCode = RandomTestUtil.randomString();
+
+		_article.setExternalReferenceCode(externalReferenceCode);
+
+		_article = JournalTestUtil.updateArticle(_article, "Version 2");
+
+		Assert.assertNotNull(_article);
+		Assert.assertEquals(
+			externalReferenceCode, _article.getExternalReferenceCode());
+
+		_latestArticle =
+			_journalArticleLocalService.
+				fetchLatestArticleByExternalReferenceCode(
+					groupId, externalReferenceCode);
+
+		Assert.assertEquals(
+			"Version 2", _latestArticle.getTitle(LocaleUtil.getDefault()));
+		Assert.assertEquals(1.1, _latestArticle.getVersion(), 0);
+		Assert.assertEquals(
+			externalReferenceCode, _latestArticle.getExternalReferenceCode());
+	}
+
+	@Test
+	public void testUpdateWithoutExternalReferenceCode() throws Exception {
+		long groupId = _article.getGroupId();
+		String oldExternalReferenceCode = _article.getExternalReferenceCode();
+
+		_article.setExternalReferenceCode(null);
+
+		_article = JournalTestUtil.updateArticle(_article, "Version 2");
+
+		Assert.assertNotNull(_article);
+		Assert.assertEquals(
+			oldExternalReferenceCode, _article.getExternalReferenceCode());
+
+		_latestArticle =
+			_journalArticleLocalService.
+				fetchLatestArticleByExternalReferenceCode(
+					groupId, oldExternalReferenceCode);
+
+		Assert.assertEquals(
+			"Version 2", _latestArticle.getTitle(LocaleUtil.getDefault()));
+		Assert.assertEquals(1.1, _latestArticle.getVersion(), 0);
+		Assert.assertEquals(
+			oldExternalReferenceCode,
+			_latestArticle.getExternalReferenceCode());
 	}
 
 	protected List<JournalArticle> addArticles(int count, String content)


### PR DESCRIPTION
Hello team,

In the APIs we need to get and manage entities by an external reference code so we need to add this new fields to all portal entities.

This issue come after a long discussion about reusing a existing field or creating a new one and the decision was creating a new one to be more confident that the new code does not interfere with any existing feature.

We have started with JournalArticle as it is one of the most important entities of the portal. We did not used the external-reference-code attribute in the service.xml to allow ServiceBuilder create the column for us becaus,e in the case of JournalArticle, we want the externalReferenceCode be the same accross all versions of a JournalArticle (like articleId).

I've overloaded the addArticle and updateArticle methods to include this new parameter. In the case of addArticle it will use the articleId if no externalReferenceCode is specified. In updateArticle it will use the old externalReferenceCode in case the externalReferenceCode parameter is empty.

I've also modified the datahandler for import/export, made the database upgrade process taking populating the new externalReferenceCode column with the articleId, and made some tests to be sure the code is working.

I know is not the best time for you, but please I beg you to take a look at this PR when you can and let me know if you require any change or there is something you don't understand.

@jkappler has helped me a lot in the process so I hope I don't cause you to much work on this

Thank you very much!