### PR TITLE
LPS-127000 Honor the value configured in # of Entries Per Feed as in the Default template

### DIFF
--- a/modules/apps/rss/rss-web/src/main/resources/com/liferay/rss/web/portlet/template/dependencies/portlet_display_template_navigation.ftl
+++ b/modules/apps/rss/rss-web/src/main/resources/com/liferay/rss/web/portlet/template/dependencies/portlet_display_template_navigation.ftl
@@ -25,7 +25,7 @@
 					<#if rssFeedEntries??>
 						<div class="tab-pane" id="tab-${curEntry_index}">
 							<#list rssFeedEntries as rssFeedEntry>
-								<#if (rssFeedEntry_index > entriesPerFeed?number)>
+								<#if (rssFeedEntry_index >= entriesPerFeed?number)>
 									<#break>
 								</#if>
 


### PR DESCRIPTION
Hi team,

This fix has low priority. It simply makes the RSS Publisher Widget Template Navigation behave as the Default one.