### PR TITLE
[TS] LPS-127637 Use article instead of articleDisplay to improve performance

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -548,14 +548,14 @@ public class JournalContentDisplayContext {
 			return _latestArticle;
 		}
 
-		JournalArticleDisplay articleDisplay = getArticleDisplay();
+		JournalArticle article = getArticle();
 
-		if (articleDisplay == null) {
+		if (article == null) {
 			return null;
 		}
 
 		_latestArticle = JournalArticleLocalServiceUtil.fetchLatestArticle(
-			articleDisplay.getGroupId(), articleDisplay.getArticleId(),
+			article.getGroupId(), article.getArticleId(),
 			WorkflowConstants.STATUS_ANY);
 
 		return _latestArticle;
@@ -1076,15 +1076,15 @@ public class JournalContentDisplayContext {
 	private DDMTemplate _getDDMTemplate(String ddmTemplateKey)
 		throws PortalException {
 
-		JournalArticleDisplay articleDisplay = getArticleDisplay();
+		JournalArticle article = getArticle();
 
-		if (articleDisplay == null) {
+		if (article == null) {
 			return null;
 		}
 
 		return DDMTemplateLocalServiceUtil.fetchTemplate(
-			articleDisplay.getGroupId(), _ddmStructureClassNameId,
-			ddmTemplateKey, true);
+			article.getGroupId(), _ddmStructureClassNameId, ddmTemplateKey,
+			true);
 	}
 
 	private static final boolean _STAGING_LIVE_GROUP_LOCKING_ENABLED =


### PR DESCRIPTION
Hi Team,

I've found that in some cases articleDisplay can be substituted with article to increase performance in some edge cases when caching is disabled and JournalContentPortlet is embedded in another JournalContentPortlet.

Can you please review?
https://issues.liferay.com/browse/LPS-127637

Thanks,
Balázs