### PR TITLE
[TS] LPS-127924 Custom fields permission checks when copying layouts

### DIFF
--- a/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoBridgeImpl.java
+++ b/portal-impl/src/com/liferay/portlet/expando/model/impl/ExpandoBridgeImpl.java
@@ -78,6 +78,10 @@ public class ExpandoBridgeImpl implements ExpandoBridge {
 		boolean secure =
 			PropsValues.PERMISSIONS_CUSTOM_ATTRIBUTE_WRITE_CHECK_BY_DEFAULT;
 
+		if (CopyLayoutThreadLocal.isCopyLayout()) {
+			secure = false;
+		}
+
 		if (ExportImportThreadLocal.isImportInProcess()) {
 			secure = false;
 		}
@@ -96,6 +100,10 @@ public class ExpandoBridgeImpl implements ExpandoBridge {
 	public void addAttribute(String name, int type) throws PortalException {
 		boolean secure =
 			PropsValues.PERMISSIONS_CUSTOM_ATTRIBUTE_WRITE_CHECK_BY_DEFAULT;
+
+		if (CopyLayoutThreadLocal.isCopyLayout()) {
+			secure = false;
+		}
 
 		if (ExportImportThreadLocal.isImportInProcess()) {
 			secure = false;
@@ -117,6 +125,10 @@ public class ExpandoBridgeImpl implements ExpandoBridge {
 
 		boolean secure =
 			PropsValues.PERMISSIONS_CUSTOM_ATTRIBUTE_WRITE_CHECK_BY_DEFAULT;
+
+		if (CopyLayoutThreadLocal.isCopyLayout()) {
+			secure = false;
+		}
 
 		if (ExportImportThreadLocal.isImportInProcess()) {
 			secure = false;
@@ -198,6 +210,10 @@ public class ExpandoBridgeImpl implements ExpandoBridge {
 		boolean secure =
 			PropsValues.PERMISSIONS_CUSTOM_ATTRIBUTE_READ_CHECK_BY_DEFAULT;
 
+		if (CopyLayoutThreadLocal.isCopyLayout()) {
+			secure = false;
+		}
+
 		if (ExportImportThreadLocal.isExportInProcess()) {
 			secure = false;
 		}
@@ -272,6 +288,10 @@ public class ExpandoBridgeImpl implements ExpandoBridge {
 		boolean secure =
 			PropsValues.PERMISSIONS_CUSTOM_ATTRIBUTE_READ_CHECK_BY_DEFAULT;
 
+		if (CopyLayoutThreadLocal.isCopyLayout()) {
+			secure = false;
+		}
+
 		if (ExportImportThreadLocal.isExportInProcess()) {
 			secure = false;
 		}
@@ -295,6 +315,10 @@ public class ExpandoBridgeImpl implements ExpandoBridge {
 	public Map<String, Serializable> getAttributes(Collection<String> names) {
 		boolean secure =
 			PropsValues.PERMISSIONS_CUSTOM_ATTRIBUTE_READ_CHECK_BY_DEFAULT;
+
+		if (CopyLayoutThreadLocal.isCopyLayout()) {
+			secure = false;
+		}
 
 		if (ExportImportThreadLocal.isExportInProcess()) {
 			secure = false;
@@ -481,6 +505,10 @@ public class ExpandoBridgeImpl implements ExpandoBridge {
 		boolean secure =
 			PropsValues.PERMISSIONS_CUSTOM_ATTRIBUTE_WRITE_CHECK_BY_DEFAULT;
 
+		if (CopyLayoutThreadLocal.isCopyLayout()) {
+			secure = false;
+		}
+
 		if (ExportImportThreadLocal.isImportInProcess()) {
 			secure = false;
 		}
@@ -515,6 +543,10 @@ public class ExpandoBridgeImpl implements ExpandoBridge {
 	public void setAttributes(Map<String, Serializable> attributes) {
 		boolean secure =
 			PropsValues.PERMISSIONS_CUSTOM_ATTRIBUTE_WRITE_CHECK_BY_DEFAULT;
+
+		if (CopyLayoutThreadLocal.isCopyLayout()) {
+			secure = false;
+		}
 
 		if (ExportImportThreadLocal.isImportInProcess()) {
 			secure = false;
@@ -559,6 +591,10 @@ public class ExpandoBridgeImpl implements ExpandoBridge {
 	public void setAttributes(ServiceContext serviceContext) {
 		boolean secure =
 			PropsValues.PERMISSIONS_CUSTOM_ATTRIBUTE_WRITE_CHECK_BY_DEFAULT;
+
+		if (CopyLayoutThreadLocal.isCopyLayout()) {
+			secure = false;
+		}
 
 		if (ExportImportThreadLocal.isImportInProcess()) {
 			secure = false;


### PR DESCRIPTION
Hi @liferay-echo team,

[LPS-127924](https://issues.liferay.com/browse/LPS-127924)

A recent change ([LPS-126159](https://issues.liferay.com/browse/LPS-126159)) skips the permission check when writing layouts during page copy. It seems like it also has to be skipped when reading these values to properly copy them.
I added this to all methods where we already skip the check for export/import.

Please review my changes.

Thanks,
Vendel