### PR TITLE
LPS-125615 Remove background color from inner container

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/LayoutDataConverter.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/LayoutDataConverter.java
@@ -89,8 +89,8 @@ public class LayoutDataConverter {
 				if (inputRowConfigJSONObject != null) {
 					JSONObject outerStylesJSONObject = JSONUtil.put(
 						"backgroundImage",
-						_getBackgroundImageJSONObject(inputRowConfigJSONObject)
-					);
+						_getBackgroundImageJSONObject(
+							inputRowConfigJSONObject));
 
 					JSONObject innerStylesJSONObject = JSONUtil.put(
 						"paddingBottom",

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/LayoutDataConverter.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/LayoutDataConverter.java
@@ -71,19 +71,17 @@ public class LayoutDataConverter {
 			if (inputRowJSONObject.getInt("type") ==
 					FragmentConstants.TYPE_COMPONENT) {
 
-				ContainerStyledLayoutStructureItem
-					outerContainerStyledLayoutStructureItem =
-						(ContainerStyledLayoutStructureItem)
-							layoutStructure.addContainerLayoutStructureItem(
-								rootLayoutStructureItem.getItemId(), i);
+				ContainerStyledLayoutStructureItem outerContainerLayoutItem =
+					(ContainerStyledLayoutStructureItem)
+						layoutStructure.addContainerLayoutStructureItem(
+							rootLayoutStructureItem.getItemId(), i);
 
-				outerContainerStyledLayoutStructureItem.setWidthType("fluid");
+				outerContainerLayoutItem.setWidthType("fluid");
 
-				ContainerStyledLayoutStructureItem
-					innerContainerStyledLayoutStructureItem =
-						(ContainerStyledLayoutStructureItem)
-							layoutStructure.addContainerLayoutStructureItem(
-								outerContainerStyledLayoutStructureItem.getItemId(), 0);
+				ContainerStyledLayoutStructureItem innerContainerLayoutItem =
+					(ContainerStyledLayoutStructureItem)
+						layoutStructure.addContainerLayoutStructureItem(
+							outerContainerLayoutItem.getItemId(), 0);
 
 				JSONObject inputRowConfigJSONObject =
 					inputRowJSONObject.getJSONObject("config");
@@ -109,17 +107,17 @@ public class LayoutDataConverter {
 					);
 
 					if (inputRowConfigJSONObject.has("containerType")) {
-						innerContainerStyledLayoutStructureItem.setWidthType(
+						innerContainerLayoutItem.setWidthType(
 							inputRowConfigJSONObject.getString(
 								"containerType", "fixed"));
 					}
 					else {
-						innerContainerStyledLayoutStructureItem.setWidthType(
+						innerContainerLayoutItem.setWidthType(
 							inputRowConfigJSONObject.getString(
 								"widthType", "fixed"));
 					}
 
-					outerContainerStyledLayoutStructureItem.updateItemConfig(
+					outerContainerLayoutItem.updateItemConfig(
 						JSONUtil.put(
 							"backgroundColorCssClass",
 							inputRowConfigJSONObject.getString(
@@ -128,7 +126,7 @@ public class LayoutDataConverter {
 							"styles", outerStylesJSONObject
 						));
 
-					innerContainerStyledLayoutStructureItem.updateItemConfig(
+					innerContainerLayoutItem.updateItemConfig(
 						JSONUtil.put(
 							"backgroundColorCssClass",
 							inputRowConfigJSONObject.getString(
@@ -141,7 +139,7 @@ public class LayoutDataConverter {
 				RowStyledLayoutStructureItem rowStyledLayoutStructureItem =
 					(RowStyledLayoutStructureItem)
 						layoutStructure.addRowLayoutStructureItem(
-							innerContainerStyledLayoutStructureItem.getItemId(), 0,
+							innerContainerLayoutItem.getItemId(), 0,
 							columnsJSONArray.length());
 
 				if (inputRowConfigJSONObject != null) {

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/LayoutDataConverter.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/LayoutDataConverter.java
@@ -72,19 +72,29 @@ public class LayoutDataConverter {
 					FragmentConstants.TYPE_COMPONENT) {
 
 				ContainerStyledLayoutStructureItem
-					containerStyledLayoutStructureItem =
+					outerContainerStyledLayoutStructureItem =
 						(ContainerStyledLayoutStructureItem)
 							layoutStructure.addContainerLayoutStructureItem(
 								rootLayoutStructureItem.getItemId(), i);
+
+				outerContainerStyledLayoutStructureItem.setWidthType("fluid");
+
+				ContainerStyledLayoutStructureItem
+					innerContainerStyledLayoutStructureItem =
+						(ContainerStyledLayoutStructureItem)
+							layoutStructure.addContainerLayoutStructureItem(
+								outerContainerStyledLayoutStructureItem.getItemId(), 0);
 
 				JSONObject inputRowConfigJSONObject =
 					inputRowJSONObject.getJSONObject("config");
 
 				if (inputRowConfigJSONObject != null) {
-					JSONObject stylesJSONObject = JSONUtil.put(
+					JSONObject outerStylesJSONObject = JSONUtil.put(
 						"backgroundImage",
 						_getBackgroundImageJSONObject(inputRowConfigJSONObject)
-					).put(
+					);
+
+					JSONObject innerStylesJSONObject = JSONUtil.put(
 						"paddingBottom",
 						inputRowConfigJSONObject.getInt("paddingVertical", 0)
 					).put(
@@ -99,30 +109,39 @@ public class LayoutDataConverter {
 					);
 
 					if (inputRowConfigJSONObject.has("containerType")) {
-						containerStyledLayoutStructureItem.setWidthType(
+						innerContainerStyledLayoutStructureItem.setWidthType(
 							inputRowConfigJSONObject.getString(
 								"containerType", "fixed"));
 					}
 					else {
-						containerStyledLayoutStructureItem.setWidthType(
+						innerContainerStyledLayoutStructureItem.setWidthType(
 							inputRowConfigJSONObject.getString(
 								"widthType", "fixed"));
 					}
 
-					containerStyledLayoutStructureItem.updateItemConfig(
+					outerContainerStyledLayoutStructureItem.updateItemConfig(
 						JSONUtil.put(
 							"backgroundColorCssClass",
 							inputRowConfigJSONObject.getString(
 								"backgroundColorCssClass")
 						).put(
-							"styles", stylesJSONObject
+							"styles", outerStylesJSONObject
+						));
+
+					innerContainerStyledLayoutStructureItem.updateItemConfig(
+						JSONUtil.put(
+							"backgroundColorCssClass",
+							inputRowConfigJSONObject.getString(
+								"backgroundColorCssClass")
+						).put(
+							"styles", innerStylesJSONObject
 						));
 				}
 
 				RowStyledLayoutStructureItem rowStyledLayoutStructureItem =
 					(RowStyledLayoutStructureItem)
 						layoutStructure.addRowLayoutStructureItem(
-							containerStyledLayoutStructureItem.getItemId(), 0,
+							innerContainerStyledLayoutStructureItem.getItemId(), 0,
 							columnsJSONArray.length());
 
 				if (inputRowConfigJSONObject != null) {

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/LayoutDataConverter.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v3_3_0/util/LayoutDataConverter.java
@@ -127,13 +127,7 @@ public class LayoutDataConverter {
 						));
 
 					innerContainerLayoutItem.updateItemConfig(
-						JSONUtil.put(
-							"backgroundColorCssClass",
-							inputRowConfigJSONObject.getString(
-								"backgroundColorCssClass")
-						).put(
-							"styles", innerStylesJSONObject
-						));
+						JSONUtil.put("styles", innerStylesJSONObject));
 				}
 
 				RowStyledLayoutStructureItem rowStyledLayoutStructureItem =


### PR DESCRIPTION
Notes from @kevhlee

> Ticket:
> https://issues.liferay.com/browse/LPS-125615
> 
> Notes:
> The goal of this fix is to preserve the full-width container styling from previous DXP versions during upgrades. The fix is based on the workaround discussed in the following Slack thread: https://liferay.slack.com/archives/CL9RTSZ52/p1610074901031100. The fix works by surrounding the container encompassing the content with a new, fluid-width container, which will be used to hold the background color and image.
> 
> So, we have the following in 7.2:
> 
> Section (fixed-width, background color)
> └── Content
> Then the upgrade needs to change the structure to the following to preserve full-width:
> 
> Container (background color, fluid)
> └── Container (fixed-width)
>     └── Content
> Let me know if you have any questions/concerns.

@kevhlee @samziemer