### PR TITLE
[TS] LPS-124229 Move the input check inside the addEventListener

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -479,18 +479,17 @@ List<AssetRendererFactory<?>> classTypesAssetRendererFactories = (List<AssetRend
 		'<portlet:namespace />ddmStructureFieldValue'
 	);
 
-	if (
-		assetSelector &&
-		ddmStructureFieldNameInput &&
-		ddmStructureFieldValueInput
-	) {
-		assetSelector.addEventListener('change', function (event) {
+	assetSelector.addEventListener('change', function (event) {
+		if (ddmStructureFieldNameInput) {
 			ddmStructureFieldNameInput.value = '';
-			ddmStructureFieldValueInput.value = '';
+		}
 
-			<portlet:namespace />toggleSubclasses(true);
-		});
-	}
+		if (ddmStructureFieldValueInput) {
+			ddmStructureFieldValueInput.value = '';
+		}
+
+		<portlet:namespace />toggleSubclasses(true);
+	});
 
 	var delegate = delegateModule.default;
 


### PR DESCRIPTION
Hi Team,

could you please check my fix?

The LPS-90336 changes caused a regression with this commit: https://github.com/liferay/liferay-portal/commit/d3eff975ca03#
The toggleSubclasses function is not added to the eventlistener, becuase the ddmStructureFieldNameInput and ddmStructureFieldValueInput are null objects
https://github.com/liferay/liferay-portal/blob/master/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp#L482-L486

Moving the if check inside the addEventListener the event is working again.

See details on https://issues.liferay.com/browse/PTR-2197

Thanks, Roland

https://issues.liferay.com/browse/LPS-124229