### PR TITLE
LPS-124170 [Experiences] As a marketer, I want to decide which languages I'm targeting when creating an experience

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -79,7 +79,6 @@ import com.liferay.layout.util.structure.CommonStylesUtil;
 import com.liferay.layout.util.structure.DropZoneLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
-import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.comment.Comment;
 import com.liferay.portal.kernel.comment.CommentManager;
@@ -831,12 +830,9 @@ public class ContentPageEditorDisplayContext {
 				HashMapBuilder.<String, Object>put(
 					"languageIcon",
 					StringUtil.toLowerCase(
-						StringUtil.replace(
-							languageId, CharPool.UNDERLINE, CharPool.DASH))
+						LocaleUtil.toW3cLanguageId(languageId))
 				).put(
-					"languageLabel",
-					StringUtil.replace(
-						languageId, CharPool.UNDERLINE, CharPool.DASH)
+					"w3cLanguageId", LocaleUtil.toW3cLanguageId(languageId)
 				).build());
 		}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddSegmentsExperienceMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddSegmentsExperienceMVCActionCommand.java
@@ -43,6 +43,9 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
@@ -87,12 +90,16 @@ public class AddSegmentsExperienceMVCActionCommand
 		SegmentsExperiment segmentsExperiment = _getSegmentsExperiment(
 			actionRequest);
 
+		String[] languageIds = StringUtil.split(
+			ParamUtil.getString(actionRequest, "languageIds", ""));
+
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			actionRequest);
 
 		SegmentsExperience segmentsExperience = _addSegmentsExperience(
 			actionRequest, _portal.getClassNameId(Layout.class),
-			themeDisplay.getPlid(), segmentsExperiment, serviceContext);
+			themeDisplay.getPlid(), languageIds, segmentsExperiment,
+			serviceContext);
 
 		long baseSegmentsExperienceId = _getBaseSegmentsExperienceId(
 			segmentsExperiment);
@@ -150,9 +157,15 @@ public class AddSegmentsExperienceMVCActionCommand
 
 	private SegmentsExperience _addSegmentsExperience(
 			ActionRequest actionRequest, long classNameId, long classPK,
-			SegmentsExperiment segmentsExperiment,
+			String[] languageIds, SegmentsExperiment segmentsExperiment,
 			ServiceContext serviceContext)
 		throws PortalException {
+
+		UnicodeProperties typeSettingsUnicodeProperties = new UnicodeProperties(
+			true);
+
+		typeSettingsUnicodeProperties.setProperty(
+			PropsKeys.LOCALES, StringUtil.merge(languageIds));
 
 		if (segmentsExperiment != null) {
 			long segmentsEntryId = SegmentsEntryConstants.ID_DEFAULT;
@@ -172,7 +185,7 @@ public class AddSegmentsExperienceMVCActionCommand
 				Collections.singletonMap(
 					LocaleUtil.getSiteDefault(),
 					ParamUtil.getString(actionRequest, "name")),
-				false, serviceContext);
+				false, typeSettingsUnicodeProperties, serviceContext);
 		}
 
 		return _segmentsExperienceService.addSegmentsExperience(
@@ -182,7 +195,7 @@ public class AddSegmentsExperienceMVCActionCommand
 				LocaleUtil.getSiteDefault(),
 				ParamUtil.getString(actionRequest, "name")),
 			ParamUtil.getBoolean(actionRequest, "active", true),
-			serviceContext);
+			typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	private SegmentsExperimentRel _addSegmentsExperimentRel(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/DuplicateSegmentsExperienceMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/DuplicateSegmentsExperienceMVCActionCommand.java
@@ -100,7 +100,9 @@ public class DuplicateSegmentsExperienceMVCActionCommand
 				segmentsExperience.getClassPK(),
 				Collections.singletonMap(
 					LocaleUtil.getSiteDefault(), sb.toString()),
-				segmentsExperience.isActive(), serviceContext);
+				segmentsExperience.isActive(),
+				segmentsExperience.getTypeSettingsUnicodeProperties(),
+				serviceContext);
 
 		SegmentsExperienceUtil.copySegmentsExperienceData(
 			themeDisplay.getPlid(), _commentManager,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateSegmentsExperienceMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateSegmentsExperienceMVCActionCommand.java
@@ -20,6 +20,9 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.segments.service.SegmentsExperienceService;
 
 import java.util.Collections;
@@ -55,12 +58,21 @@ public class UpdateSegmentsExperienceMVCActionCommand
 		long segmentsEntryId = ParamUtil.getLong(
 			actionRequest, "segmentsEntryId");
 		String name = ParamUtil.getString(actionRequest, "name");
+		String[] languageIds = StringUtil.split(
+			ParamUtil.getString(actionRequest, "languageIds", ""));
+
+		UnicodeProperties typeSettingsUnicodeProperties = new UnicodeProperties(
+			true);
+
+		typeSettingsUnicodeProperties.setProperty(
+			PropsKeys.LOCALES, StringUtil.merge(languageIds));
 
 		return JSONUtil.put(
 			"segmentsExperience",
 			_segmentsExperienceService.updateSegmentsExperience(
 				segmentsExperienceId, segmentsEntryId,
-				Collections.singletonMap(LocaleUtil.getDefault(), name), true));
+				Collections.singletonMap(LocaleUtil.getDefault(), name), true,
+				typeSettingsUnicodeProperties));
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
@@ -23,6 +23,7 @@ import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocal
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.comment.CommentManager;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONException;
@@ -46,8 +47,10 @@ import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
@@ -117,6 +120,9 @@ public class SegmentsExperienceUtil {
 		boolean addedDefault = false;
 
 		for (SegmentsExperience segmentsExperience : segmentsExperiences) {
+			UnicodeProperties typeSettingsUnicodeProperties =
+				segmentsExperience.getTypeSettingsUnicodeProperties();
+
 			if ((segmentsExperience.getPriority() <
 					SegmentsExperienceConstants.PRIORITY_DEFAULT) &&
 				!addedDefault) {
@@ -128,11 +134,17 @@ public class SegmentsExperienceUtil {
 				addedDefault = true;
 			}
 
+			String[] languageIds = StringUtil.split(
+				typeSettingsUnicodeProperties.getProperty(
+					PropsKeys.LOCALES, StringPool.BLANK));
+
 			availableSegmentsExperiences.put(
 				String.valueOf(segmentsExperience.getSegmentsExperienceId()),
 				HashMapBuilder.<String, Object>put(
 					"hasLockedSegmentsExperiment",
 					segmentsExperience.hasSegmentsExperiment()
+				).put(
+					"languageIds", languageIds
 				).put(
 					"name", segmentsExperience.getName(themeDisplay.getLocale())
 				).put(
@@ -168,8 +180,17 @@ public class SegmentsExperienceUtil {
 	public static JSONObject getSegmentsExperienceJSONObject(
 		SegmentsExperience segmentsExperience) {
 
+		UnicodeProperties typeSettingsUnicodeProperties =
+			segmentsExperience.getTypeSettingsUnicodeProperties();
+
+		String[] languageIds = StringUtil.split(
+			typeSettingsUnicodeProperties.getProperty(
+				PropsKeys.LOCALES, StringPool.BLANK));
+
 		return JSONUtil.put(
 			"active", segmentsExperience.isActive()
+		).put(
+			"languageIds", languageIds
 		).put(
 			"name", segmentsExperience.getNameCurrentValue()
 		).put(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Translation.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Translation.js
@@ -264,10 +264,10 @@ export default function Translation({
 Translation.propTypes = {
 	availableLanguages: PropTypes.objectOf(
 		PropTypes.shape({
-			default: PropTypes.bool.isRequired,
-			displayName: PropTypes.string.isRequired,
+			default: PropTypes.bool,
+			displayName: PropTypes.string,
 			languageIcon: PropTypes.string.isRequired,
-			languageId: PropTypes.string.isRequired,
+			languageId: PropTypes.string,
 			w3cLanguageId: PropTypes.string.isRequired,
 		})
 	).isRequired,
@@ -275,6 +275,6 @@ Translation.propTypes = {
 	dispatch: PropTypes.func.isRequired,
 	fragmentEntryLinks: PropTypes.object.isRequired,
 	languageId: PropTypes.string.isRequired,
-	segmentsExperienceId: PropTypes.string.isRequired,
+	segmentsExperienceId: PropTypes.string,
 	showNotTranslated: PropTypes.bool,
 };

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Translation.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/Translation.js
@@ -24,7 +24,7 @@ import {BACKGROUND_IMAGE_FRAGMENT_ENTRY_PROCESSOR} from '../config/constants/bac
 import {EDITABLE_FRAGMENT_ENTRY_PROCESSOR} from '../config/constants/editableFragmentEntryProcessor';
 import {TRANSLATION_STATUS_TYPE} from '../config/constants/translationStatusType';
 import {useSelector} from '../store/index';
-import getSegmentsExperienceLanguages from '../utils/getSegmentsExperienceLanguages';
+import getLanguages from '../utils/getLanguages';
 
 const getEditableValues = (fragmentEntryLinks) =>
 	Object.values(fragmentEntryLinks)
@@ -142,16 +142,16 @@ export default function Translation({
 		(state) => state.availableSegmentsExperiences
 	);
 
-	const availableExperienceLanguages = getSegmentsExperienceLanguages(
+	const languages = getLanguages(
 		availableLanguages,
 		availableSegmentsExperiences,
 		segmentsExperienceId
 	);
 
 	const languageValues = useMemo(() => {
-		const availableLanguagesMut = {...availableExperienceLanguages};
+		const availableLanguagesMut = {...languages};
 
-		const defaultLanguage = availableExperienceLanguages[defaultLanguageId];
+		const defaultLanguage = languages[defaultLanguageId];
 
 		delete availableLanguagesMut[defaultLanguageId];
 
@@ -174,39 +174,30 @@ export default function Translation({
 					isTranslated(editableValue, languageId)
 				),
 			}));
-	}, [
-		availableExperienceLanguages,
-		defaultLanguageId,
-		editableValues,
-		showNotTranslated,
-	]);
+	}, [defaultLanguageId, editableValues, languages, showNotTranslated]);
 
 	const selectedExperienceLanguage = (
-		availableExperienceLanguages,
 		defaultLanguageId,
-		languageId
+		languageId,
+		languages
 	) => {
-		if (!availableExperienceLanguages[languageId]) {
+		if (!languages[languageId]) {
 			dispatch(
 				updateLanguageId({
 					languageId: defaultLanguageId,
 				})
 			);
 
-			return availableExperienceLanguages[defaultLanguageId];
+			return languages[defaultLanguageId];
 		}
 
-		return availableExperienceLanguages[languageId];
+		return languages[languageId];
 	};
 
 	const {
 		languageIcon,
 		w3cLanguageId: languageLabel,
-	} = selectedExperienceLanguage(
-		availableExperienceLanguages,
-		defaultLanguageId,
-		languageId
-	);
+	} = selectedExperienceLanguage(defaultLanguageId, languageId, languages);
 
 	return (
 		<ClayDropDown
@@ -237,13 +228,11 @@ export default function Translation({
 						key={language.languageId}
 						language={language}
 						languageIcon={
-							availableExperienceLanguages[language.languageId]
-								.languageIcon
+							languages[language.languageId].languageIcon
 						}
 						languageId={languageId}
 						languageLabel={
-							availableExperienceLanguages[language.languageId]
-								.w3cLanguageId
+							languages[language.languageId].w3cLanguageId
 						}
 						onClick={() => {
 							dispatch(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/ExperienceService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/ExperienceService.js
@@ -40,10 +40,11 @@ export default {
 	 * @param {function} options.dispatch
 	 */
 	createExperience({body, dispatch}) {
-		const {name, segmentsEntryId} = body;
+		const {languageIds, name, segmentsEntryId} = body;
 
 		const payload = {
 			active: true,
+			languageIds,
 			name,
 			segmentsEntryId,
 		};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/ExperienceService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/ExperienceService.js
@@ -87,13 +87,9 @@ export default {
 	removeExperience({body, dispatch}) {
 		const {segmentsExperienceId} = body;
 
-		const payload = {
-			segmentsExperienceId,
-		};
-
 		return serviceFetch(
 			config.deleteSegmentsExperienceURL,
-			{body: payload},
+			{body: {segmentsExperienceId}},
 			dispatch
 		);
 	},

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/ExperienceService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/ExperienceService.js
@@ -117,9 +117,18 @@ export default {
 	 * @param {function} options.dispatch
 	 */
 	updateExperience({body, dispatch}) {
+		const {languageIds, name, segmentsEntryId, segmentsExperienceId} = body;
+
+		const payload = {
+			languageIds,
+			name,
+			segmentsEntryId,
+			segmentsExperienceId,
+		};
+
 		return serviceFetch(
 			config.updateSegmentsExperienceURL,
-			{body},
+			{body: payload},
 			dispatch
 		);
 	},

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getLanguages.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getLanguages.js
@@ -12,16 +12,23 @@
  * details.
  */
 
+import {config} from '../../app/config/index';
+
 export default function getLanguages(
 	availableLanguages,
 	availableSegmentsExperiences,
 	segmentsExperienceId
 ) {
+	if (
+		!availableSegmentsExperiences ||
+		!segmentsExperienceId ||
+		segmentsExperienceId === config.defaultSegmentsExperienceId
+	) {
+		return availableLanguages;
+	}
+
 	const languages =
-		(availableSegmentsExperiences &&
-			segmentsExperienceId &&
-			availableSegmentsExperiences[segmentsExperienceId]?.languageIds) ||
-		Object.keys(availableLanguages);
+		availableSegmentsExperiences[segmentsExperienceId].languageIds;
 
 	return languages.reduce((acc, languageId) => {
 		if (availableLanguages[languageId]) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getLanguages.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getLanguages.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-export default function getSegmentsExperienceLanguages(
+export default function getLanguages(
 	availableLanguages,
 	availableSegmentsExperiences,
 	segmentsExperienceId

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getSegmentsExperienceLanguages.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getSegmentsExperienceLanguages.js
@@ -22,9 +22,13 @@ export default function getSegmentsExperienceLanguages(
 		Object.keys(availableLanguages);
 
 	return experienceLanguages.reduce((acc, languageId) => {
-		return {
-			...acc,
-			[languageId]: {...availableLanguages[languageId]},
-		};
+		if (availableLanguages[languageId]) {
+			return {
+				...acc,
+				[languageId]: {...availableLanguages[languageId]},
+			};
+		}
+
+		return {...acc};
 	}, {});
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getSegmentsExperienceLanguages.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getSegmentsExperienceLanguages.js
@@ -17,11 +17,13 @@ export default function getSegmentsExperienceLanguages(
 	availableSegmentsExperiences,
 	segmentsExperienceId
 ) {
-	const experienceLanguages =
-		availableSegmentsExperiences[segmentsExperienceId]?.languageIds ||
+	const languages =
+		(availableSegmentsExperiences &&
+			segmentsExperienceId &&
+			availableSegmentsExperiences[segmentsExperienceId]?.languageIds) ||
 		Object.keys(availableLanguages);
 
-	return experienceLanguages.reduce((acc, languageId) => {
+	return languages.reduce((acc, languageId) => {
 		if (availableLanguages[languageId]) {
 			return {
 				...acc,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getSegmentsExperienceLanguages.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getSegmentsExperienceLanguages.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function getSegmentsExperienceLanguages(
+	availableLanguages,
+	availableSegmentsExperiences,
+	segmentsExperienceId
+) {
+	const experienceLanguages =
+		availableSegmentsExperiences[segmentsExperienceId]?.languageIds ||
+		Object.keys(availableLanguages);
+
+	return experienceLanguages.reduce((acc, languageId) => {
+		return {
+			...acc,
+			[languageId]: {...availableLanguages[languageId]},
+		};
+	}, {});
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/actions/updateExperience.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/actions/updateExperience.js
@@ -15,12 +15,14 @@
 import {UPDATE_SEGMENTS_EXPERIENCE} from '../actions';
 
 export default function updateExperience({
+	languageIds,
 	name,
 	segmentsEntryId,
 	segmentsExperienceId,
 }) {
 	return {
 		payload: {
+			languageIds,
 			name,
 			segmentsEntryId,
 			segmentsExperienceId,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceItem.js
@@ -53,9 +53,19 @@ const ExperienceItem = ({
 			experience.priority
 		);
 	const handleExperienceEdit = () => {
-		const {name, segmentsEntryId, segmentsExperienceId} = experience;
+		const {
+			languageIds,
+			name,
+			segmentsEntryId,
+			segmentsExperienceId,
+		} = experience;
 
-		onEditExperience({name, segmentsEntryId, segmentsExperienceId});
+		onEditExperience({
+			languageIds,
+			name,
+			segmentsEntryId,
+			segmentsExperienceId,
+		});
 	};
 	const handleExperienceDelete = () => {
 		const experienceHasRunningExperiment =

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceModal.js
@@ -22,7 +22,7 @@ import ClayModal from '@clayui/modal';
 import classNames from 'classnames';
 import {useIsMounted} from 'frontend-js-react-web';
 import PropTypes from 'prop-types';
-import React, {useEffect, useState} from 'react';
+import React, {useState} from 'react';
 
 import {config} from '../../../app/config/index';
 import Button from '../../../common/components/Button';
@@ -53,35 +53,29 @@ const ExperienceModal = ({
 	const [requiredNameError, setRequiredNameError] = useState(false);
 	const [loading, setLoading] = useState(false);
 
-	const [selectedLanguages, setSelectedLanguages] = useState(
-		Object.values(config.availableLanguages).filter(
-			({default: isDefault, languageId}) =>
-				isDefault || languageIds.includes(languageId)
-		)
-	);
-
 	const [selectedLanguagesIds, setSelectedLanguagesIds] = useState(
-		selectedLanguages.map(({languageId}) => languageId)
+		Object.values(config.availableLanguages)
+			.filter(
+				({default: isDefault, languageId}) =>
+					isDefault || languageIds.includes(languageId)
+			)
+			.map(({languageId}) => languageId)
 	);
 
-	const onChangeLocale = (isChecked, selectedLocale) => {
+	const onChangeLocale = (isChecked, selectedLenguageId) => {
 		if (!isChecked) {
-			setSelectedLanguages(selectedLanguages.concat(selectedLocale));
+			setSelectedLanguagesIds(
+				selectedLanguagesIds.concat(selectedLenguageId)
+			);
 		}
 		else {
-			setSelectedLanguages(
-				selectedLanguages.filter(
-					({languageId}) => languageId != selectedLocale.languageId
+			setSelectedLanguagesIds(
+				selectedLanguagesIds.filter(
+					(languageId) => languageId != selectedLenguageId
 				)
 			);
 		}
 	};
-
-	useEffect(() => {
-		setSelectedLanguagesIds(
-			selectedLanguages.map(({languageId}) => languageId)
-		);
-	}, [selectedLanguages]);
 
 	const handleFormSubmit = (event) => {
 		event.preventDefault();
@@ -288,7 +282,7 @@ const ExperienceModal = ({
 												onChange={() => {
 													onChangeLocale(
 														isChecked,
-														locale
+														languageId
 													);
 												}}
 											>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceModal.js
@@ -62,7 +62,7 @@ const ExperienceModal = ({
 			.map(({languageId}) => languageId)
 	);
 
-	const onChangeLocale = (isChecked, selectedLenguageId) => {
+	const onChangeLanguage = (isChecked, selectedLenguageId) => {
 		if (!isChecked) {
 			setSelectedLanguagesIds(
 				selectedLanguagesIds.concat(selectedLenguageId)
@@ -127,7 +127,7 @@ const ExperienceModal = ({
 
 	const nameInputId = `${config.portletNamespace}segmentsExperienceName`;
 	const segmentSelectId = `${config.portletNamespace}segmentsExperienceSegment`;
-	const localesChexboxesId = `${config.portletNamespace}segmentsExperienceLocales`;
+	const languagesCheckboxesId = `${config.portletNamespace}segmentsExperienceLanguages`;
 
 	const nameGroupClassName = classNames('c-mb-4', {
 		'has-error': requiredNameError,
@@ -244,7 +244,7 @@ const ExperienceModal = ({
 					</ClayForm.Group>
 
 					<ClayForm.Group>
-						<label htmlFor={localesChexboxesId}>
+						<label htmlFor={languagesCheckboxesId}>
 							{Liferay.Language.get('languages')}
 
 							<ClayIcon
@@ -254,14 +254,14 @@ const ExperienceModal = ({
 								symbol="asterisk"
 							/>
 						</label>
-						<ClayLayout.Row id={localesChexboxesId}>
+						<ClayLayout.Row id={languagesCheckboxesId}>
 							{Object.values(config.availableLanguages).map(
-								(locale) => {
+								(language) => {
 									const {
 										default: isDefault,
 										displayName,
 										languageId,
-									} = locale;
+									} = language;
 
 									const isChecked =
 										selectedLanguagesIds.indexOf(
@@ -280,7 +280,7 @@ const ExperienceModal = ({
 												disabled={isDefault}
 												label={displayName}
 												onChange={() => {
-													onChangeLocale(
+													onChangeLanguage(
 														isChecked,
 														languageId
 													);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
@@ -150,6 +150,7 @@ const ExperienceSelector = ({
 	}, []);
 
 	const handleExperienceCreation = ({
+		languageIds,
 		name,
 		segmentsEntryId,
 		segmentsExperienceId,
@@ -185,6 +186,7 @@ const ExperienceSelector = ({
 		else {
 			return dispatch(
 				createExperience({
+					languageIds,
 					name,
 					segmentsEntryId,
 				})
@@ -206,6 +208,7 @@ const ExperienceSelector = ({
 							error: Liferay.Language.get(
 								'an-unexpected-error-occurred-while-creating-the-experience'
 							),
+							languageIds,
 							name,
 							segmentsEntryId,
 							segmentsExperienceId,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceSelector.js
@@ -139,6 +139,7 @@ const ExperienceSelector = ({
 			) {
 				setOpenModal(true);
 				setEditingExperience({
+					languageIds: modalExperienceState.languageIds,
 					name: modalExperienceState.experienceName,
 					segmentsEntryId:
 						config.selectedSegmentsEntryId ||
@@ -157,7 +158,12 @@ const ExperienceSelector = ({
 	}) => {
 		if (segmentsExperienceId) {
 			return dispatch(
-				updateExperience({name, segmentsEntryId, segmentsExperienceId})
+				updateExperience({
+					languageIds,
+					name,
+					segmentsEntryId,
+					segmentsExperienceId,
+				})
 			)
 				.then(() => {
 					if (isMounted()) {
@@ -176,6 +182,7 @@ const ExperienceSelector = ({
 							error: Liferay.Language.get(
 								'an-unexpected-error-occurred-while-updating-the-experience'
 							),
+							languageIds,
 							name,
 							segmentsEntryId,
 							segmentsExperienceId,
@@ -221,11 +228,17 @@ const ExperienceSelector = ({
 	const handleOnNewExperiecneClick = () => setOpenModal(true);
 
 	const handleEditExperienceClick = (experienceData) => {
-		const {name, segmentsEntryId, segmentsExperienceId} = experienceData;
+		const {
+			languageIds,
+			name,
+			segmentsEntryId,
+			segmentsExperienceId,
+		} = experienceData;
 
 		setOpenModal(true);
 
 		setEditingExperience({
+			languageIds,
 			name,
 			segmentsEntryId,
 			segmentsExperienceId,
@@ -373,6 +386,7 @@ const ExperienceSelector = ({
 					errorMessage={editingExperience.error}
 					experienceId={editingExperience.segmentsExperienceId}
 					initialName={editingExperience.name}
+					languageIds={editingExperience.languageIds}
 					observer={modalObserver}
 					onClose={onModalClose}
 					onErrorDismiss={() => setEditingExperience({error: null})}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/thunks/createExperience.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/thunks/createExperience.js
@@ -16,10 +16,11 @@ import ExperienceService from '../../../app/services/ExperienceService';
 import createExperienceAction from '../actions/createExperience';
 import selectExperienceAction from '../actions/selectExperience';
 
-export default function createExperience({name, segmentsEntryId}) {
+export default function createExperience({languageIds, name, segmentsEntryId}) {
 	return (dispatch) => {
 		return ExperienceService.createExperience({
 			body: {
+				languageIds,
 				name,
 				segmentsEntryId,
 			},

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/thunks/updateExperience.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/thunks/updateExperience.js
@@ -16,6 +16,7 @@ import ExperienceService from '../../../app/services/ExperienceService';
 import updateExperienceAction from '../actions/updateExperience';
 
 export default function updateExperience({
+	languageIds,
 	name,
 	segmentsEntryId,
 	segmentsExperienceId,
@@ -24,6 +25,7 @@ export default function updateExperience({
 		return ExperienceService.updateExperience({
 			body: {
 				active: true,
+				languageIds,
 				name,
 				segmentsEntryId,
 				segmentsExperienceId,
@@ -32,6 +34,7 @@ export default function updateExperience({
 		}).then(() => {
 			return dispatch(
 				updateExperienceAction({
+					languageIds,
 					name,
 					segmentsEntryId,
 					segmentsExperienceId,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/CommonStyles.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/CommonStyles.js
@@ -63,6 +63,7 @@ export const CommonStyles = ({commonStylesValues, item}) => {
 			{commonStyles.map((fieldSet, index) => {
 				return (
 					<FieldSet
+						availableLanguages={config.availableLanguages}
 						fields={fieldSet.styles}
 						item={item}
 						key={index}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/FieldSet.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/FieldSet.js
@@ -22,7 +22,7 @@ import {LAYOUT_DATA_ITEM_TYPES} from '../../../../app/config/constants/layoutDat
 import {VIEWPORT_SIZES} from '../../../../app/config/constants/viewportSizes';
 import {config} from '../../../../app/config/index';
 import {useSelector} from '../../../../app/store/index';
-import getSegmentsExperienceLanguages from '../../../../app/utils/getSegmentsExperienceLanguages';
+import getLanguages from '../../../../app/utils/getLanguages';
 import {ConfigurationFieldPropTypes} from '../../../../prop-types/index';
 
 const DISPLAY_SIZES = {
@@ -59,7 +59,7 @@ export const FieldSet = ({
 						field.responsive || field.name === 'backgroundImage'
 			  );
 
-	const availableExperienceLanguages = getSegmentsExperienceLanguages(
+	const languages = getLanguages(
 		availableLanguages,
 		availableSegmentsExperiences,
 		segmentsExperienceId
@@ -145,16 +145,14 @@ export const FieldSet = ({
 										>
 											<ClayIcon
 												symbol={
-													availableExperienceLanguages[
-														languageId
-													].languageIcon
+													languages[languageId]
+														.languageIcon
 												}
 											/>
 											<span className="sr-only">
 												{
-													availableExperienceLanguages[
-														languageId
-													].w3cLanguageId
+													languages[languageId]
+														.w3cLanguageId
 												}
 											</span>
 										</div>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/FieldSet.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/FieldSet.js
@@ -22,6 +22,7 @@ import {LAYOUT_DATA_ITEM_TYPES} from '../../../../app/config/constants/layoutDat
 import {VIEWPORT_SIZES} from '../../../../app/config/constants/viewportSizes';
 import {config} from '../../../../app/config/index';
 import {useSelector} from '../../../../app/store/index';
+import getSegmentsExperienceLanguages from '../../../../app/utils/getSegmentsExperienceLanguages';
 import {ConfigurationFieldPropTypes} from '../../../../prop-types/index';
 
 const DISPLAY_SIZES = {
@@ -34,6 +35,7 @@ const fieldIsDisabled = (item, field) =>
 	(field.name === 'marginRight' || field.name === 'marginLeft');
 
 export const FieldSet = ({
+	availableLanguages,
 	fields,
 	item = {},
 	label,
@@ -41,9 +43,13 @@ export const FieldSet = ({
 	onValueSelect,
 	values,
 }) => {
-	const selectedViewportSize = useSelector(
-		(state) => state.selectedViewportSize
-	);
+	const store = useSelector((state) => state);
+
+	const {
+		availableSegmentsExperiences,
+		segmentsExperienceId,
+		selectedViewportSize,
+	} = store;
 
 	const availableFields =
 		selectedViewportSize === VIEWPORT_SIZES.desktop
@@ -53,7 +59,11 @@ export const FieldSet = ({
 						field.responsive || field.name === 'backgroundImage'
 			  );
 
-	const availableLanguages = config.availableLanguages;
+	const availableExperienceLanguages = getSegmentsExperienceLanguages(
+		availableLanguages,
+		availableSegmentsExperiences,
+		segmentsExperienceId
+	);
 
 	return (
 		availableFields.length > 0 && (
@@ -135,16 +145,16 @@ export const FieldSet = ({
 										>
 											<ClayIcon
 												symbol={
-													availableLanguages[
+													availableExperienceLanguages[
 														languageId
 													].languageIcon
 												}
 											/>
 											<span className="sr-only">
 												{
-													availableLanguages[
+													availableExperienceLanguages[
 														languageId
-													].languageLabel
+													].w3cLanguageId
 												}
 											</span>
 										</div>
@@ -160,6 +170,15 @@ export const FieldSet = ({
 };
 
 FieldSet.propTypes = {
+	availableLanguages: PropTypes.objectOf(
+		PropTypes.shape({
+			default: PropTypes.bool.isRequired,
+			displayName: PropTypes.string.isRequired,
+			languageIcon: PropTypes.string.isRequired,
+			languageId: PropTypes.string.isRequired,
+			w3cLanguageId: PropTypes.string.isRequired,
+		})
+	).isRequired,
 	fields: PropTypes.arrayOf(PropTypes.shape(ConfigurationFieldPropTypes)),
 	item: PropTypes.object,
 	label: PropTypes.string,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/FragmentGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/FragmentGeneralPanel.js
@@ -100,6 +100,7 @@ export const FragmentGeneralPanel = ({item}) => {
 			{fieldSets.map((fieldSet, index) => {
 				return (
 					<FieldSet
+						availableLanguages={config.availableLanguages}
 						fields={fieldSet.fields}
 						key={index}
 						label={fieldSet.label}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/FragmentStylesPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/FragmentStylesPanel.js
@@ -117,6 +117,7 @@ const CustomStyles = ({fragmentEntryLink, onValueSelect}) => {
 			{fieldSets.map((fieldSet, index) => {
 				return (
 					<FieldSet
+						availableLanguages={config.availableLanguages}
 						fields={fieldSet.fields}
 						key={index}
 						label={fieldSet.label}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/config.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/config.d.ts
@@ -30,8 +30,11 @@ export interface Config {
 
 	availableLanguages: {
 		[key: string]: {
+			default: boolean;
+			displayName: string;
 			languageIcon: string;
-			languageLabel: string;
+			languageId: string;
+			w3cLanguageId: string;
 		};
 	};
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/test/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtilTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/test/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtilTest.java
@@ -18,6 +18,7 @@ import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.segments.model.SegmentsExperience;
 
 import org.junit.Assert;
@@ -73,9 +74,17 @@ public class SegmentsExperienceUtilTest {
 			RandomTestUtil.randomLong()
 		);
 
+		Mockito.when(
+			segmentsExperience.getTypeSettingsUnicodeProperties()
+		).thenReturn(
+			new UnicodeProperties(true)
+		);
+
 		Assert.assertEquals(
 			JSONUtil.put(
 				"active", segmentsExperience.isActive()
+			).put(
+				"languageIds", new String[0]
 			).put(
 				"name", segmentsExperience.getNameCurrentValue()
 			).put(

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Translation.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Translation.test.js
@@ -34,10 +34,34 @@ jest.mock(
 );
 
 const availableLanguages = {
-	language_1: {languageIcon: 'language-1', languageLabel: 'language-1'},
-	language_2: {languageIcon: 'langauge-2', languageLabel: 'langauge-2'},
-	language_3: {languageIcon: 'language-3', languageLabel: 'language-3'},
-	language_4: {languageIcon: 'language-4', languageLabel: 'language-4'},
+	language_1: {
+		default: true,
+		displayName: 'language-1',
+		languageIcon: 'language-1',
+		languageId: 'language-1',
+		w3cLanguageId: 'language-1',
+	},
+	language_2: {
+		default: true,
+		displayName: 'language-2',
+		languageIcon: 'language-2',
+		languageId: 'language-2',
+		w3cLanguageId: 'language-2',
+	},
+	language_3: {
+		default: true,
+		displayName: 'language-3',
+		languageIcon: 'language-3',
+		languageId: 'language-3',
+		w3cLanguageId: 'language-3',
+	},
+	language_4: {
+		default: true,
+		displayName: 'language-4',
+		languageIcon: 'language-4',
+		languageId: 'language-4',
+		w3cLanguageId: 'language-4',
+	},
 };
 const FRAGMENT_ENTRY_LINK_ID = '1';
 const FRAGMENT_ENTRY_LINK_ID_2 = '2';
@@ -77,9 +101,22 @@ const fragmentEntryLink2 = {
 		},
 	},
 };
+
 const languageId = 'language_2';
 
 const defaultState = {
+	availableSegmentsExperiences: {
+		0: {
+			hasLockedSegmentsExperiment: false,
+			name: 'Default Experience',
+			priority: -1,
+			segmentsEntryId: 'test-segment-id-00',
+			segmentsExperienceId: '0',
+			segmentsExperimentStatus: undefined,
+			segmentsExperimentURL: 'https//:default-experience.com',
+		},
+	},
+	defaultSegmentsExperienceId: '0',
 	fragmentEntryLinks: {[FRAGMENT_ENTRY_LINK_ID]: fragmentEntryLink},
 };
 
@@ -92,6 +129,7 @@ const renderTranslation = ({state}) => {
 				dispatch={() => {}}
 				fragmentEntryLinks={state.fragmentEntryLinks}
 				languageId={languageId}
+				segmentsExperienceId={state.defaultSegmentsExperienceId}
 			/>
 		</StoreAPIContextProvider>
 	);

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Translation.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Translation.test.js
@@ -25,7 +25,7 @@ import {StoreAPIContextProvider} from '../../../../src/main/resources/META-INF/r
 
 jest.mock(
 	'../../../../src/main/resources/META-INF/resources/page_editor/app/config',
-	() => ({config: {}})
+	() => ({config: {defaultSegmentsExperienceId: '0'}})
 );
 
 jest.mock(

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/experience/components/ExperienceToolbarSection.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/experience/components/ExperienceToolbarSection.test.js
@@ -87,7 +87,7 @@ const mockState = {
 		},
 		'test-experience-id-01': {
 			hasLockedSegmentsExperiment: false,
-			languageIds: ['en_US', 'es_ES'],
+			languageIds: ['es_ES', 'en_US'],
 			name: 'Experience #1',
 			priority: 3,
 			segmentsEntryId: 'test-segment-id-00',
@@ -97,7 +97,7 @@ const mockState = {
 		},
 		'test-experience-id-02': {
 			hasLockedSegmentsExperiment: false,
-			languageIds: ['en_US', 'es_ES', 'ar_SA'],
+			languageIds: ['es_ES', 'en_US', 'ar_SA'],
 			name: 'Experience #2',
 			priority: 1,
 			segmentsEntryId: 'test-segment-id-01',
@@ -263,7 +263,7 @@ describe('ExperienceToolbarSection', () => {
 	});
 
 	it('calls the backend to increase priority', async () => {
-		serviceFetch.mockImplementation((url, {body}) =>
+		serviceFetch.mockImplementation((_, {body}) =>
 			Promise.resolve({
 				priority: body.newPriority,
 				segmentsExperienceId: 'test-experience-id-02',
@@ -339,7 +339,7 @@ describe('ExperienceToolbarSection', () => {
 	});
 
 	it('calls the backend to decrease priority', async () => {
-		serviceFetch.mockImplementation((url, {body}) =>
+		serviceFetch.mockImplementation((_, {body}) =>
 			Promise.resolve({
 				priority: body.newPriority,
 				segmentsExperienceId: 'test-experience-id-01',
@@ -416,10 +416,10 @@ describe('ExperienceToolbarSection', () => {
 
 	it('calls the backend to create a new experience', async () => {
 		serviceFetch
-			.mockImplementationOnce((url, {body}) =>
+			.mockImplementationOnce((_, {body}) =>
 				Promise.resolve({
 					segmentsExperience: {
-						active: true,
+						languageIds: body.languageIds,
 						name: body.name,
 						priority: '1000',
 						segmentsEntryId: body.segmentsEntryId,
@@ -460,12 +460,11 @@ describe('ExperienceToolbarSection', () => {
 
 		await wait(() => getByLabelText('name'));
 
-		const nameInput = getByLabelText('name');
-		const audienceInput = getByLabelText('audience');
+		userEvent.type(getByLabelText('name'), 'New Experience #1');
 
-		userEvent.type(nameInput, 'New Experience #1');
+		userEvent.selectOptions(getByLabelText('audience'), 'A segment #1');
 
-		userEvent.selectOptions(audienceInput, 'A segment #1');
+		getByLabelText('languages');
 
 		// Grab parentElement here to work around jsdom v13 issue.
 		// "TypeError: Cannot read property '_defaultView' of undefined"
@@ -478,6 +477,8 @@ describe('ExperienceToolbarSection', () => {
 			expect.stringContaining(MOCK_CREATE_URL),
 			expect.objectContaining({
 				body: expect.objectContaining({
+					active: true,
+					languageIds: ['es_ES'],
 					name: 'New Experience #1',
 					segmentsEntryId: 'test-segment-id-00',
 				}),
@@ -493,10 +494,12 @@ describe('ExperienceToolbarSection', () => {
 	});
 
 	it('calls the backend to update the experience', async () => {
-		serviceFetch.mockImplementation((url, {body}) =>
+		serviceFetch.mockImplementation((_, {body}) =>
 			Promise.resolve({
+				languageIds: body.languageIds,
 				name: body.name,
 				segmentsEntryId: body.segmentsEntryId,
+				segmentsExperienceId: body.segmentsExperienceId,
 			})
 		);
 
@@ -560,6 +563,7 @@ describe('ExperienceToolbarSection', () => {
 			expect.stringContaining(MOCK_UPDATE_URL),
 			expect.objectContaining({
 				body: expect.objectContaining({
+					languageIds: ['en_US', 'es_ES'],
 					name: 'New Experience #1',
 					segmentsEntryId: 'test-segment-id-00',
 					segmentsExperienceId: 'test-experience-id-01',
@@ -723,10 +727,11 @@ describe('ExperienceToolbarSection', () => {
 
 	it('calls the backend to duplicate an experience', async () => {
 		serviceFetch
-			.mockImplementationOnce((url, {body}) =>
+			.mockImplementationOnce((_, {body}) =>
 				Promise.resolve({
 					segmentsExperience: {
 						active: true,
+						languageIds: body.languageIds,
 						name: body.name,
 						priority: '1000',
 						segmentsEntryId: body.segmentsEntryId,

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/experience/components/ExperienceToolbarSection.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/experience/components/ExperienceToolbarSection.test.js
@@ -77,7 +77,6 @@ function renderExperienceToolbarSection(
 const mockState = {
 	availableSegmentsExperiences: {
 		0: {
-			active: true,
 			hasLockedSegmentsExperiment: false,
 			name: 'Default Experience',
 			priority: -1,
@@ -87,8 +86,8 @@ const mockState = {
 			segmentsExperimentURL: 'https//:default-experience.com',
 		},
 		'test-experience-id-01': {
-			active: true,
 			hasLockedSegmentsExperiment: false,
+			languageIds: ['en_US', 'es_ES'],
 			name: 'Experience #1',
 			priority: 3,
 			segmentsEntryId: 'test-segment-id-00',
@@ -97,8 +96,8 @@ const mockState = {
 			segmentsExperimentURL: 'https//:experience-1.com',
 		},
 		'test-experience-id-02': {
-			active: true,
 			hasLockedSegmentsExperiment: false,
+			languageIds: ['en_US', 'es_ES', 'ar_SA'],
 			name: 'Experience #2',
 			priority: 1,
 			segmentsEntryId: 'test-segment-id-01',
@@ -117,6 +116,29 @@ const mockState = {
 
 const mockConfig = {
 	addSegmentsExperienceURL: MOCK_CREATE_URL,
+	availableLanguages: {
+		ar_SA: {
+			default: false,
+			displayName: 'Arabic (Saudi Arabia)',
+			languageIcon: 'ar-sa',
+			languageId: 'ar_SA',
+			w3cLanguageId: 'ar-SA',
+		},
+		en_US: {
+			default: false,
+			displayName: 'English (United States)',
+			languageIcon: 'en-us',
+			languageId: 'en_US',
+			w3cLanguageId: 'en-US',
+		},
+		es_ES: {
+			default: true,
+			displayName: 'Spanish (Spain)',
+			languageIcon: 'es-es',
+			languageId: 'es_ES',
+			w3cLanguageId: 'es-ES',
+		},
+	},
 	availableSegmentsEntries: {
 		'test-segment-id-00': {
 			name: 'A segment 0',
@@ -184,7 +206,6 @@ describe('ExperienceToolbarSection', () => {
 			availableSegmentsExperiences: {
 				...mockState.availableSegmentsExperiences,
 				'test-experience-id-03': {
-					active: true,
 					hasLockedSegmentsExperiment: true,
 					name: 'Experience #3',
 					priority: 5,
@@ -539,7 +560,6 @@ describe('ExperienceToolbarSection', () => {
 			expect.stringContaining(MOCK_UPDATE_URL),
 			expect.objectContaining({
 				body: expect.objectContaining({
-					active: true,
 					name: 'New Experience #1',
 					segmentsEntryId: 'test-segment-id-00',
 					segmentsExperienceId: 'test-experience-id-01',

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/CommonStyles.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/CommonStyles.test.js
@@ -21,6 +21,17 @@ import updateItemConfig from '../../../../../../../src/main/resources/META-INF/r
 import {CommonStyles} from '../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/CommonStyles';
 
 const STATE = {
+	availableSegmentsExperiences: {
+		0: {
+			hasLockedSegmentsExperiment: false,
+			name: 'Default Experience',
+			priority: -1,
+			segmentsEntryId: 'test-segment-id-00',
+			segmentsExperienceId: '0',
+			segmentsExperimentStatus: undefined,
+			segmentsExperimentURL: 'https//:default-experience.com',
+		},
+	},
 	segmentsExperienceId: '0',
 	selectedViewportSize: 'desktop',
 };
@@ -57,6 +68,29 @@ jest.mock(
 	'../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config',
 	() => ({
 		config: {
+			availableLanguages: {
+				ar_SA: {
+					default: false,
+					displayName: 'Arabic (Saudi Arabia)',
+					languageIcon: 'ar-sa',
+					languageId: 'ar_SA',
+					w3cLanguageId: 'ar-SA',
+				},
+				en_US: {
+					default: false,
+					displayName: 'English (United States)',
+					languageIcon: 'en-us',
+					languageId: 'en_US',
+					w3cLanguageId: 'en-US',
+				},
+				es_ES: {
+					default: true,
+					displayName: 'Spanish (Spain)',
+					languageIcon: 'es-es',
+					languageId: 'es_ES',
+					w3cLanguageId: 'es-ES',
+				},
+			},
 			availableViewportSizes: {
 				desktop: {label: 'Desktop'},
 				tablet: {label: 'tablet'},
@@ -108,6 +142,8 @@ jest.mock(
 					],
 				},
 			],
+			defaultLanguageId: 'es_ES',
+			defaultSegmentsExperienceId: '0',
 			responsiveEnabled: true,
 		},
 	})

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/ContainerStylesPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/ContainerStylesPanel.test.js
@@ -60,7 +60,7 @@ jest.mock(
 				tablet: {label: 'Tablet', sizeId: 'tablet'},
 			},
 			commonStyles: [],
-			defaultSegmentsExperienceId: 0,
+			defaultSegmentsExperienceId: '0',
 			marginOptions: [],
 			paddingOptions: [],
 		},

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/FragmentGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/FragmentGeneralPanel.test.js
@@ -21,7 +21,6 @@ import '@testing-library/jest-dom/extend-expect';
 import {cleanup, fireEvent, render} from '@testing-library/react';
 
 import {VIEWPORT_SIZES} from '../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/constants/viewportSizes';
-import {config} from '../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/index';
 import FragmentService from '../../../../../../../src/main/resources/META-INF/resources/page_editor/app/services/FragmentService';
 import {StoreAPIContextProvider} from '../../../../../../../src/main/resources/META-INF/resources/page_editor/app/store/index';
 import {FragmentGeneralPanel} from '../../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/FragmentGeneralPanel';
@@ -149,7 +148,28 @@ const renderGeneralPanel = ({
 				segmentsExperimentStatus: undefined,
 				segmentsExperimentURL: 'https//:default-experience.com',
 			},
+			1: {
+				hasLockedSegmentsExperiment: false,
+				languageIds: ['es_ES', 'en_US'],
+				name: 'Experience #1',
+				priority: 3,
+				segmentsEntryId: 'test-segment-id-00',
+				segmentsExperienceId: 'test-experience-id-01',
+				segmentsExperimentStatus: undefined,
+				segmentsExperimentURL: 'https//:experience-1.com',
+			},
+			2: {
+				hasLockedSegmentsExperiment: false,
+				languageIds: ['es_ES', 'en_US', 'ar_SA'],
+				name: 'Experience #2',
+				priority: 1,
+				segmentsEntryId: 'test-segment-id-01',
+				segmentsExperienceId: 'test-experience-id-02',
+				segmentsExperimentStatus: undefined,
+				segmentsExperimentURL: 'https//:experience-2.com',
+			},
 		},
+		defaultSegmentsExperienceId: '0',
 		fragmentEntryLinks: {[FRAGMENT_ENTRY_LINK_ID]: fragmentEntryLink},
 		languageId: 'en_US',
 		segmentsExperienceId,
@@ -172,8 +192,6 @@ describe('FragmentGeneralPanel', () => {
 	});
 
 	it('does not prefix values with segments if we do not have experiences', async () => {
-		config.defaultSegmentsExperienceId = null;
-
 		const {getByLabelText} = renderGeneralPanel({
 			segmentsExperienceId: null,
 		});
@@ -197,8 +215,6 @@ describe('FragmentGeneralPanel', () => {
 	});
 
 	it('does not show flag icon when localizable property is false', async () => {
-		config.defaultSegmentsExperienceId = null;
-
 		const {getByLabelText} = renderGeneralPanel({
 			fragmentEntryLink: defaultFragmentEntryLink(false),
 			segmentsExperienceId: null,
@@ -212,8 +228,6 @@ describe('FragmentGeneralPanel', () => {
 	});
 
 	it('prefix values with segments when we have experiences', async () => {
-		config.defaultSegmentsExperienceId = '2';
-
 		const {getByLabelText} = renderGeneralPanel({
 			segmentsExperienceId: '1',
 		});
@@ -237,8 +251,6 @@ describe('FragmentGeneralPanel', () => {
 	});
 
 	it('prefix values with default experience when segmentsExperience is null', async () => {
-		config.defaultSegmentsExperienceId = '2';
-
 		const {getByLabelText} = renderGeneralPanel({
 			segmentsExperienceId: null,
 		});
@@ -262,8 +274,6 @@ describe('FragmentGeneralPanel', () => {
 	});
 
 	it('merges configuration values when a new one is added', async () => {
-		config.defaultSegmentsExperienceId = '0';
-
 		const fragmentEntryLink = {
 			comments: [],
 			configuration: {
@@ -337,8 +347,6 @@ describe('FragmentGeneralPanel', () => {
 	});
 
 	it('shows corresponding flag icon when localizable property is true', async () => {
-		config.defaultSegmentsExperienceId = null;
-
 		const {getByLabelText} = renderGeneralPanel({
 			fragmentEntryLink: defaultFragmentEntryLink(true),
 			segmentsExperienceId: null,

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/FragmentGeneralPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/FragmentGeneralPanel.test.js
@@ -31,13 +31,26 @@ jest.mock(
 	() => ({
 		config: {
 			availableLanguages: {
-				language_1: {
-					languageIcon: 'language-1',
-					languageLabel: 'language-1',
+				ar_SA: {
+					default: false,
+					displayName: 'Arabic (Saudi Arabia)',
+					languageIcon: 'ar-sa',
+					languageId: 'ar_SA',
+					w3cLanguageId: 'ar-SA',
 				},
-				language_2: {
-					languageIcon: 'langauge-2',
-					languageLabel: 'langauge-2',
+				en_US: {
+					default: false,
+					displayName: 'English (United States)',
+					languageIcon: 'en-us',
+					languageId: 'en_US',
+					w3cLanguageId: 'en-US',
+				},
+				es_ES: {
+					default: true,
+					displayName: 'Spanish (Spain)',
+					languageIcon: 'es-es',
+					languageId: 'es_ES',
+					w3cLanguageId: 'es-ES',
 				},
 			},
 			availableViewportSizes: {
@@ -45,7 +58,8 @@ jest.mock(
 				mobile: {label: 'Mobile', sizeId: 'mobile'},
 				tablet: {label: 'Tablet', sizeId: 'tablet'},
 			},
-			defaultLanguageId: 'language_1',
+			defaultLanguageId: 'es_ES',
+			defaultSegmentsExperienceId: '0',
 		},
 	})
 );
@@ -125,8 +139,19 @@ const renderGeneralPanel = ({
 	fragmentEntryLink = defaultFragmentEntryLink(),
 }) => {
 	const state = {
+		availableSegmentsExperiences: {
+			0: {
+				hasLockedSegmentsExperiment: false,
+				name: 'Default Experience',
+				priority: -1,
+				segmentsEntryId: 'test-segment-id-00',
+				segmentsExperienceId: '0',
+				segmentsExperimentStatus: undefined,
+				segmentsExperimentURL: 'https//:default-experience.com',
+			},
+		},
 		fragmentEntryLinks: {[FRAGMENT_ENTRY_LINK_ID]: fragmentEntryLink},
-		languageId: 'language_1',
+		languageId: 'en_US',
 		segmentsExperienceId,
 		selectedViewportSize: VIEWPORT_SIZES.desktop,
 	};
@@ -323,8 +348,6 @@ describe('FragmentGeneralPanel', () => {
 
 		const wrapperDiv = input.parentElement.parentElement.parentElement;
 
-		expect(wrapperDiv.querySelector('.sr-only')).toHaveTextContent(
-			'language-1'
-		);
+		expect(wrapperDiv.querySelector('.sr-only')).toHaveTextContent('en-US');
 	});
 });

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/FragmentStylesPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/FragmentStylesPanel.test.js
@@ -71,6 +71,17 @@ const renderComponent = ({
 		<StoreAPIContextProvider
 			dispatch={dispatch}
 			getState={() => ({
+				availableSegmentsExperiences: {
+					0: {
+						hasLockedSegmentsExperiment: false,
+						name: 'Default Experience',
+						priority: -1,
+						segmentsEntryId: 'test-segment-id-00',
+						segmentsExperienceId: '0',
+						segmentsExperimentStatus: undefined,
+						segmentsExperimentURL: 'https//:default-experience.com',
+					},
+				},
 				fragmentEntryLinks: {
 					[FRAGMENT_ENTRY_LINK_ID]: fragmentEntryLink,
 				},
@@ -102,6 +113,29 @@ jest.mock(
 	'../../../../../../../src/main/resources/META-INF/resources/page_editor/app/config',
 	() => ({
 		config: {
+			availableLanguages: {
+				ar_SA: {
+					default: false,
+					displayName: 'Arabic (Saudi Arabia)',
+					languageIcon: 'ar-sa',
+					languageId: 'ar_SA',
+					w3cLanguageId: 'ar-SA',
+				},
+				en_US: {
+					default: false,
+					displayName: 'English (United States)',
+					languageIcon: 'en-us',
+					languageId: 'en_US',
+					w3cLanguageId: 'en-US',
+				},
+				es_ES: {
+					default: true,
+					displayName: 'Spanish (Spain)',
+					languageIcon: 'es-es',
+					languageId: 'es_ES',
+					w3cLanguageId: 'es-ES',
+				},
+			},
 			availableViewportSizes: {
 				desktop: {label: 'Desktop', sizeId: 'desktop'},
 				mobile: {label: 'Mobile', sizeId: 'mobile'},
@@ -135,6 +169,7 @@ jest.mock(
 					],
 				},
 			],
+			defaultLanguageId: 'es_ES',
 			defaultSegmentsExperienceId: 0,
 			marginOptions: [],
 			paddingOptions: [],

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/FragmentStylesPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/FragmentStylesPanel.test.js
@@ -170,7 +170,7 @@ jest.mock(
 				},
 			],
 			defaultLanguageId: 'es_ES',
-			defaultSegmentsExperienceId: 0,
+			defaultSegmentsExperienceId: '0',
 			marginOptions: [],
 			paddingOptions: [],
 		},

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/modal/DisplayPageModal.es.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/modal/DisplayPageModal.es.js
@@ -159,7 +159,7 @@ DisplayPageModal.propTypes = {
 	mappingTypes: PropTypes.array,
 	namespace: PropTypes.string.isRequired,
 	onClose: PropTypes.func.isRequired,
-	title: PropTypes.func.isRequired,
+	title: PropTypes.string.isRequired,
 };
 
 export {DisplayPageModal};

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/modal/DisplayPageModalForm.es.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/modal/DisplayPageModalForm.es.js
@@ -151,7 +151,7 @@ DisplayPageModalForm.propTypes = {
 		})
 	),
 	namespace: PropTypes.string.isRequired,
-	onSubmit: PropTypes.func.isRequire,
+	onSubmit: PropTypes.func.isRequired,
 };
 
 export {DisplayPageModalForm};

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/model/SegmentsExperience.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/model/SegmentsExperience.java
@@ -60,6 +60,13 @@ public interface SegmentsExperience
 
 			};
 
+	public com.liferay.portal.kernel.util.UnicodeProperties
+		getTypeSettingsUnicodeProperties();
+
 	public boolean hasSegmentsExperiment();
+
+	public void setTypeSettingsUnicodeProperties(
+		com.liferay.portal.kernel.util.UnicodeProperties
+			typeSettingsUnicodeProperties);
 
 }

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/model/SegmentsExperienceModel.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/model/SegmentsExperienceModel.java
@@ -451,6 +451,21 @@ public interface SegmentsExperienceModel
 	public void setActive(boolean active);
 
 	/**
+	 * Returns the type settings of this segments experience.
+	 *
+	 * @return the type settings of this segments experience
+	 */
+	@AutoEscape
+	public String getTypeSettings();
+
+	/**
+	 * Sets the type settings of this segments experience.
+	 *
+	 * @param typeSettings the type settings of this segments experience
+	 */
+	public void setTypeSettings(String typeSettings);
+
+	/**
 	 * Returns the last publish date of this segments experience.
 	 *
 	 * @return the last publish date of this segments experience

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/model/SegmentsExperienceSoap.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/model/SegmentsExperienceSoap.java
@@ -50,6 +50,7 @@ public class SegmentsExperienceSoap implements Serializable {
 		soapModel.setName(model.getName());
 		soapModel.setPriority(model.getPriority());
 		soapModel.setActive(model.isActive());
+		soapModel.setTypeSettings(model.getTypeSettings());
 		soapModel.setLastPublishDate(model.getLastPublishDate());
 
 		return soapModel;
@@ -253,6 +254,14 @@ public class SegmentsExperienceSoap implements Serializable {
 		_active = active;
 	}
 
+	public String getTypeSettings() {
+		return _typeSettings;
+	}
+
+	public void setTypeSettings(String typeSettings) {
+		_typeSettings = typeSettings;
+	}
+
 	public Date getLastPublishDate() {
 		return _lastPublishDate;
 	}
@@ -278,6 +287,7 @@ public class SegmentsExperienceSoap implements Serializable {
 	private String _name;
 	private int _priority;
 	private boolean _active;
+	private String _typeSettings;
 	private Date _lastPublishDate;
 
 }

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/model/SegmentsExperienceTable.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/model/SegmentsExperienceTable.java
@@ -80,6 +80,9 @@ public class SegmentsExperienceTable
 			"priority", Integer.class, Types.INTEGER, Column.FLAG_DEFAULT);
 	public final Column<SegmentsExperienceTable, Boolean> active = createColumn(
 		"active_", Boolean.class, Types.BOOLEAN, Column.FLAG_DEFAULT);
+	public final Column<SegmentsExperienceTable, String> typeSettings =
+		createColumn(
+			"typeSettings", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
 	public final Column<SegmentsExperienceTable, Date> lastPublishDate =
 		createColumn(
 			"lastPublishDate", Date.class, Types.TIMESTAMP,

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/model/SegmentsExperienceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/model/SegmentsExperienceWrapper.java
@@ -62,6 +62,7 @@ public class SegmentsExperienceWrapper
 		attributes.put("name", getName());
 		attributes.put("priority", getPriority());
 		attributes.put("active", isActive());
+		attributes.put("typeSettings", getTypeSettings());
 		attributes.put("lastPublishDate", getLastPublishDate());
 
 		return attributes;
@@ -171,6 +172,12 @@ public class SegmentsExperienceWrapper
 
 		if (active != null) {
 			setActive(active);
+		}
+
+		String typeSettings = (String)attributes.get("typeSettings");
+
+		if (typeSettings != null) {
+			setTypeSettings(typeSettings);
 		}
 
 		Date lastPublishDate = (Date)attributes.get("lastPublishDate");
@@ -424,6 +431,23 @@ public class SegmentsExperienceWrapper
 	@Override
 	public String getSegmentsExperienceKey() {
 		return model.getSegmentsExperienceKey();
+	}
+
+	/**
+	 * Returns the type settings of this segments experience.
+	 *
+	 * @return the type settings of this segments experience
+	 */
+	@Override
+	public String getTypeSettings() {
+		return model.getTypeSettings();
+	}
+
+	@Override
+	public com.liferay.portal.kernel.util.UnicodeProperties
+		getTypeSettingsUnicodeProperties() {
+
+		return model.getTypeSettingsUnicodeProperties();
 	}
 
 	/**
@@ -717,6 +741,24 @@ public class SegmentsExperienceWrapper
 	@Override
 	public void setSegmentsExperienceKey(String segmentsExperienceKey) {
 		model.setSegmentsExperienceKey(segmentsExperienceKey);
+	}
+
+	/**
+	 * Sets the type settings of this segments experience.
+	 *
+	 * @param typeSettings the type settings of this segments experience
+	 */
+	@Override
+	public void setTypeSettings(String typeSettings) {
+		model.setTypeSettings(typeSettings);
+	}
+
+	@Override
+	public void setTypeSettingsUnicodeProperties(
+		com.liferay.portal.kernel.util.UnicodeProperties
+			typeSettingsUnicodeProperties) {
+
+		model.setTypeSettingsUnicodeProperties(typeSettingsUnicodeProperties);
 	}
 
 	/**

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalService.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.segments.model.SegmentsExperience;
 
 import java.io.Serializable;
@@ -82,7 +83,21 @@ public interface SegmentsExperienceLocalService
 
 	public SegmentsExperience addSegmentsExperience(
 			long segmentsEntryId, long classNameId, long classPK,
+			Map<Locale, String> nameMap, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public SegmentsExperience addSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
 			Map<Locale, String> nameMap, int priority, boolean active,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public SegmentsExperience addSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			Map<Locale, String> nameMap, int priority, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException;
 
@@ -103,6 +118,13 @@ public interface SegmentsExperienceLocalService
 	public SegmentsExperience appendSegmentsExperience(
 			long segmentsEntryId, long classNameId, long classPK,
 			Map<Locale, String> nameMap, boolean active,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public SegmentsExperience appendSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			Map<Locale, String> nameMap, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException;
 
@@ -399,6 +421,12 @@ public interface SegmentsExperienceLocalService
 	public SegmentsExperience updateSegmentsExperience(
 			long segmentsExperienceId, long segmentsEntryId,
 			Map<Locale, String> nameMap, boolean active)
+		throws PortalException;
+
+	public SegmentsExperience updateSegmentsExperience(
+			long segmentsExperienceId, long segmentsEntryId,
+			Map<Locale, String> nameMap, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties)
 		throws PortalException;
 
 	/**

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalServiceUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalServiceUtil.java
@@ -52,6 +52,20 @@ public class SegmentsExperienceLocalServiceUtil {
 	public static com.liferay.segments.model.SegmentsExperience
 			addSegmentsExperience(
 				long segmentsEntryId, long classNameId, long classPK,
+				java.util.Map<java.util.Locale, String> nameMap, boolean active,
+				com.liferay.portal.kernel.util.UnicodeProperties
+					typeSettingsUnicodeProperties,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, active,
+			typeSettingsUnicodeProperties, serviceContext);
+	}
+
+	public static com.liferay.segments.model.SegmentsExperience
+			addSegmentsExperience(
+				long segmentsEntryId, long classNameId, long classPK,
 				java.util.Map<java.util.Locale, String> nameMap, int priority,
 				boolean active,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -60,6 +74,21 @@ public class SegmentsExperienceLocalServiceUtil {
 		return getService().addSegmentsExperience(
 			segmentsEntryId, classNameId, classPK, nameMap, priority, active,
 			serviceContext);
+	}
+
+	public static com.liferay.segments.model.SegmentsExperience
+			addSegmentsExperience(
+				long segmentsEntryId, long classNameId, long classPK,
+				java.util.Map<java.util.Locale, String> nameMap, int priority,
+				boolean active,
+				com.liferay.portal.kernel.util.UnicodeProperties
+					typeSettingsUnicodeProperties,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, priority, active,
+			typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	/**
@@ -89,6 +118,20 @@ public class SegmentsExperienceLocalServiceUtil {
 		return getService().appendSegmentsExperience(
 			segmentsEntryId, classNameId, classPK, nameMap, active,
 			serviceContext);
+	}
+
+	public static com.liferay.segments.model.SegmentsExperience
+			appendSegmentsExperience(
+				long segmentsEntryId, long classNameId, long classPK,
+				java.util.Map<java.util.Locale, String> nameMap, boolean active,
+				com.liferay.portal.kernel.util.UnicodeProperties
+					typeSettingsUnicodeProperties,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().appendSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, active,
+			typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	/**
@@ -514,6 +557,19 @@ public class SegmentsExperienceLocalServiceUtil {
 
 		return getService().updateSegmentsExperience(
 			segmentsExperienceId, segmentsEntryId, nameMap, active);
+	}
+
+	public static com.liferay.segments.model.SegmentsExperience
+			updateSegmentsExperience(
+				long segmentsExperienceId, long segmentsEntryId,
+				java.util.Map<java.util.Locale, String> nameMap, boolean active,
+				com.liferay.portal.kernel.util.UnicodeProperties
+					typeSettingsUnicodeProperties)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().updateSegmentsExperience(
+			segmentsExperienceId, segmentsEntryId, nameMap, active,
+			typeSettingsUnicodeProperties);
 	}
 
 	/**

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalServiceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceLocalServiceWrapper.java
@@ -51,6 +51,20 @@ public class SegmentsExperienceLocalServiceWrapper
 	@Override
 	public SegmentsExperience addSegmentsExperience(
 			long segmentsEntryId, long classNameId, long classPK,
+			java.util.Map<java.util.Locale, String> nameMap, boolean active,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _segmentsExperienceLocalService.addSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, active,
+			typeSettingsUnicodeProperties, serviceContext);
+	}
+
+	@Override
+	public SegmentsExperience addSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
 			java.util.Map<java.util.Locale, String> nameMap, int priority,
 			boolean active,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
@@ -59,6 +73,21 @@ public class SegmentsExperienceLocalServiceWrapper
 		return _segmentsExperienceLocalService.addSegmentsExperience(
 			segmentsEntryId, classNameId, classPK, nameMap, priority, active,
 			serviceContext);
+	}
+
+	@Override
+	public SegmentsExperience addSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			java.util.Map<java.util.Locale, String> nameMap, int priority,
+			boolean active,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _segmentsExperienceLocalService.addSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, priority, active,
+			typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	/**
@@ -89,6 +118,20 @@ public class SegmentsExperienceLocalServiceWrapper
 		return _segmentsExperienceLocalService.appendSegmentsExperience(
 			segmentsEntryId, classNameId, classPK, nameMap, active,
 			serviceContext);
+	}
+
+	@Override
+	public SegmentsExperience appendSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			java.util.Map<java.util.Locale, String> nameMap, boolean active,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _segmentsExperienceLocalService.appendSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, active,
+			typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	/**
@@ -548,6 +591,19 @@ public class SegmentsExperienceLocalServiceWrapper
 
 		return _segmentsExperienceLocalService.updateSegmentsExperience(
 			segmentsExperienceId, segmentsEntryId, nameMap, active);
+	}
+
+	@Override
+	public SegmentsExperience updateSegmentsExperience(
+			long segmentsExperienceId, long segmentsEntryId,
+			java.util.Map<java.util.Locale, String> nameMap, boolean active,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _segmentsExperienceLocalService.updateSegmentsExperience(
+			segmentsExperienceId, segmentsEntryId, nameMap, active,
+			typeSettingsUnicodeProperties);
 	}
 
 	/**

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceService.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.transaction.Isolation;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.segments.model.SegmentsExperience;
 
 import java.util.List;
@@ -63,9 +64,23 @@ public interface SegmentsExperienceService extends BaseService {
 			ServiceContext serviceContext)
 		throws PortalException;
 
+	public SegmentsExperience addSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			Map<Locale, String> nameMap, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 	public SegmentsExperience appendSegmentsExperience(
 			long segmentsEntryId, long classNameId, long classPK,
 			Map<Locale, String> nameMap, boolean active,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public SegmentsExperience appendSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			Map<Locale, String> nameMap, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException;
 
@@ -109,6 +124,12 @@ public interface SegmentsExperienceService extends BaseService {
 	public SegmentsExperience updateSegmentsExperience(
 			long segmentsExperienceId, long segmentsEntryId,
 			Map<Locale, String> nameMap, boolean active)
+		throws PortalException;
+
+	public SegmentsExperience updateSegmentsExperience(
+			long segmentsExperienceId, long segmentsEntryId,
+			Map<Locale, String> nameMap, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties)
 		throws PortalException;
 
 	public void updateSegmentsExperiencePriority(

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceServiceUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceServiceUtil.java
@@ -50,6 +50,20 @@ public class SegmentsExperienceServiceUtil {
 	}
 
 	public static com.liferay.segments.model.SegmentsExperience
+			addSegmentsExperience(
+				long segmentsEntryId, long classNameId, long classPK,
+				java.util.Map<java.util.Locale, String> nameMap, boolean active,
+				com.liferay.portal.kernel.util.UnicodeProperties
+					typeSettingsUnicodeProperties,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().addSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, active,
+			typeSettingsUnicodeProperties, serviceContext);
+	}
+
+	public static com.liferay.segments.model.SegmentsExperience
 			appendSegmentsExperience(
 				long segmentsEntryId, long classNameId, long classPK,
 				java.util.Map<java.util.Locale, String> nameMap, boolean active,
@@ -59,6 +73,20 @@ public class SegmentsExperienceServiceUtil {
 		return getService().appendSegmentsExperience(
 			segmentsEntryId, classNameId, classPK, nameMap, active,
 			serviceContext);
+	}
+
+	public static com.liferay.segments.model.SegmentsExperience
+			appendSegmentsExperience(
+				long segmentsEntryId, long classNameId, long classPK,
+				java.util.Map<java.util.Locale, String> nameMap, boolean active,
+				com.liferay.portal.kernel.util.UnicodeProperties
+					typeSettingsUnicodeProperties,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().appendSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, active,
+			typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	public static com.liferay.segments.model.SegmentsExperience
@@ -131,6 +159,19 @@ public class SegmentsExperienceServiceUtil {
 
 		return getService().updateSegmentsExperience(
 			segmentsExperienceId, segmentsEntryId, nameMap, active);
+	}
+
+	public static com.liferay.segments.model.SegmentsExperience
+			updateSegmentsExperience(
+				long segmentsExperienceId, long segmentsEntryId,
+				java.util.Map<java.util.Locale, String> nameMap, boolean active,
+				com.liferay.portal.kernel.util.UnicodeProperties
+					typeSettingsUnicodeProperties)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return getService().updateSegmentsExperience(
+			segmentsExperienceId, segmentsEntryId, nameMap, active,
+			typeSettingsUnicodeProperties);
 	}
 
 	public static void updateSegmentsExperiencePriority(

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceServiceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceServiceWrapper.java
@@ -47,6 +47,20 @@ public class SegmentsExperienceServiceWrapper
 	}
 
 	@Override
+	public SegmentsExperience addSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			java.util.Map<java.util.Locale, String> nameMap, boolean active,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _segmentsExperienceService.addSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, active,
+			typeSettingsUnicodeProperties, serviceContext);
+	}
+
+	@Override
 	public SegmentsExperience appendSegmentsExperience(
 			long segmentsEntryId, long classNameId, long classPK,
 			java.util.Map<java.util.Locale, String> nameMap, boolean active,
@@ -56,6 +70,20 @@ public class SegmentsExperienceServiceWrapper
 		return _segmentsExperienceService.appendSegmentsExperience(
 			segmentsEntryId, classNameId, classPK, nameMap, active,
 			serviceContext);
+	}
+
+	@Override
+	public SegmentsExperience appendSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			java.util.Map<java.util.Locale, String> nameMap, boolean active,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _segmentsExperienceService.appendSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, active,
+			typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	@Override
@@ -133,6 +161,19 @@ public class SegmentsExperienceServiceWrapper
 
 		return _segmentsExperienceService.updateSegmentsExperience(
 			segmentsExperienceId, segmentsEntryId, nameMap, active);
+	}
+
+	@Override
+	public SegmentsExperience updateSegmentsExperience(
+			long segmentsExperienceId, long segmentsEntryId,
+			java.util.Map<java.util.Locale, String> nameMap, boolean active,
+			com.liferay.portal.kernel.util.UnicodeProperties
+				typeSettingsUnicodeProperties)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _segmentsExperienceService.updateSegmentsExperience(
+			segmentsExperienceId, segmentsEntryId, nameMap, active,
+			typeSettingsUnicodeProperties);
 	}
 
 	@Override

--- a/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/model/packageinfo
+++ b/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/model/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/service/packageinfo
+++ b/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.9.0
+version 1.10.0

--- a/modules/apps/segments/segments-service/bnd.bnd
+++ b/modules/apps/segments/segments-service/bnd.bnd
@@ -1,7 +1,7 @@
 Bundle-Name: Liferay Segments Service
 Bundle-SymbolicName: com.liferay.segments.service
 Bundle-Version: 3.0.0
-Liferay-Require-SchemaVersion: 2.3.0
+Liferay-Require-SchemaVersion: 2.4.0
 Liferay-Service: true
 Provide-Capability:\
 	liferay.resource.bundle;\

--- a/modules/apps/segments/segments-service/service.xml
+++ b/modules/apps/segments/segments-service/service.xml
@@ -181,6 +181,7 @@
 		<column localized="true" name="name" type="String" />
 		<column name="priority" type="int" />
 		<column name="active" type="boolean" />
+		<column name="typeSettings" type="String" />
 		<column name="lastPublishDate" type="Date" />
 
 		<!-- Order -->

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/SegmentsServiceUpgrade.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/SegmentsServiceUpgrade.java
@@ -15,7 +15,6 @@
 package com.liferay.segments.internal.upgrade;
 
 import com.liferay.counter.kernel.service.CounterLocalService;
-import com.liferay.portal.kernel.upgrade.UpgradeCTModel;
 import com.liferay.portal.kernel.upgrade.UpgradeMVCCVersion;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 import com.liferay.segments.internal.upgrade.v2_0_0.UpgradeSchema;
@@ -57,12 +56,7 @@ public class SegmentsServiceUpgrade implements UpgradeStepRegistrator {
 			"2.1.0", "2.2.0",
 			new com.liferay.segments.internal.upgrade.v2_2_0.UpgradeSchema());
 
-		registry.register(
-			"2.2.0", "2.3.0",
-			new UpgradeCTModel(
-				"SegmentsEntry", "SegmentsEntryRel", "SegmentsEntryRole",
-				"SegmentsExperience", "SegmentsExperiment",
-				"SegmentsExperimentRel"));
+		registry.register("2.3.0", "2.4.0", new UpgradeSchema());
 	}
 
 	@Reference

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/v2_4_0/UpgradeSchema.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/v2_4_0/UpgradeSchema.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.segments.internal.upgrade.v2_4_0;
+
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.segments.internal.upgrade.v2_4_0.util.SegmentsExperienceTable;
+
+/**
+ * @author Cristina González
+ */
+public class UpgradeSchema extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		alter(
+			SegmentsExperienceTable.class,
+			new AlterTableAddColumn("typeSettings", "VARCHAR(75) null"));
+	}
+
+}

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/v2_4_0/util/SegmentsExperienceTable.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/upgrade/v2_4_0/util/SegmentsExperienceTable.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.segments.internal.upgrade.v2_4_0.util;
+
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Brian Wing Shun Chan
+ * @generated
+ */
+public class SegmentsExperienceTable {
+
+	public static final String TABLE_NAME = "SegmentsExperience";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
+		{"uuid_", Types.VARCHAR}, {"segmentsExperienceId", Types.BIGINT},
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"segmentsEntryId", Types.BIGINT},
+		{"segmentsExperienceKey", Types.VARCHAR}, {"classNameId", Types.BIGINT},
+		{"classPK", Types.BIGINT}, {"name", Types.VARCHAR},
+		{"priority", Types.INTEGER}, {"active_", Types.BOOLEAN},
+		{"typeSettings", Types.VARCHAR}, {"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
+new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("segmentsExperienceId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("segmentsEntryId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("segmentsExperienceKey", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("classNameId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("priority", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("active_", Types.BOOLEAN);
+
+TABLE_COLUMNS_MAP.put("typeSettings", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE =
+"create table SegmentsExperience (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,segmentsExperienceId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,segmentsEntryId LONG,segmentsExperienceKey VARCHAR(75) null,classNameId LONG,classPK LONG,name STRING null,priority INTEGER,active_ BOOLEAN,typeSettings VARCHAR(75) null,lastPublishDate DATE null,primary key (segmentsExperienceId, ctCollectionId))";
+
+	public static final String TABLE_SQL_DROP = "drop table SegmentsExperience";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_99B31F58 on SegmentsExperience (groupId, classNameId, classPK, active_, ctCollectionId)",
+		"create index IX_B42F674D on SegmentsExperience (groupId, classNameId, classPK, ctCollectionId)",
+		"create unique index IX_8AD425 on SegmentsExperience (groupId, classNameId, classPK, priority, ctCollectionId)",
+		"create index IX_874CAE78 on SegmentsExperience (groupId, ctCollectionId)",
+		"create index IX_F48D81CF on SegmentsExperience (groupId, segmentsEntryId, classNameId, classPK, active_, ctCollectionId)",
+		"create index IX_D78112F6 on SegmentsExperience (groupId, segmentsEntryId, classNameId, classPK, ctCollectionId)",
+		"create unique index IX_789CF949 on SegmentsExperience (groupId, segmentsExperienceKey[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create index IX_BAA8E72B on SegmentsExperience (segmentsEntryId, ctCollectionId)",
+		"create index IX_BDBB56E2 on SegmentsExperience (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId)",
+		"create index IX_7F7B2B82 on SegmentsExperience (uuid_[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create unique index IX_3C28EA64 on SegmentsExperience (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId)"
+	};
+
+}

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/model/impl/SegmentsExperienceCacheModel.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/model/impl/SegmentsExperienceCacheModel.java
@@ -78,7 +78,7 @@ public class SegmentsExperienceCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(37);
+		StringBundler sb = new StringBundler(39);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -114,6 +114,8 @@ public class SegmentsExperienceCacheModel
 		sb.append(priority);
 		sb.append(", active=");
 		sb.append(active);
+		sb.append(", typeSettings=");
+		sb.append(typeSettings);
 		sb.append(", lastPublishDate=");
 		sb.append(lastPublishDate);
 		sb.append("}");
@@ -185,6 +187,13 @@ public class SegmentsExperienceCacheModel
 		segmentsExperienceImpl.setPriority(priority);
 		segmentsExperienceImpl.setActive(active);
 
+		if (typeSettings == null) {
+			segmentsExperienceImpl.setTypeSettings("");
+		}
+		else {
+			segmentsExperienceImpl.setTypeSettings(typeSettings);
+		}
+
 		if (lastPublishDate == Long.MIN_VALUE) {
 			segmentsExperienceImpl.setLastPublishDate(null);
 		}
@@ -227,6 +236,7 @@ public class SegmentsExperienceCacheModel
 		priority = objectInput.readInt();
 
 		active = objectInput.readBoolean();
+		typeSettings = objectInput.readUTF();
 		lastPublishDate = objectInput.readLong();
 	}
 
@@ -284,6 +294,14 @@ public class SegmentsExperienceCacheModel
 		objectOutput.writeInt(priority);
 
 		objectOutput.writeBoolean(active);
+
+		if (typeSettings == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(typeSettings);
+		}
+
 		objectOutput.writeLong(lastPublishDate);
 	}
 
@@ -304,6 +322,7 @@ public class SegmentsExperienceCacheModel
 	public String name;
 	public int priority;
 	public boolean active;
+	public String typeSettings;
 	public long lastPublishDate;
 
 }

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/model/impl/SegmentsExperienceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/model/impl/SegmentsExperienceImpl.java
@@ -14,8 +14,13 @@
 
 package com.liferay.segments.model.impl;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.segments.constants.SegmentsExperimentConstants;
 import com.liferay.segments.service.SegmentsExperimentLocalServiceUtil;
+
+import java.io.IOException;
 
 /**
  * @author Eduardo García
@@ -26,10 +31,40 @@ public class SegmentsExperienceImpl extends SegmentsExperienceBaseImpl {
 	}
 
 	@Override
+	public UnicodeProperties getTypeSettingsUnicodeProperties() {
+		if (_typeSettingsUnicodeProperties == null) {
+			_typeSettingsUnicodeProperties = new UnicodeProperties(true);
+
+			try {
+				_typeSettingsUnicodeProperties.load(super.getTypeSettings());
+			}
+			catch (IOException ioException) {
+				_log.error(ioException, ioException);
+			}
+		}
+
+		return _typeSettingsUnicodeProperties;
+	}
+
+	@Override
 	public boolean hasSegmentsExperiment() {
 		return SegmentsExperimentLocalServiceUtil.hasSegmentsExperiment(
 			getSegmentsExperienceId(), getClassNameId(), getClassPK(),
 			SegmentsExperimentConstants.Status.getLockedStatusValues());
 	}
+
+	@Override
+	public void setTypeSettingsUnicodeProperties(
+		UnicodeProperties typeSettingsUnicodeProperties) {
+
+		_typeSettingsUnicodeProperties = typeSettingsUnicodeProperties;
+
+		super.setTypeSettings(_typeSettingsUnicodeProperties.toString());
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SegmentsExperienceImpl.class);
+
+	private UnicodeProperties _typeSettingsUnicodeProperties;
 
 }

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/model/impl/SegmentsExperienceModelImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/model/impl/SegmentsExperienceModelImpl.java
@@ -91,7 +91,7 @@ public class SegmentsExperienceModelImpl
 		{"segmentsExperienceKey", Types.VARCHAR}, {"classNameId", Types.BIGINT},
 		{"classPK", Types.BIGINT}, {"name", Types.VARCHAR},
 		{"priority", Types.INTEGER}, {"active_", Types.BOOLEAN},
-		{"lastPublishDate", Types.TIMESTAMP}
+		{"typeSettings", Types.VARCHAR}, {"lastPublishDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -115,11 +115,12 @@ public class SegmentsExperienceModelImpl
 		TABLE_COLUMNS_MAP.put("name", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("priority", Types.INTEGER);
 		TABLE_COLUMNS_MAP.put("active_", Types.BOOLEAN);
+		TABLE_COLUMNS_MAP.put("typeSettings", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table SegmentsExperience (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,segmentsExperienceId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,segmentsEntryId LONG,segmentsExperienceKey VARCHAR(75) null,classNameId LONG,classPK LONG,name STRING null,priority INTEGER,active_ BOOLEAN,lastPublishDate DATE null,primary key (segmentsExperienceId, ctCollectionId))";
+		"create table SegmentsExperience (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,segmentsExperienceId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,segmentsEntryId LONG,segmentsExperienceKey VARCHAR(75) null,classNameId LONG,classPK LONG,name STRING null,priority INTEGER,active_ BOOLEAN,typeSettings VARCHAR(75) null,lastPublishDate DATE null,primary key (segmentsExperienceId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table SegmentsExperience";
 
@@ -235,6 +236,7 @@ public class SegmentsExperienceModelImpl
 		model.setName(soapModel.getName());
 		model.setPriority(soapModel.getPriority());
 		model.setActive(soapModel.isActive());
+		model.setTypeSettings(soapModel.getTypeSettings());
 		model.setLastPublishDate(soapModel.getLastPublishDate());
 
 		return model;
@@ -490,6 +492,12 @@ public class SegmentsExperienceModelImpl
 			"active",
 			(BiConsumer<SegmentsExperience, Boolean>)
 				SegmentsExperience::setActive);
+		attributeGetterFunctions.put(
+			"typeSettings", SegmentsExperience::getTypeSettings);
+		attributeSetterBiConsumers.put(
+			"typeSettings",
+			(BiConsumer<SegmentsExperience, String>)
+				SegmentsExperience::setTypeSettings);
 		attributeGetterFunctions.put(
 			"lastPublishDate", SegmentsExperience::getLastPublishDate);
 		attributeSetterBiConsumers.put(
@@ -1001,6 +1009,26 @@ public class SegmentsExperienceModelImpl
 
 	@JSON
 	@Override
+	public String getTypeSettings() {
+		if (_typeSettings == null) {
+			return "";
+		}
+		else {
+			return _typeSettings;
+		}
+	}
+
+	@Override
+	public void setTypeSettings(String typeSettings) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_typeSettings = typeSettings;
+	}
+
+	@JSON
+	@Override
 	public Date getLastPublishDate() {
 		return _lastPublishDate;
 	}
@@ -1162,6 +1190,7 @@ public class SegmentsExperienceModelImpl
 		segmentsExperienceImpl.setName(getName());
 		segmentsExperienceImpl.setPriority(getPriority());
 		segmentsExperienceImpl.setActive(isActive());
+		segmentsExperienceImpl.setTypeSettings(getTypeSettings());
 		segmentsExperienceImpl.setLastPublishDate(getLastPublishDate());
 
 		segmentsExperienceImpl.resetOriginalValues();
@@ -1328,6 +1357,14 @@ public class SegmentsExperienceModelImpl
 
 		segmentsExperienceCacheModel.active = isActive();
 
+		segmentsExperienceCacheModel.typeSettings = getTypeSettings();
+
+		String typeSettings = segmentsExperienceCacheModel.typeSettings;
+
+		if ((typeSettings != null) && (typeSettings.length() == 0)) {
+			segmentsExperienceCacheModel.typeSettings = null;
+		}
+
 		Date lastPublishDate = getLastPublishDate();
 
 		if (lastPublishDate != null) {
@@ -1430,6 +1467,7 @@ public class SegmentsExperienceModelImpl
 	private String _nameCurrentLanguageId;
 	private int _priority;
 	private boolean _active;
+	private String _typeSettings;
 	private Date _lastPublishDate;
 
 	public <T> T getColumnValue(String columnName) {
@@ -1480,6 +1518,7 @@ public class SegmentsExperienceModelImpl
 		_columnOriginalValues.put("name", _name);
 		_columnOriginalValues.put("priority", _priority);
 		_columnOriginalValues.put("active_", _active);
+		_columnOriginalValues.put("typeSettings", _typeSettings);
 		_columnOriginalValues.put("lastPublishDate", _lastPublishDate);
 	}
 
@@ -1539,7 +1578,9 @@ public class SegmentsExperienceModelImpl
 
 		columnBitmasks.put("active_", 65536L);
 
-		columnBitmasks.put("lastPublishDate", 131072L);
+		columnBitmasks.put("typeSettings", 131072L);
+
+		columnBitmasks.put("lastPublishDate", 262144L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/http/SegmentsExperienceServiceHttp.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/http/SegmentsExperienceServiceHttp.java
@@ -97,6 +97,53 @@ public class SegmentsExperienceServiceHttp {
 	}
 
 	public static com.liferay.segments.model.SegmentsExperience
+			addSegmentsExperience(
+				HttpPrincipal httpPrincipal, long segmentsEntryId,
+				long classNameId, long classPK,
+				java.util.Map<java.util.Locale, String> nameMap, boolean active,
+				com.liferay.portal.kernel.util.UnicodeProperties
+					typeSettingsUnicodeProperties,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				SegmentsExperienceServiceUtil.class, "addSegmentsExperience",
+				_addSegmentsExperienceParameterTypes1);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, segmentsEntryId, classNameId, classPK, nameMap,
+				active, typeSettingsUnicodeProperties, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.segments.model.SegmentsExperience)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.segments.model.SegmentsExperience
 			appendSegmentsExperience(
 				HttpPrincipal httpPrincipal, long segmentsEntryId,
 				long classNameId, long classPK,
@@ -107,11 +154,58 @@ public class SegmentsExperienceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class, "appendSegmentsExperience",
-				_appendSegmentsExperienceParameterTypes1);
+				_appendSegmentsExperienceParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsEntryId, classNameId, classPK, nameMap,
 				active, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.segments.model.SegmentsExperience)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.segments.model.SegmentsExperience
+			appendSegmentsExperience(
+				HttpPrincipal httpPrincipal, long segmentsEntryId,
+				long classNameId, long classPK,
+				java.util.Map<java.util.Locale, String> nameMap, boolean active,
+				com.liferay.portal.kernel.util.UnicodeProperties
+					typeSettingsUnicodeProperties,
+				com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				SegmentsExperienceServiceUtil.class, "appendSegmentsExperience",
+				_appendSegmentsExperienceParameterTypes3);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, segmentsEntryId, classNameId, classPK, nameMap,
+				active, typeSettingsUnicodeProperties, serviceContext);
 
 			Object returnObj = null;
 
@@ -149,7 +243,7 @@ public class SegmentsExperienceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class, "deleteSegmentsExperience",
-				_deleteSegmentsExperienceParameterTypes2);
+				_deleteSegmentsExperienceParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsExperienceId);
@@ -191,7 +285,7 @@ public class SegmentsExperienceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class, "fetchSegmentsExperience",
-				_fetchSegmentsExperienceParameterTypes3);
+				_fetchSegmentsExperienceParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, segmentsExperienceKey);
@@ -232,7 +326,7 @@ public class SegmentsExperienceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class, "getSegmentsExperience",
-				_getSegmentsExperienceParameterTypes4);
+				_getSegmentsExperienceParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsExperienceId);
@@ -274,7 +368,7 @@ public class SegmentsExperienceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class, "getSegmentsExperiences",
-				_getSegmentsExperiencesParameterTypes5);
+				_getSegmentsExperiencesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classPK, active);
@@ -320,7 +414,7 @@ public class SegmentsExperienceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class, "getSegmentsExperiences",
-				_getSegmentsExperiencesParameterTypes6);
+				_getSegmentsExperiencesParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classPK, active, start, end,
@@ -364,7 +458,7 @@ public class SegmentsExperienceServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class,
 				"getSegmentsExperiencesCount",
-				_getSegmentsExperiencesCountParameterTypes7);
+				_getSegmentsExperiencesCountParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classPK, active);
@@ -407,11 +501,57 @@ public class SegmentsExperienceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class, "updateSegmentsExperience",
-				_updateSegmentsExperienceParameterTypes8);
+				_updateSegmentsExperienceParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsExperienceId, segmentsEntryId, nameMap,
 				active);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.segments.model.SegmentsExperience)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.segments.model.SegmentsExperience
+			updateSegmentsExperience(
+				HttpPrincipal httpPrincipal, long segmentsExperienceId,
+				long segmentsEntryId,
+				java.util.Map<java.util.Locale, String> nameMap, boolean active,
+				com.liferay.portal.kernel.util.UnicodeProperties
+					typeSettingsUnicodeProperties)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				SegmentsExperienceServiceUtil.class, "updateSegmentsExperience",
+				_updateSegmentsExperienceParameterTypes11);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, segmentsExperienceId, segmentsEntryId, nameMap,
+				active, typeSettingsUnicodeProperties);
 
 			Object returnObj = null;
 
@@ -450,7 +590,7 @@ public class SegmentsExperienceServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class,
 				"updateSegmentsExperiencePriority",
-				_updateSegmentsExperiencePriorityParameterTypes9);
+				_updateSegmentsExperiencePriorityParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsExperienceId, newPriority);
@@ -488,35 +628,54 @@ public class SegmentsExperienceServiceHttp {
 			boolean.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _appendSegmentsExperienceParameterTypes1 =
+	private static final Class<?>[] _addSegmentsExperienceParameterTypes1 =
+		new Class[] {
+			long.class, long.class, long.class, java.util.Map.class,
+			boolean.class,
+			com.liferay.portal.kernel.util.UnicodeProperties.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _appendSegmentsExperienceParameterTypes2 =
 		new Class[] {
 			long.class, long.class, long.class, java.util.Map.class,
 			boolean.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _deleteSegmentsExperienceParameterTypes2 =
+	private static final Class<?>[] _appendSegmentsExperienceParameterTypes3 =
+		new Class[] {
+			long.class, long.class, long.class, java.util.Map.class,
+			boolean.class,
+			com.liferay.portal.kernel.util.UnicodeProperties.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _deleteSegmentsExperienceParameterTypes4 =
 		new Class[] {long.class};
-	private static final Class<?>[] _fetchSegmentsExperienceParameterTypes3 =
+	private static final Class<?>[] _fetchSegmentsExperienceParameterTypes5 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _getSegmentsExperienceParameterTypes4 =
+	private static final Class<?>[] _getSegmentsExperienceParameterTypes6 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getSegmentsExperiencesParameterTypes5 =
+	private static final Class<?>[] _getSegmentsExperiencesParameterTypes7 =
 		new Class[] {long.class, long.class, long.class, boolean.class};
-	private static final Class<?>[] _getSegmentsExperiencesParameterTypes6 =
+	private static final Class<?>[] _getSegmentsExperiencesParameterTypes8 =
 		new Class[] {
 			long.class, long.class, long.class, boolean.class, int.class,
 			int.class, com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getSegmentsExperiencesCountParameterTypes7 = new Class[] {
+		_getSegmentsExperiencesCountParameterTypes9 = new Class[] {
 			long.class, long.class, long.class, boolean.class
 		};
-	private static final Class<?>[] _updateSegmentsExperienceParameterTypes8 =
+	private static final Class<?>[] _updateSegmentsExperienceParameterTypes10 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class, boolean.class
 		};
+	private static final Class<?>[] _updateSegmentsExperienceParameterTypes11 =
+		new Class[] {
+			long.class, long.class, java.util.Map.class, boolean.class,
+			com.liferay.portal.kernel.util.UnicodeProperties.class
+		};
 	private static final Class<?>[]
-		_updateSegmentsExperiencePriorityParameterTypes9 = new Class[] {
+		_updateSegmentsExperiencePriorityParameterTypes12 = new Class[] {
 			long.class, int.class
 		};
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
@@ -440,6 +440,22 @@ public class SegmentsExperienceLocalServiceImpl
 			Map<Locale, String> nameMap, boolean active)
 		throws PortalException {
 
+		SegmentsExperience segmentsExperience =
+			segmentsExperiencePersistence.findByPrimaryKey(
+				segmentsExperienceId);
+
+		return updateSegmentsExperience(
+			segmentsExperienceId, segmentsEntryId, nameMap, active,
+			segmentsExperience.getTypeSettingsUnicodeProperties());
+	}
+
+	@Override
+	public SegmentsExperience updateSegmentsExperience(
+			long segmentsExperienceId, long segmentsEntryId,
+			Map<Locale, String> nameMap, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties)
+		throws PortalException {
+
 		_validateName(nameMap);
 
 		SegmentsExperience segmentsExperience =
@@ -455,6 +471,8 @@ public class SegmentsExperienceLocalServiceImpl
 		segmentsExperience.setSegmentsEntryId(segmentsEntryId);
 		segmentsExperience.setNameMap(nameMap);
 		segmentsExperience.setActive(active);
+		segmentsExperience.setTypeSettingsUnicodeProperties(
+			typeSettingsUnicodeProperties);
 
 		return segmentsExperiencePersistence.update(segmentsExperience);
 	}

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.exception.LockedSegmentsExperimentException;
@@ -64,6 +65,19 @@ public class SegmentsExperienceLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
+		return addSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, active,
+			new UnicodeProperties(true), serviceContext);
+	}
+
+	@Override
+	public SegmentsExperience addSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			Map<Locale, String> nameMap, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties,
+			ServiceContext serviceContext)
+		throws PortalException {
+
 		int lowestPriority = _getLowestPriority(
 			serviceContext.getScopeGroupId(), classNameId,
 			_getPublishedLayoutClassPK(classPK));
@@ -76,13 +90,26 @@ public class SegmentsExperienceLocalServiceImpl
 
 		return addSegmentsExperience(
 			segmentsEntryId, classNameId, classPK, nameMap, lowestPriority - 1,
-			active, serviceContext);
+			active, typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	@Override
 	public SegmentsExperience addSegmentsExperience(
 			long segmentsEntryId, long classNameId, long classPK,
 			Map<Locale, String> nameMap, int priority, boolean active,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return addSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, priority, active,
+			new UnicodeProperties(true), serviceContext);
+	}
+
+	@Override
+	public SegmentsExperience addSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			Map<Locale, String> nameMap, int priority, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -118,6 +145,8 @@ public class SegmentsExperienceLocalServiceImpl
 		segmentsExperience.setNameMap(nameMap);
 		segmentsExperience.setPriority(priority);
 		segmentsExperience.setActive(active);
+		segmentsExperience.setTypeSettingsUnicodeProperties(
+			typeSettingsUnicodeProperties);
 
 		segmentsExperience = segmentsExperiencePersistence.update(
 			segmentsExperience);
@@ -137,6 +166,19 @@ public class SegmentsExperienceLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
+		return appendSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, active,
+			new UnicodeProperties(true), serviceContext);
+	}
+
+	@Override
+	public SegmentsExperience appendSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			Map<Locale, String> nameMap, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties,
+			ServiceContext serviceContext)
+		throws PortalException {
+
 		int highestPriority = _getHighestPriority(
 			serviceContext.getScopeGroupId(), classNameId,
 			_getPublishedLayoutClassPK(classPK));
@@ -149,7 +191,7 @@ public class SegmentsExperienceLocalServiceImpl
 
 		return addSegmentsExperience(
 			segmentsEntryId, classNameId, classPK, nameMap, highestPriority + 1,
-			active, serviceContext);
+			active, typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceServiceImpl.java
@@ -213,6 +213,21 @@ public class SegmentsExperienceServiceImpl
 			Map<Locale, String> nameMap, boolean active)
 		throws PortalException {
 
+		SegmentsExperience segmentsExperience = getSegmentsExperience(
+			segmentsExperienceId);
+
+		return updateSegmentsExperience(
+			segmentsExperienceId, segmentsEntryId, nameMap, active,
+			segmentsExperience.getTypeSettingsUnicodeProperties());
+	}
+
+	@Override
+	public SegmentsExperience updateSegmentsExperience(
+			long segmentsExperienceId, long segmentsEntryId,
+			Map<Locale, String> nameMap, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties)
+		throws PortalException {
+
 		_segmentsExperienceResourcePermission.check(
 			getPermissionChecker(),
 			segmentsExperienceLocalService.getSegmentsExperience(
@@ -220,7 +235,8 @@ public class SegmentsExperienceServiceImpl
 			ActionKeys.UPDATE);
 
 		return segmentsExperienceLocalService.updateSegmentsExperience(
-			segmentsExperienceId, segmentsEntryId, nameMap, active);
+			segmentsExperienceId, segmentsEntryId, nameMap, active,
+			typeSettingsUnicodeProperties);
 	}
 
 	@Override

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceServiceImpl.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.security.permission.resource.PortletResourcePer
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.segments.constants.SegmentsActionKeys;
 import com.liferay.segments.constants.SegmentsConstants;
 import com.liferay.segments.model.SegmentsExperience;
@@ -55,6 +56,19 @@ public class SegmentsExperienceServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
+		return addSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, active,
+			new UnicodeProperties(true), serviceContext);
+	}
+
+	@Override
+	public SegmentsExperience addSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			Map<Locale, String> nameMap, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties,
+			ServiceContext serviceContext)
+		throws PortalException {
+
 		if (!_hasUpdateLayoutPermission(_getPublishedLayoutClassPK(classPK))) {
 			_portletResourcePermission.check(
 				getPermissionChecker(), serviceContext.getScopeGroupId(),
@@ -63,13 +77,26 @@ public class SegmentsExperienceServiceImpl
 
 		return segmentsExperienceLocalService.addSegmentsExperience(
 			segmentsEntryId, classNameId, classPK, nameMap, active,
-			serviceContext);
+			typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	@Override
 	public SegmentsExperience appendSegmentsExperience(
 			long segmentsEntryId, long classNameId, long classPK,
 			Map<Locale, String> nameMap, boolean active,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return appendSegmentsExperience(
+			segmentsEntryId, classNameId, classPK, nameMap, active,
+			new UnicodeProperties(true), serviceContext);
+	}
+
+	@Override
+	public SegmentsExperience appendSegmentsExperience(
+			long segmentsEntryId, long classNameId, long classPK,
+			Map<Locale, String> nameMap, boolean active,
+			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -81,7 +108,7 @@ public class SegmentsExperienceServiceImpl
 
 		return segmentsExperienceLocalService.appendSegmentsExperience(
 			segmentsEntryId, classNameId, classPK, nameMap, active,
-			serviceContext);
+			typeSettingsUnicodeProperties, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/persistence/impl/SegmentsExperiencePersistenceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/persistence/impl/SegmentsExperiencePersistenceImpl.java
@@ -11454,6 +11454,7 @@ public class SegmentsExperiencePersistenceImpl
 		ctStrictColumnNames.add("name");
 		ctStrictColumnNames.add("priority");
 		ctStrictColumnNames.add("active_");
+		ctStrictColumnNames.add("typeSettings");
 		ctStrictColumnNames.add("lastPublishDate");
 
 		_ctColumnNamesMap.put(

--- a/modules/apps/segments/segments-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/segments/segments-service/src/main/resources/META-INF/module-hbm.xml
@@ -80,6 +80,7 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="name" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="priority" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" column="active_" name="active" type="com.liferay.portal.dao.orm.hibernate.BooleanType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="typeSettings" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="lastPublishDate" type="org.hibernate.type.TimestampType" />
 	</class>
 	<class dynamic-update="true" name="com.liferay.segments.model.impl.SegmentsExperimentImpl" table="SegmentsExperiment">

--- a/modules/apps/segments/segments-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/segments/segments-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -69,6 +69,7 @@
 		<field localized="true" name="name" type="String" />
 		<field name="priority" type="int" />
 		<field name="active" type="boolean" />
+		<field name="typeSettings" type="String" />
 		<field name="lastPublishDate" type="Date" />
 	</model>
 	<model name="com.liferay.segments.model.SegmentsExperiment">

--- a/modules/apps/segments/segments-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/segments/segments-service/src/main/resources/META-INF/sql/tables.sql
@@ -68,6 +68,7 @@ create table SegmentsExperience (
 	name STRING null,
 	priority INTEGER,
 	active_ BOOLEAN,
+	typeSettings VARCHAR(75) null,
 	lastPublishDate DATE null,
 	primary key (segmentsExperienceId, ctCollectionId)
 );

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperiencePersistenceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/persistence/test/SegmentsExperiencePersistenceTest.java
@@ -158,6 +158,8 @@ public class SegmentsExperiencePersistenceTest {
 
 		newSegmentsExperience.setActive(RandomTestUtil.randomBoolean());
 
+		newSegmentsExperience.setTypeSettings(RandomTestUtil.randomString());
+
 		newSegmentsExperience.setLastPublishDate(RandomTestUtil.nextDate());
 
 		_segmentsExperiences.add(_persistence.update(newSegmentsExperience));
@@ -218,6 +220,9 @@ public class SegmentsExperiencePersistenceTest {
 		Assert.assertEquals(
 			existingSegmentsExperience.isActive(),
 			newSegmentsExperience.isActive());
+		Assert.assertEquals(
+			existingSegmentsExperience.getTypeSettings(),
+			newSegmentsExperience.getTypeSettings());
 		Assert.assertEquals(
 			Time.getShortTimestamp(
 				existingSegmentsExperience.getLastPublishDate()),
@@ -385,8 +390,8 @@ public class SegmentsExperiencePersistenceTest {
 			"companyId", true, "userId", true, "userName", true, "createDate",
 			true, "modifiedDate", true, "segmentsEntryId", true,
 			"segmentsExperienceKey", true, "classNameId", true, "classPK", true,
-			"name", true, "priority", true, "active", true, "lastPublishDate",
-			true);
+			"name", true, "priority", true, "active", true, "typeSettings",
+			true, "lastPublishDate", true);
 	}
 
 	@Test
@@ -746,6 +751,8 @@ public class SegmentsExperiencePersistenceTest {
 		segmentsExperience.setPriority(RandomTestUtil.nextInt());
 
 		segmentsExperience.setActive(RandomTestUtil.randomBoolean());
+
+		segmentsExperience.setTypeSettings(RandomTestUtil.randomString());
 
 		segmentsExperience.setLastPublishDate(RandomTestUtil.nextDate());
 

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
@@ -468,16 +468,29 @@ public class SegmentsExperienceLocalServiceTest {
 		Map<Locale, String> nameMap = RandomTestUtil.randomLocaleStringMap();
 		boolean active = RandomTestUtil.randomBoolean();
 
+		UnicodeProperties initialTypeSettingsUnicodeProperties =
+			new UnicodeProperties(true);
+
+		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
+
 		SegmentsExperience updatedSegmentsExperience =
 			_segmentsExperienceLocalService.updateSegmentsExperience(
 				segmentsExperience.getSegmentsExperienceId(),
-				segmentsEntry.getSegmentsEntryId(), nameMap, active);
+				segmentsEntry.getSegmentsEntryId(), nameMap, active,
+				initialTypeSettingsUnicodeProperties);
 
 		Assert.assertEquals(
 			segmentsEntry.getSegmentsEntryId(),
 			updatedSegmentsExperience.getSegmentsEntryId());
 		Assert.assertEquals(nameMap, updatedSegmentsExperience.getNameMap());
 		Assert.assertEquals(active, updatedSegmentsExperience.isActive());
+
+		UnicodeProperties actualTypeSettingsUnicodeProperties =
+			updatedSegmentsExperience.getTypeSettingsUnicodeProperties();
+
+		Assert.assertEquals(
+			"value",
+			actualTypeSettingsUnicodeProperties.getProperty("property"));
 	}
 
 	@Test
@@ -710,6 +723,37 @@ public class SegmentsExperienceLocalServiceTest {
 		Assert.assertEquals(
 			SegmentsExperienceConstants.PRIORITY_DEFAULT - 2,
 			segmentsExperience2.getPriority());
+	}
+
+	@Test
+	public void testUpdateSegmentsExperienceWithoutTypeSettings()
+		throws Exception {
+
+		UnicodeProperties initialTypeSettingsUnicodeProperties =
+			new UnicodeProperties(true);
+
+		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.appendSegmentsExperience(
+				SegmentsEntryConstants.ID_DEFAULT, _classNameId, _classPK,
+				RandomTestUtil.randomLocaleStringMap(), true,
+				initialTypeSettingsUnicodeProperties,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		SegmentsExperience updatedSegmentsExperience =
+			_segmentsExperienceLocalService.updateSegmentsExperience(
+				segmentsExperience.getSegmentsExperienceId(),
+				SegmentsEntryConstants.ID_DEFAULT,
+				RandomTestUtil.randomLocaleStringMap(),
+				RandomTestUtil.randomBoolean());
+
+		UnicodeProperties actualTypeSettingsUnicodeProperties =
+			updatedSegmentsExperience.getTypeSettingsUnicodeProperties();
+
+		Assert.assertEquals(
+			"value",
+			actualTypeSettingsUnicodeProperties.getProperty("property"));
 	}
 
 	@Test(expected = LockedSegmentsExperimentException.class)

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceLocalServiceTest.java
@@ -16,6 +16,7 @@ package com.liferay.segments.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
@@ -30,6 +31,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.segments.constants.SegmentsEntryConstants;
@@ -112,6 +114,8 @@ public class SegmentsExperienceLocalServiceTest {
 		Assert.assertEquals(_classPK, segmentsExperience.getClassPK());
 		Assert.assertEquals(nameMap, segmentsExperience.getNameMap());
 		Assert.assertEquals(active, segmentsExperience.isActive());
+		Assert.assertEquals(
+			StringPool.BLANK, segmentsExperience.getTypeSettings());
 
 		Assert.assertEquals(
 			1,
@@ -192,6 +196,77 @@ public class SegmentsExperienceLocalServiceTest {
 			1,
 			_segmentsExperienceLocalService.getSegmentsExperiencesCount(
 				_group.getGroupId(), _classNameId, _classPK, active));
+	}
+
+	@Test
+	public void testAddSegmentsExperienceWithTypeSetting() throws Exception {
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		UnicodeProperties initialTypeSettingsUnicodeProperties =
+			new UnicodeProperties(true);
+
+		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.addSegmentsExperience(
+				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
+				RandomTestUtil.randomLocaleStringMap(),
+				RandomTestUtil.randomInt(), RandomTestUtil.randomBoolean(),
+				initialTypeSettingsUnicodeProperties,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		UnicodeProperties actualTypeSettingsUnicodeProperties =
+			segmentsExperience.getTypeSettingsUnicodeProperties();
+
+		Assert.assertEquals(
+			"value",
+			actualTypeSettingsUnicodeProperties.getProperty("property"));
+	}
+
+	@Test
+	public void testAppendSegmentsExperience() throws Exception {
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+		Map<Locale, String> nameMap = RandomTestUtil.randomLocaleStringMap();
+		boolean active = RandomTestUtil.randomBoolean();
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.appendSegmentsExperience(
+				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
+				nameMap, active,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Assert.assertEquals(
+			segmentsEntry.getSegmentsEntryId(),
+			segmentsExperience.getSegmentsEntryId());
+		Assert.assertEquals(_classNameId, segmentsExperience.getClassNameId());
+		Assert.assertEquals(_classPK, segmentsExperience.getClassPK());
+		Assert.assertEquals(nameMap, segmentsExperience.getNameMap());
+		Assert.assertEquals(active, segmentsExperience.isActive());
+		Assert.assertEquals(
+			SegmentsExperienceConstants.PRIORITY_DEFAULT + 1,
+			segmentsExperience.getPriority());
+		Assert.assertEquals(
+			StringPool.BLANK, segmentsExperience.getTypeSettings());
+	}
+
+	@Test
+	public void testAppendSegmentsExperienceWithoutTypeSettings()
+		throws Exception {
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.appendSegmentsExperience(
+				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
+				RandomTestUtil.randomLocaleStringMap(),
+				RandomTestUtil.randomBoolean(),
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		Assert.assertEquals(
+			StringPool.BLANK, segmentsExperience.getTypeSettings());
 	}
 
 	@Test

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceServiceTest.java
@@ -627,6 +627,74 @@ public class SegmentsExperienceServiceTest {
 		}
 	}
 
+	@Test
+	public void testUpdateSegmentsExperience() throws Exception {
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceService.addSegmentsExperience(
+				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
+				RandomTestUtil.randomLocaleStringMap(), true,
+				ServiceContextTestUtil.getServiceContext(
+					_group, TestPropsValues.getUserId()));
+
+		UnicodeProperties initialTypeSettingsUnicodeProperties =
+			new UnicodeProperties(true);
+
+		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
+
+		SegmentsExperience updatedSegmentsExperience =
+			_segmentsExperienceService.updateSegmentsExperience(
+				segmentsExperience.getSegmentsExperienceId(),
+				RandomTestUtil.randomLong(),
+				RandomTestUtil.randomLocaleStringMap(),
+				RandomTestUtil.randomBoolean(),
+				initialTypeSettingsUnicodeProperties);
+
+		UnicodeProperties actualTypeSettingsUnicodeProperties =
+			updatedSegmentsExperience.getTypeSettingsUnicodeProperties();
+
+		Assert.assertEquals(
+			"value",
+			actualTypeSettingsUnicodeProperties.getProperty("property"));
+	}
+
+	@Test
+	public void testUpdateSegmentsExperienceWithoutTypeSettings()
+		throws Exception {
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		UnicodeProperties initialTypeSettingsUnicodeProperties =
+			new UnicodeProperties(true);
+
+		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceService.addSegmentsExperience(
+				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
+				RandomTestUtil.randomLocaleStringMap(), true,
+				initialTypeSettingsUnicodeProperties,
+				ServiceContextTestUtil.getServiceContext(
+					_group, TestPropsValues.getUserId()));
+
+		SegmentsExperience updatedSegmentsExperience =
+			_segmentsExperienceService.updateSegmentsExperience(
+				segmentsExperience.getSegmentsExperienceId(),
+				RandomTestUtil.randomLong(),
+				RandomTestUtil.randomLocaleStringMap(),
+				RandomTestUtil.randomBoolean());
+
+		UnicodeProperties actualTypeSettingsUnicodeProperties =
+			updatedSegmentsExperience.getTypeSettingsUnicodeProperties();
+
+		Assert.assertEquals(
+			"value",
+			actualTypeSettingsUnicodeProperties.getProperty("property"));
+	}
+
 	@Test(expected = PrincipalException.MustHavePermission.class)
 	public void testUpdateSegmentsExperienceWithoutUpdatePermission()
 		throws Exception {

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceServiceTest.java
@@ -16,6 +16,7 @@ package com.liferay.segments.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -40,6 +41,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -96,6 +98,32 @@ public class SegmentsExperienceServiceTest {
 	}
 
 	@Test
+	public void testAddSegmentsExperience() throws Exception {
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		UnicodeProperties initialTypeSettingsUnicodeProperties =
+			new UnicodeProperties(true);
+
+		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceService.addSegmentsExperience(
+				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
+				RandomTestUtil.randomLocaleStringMap(), true,
+				initialTypeSettingsUnicodeProperties,
+				ServiceContextTestUtil.getServiceContext(
+					_group, TestPropsValues.getUserId()));
+
+		UnicodeProperties actualTypeSettingsUnicodeProperties =
+			segmentsExperience.getTypeSettingsUnicodeProperties();
+
+		Assert.assertEquals(
+			"value",
+			actualTypeSettingsUnicodeProperties.getProperty("property"));
+	}
+
+	@Test
 	public void testAddSegmentsExperienceWithManageSegmentsEntriesPermission()
 		throws Exception {
 
@@ -142,6 +170,68 @@ public class SegmentsExperienceServiceTest {
 				ServiceContextTestUtil.getServiceContext(
 					_group, _user.getUserId()));
 		}
+	}
+
+	@Test
+	public void testAddSegmentsExperienceWithoutTypeSettings()
+		throws Exception {
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceService.addSegmentsExperience(
+				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
+				RandomTestUtil.randomLocaleStringMap(), true,
+				ServiceContextTestUtil.getServiceContext(
+					_group, TestPropsValues.getUserId()));
+
+		Assert.assertEquals(
+			StringPool.BLANK, segmentsExperience.getTypeSettings());
+	}
+
+	@Test
+	public void testAppendSegmentsExperience() throws Exception {
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		UnicodeProperties initialTypeSettingsUnicodeProperties =
+			new UnicodeProperties(true);
+
+		initialTypeSettingsUnicodeProperties.setProperty("property", "value");
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceService.appendSegmentsExperience(
+				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
+				RandomTestUtil.randomLocaleStringMap(), true,
+				initialTypeSettingsUnicodeProperties,
+				ServiceContextTestUtil.getServiceContext(
+					_group, TestPropsValues.getUserId()));
+
+		UnicodeProperties actualTypeSettingsUnicodeProperties =
+			segmentsExperience.getTypeSettingsUnicodeProperties();
+
+		Assert.assertEquals(
+			"value",
+			actualTypeSettingsUnicodeProperties.getProperty("property"));
+	}
+
+	@Test
+	public void testAppendSegmentsExperienceWithoutTypeSettings()
+		throws Exception {
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceService.appendSegmentsExperience(
+				segmentsEntry.getSegmentsEntryId(), _classNameId, _classPK,
+				RandomTestUtil.randomLocaleStringMap(), true,
+				ServiceContextTestUtil.getServiceContext(
+					_group, TestPropsValues.getUserId()));
+
+		Assert.assertEquals(
+			StringPool.BLANK, segmentsExperience.getTypeSettings());
 	}
 
 	@Test


### PR DESCRIPTION
**Description**

So far we’ve kept as separated features experience variations and translation variations, but there are use cases where both are involved or one interferes in the other one. For example, when creating experiences targeting locales’ segments, multi-language feature becomes useless and fuzzy. So in this story we are proposing that the user will decide which locales s/he wants to translate into when creating an experience.

For more information or see acceptance criteria, see https://issues.liferay.com/browse/LPS-124170.

**Solution**

- Add possibility to select languages inside the experience modal
- The user can select/deselect languages with the experience modal when creating or editing an experience
- The languages dropdown in the Toolbar now shows the experience languages instead of the site ones
- The languages dropdown in the PreviewModal now shoes the experience languages instead of the site ones
- If the user select a language and change the experience, if the experience has the selected language, the page displays that language, if not, the default language is shown. It happens in Toolbar languages dropdown and PreviewModal language dropdown
- If the user has a localizable fragment in the page, the language icon should show the same as the selected in the languages dropdown in the Toolbar

The selected languageIds for every experience could be obtained from the field languageIds inside `state.availableSegmentsExperiences`: `languageIds: ['en_US', 'es_ES']`.

The available locales information will be sent to the frontend following the next schema:

```
"availableLanguages":{
   es_ES: {
      "default": true,
      "displayName": "Spanish (Spain)",
      "languageIcon": "es-es",
      "languageId": "es_ES",
      "w3cLanguageId": "es-ES"
   },
   en_US: {
      "default": false,
      "displayName": "English (United States)",
      "languageIcon": "en-us",
      "languageId": "en_US",
      "w3cLanguageId": "en-US"
   },
   ...
}
```

**Review only frontend changes** 

From https://github.com/liferay-echo/liferay-portal/pull/3701/commits/0a30c4faad2ee86e6c04dd95d6039e2ed0077625 till the end of the pull request 😃 

**Screenshots**

![Screenshot 2021-02-09 at 19 06 13](https://user-images.githubusercontent.com/15845466/107407536-115bb580-6b0a-11eb-8eab-feb055ca325f.png)

<img width="400" src="https://user-images.githubusercontent.com/15845466/107406881-3e5b9880-6b09-11eb-8b1d-dfb7bd68582c.png" />

![Screenshot 2021-02-09 at 19 06 44](https://user-images.githubusercontent.com/15845466/107407549-1587d300-6b0a-11eb-93f3-4f8826407570.png)

![Screenshot 2021-02-09 at 19 10 06](https://user-images.githubusercontent.com/15845466/107407829-71eaf280-6b0a-11eb-9578-5c0d61f219e0.png)
