### PR TITLE
LPS-125853 [Bug] Widget section doesn't appear when an AB testing is running in other experience

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Sidebar.js
@@ -41,6 +41,27 @@ const {Suspense, useCallback, useEffect} = React;
  */
 const swallow = [(value) => value, (_error) => undefined];
 
+/**
+ * Load the first available panel if the selected sidebar panel ID is not found.
+ * This may happen because the list of panels is modified depending on the user permissions.
+ *
+ * @param {string} panelId
+ * @param {Array} panels
+ * @param {object} sidebarPanels
+ */
+const getActivePanelData = ({panelId, panels, sidebarPanels}) => {
+	let sidebarPanelId = panelId;
+
+	let panel = sidebarPanels[sidebarPanelId];
+
+	if (!panel) {
+		sidebarPanelId = panels[0][0];
+		panel = sidebarPanels[sidebarPanelId];
+	}
+
+	return {panel, sidebarPanelId};
+};
+
 export default function Sidebar() {
 	const dropClearRef = useDropClear();
 	const [hasError, setHasError] = useStateSafe(false);
@@ -57,9 +78,12 @@ export default function Sidebar() {
 		selectAvailableSidebarPanels(config.sidebarPanels)
 	);
 	const sidebarOpen = store.sidebar.open;
-	const sidebarPanelId = store.sidebar.panelId;
+	const {panel, sidebarPanelId} = getActivePanelData({
+		panelId: store.sidebar.panelId,
+		panels,
+		sidebarPanels,
+	});
 
-	const panel = sidebarPanels[sidebarPanelId];
 	const promise = panel
 		? load(sidebarPanelId, panel.pluginEntryPoint)
 		: Promise.resolve();


### PR DESCRIPTION
**Description**

When the user has several experiences but one of them has an A/B Test, some sidebars hide (Fragments and Widgets and Page Design Options) because the user cannot change the page during an active A/B Test. To do this, we check the permission `LOCKED_SEGMENTS_EXPERIMENT`.

**Steps to reproduce it**

* Connect Liferay Portal DXP with Analytics Cloud (AC)
* Create a Page (cp)
* Create an Experience (exp1)
* Create an A/B Test for Default experience
* Click Edit to edit the page and change between Default and exp1 experience to see the bug

**Solution**

In the file `sidebarReducer.js` we specify that the default panel ID is `fragments-widgets`:

```
const DEFAULT_PANEL_ID = 'fragments-widgets';
```

In this case, the experience (the one with the A/B Test) doesn't have that panel available and it's not able to render the first one available (Page Structure).

The solution proposed is create a function that retrieves the `panel` and `sidebarPanelId` of the first available panel if the selected sidebar panel ID is not found.