### PR TITLE
LPS-127318 Optimize SQL search queries

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleFinderImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleFinderImpl.java
@@ -1233,6 +1233,15 @@ public class JournalArticleFinderImpl
 
 			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
 
+			if (_isKeywordsDefined(titles) ||
+				_isKeywordsDefined(descriptions)) {
+
+				queryPos.add(1);
+			}
+			else {
+				queryPos.add(0);
+			}
+
 			queryPos.add(companyId);
 
 			if (groupId > 0) {
@@ -1905,8 +1914,11 @@ public class JournalArticleFinderImpl
 			}
 
 			sql = _customSQL.replaceAndOperator(sql, andOperator);
-			sql = _customSQL.replaceOrderBy(
-				sql, queryDefinition.getOrderByComparator());
+
+			OrderByComparator<JournalArticle> orderByComparator =
+				queryDefinition.getOrderByComparator();
+
+			sql = _customSQL.replaceOrderBy(sql, orderByComparator);
 
 			if (inlineSQLHelper) {
 				sql = InlineSQLHelperUtil.replacePermissionCheck(
@@ -1923,6 +1935,16 @@ public class JournalArticleFinderImpl
 				JournalArticleImpl.TABLE_NAME, JournalArticleImpl.class);
 
 			QueryPos queryPos = QueryPos.getInstance(sqlQuery);
+
+			if (_isOrderByTitle(orderByComparator) ||
+				_isKeywordsDefined(titles) ||
+				_isKeywordsDefined(descriptions)) {
+
+				queryPos.add(1);
+			}
+			else {
+				queryPos.add(0);
+			}
 
 			queryPos.add(titles, 2);
 			queryPos.add(descriptions, 2);
@@ -2151,6 +2173,20 @@ public class JournalArticleFinderImpl
 		}
 
 		return StringUtil.replace(sql, "[$STRUCTURE_TEMPLATE$]", sb.toString());
+	}
+
+	private boolean _isKeywordsDefined(String[] keywords) {
+		if (ArrayUtil.isEmpty(keywords)) {
+			return false;
+		}
+
+		for (String keyword : keywords) {
+			if (Validator.isNotNull(keyword)) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	private boolean _isOrderByTitle(

--- a/modules/apps/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -91,6 +91,7 @@
 					(JournalArticle.version < tempJournalArticle.version)
 			LEFT JOIN
 				JournalArticleLocalization ON
+					(1 = ?) AND
 					(JournalArticle.companyId = JournalArticleLocalization.companyId) AND
 					(JournalArticle.id_ = JournalArticleLocalization.articlePK)
 			WHERE
@@ -432,8 +433,11 @@
 					FROM
 						JournalArticleLocalization
 					WHERE
-						(LOWER(JournalArticleLocalization.title) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
-						(JournalArticleLocalization.description LIKE ? [$AND_OR_NULL_CHECK$])
+						(1 = ?) AND
+						(
+							(LOWER(JournalArticleLocalization.title) LIKE ? [$AND_OR_NULL_CHECK$]) [$AND_OR_CONNECTOR$]
+							(JournalArticleLocalization.description LIKE ? [$AND_OR_NULL_CHECK$])
+						)
 					GROUP BY
 						JournalArticleLocalization.companyId, JournalArticleLocalization.articlePK, JournalArticleLocalization.title, JournalArticleLocalization.description
 				) JournalArticleLocalization ON


### PR DESCRIPTION
Hi @liferay-echo team,

I've made an optimization similar to [LPS-109979](https://issues.liferay.com/browse/LPS-109979). When the `title` and `description` fields are not used, `(1 = 0)` is added to the conditions and the DBMS will ignore the JournalArticleLocalization joins. 

Please review my changes.

Thanks,
Vendel