### PR TITLE
LPS-127078 Remove url rewrite as it is too broad and it is affecting tag application

### DIFF
--- a/portal-web/docroot/WEB-INF/urlrewrite.xml
+++ b/portal-web/docroot/WEB-INF/urlrewrite.xml
@@ -26,8 +26,4 @@
 		<from>^/web/guest/community/forums/message_boards(.{0,2000})$</from>
 		<to type="permanent-redirect">%{context-path}/web/guest/community/forums/-/message_boards$1</to>
 	</rule>
-	<rule>
-		<from>^(.*)\/-\/(questions|activity|tags)(.*)$</from>
-		<to type="redirect" qsappend="true">%{context-path}$1/#/$2$3?</to>
-	</rule>
 </urlrewrite>


### PR DESCRIPTION
This is caused by https://issues.liferay.com/browse/LPS-123231 implementation. The regex has to be rethink, I'm removing it for now to avoid more related bugs. The ticket is going to be reopen to refine the solution