### PR TITLE
[TS] LPS-124315

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -226,7 +226,33 @@ public class UpdateLanguageAction implements Action {
 			redirect = redirect + queryString;
 		}
 
-		return redirect;
+		return adaptRedirectToVirtualHostLanguage(
+			locale, redirect,
+			(String)httpServletRequest.getAttribute(
+				WebKeys.VIRTUAL_HOST_I18N_LANGUAGE_ID));
+	}
+
+	protected String adaptRedirectToVirtualHostLanguage(
+		Locale locale, String redirect, String virtualHostI18nLanguageId) {
+
+		if ((PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 0) ||
+			Validator.isNull(virtualHostI18nLanguageId) ||
+			!redirect.startsWith(StringPool.SLASH)) {
+
+			return redirect;
+		}
+
+		if (locale.equals(
+				LocaleUtil.fromLanguageId(virtualHostI18nLanguageId))) {
+
+			return redirect;
+		}
+
+		if (redirect.endsWith(StringPool.SLASH)) {
+			redirect = redirect.substring(0, redirect.length() - 1);
+		}
+
+		return StringPool.SLASH + locale.toLanguageTag() + redirect;
 	}
 
 	protected boolean isFriendlyURLResolver(String layoutURL) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8131,10 +8131,27 @@ public class PortalImpl implements Portal {
 
 		Set<String> languageIds = I18nFilter.getLanguageIds();
 
-		if ((languageIds.contains(locale.toString()) &&
-			 (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 1) &&
-			 !locale.equals(LocaleUtil.getDefault())) ||
-			(PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2)) {
+		HttpServletRequest httpServletRequest = themeDisplay.getRequest();
+
+		String virtualHostI18nLanguageId =
+			(String)httpServletRequest.getAttribute(
+				WebKeys.VIRTUAL_HOST_I18N_LANGUAGE_ID);
+
+		if (Validator.isNotNull(virtualHostI18nLanguageId)) {
+			Locale virtualHostI18nLocale = LocaleUtil.fromLanguageId(
+				virtualHostI18nLanguageId);
+
+			if (locale.equals(virtualHostI18nLocale)) {
+				i18nPath = null;
+			}
+			else {
+				i18nPath = _buildI18NPath(locale, themeDisplay.getSiteGroup());
+			}
+		}
+		else if ((languageIds.contains(locale.toString()) &&
+				  (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 1) &&
+				  !locale.equals(LocaleUtil.getSiteDefault())) ||
+				 (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2)) {
 
 			i18nPath = _buildI18NPath(locale, themeDisplay.getSiteGroup());
 		}

--- a/portal-impl/src/com/liferay/portal/util/PortalInstances.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalInstances.java
@@ -483,6 +483,9 @@ public class PortalInstances {
 
 					httpServletRequest.setAttribute(
 						WebKeys.I18N_LANGUAGE_ID, languageId);
+
+					httpServletRequest.setAttribute(
+						WebKeys.VIRTUAL_HOST_I18N_LANGUAGE_ID, languageId);
 				}
 			}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/WebKeys.java
@@ -784,6 +784,9 @@ public interface WebKeys {
 
 	public static final String USERS_NOTIFIED = "USERS_NOTIFIED";
 
+	public static final String VIRTUAL_HOST_I18N_LANGUAGE_ID =
+		"VIRTUAL_HOST_I18N_LANGUAGE_ID";
+
 	public static final String VIRTUAL_HOST_LAYOUT_SET =
 		"VIRTUAL_HOST_LAYOUT_SET";
 


### PR DESCRIPTION
Hi team,

After the introduction of the possibility of configuring virtualhost per language in LPS-44217, it is not possible to change the language via Language Selector widget since it is not longer possible to rely on i18nFilter to prepend the language prefix and make the language change effective.

This solution tries to detect that a virtualhost per language is active and prepares the redirect to prepend or remove the proper language prefix.

Could you please review it? If you think that this PR should be send to someone else, please, let me know who.

Please, also let me know if further clarifications are needed.

Thanks in advance