### PR TITLE
LPS-121862 Migrate v2 usages in asset/asset-tags-admin-web

### DIFF
--- a/modules/apps/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsManagementToolbarDisplayContext.java
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/java/com/liferay/asset/tags/admin/web/internal/display/context/AssetTagsManagementToolbarDisplayContext.java
@@ -110,11 +110,6 @@ public class AssetTagsManagementToolbarDisplayContext
 	}
 
 	@Override
-	public String getDefaultEventHandler() {
-		return "assetTagsManagementToolbarDefaultEventHandler";
-	}
-
-	@Override
 	public String getSearchActionURL() {
 		PortletURL searchTagURL = getPortletURL();
 

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
@@ -12,30 +12,44 @@
  * details.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
-
-class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
-	deleteTags() {
+export default function propsTransformer({portletNamespace, ...otherProps}) {
+	const deleteTags = () => {
 		if (
 			confirm(
 				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
 			)
 		) {
-			submitForm(this.one('#fm'));
-		}
-	}
+			const form = document.getElementById(`${portletNamespace}fm`);
 
-	mergeTags(itemData) {
+			if (form) {
+				submitForm(form);
+			}
+		}
+	};
+
+	const mergeTags = (itemData) => {
 		const mergeURL = itemData.mergeTagsURL;
 
 		location.href = mergeURL.replace(
 			escape('[$MERGE_TAGS_IDS$]'),
 			Liferay.Util.listCheckedExcept(
-				this.one('#fm'),
-				this.ns('allRowIds')
+				document.getElementById(`${portletNamespace}fm`),
+				`${portletNamespace}allRowIds`
 			)
 		);
-	}
-}
+	};
 
-export default ManagementToolbarDefaultEventHandler;
+	return {
+		...otherProps,
+		onActionButtonClick(event, {item}) {
+			const action = item.data?.action;
+
+			if (action === 'deleteTags') {
+				deleteTags();
+			}
+			else if (action === 'mergeTags') {
+				mergeTags(item.data);
+			}
+		},
+	};
+}

--- a/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-tags-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -16,12 +16,9 @@
 
 <%@ include file="/init.jsp" %>
 
-<%
-AssetTagsManagementToolbarDisplayContext assetTagsManagementToolbarDisplayContext = new AssetTagsManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetTagsDisplayContext);
-%>
-
-<clay:management-toolbar-v2
-	displayContext="<%= assetTagsManagementToolbarDisplayContext %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new AssetTagsManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetTagsDisplayContext) %>"
+	propsTransformer="js/ManagementToolbarPropsTransformer"
 />
 
 <portlet:actionURL name="deleteTag" var="deleteTagURL">
@@ -96,8 +93,3 @@ AssetTagsManagementToolbarDisplayContext assetTagsManagementToolbarDisplayContex
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<liferay-frontend:component
-	componentId="<%= assetTagsManagementToolbarDisplayContext.getDefaultEventHandler() %>"
-	module="js/ManagementToolbarDefaultEventHandler.es"
-/>


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

Creating, merging and deleting tags should work as expected.

![](https://user-images.githubusercontent.com/5572/108701599-751daf80-7508-11eb-80c5-c4399aede37a.gif)

**Test plan**:
- Navigate to **Categorization**>**Tags**
- Assert that you can create a tag
- Assert that you can delete the tag you created previously
- Assert that you can merge two or more tags correctly.

**Additional notes**
Originally reviewed [here](https://github.com/liferay-frontend/liferay-portal/pull/823)