### PR TITLE
LPS-126190 Do not restrict elements to notify when dynamic subscription limit is set to 0

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/messaging/AssetEntriesCheckerHelper.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/messaging/AssetEntriesCheckerHelper.java
@@ -26,6 +26,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.User;
@@ -233,9 +234,21 @@ public class AssetEntriesCheckerHelper {
 			_assetPublisherHelper.getAssetEntryQuery(
 				portletPreferences, layout.getGroupId(), layout, null, null);
 
-		assetEntryQuery.setEnd(
-			assetPublisherWebConfiguration.dynamicSubscriptionLimit());
-		assetEntryQuery.setStart(0);
+		int end = assetPublisherWebConfiguration.dynamicSubscriptionLimit();
+
+		if (end == 0) {
+			end = QueryUtil.ALL_POS;
+		}
+
+		assetEntryQuery.setEnd(end);
+
+		int start = 0;
+
+		if (end == 0) {
+			start = QueryUtil.ALL_POS;
+		}
+
+		assetEntryQuery.setStart(start);
 
 		try {
 			SearchContext searchContext = SearchContextFactory.getInstance(
@@ -246,8 +259,7 @@ public class AssetEntriesCheckerHelper {
 
 			BaseModelSearchResult<AssetEntry> baseModelSearchResult =
 				_assetHelper.searchAssetEntries(
-					searchContext, assetEntryQuery, 0,
-					assetPublisherWebConfiguration.dynamicSubscriptionLimit());
+					searchContext, assetEntryQuery, start, end);
 
 			return baseModelSearchResult.getBaseModels();
 		}


### PR DESCRIPTION
Hi team,

According to the specification defined in https://issues.liferay.com/browse/LPS-33001 setting dynamicSubscriptionLimit to 0 should not impose any restriction to the number of elements to notify.

The present solution tries to honor this expected behavior.

Could you please review it?

Thanks in advance