### PR TITLE
[TS] LPS-127615 Use utility method to retrieve a URI from a URL

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -1012,9 +1012,10 @@ public class LayoutReferencesExportImportContentProcessor
 		throws PortalException {
 
 		try {
-			URI uri = new URI(url);
+			URI uri = _http.getURI(url);
 
-			if (InetAddressUtil.isLocalInetAddress(
+			if ((uri != null) &&
+				InetAddressUtil.isLocalInetAddress(
 					InetAddress.getByName(uri.getHost()))) {
 
 				StringBundler sb = new StringBundler(5);


### PR DESCRIPTION
[LPS-127615](https://issues.liferay.com/browse/LPS-127615)

From @jesseyeh-liferay 

> This is an update to [LPS-126914](https://issues.liferay.com/browse/LPS-126914), which introduced a change to use a URI instead of a URL in order to account for links containing non-URL schemes. The approach that was utilized created a new URI object from a URL, but this does not account for the possibility of invalid characters being present in the URL, such as a trailing whitespace in [LPS-127272](https://issues.liferay.com/browse/LPS-127272). To resolve this, the URI is instead retrieved using a utility method which trims whitespace from the URL (or returns `null` if the URL is still malformed).