### PR TITLE
[TS] LPS-127637

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -548,14 +548,14 @@ public class JournalContentDisplayContext {
 			return _latestArticle;
 		}
 
-		JournalArticleDisplay articleDisplay = getArticleDisplay();
+		JournalArticle article = getArticle();
 
-		if (articleDisplay == null) {
+		if (article == null) {
 			return null;
 		}
 
 		_latestArticle = JournalArticleLocalServiceUtil.fetchLatestArticle(
-			articleDisplay.getGroupId(), articleDisplay.getArticleId(),
+			article.getGroupId(), article.getArticleId(),
 			WorkflowConstants.STATUS_ANY);
 
 		return _latestArticle;
@@ -1076,15 +1076,15 @@ public class JournalContentDisplayContext {
 	private DDMTemplate _getDDMTemplate(String ddmTemplateKey)
 		throws PortalException {
 
-		JournalArticleDisplay articleDisplay = getArticleDisplay();
+		JournalArticle article = getArticle();
 
-		if (articleDisplay == null) {
+		if (article == null) {
 			return null;
 		}
 
 		return DDMTemplateLocalServiceUtil.fetchTemplate(
-			articleDisplay.getGroupId(), _ddmStructureClassNameId,
-			ddmTemplateKey, true);
+			article.getGroupId(), _ddmStructureClassNameId, ddmTemplateKey,
+			true);
 	}
 
 	private static final boolean _STAGING_LIVE_GROUP_LOCKING_ENABLED =

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -792,12 +792,10 @@ public class JournalContentDisplayContext {
 	}
 
 	public void incrementViewCounter() throws PortalException {
-		JournalArticle article = getArticle();
 		JournalArticleDisplay articleDisplay = getArticleDisplay();
 
-		if ((article == null) || !hasViewPermission() ||
-			(articleDisplay == null) || isExpired() ||
-			!isEnableViewCountIncrement()) {
+		if ((articleDisplay == null) || !hasViewPermission() ||
+			isExpired() || !isEnableViewCountIncrement()) {
 
 			return;
 		}
@@ -870,14 +868,6 @@ public class JournalContentDisplayContext {
 
 	public boolean isShowArticle() throws PortalException {
 		if (_showArticle != null) {
-			return _showArticle;
-		}
-
-		JournalArticle article = getArticle();
-
-		if (article == null) {
-			_showArticle = false;
-
 			return _showArticle;
 		}
 


### PR DESCRIPTION
Hi Team,

I've found that in some cases articleDisplay can be substituted with article to increase performance in some edge cases when caching is disabled and JournalContentPortlet is embedded in another JournalContentPortlet.

Also, and this is purely cosmetical, I'd like to suggest the removal of article checks where articleDisplay is also checked, as getArticleDisplay already depends on getArticle.

Can you please review?
https://issues.liferay.com/browse/LPS-127637

Thanks,
Balázs