### PR TITLE
[TS] LPS-128092 | Sort order does not persist in the web content history

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalHistoryDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalHistoryDisplayContext.java
@@ -23,10 +23,13 @@ import com.liferay.journal.web.internal.util.JournalPortletUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.portlet.PortalPreferences;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.portlet.SearchDisplayStyleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
 
@@ -50,6 +53,9 @@ public class JournalHistoryDisplayContext {
 		_article = article;
 
 		_httpServletRequest = PortalUtil.getHttpServletRequest(renderRequest);
+
+		_portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(
+			_httpServletRequest);
 	}
 
 	public SearchContainer<JournalArticle> getArticleSearchContainer() {
@@ -134,8 +140,18 @@ public class JournalHistoryDisplayContext {
 			return _orderByType;
 		}
 
-		_orderByType = ParamUtil.getString(
-			_renderRequest, "orderByType", "asc");
+		String orderByType = ParamUtil.getString(_renderRequest, "orderByType");
+
+		if (Validator.isNotNull(orderByType)) {
+			_portalPreferences.setValue(
+				JournalPortletKeys.JOURNAL, "orderByType", orderByType);
+		}
+		else {
+			orderByType = _portalPreferences.getValue(
+				JournalPortletKeys.JOURNAL, "orderByType", "asc");
+		}
+
+		_orderByType = orderByType;
 
 		return _orderByType;
 	}
@@ -185,6 +201,7 @@ public class JournalHistoryDisplayContext {
 	private final HttpServletRequest _httpServletRequest;
 	private String _orderByCol;
 	private String _orderByType;
+	private final PortalPreferences _portalPreferences;
 	private String _redirect;
 	private String _referringPortletResource;
 	private final RenderRequest _renderRequest;


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?

I modified the previous implementation to be more in line with the pattern from AssetBrowserDisplayContext.getOrderByType().

Also, the setValue call in the PortalPreferencesImpl uses the retryableStore method which will store the portal preferences in the DB.

Thank you!

brianchandotcom#99014
#3787