### PR TITLE
[TS] LPS-127700

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ShortcutManager.js
@@ -42,6 +42,9 @@ const ctrlOrMeta = (event) =>
 const isEditableField = (element) =>
 	!!element.closest('.page-editor__editable');
 
+const isEditingEditableField = () =>
+	!!document.activeElement.getAttribute('contenteditable');
+
 const isInteractiveElement = (element) => {
 	return (
 		['INPUT', 'OPTION', 'SELECT', 'TEXTAREA'].includes(element.tagName) ||
@@ -200,7 +203,8 @@ export default function ShortcutManager() {
 			canBeExecuted: (event) =>
 				(isEditableField(event.target) ||
 					!isInteractiveElement(event.target)) &&
-				!isWithinIframe(),
+				!isWithinIframe() &&
+				!isEditingEditableField(),
 			isKeyCombination: (event) =>
 				ctrlOrMeta(event) &&
 				event.keyCode === Z_KEYCODE &&


### PR DESCRIPTION
[LPS-127700](https://issues.liferay.com/browse/LPS-127700)

From @jesseyeh-liferay

> While editing fragments, using Ctrl+Z does not undo text changes. This is due to [LPS-120261](https://issues.liferay.com/browse/LPS-120261), which overrides the browser's default Ctrl+Z behavior. Per [PTR-2233](https://issues.liferay.com/browse/PTR-2233), this solution makes it so that Ctrl+Z will undo text changes, but only if the user is actively editing text. Otherwise, Ctrl+Z will undo changes listed within the saved actions history instead.