### PR TITLE
[TS] LPS-128069 - instance names are double escaped

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/display/context/ApplicationsMenuDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/display/context/ApplicationsMenuDisplayContext.java
@@ -22,7 +22,6 @@ import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.webserver.WebServerServletTokenUtil;
@@ -96,7 +95,7 @@ public class ApplicationsMenuDisplayContext {
 		).put(
 			"virtualInstance",
 			HashMapBuilder.<String, Object>put(
-				"label", HtmlUtil.escape(company.getName())
+				"label", company.getName()
 			).put(
 				"logoURL",
 				StringBundler.concat(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-122234

Hi Echo team!

This handles an issue where instance names are being double-escaped when displayed in the applications menu. Since React [automatically escapes JSX](https://reactjs.org/docs/introducing-jsx.html#jsx-prevents-injection-attacks) the call to [virtualInstance's label](https://github.com/wanderlast/liferay-portal/blob/181de00d31d8a36db157b737ce71a8de4c736b84/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js#L68) should be safe, I've removed the explicit call to escape to prevent the name from being escaped twice.

Please let me know if I can clarify anything. Thanks!