### PR TITLE
[TS] LPS-128151

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateStructureStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateStructureStagedModelDataHandler.java
@@ -22,6 +22,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -95,6 +96,14 @@ public class LayoutPageTemplateStructureStagedModelDataHandler
 			_stagedModelRepository.fetchStagedModelByUuidAndGroupId(
 				layoutPageTemplateStructure.getUuid(),
 				portletDataContext.getScopeGroupId());
+
+		if (existingLayoutPageTemplateStructure == null) {
+			existingLayoutPageTemplateStructure =
+				_layoutPageTemplateStructureLocalService.
+					fetchLayoutPageTemplateStructure(
+						portletDataContext.getScopeGroupId(),
+						importedLayoutPageTemplateStructure.getClassPK());
+		}
 
 		if ((existingLayoutPageTemplateStructure == null) ||
 			!portletDataContext.isDataStrategyMirror()) {
@@ -187,6 +196,10 @@ public class LayoutPageTemplateStructureStagedModelDataHandler
 				portletDataContext, layoutPageTemplateStructureRelElement);
 		}
 	}
+
+	@Reference
+	private LayoutPageTemplateStructureLocalService
+		_layoutPageTemplateStructureLocalService;
 
 	@Reference
 	private LayoutPageTemplateStructureRelLocalService


### PR DESCRIPTION
Hi team,

This PR tries to fix the import over a site where a preexisting content page is updated by matching its Friendly URL with differentLayoutPageTemplateStructure UUIDs.

The solution checks if there is an existing LayoutPageTemplateStructure with the same plid (classPK). If so, do the update, if not it behaves as usual creating a new LayoutPageTemplateStructure entry.

Could you please review it?

Thanks in advance