### PR TITLE
LPS-127107 Resolve layout friendly URL in view mode for links

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-api/src/main/java/com/liferay/fragment/entry/processor/helper/FragmentEntryProcessorHelper.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-api/src/main/java/com/liferay/fragment/entry/processor/helper/FragmentEntryProcessorHelper.java
@@ -48,6 +48,11 @@ public interface FragmentEntryProcessorHelper {
 			FragmentEntryProcessorContext fragmentEntryProcessorContext)
 		throws PortalException;
 
+	public Object getMappedLayoutValue(
+			JSONObject jsonObject,
+			FragmentEntryProcessorContext fragmentEntryProcessorContext)
+		throws PortalException;
+
 	public Object getMappedValue(
 			JSONObject jsonObject,
 			Map<Long, Map<String, Object>> infoDisplaysFieldValues,
@@ -77,6 +82,8 @@ public interface FragmentEntryProcessorHelper {
 	public boolean isMapped(JSONObject jsonObject);
 
 	public boolean isMappedCollection(JSONObject jsonObject);
+
+	public boolean isMappedLayout(JSONObject jsonObject);
 
 	public String processTemplate(
 			String html,

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/mapper/LinkEditableElementMapper.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/mapper/LinkEditableElementMapper.java
@@ -64,11 +64,13 @@ public class LinkEditableElementMapper implements EditableElementMapper {
 				fragmentEntryProcessorContext.getMode());
 		boolean collectionMapped =
 			_fragmentEntryProcessorHelper.isMappedCollection(configJSONObject);
+		boolean layoutMapped = _fragmentEntryProcessorHelper.isMappedLayout(
+			configJSONObject);
 		boolean mapped = _fragmentEntryProcessorHelper.isMapped(
 			configJSONObject);
 
 		if (Validator.isNull(href) && !assetDisplayPage && !collectionMapped &&
-			!mapped) {
+			!layoutMapped && !mapped) {
 
 			return;
 		}
@@ -76,6 +78,11 @@ public class LinkEditableElementMapper implements EditableElementMapper {
 		if (collectionMapped) {
 			href = GetterUtil.getString(
 				_fragmentEntryProcessorHelper.getMappedCollectionValue(
+					configJSONObject, fragmentEntryProcessorContext));
+		}
+		else if (layoutMapped) {
+			href = GetterUtil.getString(
+				_fragmentEntryProcessorHelper.getMappedLayoutValue(
 					configJSONObject, fragmentEntryProcessorContext));
 		}
 		else if (mapped) {

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java
@@ -41,7 +41,9 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.ClassedModel;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.template.StringTemplateResource;
 import com.liferay.portal.kernel.template.Template;
 import com.liferay.portal.kernel.template.TemplateConstants;
@@ -223,6 +225,28 @@ public class FragmentEntryProcessorHelperImpl
 	}
 
 	@Override
+	public Object getMappedLayoutValue(
+			JSONObject jsonObject,
+			FragmentEntryProcessorContext fragmentEntryProcessorContext)
+		throws PortalException {
+
+		if (!isMappedLayout(jsonObject)) {
+			return JSONFactoryUtil.createJSONObject();
+		}
+
+		JSONObject layoutJSONObject = jsonObject.getJSONObject("layout");
+
+		long groupId = layoutJSONObject.getLong("groupId");
+		boolean privateLayout = layoutJSONObject.getBoolean("privateLayout");
+		long layoutId = layoutJSONObject.getLong("layoutId");
+
+		Layout layout = _layoutLocalService.getLayout(
+			groupId, privateLayout, layoutId);
+
+		return layout.getFriendlyURL(fragmentEntryProcessorContext.getLocale());
+	}
+
+	@Override
 	public Object getMappedValue(
 			JSONObject jsonObject,
 			Map<Long, Map<String, Object>> infoDisplaysFieldValues,
@@ -392,6 +416,15 @@ public class FragmentEntryProcessorHelperImpl
 	}
 
 	@Override
+	public boolean isMappedLayout(JSONObject jsonObject) {
+		if (jsonObject.has("layout")) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	public String processTemplate(
 			String html,
 			FragmentEntryProcessorContext fragmentEntryProcessorContext)
@@ -477,6 +510,9 @@ public class FragmentEntryProcessorHelperImpl
 
 	@Reference
 	private InfoItemServiceTracker _infoItemServiceTracker;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -441,6 +441,10 @@ public class ContentPageEditorDisplayContext {
 				getResourceURL(
 					"/layout_content_page_editor/get_info_item_mapping_fields")
 			).put(
+				"getLayoutFriendlyURL",
+				getResourceURL(
+					"/layout_content_page_editor/get_layout_friendly_url")
+			).put(
 				"getPageContentsURL",
 				getResourceURL("/layout_content_page_editor/get_page_content")
 			).put(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -1683,6 +1683,7 @@ public class ContentPageEditorDisplayContext {
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new UUIDItemSelectorReturnType());
 		layoutItemSelectorCriterion.setMultiSelection(false);
+		layoutItemSelectorCriterion.setShowPrivatePages(true);
 
 		PortletURL itemSelectorURL = _itemSelector.getItemSelectorURL(
 			RequestBackedPortletURLFactoryUtil.create(httpServletRequest),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -1683,7 +1683,6 @@ public class ContentPageEditorDisplayContext {
 		layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new UUIDItemSelectorReturnType());
 		layoutItemSelectorCriterion.setMultiSelection(false);
-		layoutItemSelectorCriterion.setMultiSelection(false);
 
 		PortletURL itemSelectorURL = _itemSelector.getItemSelectorURL(
 			RequestBackedPortletURLFactoryUtil.create(httpServletRequest),

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetLayoutFriendlyURLMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetLayoutFriendlyURLMVCResourceCommand.java
@@ -1,0 +1,99 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action;
+
+import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Pablo Molina
+ */
+@Component(
+	immediate = true,
+	property = {
+		"javax.portlet.name=" + ContentPageEditorPortletKeys.CONTENT_PAGE_EDITOR_PORTLET,
+		"mvc.command.name=/layout_content_page_editor/get_layout_friendly_url"
+	},
+	service = MVCResourceCommand.class
+)
+public class GetLayoutFriendlyURLMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		long groupId = ParamUtil.getLong(resourceRequest, "groupId");
+		boolean privateLayout = ParamUtil.getBoolean(
+			resourceRequest, "privateLayout");
+		long layoutId = ParamUtil.getLong(resourceRequest, "layoutId");
+
+		try {
+			Layout layout = _layoutLocalService.getLayout(
+				groupId, privateLayout, layoutId);
+
+			JSONPortletResponseUtil.writeJSON(
+				resourceRequest, resourceResponse,
+				JSONUtil.put(
+					"friendlyURL",
+					layout.getFriendlyURL(resourceRequest.getLocale())));
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException, portalException);
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)resourceRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			JSONPortletResponseUtil.writeJSON(
+				resourceRequest, resourceResponse,
+				JSONUtil.put(
+					"error",
+					LanguageUtil.get(
+						themeDisplay.getRequest(),
+						"an-unexpected-error-occurred")));
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GetLayoutFriendlyURLMVCResourceCommand.class);
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/CollectionItemContext.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/CollectionItemContext.js
@@ -17,8 +17,10 @@ import React, {useCallback, useContext, useEffect} from 'react';
 import {updateFragmentEntryLinkContent} from '../actions/index';
 import FragmentService from '../services/FragmentService';
 import InfoItemService from '../services/InfoItemService';
+import LayoutService from '../services/LayoutService';
 import {useDispatch} from '../store/index';
 import isMappedToInfoItem from '../utils/editable-value/isMappedToInfoItem';
+import isMappedToLayout from '../utils/editable-value/isMappedToLayout';
 
 const defaultFromControlsId = (itemId) => itemId;
 const defaultToControlsId = (controlId) => controlId;
@@ -134,6 +136,12 @@ const useGetFieldValue = () => {
 
 				return fieldValue;
 			});
+		}
+
+		if (isMappedToLayout(editable)) {
+			return LayoutService.getLayoutFriendlyURL(editable.layout).then(
+				(response) => response.friendlyURL || ''
+			);
 		}
 
 		return Promise.resolve(editable);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/CollectionItemContext.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/CollectionItemContext.js
@@ -18,6 +18,7 @@ import {updateFragmentEntryLinkContent} from '../actions/index';
 import FragmentService from '../services/FragmentService';
 import InfoItemService from '../services/InfoItemService';
 import {useDispatch} from '../store/index';
+import isMappedToInfoItem from '../utils/editable-value/isMappedToInfoItem';
 
 const defaultFromControlsId = (itemId) => itemId;
 const defaultToControlsId = (controlId) => controlId;
@@ -119,13 +120,10 @@ const useGetContent = (fragmentEntryLink, languageId, segmentsExperienceId) => {
 const useGetFieldValue = () => {
 	const {collectionItem} = useContext(CollectionItemContext);
 
-	const getFromServer = useCallback(
-		({classNameId, classPK, fieldId, languageId}) =>
-			InfoItemService.getInfoItemFieldValue({
-				classNameId,
-				classPK,
-				fieldId,
-				languageId,
+	const getFromServer = useCallback((editable) => {
+		if (isMappedToInfoItem(editable)) {
+			return InfoItemService.getInfoItemFieldValue({
+				...editable,
 				onNetworkStatus: () => {},
 			}).then((response) => {
 				if (!response || !Object.keys(response).length) {
@@ -135,9 +133,11 @@ const useGetFieldValue = () => {
 				const {fieldValue = ''} = response;
 
 				return fieldValue;
-			}),
-		[]
-	);
+			});
+		}
+
+		return Promise.resolve(editable);
+	}, []);
 
 	const getFromCollectionItem = useCallback(
 		({collectionFieldId}) =>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/LinkField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/LinkField.js
@@ -20,12 +20,14 @@ import ClayForm, {
 import PropTypes from 'prop-types';
 import React, {useEffect, useState} from 'react';
 
+import {LayoutSelector} from '../../../common/components/LayoutSelector';
 import MappingSelector from '../../../common/components/MappingSelector';
 import {ConfigurationFieldPropTypes} from '../../../prop-types/index';
 import {EDITABLE_TYPES} from '../../config/constants/editableTypes';
 import selectLanguageId from '../../selectors/selectLanguageId';
 import {useSelector} from '../../store/index';
 import isMapped from '../../utils/editable-value/isMapped';
+import isMappedToLayout from '../../utils/editable-value/isMappedToLayout';
 import resolveEditableValue from '../../utils/editable-value/resolveEditableValue';
 import {useId} from '../../utils/useId';
 import {useGetFieldValue} from '../CollectionItemContext';
@@ -34,6 +36,11 @@ const SOURCE_OPTIONS = {
 	fromContentField: {
 		label: Liferay.Language.get('from-content-field'),
 		value: 'fromContentField',
+	},
+
+	fromLayout: {
+		label: Liferay.Language.get('page'),
+		value: 'fromLayout',
 	},
 
 	manual: {
@@ -65,7 +72,10 @@ export default function LinkField({field, onValueSelect, value}) {
 		setNextHref(value.href);
 		setOpenNewTab(value.target === '_blank');
 
-		if (isMapped(value)) {
+		if (isMappedToLayout(value)) {
+			setSource(SOURCE_OPTIONS.fromLayout.value);
+		}
+		else if (isMapped(value)) {
 			setSource(SOURCE_OPTIONS.fromContentField.value);
 		}
 		else if (value.href) {
@@ -138,6 +148,13 @@ export default function LinkField({field, onValueSelect, value}) {
 						value={nextHref || ''}
 					/>
 				</ClayForm.Group>
+			)}
+
+			{source === SOURCE_OPTIONS.fromLayout.value && (
+				<LayoutSelector
+					mappedLayout={nextValue?.layout}
+					onLayoutSelect={(layout) => handleChange({layout})}
+				/>
 			)}
 
 			{source === SOURCE_OPTIONS.fromContentField.value && (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/LayoutService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/LayoutService.js
@@ -114,6 +114,26 @@ export default {
 	},
 
 	/**
+	 * @param {string} groupId
+	 * @param {string} layoutId
+	 * @param {boolean} privateLayout
+	 * @returns {Promise<{error: Error, friendlyURL: string}>}
+	 */
+	getLayoutFriendlyURL({groupId, layoutId, privateLayout}) {
+		return layoutServiceFetch(
+			config.getLayoutFriendlyURL,
+			{
+				body: {
+					groupId,
+					layoutId,
+					privateLayout,
+				},
+			},
+			() => {}
+		);
+	},
+
+	/**
 	 * Marks an item for deletion
 	 * @param {object} options
 	 * @param {string} options.itemId id of the item to be updated

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/editable-value/isMapped.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/editable-value/isMapped.js
@@ -28,12 +28,14 @@
 
 import isMappedToCollection from './isMappedToCollection';
 import isMappedToInfoItem from './isMappedToInfoItem';
+import isMappedToLayout from './isMappedToLayout';
 import isMappedToStructure from './isMappedToStructure';
 
 export default function isMapped(editable) {
 	return (
 		isMappedToCollection(editable) ||
 		isMappedToInfoItem(editable) ||
-		isMappedToStructure(editable)
+		isMappedToStructure(editable) ||
+		isMappedToLayout(editable)
 	);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/editable-value/isMappedToLayout.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/editable-value/isMappedToLayout.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function isMappedToLayout(editable) {
+	return !!(editable?.layout?.layoutId && editable?.layout?.groupId);
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/LayoutSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/LayoutSelector.js
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import {config} from '../../app/config/index';
+import ItemSelector from './ItemSelector';
+
+export const LayoutSelector = ({mappedLayout, onLayoutSelect}) => {
+	return (
+		<div className="mb-3">
+			<ItemSelector
+				eventName={`${config.portletNamespace}selectLayout`}
+				itemSelectorURL={config.layoutItemSelectorURL}
+				onItemSelect={(layout) => onLayoutSelect(layout)}
+				selectedItemTitle={mappedLayout?.name || ''}
+			/>
+		</div>
+	);
+};
+
+LayoutSelector.propTypes = {
+	mappedLayout: PropTypes.shape({
+		groupId: PropTypes.string.isRequired,
+		layoutId: PropTypes.string.isRequired,
+		name: PropTypes.string.isRequired,
+		privateLayout: PropTypes.bool.isRequired,
+	}),
+	onLayoutSelect: PropTypes.func.isRequired,
+};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/config.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/config.d.ts
@@ -122,6 +122,7 @@ export interface Config {
 	getIframeContentURL: string;
 	getInfoItemFieldValueURL: string;
 	getInfoItemMappingFieldsURL: string;
+	getLayoutFriendlyURL: string;
 	getPageContentsURL: string;
 	imageSelectorURL: string;
 	infoItemSelectorURL: string;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -66,6 +66,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -337,6 +338,25 @@ public class RenderLayoutStructureDisplayContext {
 
 			if (Validator.isNotNull(mappedCollectionValue)) {
 				return mappedCollectionValue;
+			}
+		}
+
+		JSONObject layoutJSONObject = linkJSONObject.getJSONObject("layout");
+
+		if (layoutJSONObject != null) {
+			long groupId = layoutJSONObject.getLong("groupId");
+			boolean privateLayout = layoutJSONObject.getBoolean(
+				"privateLayout");
+			long layoutId = layoutJSONObject.getLong("layoutId");
+
+			try {
+				Layout layout = LayoutLocalServiceUtil.getLayout(
+					groupId, privateLayout, layoutId);
+
+				return layout.getFriendlyURL(locale);
+			}
+			catch (PortalException portalException) {
+				_log.error(portalException, portalException);
 			}
 		}
 


### PR DESCRIPTION
### FrontEnd
1. Add new "page" option to LinkField (works both for containers and editable links) and save this information into `editableValue > layout > { layoutId, groupId, privatePage }` (I am saving the whole JSON that is being returned from backend).
2. Create `isMappedToLayout()` and `LayoutService.getLayoutFriendlyURL()` helpers to check/resolve a FriendlyURL based on a LayoutId.
3. Update `getFieldValue()` function to resolve editables mapped to layouts.

> We are treating Layout's as a special usecase, so we cannot store them as InfoItems.

### Backend part
1. ~Break things~
2. Add `MVCResourceCommand` to get the friendly URL of a given layout
3. Resolve links mapped to layouts in `RenderLayoutStructureDisplayContext` (for container links) and `LinkEditableElementMapper` (for editable links).

I haven't changed anything from export/import, that will go in another PR.

/cc @jkappler 
/cc @ruben-pulido 