### PR TITLE
LPS-127642 [Bug: Experiences] Fragments and Widgets sidebar in the Page Editor disappear when editing an experience

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/components/ExperienceModal.js
@@ -28,14 +28,14 @@ import {config} from '../../../app/config/index';
 import Button from '../../../common/components/Button';
 
 const ExperienceModal = ({
+	canUpdateSegments,
 	errorMessage,
 	experienceId,
-	canUpdateSegments,
 	initialName = '',
 	languageIds = [],
 	observer,
-	onErrorDismiss,
 	onClose,
+	onErrorDismiss,
 	onNewSegmentClick,
 	onSubmit,
 	segmentId,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/reducers/updateExperience.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/reducers/updateExperience.js
@@ -28,8 +28,8 @@ function updateExperienceReducer(state, payload) {
 			availableSegmentsExperiences: {
 				...nextState.availableSegmentsExperiences,
 				[experience.segmentsExperienceId]: {
+					...experience,
 					...updatedExperience,
-					priority: experience.priority,
 				},
 			},
 		};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/types.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/experience/types.js
@@ -20,7 +20,7 @@ export const ExperimentStatusType = {
 };
 
 export const ExperienceType = {
-	hasLockedSegmentsExperiment: PropTypes.bool,
+	hasLockedSegmentsExperiment: PropTypes.bool.isRequired,
 	name: PropTypes.string.isRequired,
 	priority: PropTypes.number.isRequired,
 	segmentsEntryId: PropTypes.string.isRequired,


### PR DESCRIPTION
**Description of the bug**

Fragments and widgets sidebar panel is NOT available when editing an experience. The behavior is similar to an experience with an AB Test (`hasLockedSegmentsExperiment`) but in this case, the experience doesn't have any experiment running.

**How to test it**

- Create a page
- Create an experience (exp1)
- Select the exp1 in the experience list
- Edit the experience name (exp1 edited)

**Solution**

On experience edition, we were only taking the priority of the experience and merging it with the updated information. To fix this bug, I merged the whole experience with the updated experiences:

```
[experience.segmentsExperienceId]: {
	...experience,
	...updatedExperience,
}
```