### PR TITLE
LPS-128329 Build lang

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/exception/ArticleFriendlyURLException.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/exception/ArticleFriendlyURLException.java
@@ -36,4 +36,48 @@ public class ArticleFriendlyURLException extends PortalException {
 		super(throwable);
 	}
 
+	public static class MustDefineDefaultLanguageFriendlyURL
+		extends ArticleFriendlyURLException {
+
+		public MustDefineDefaultLanguageFriendlyURL() {
+		}
+
+		public MustDefineDefaultLanguageFriendlyURL(String msg) {
+			super(msg);
+		}
+
+		public MustDefineDefaultLanguageFriendlyURL(
+			String msg, Throwable throwable) {
+
+			super(msg, throwable);
+		}
+
+		public MustDefineDefaultLanguageFriendlyURL(Throwable throwable) {
+			super(throwable);
+		}
+
+	}
+
+	public static class MustNotContainInvalidCharacters
+		extends ArticleFriendlyURLException {
+
+		public MustNotContainInvalidCharacters() {
+		}
+
+		public MustNotContainInvalidCharacters(String msg) {
+			super(msg);
+		}
+
+		public MustNotContainInvalidCharacters(
+			String msg, Throwable throwable) {
+
+			super(msg, throwable);
+		}
+
+		public MustNotContainInvalidCharacters(Throwable throwable) {
+			super(throwable);
+		}
+
+	}
+
 }

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field.
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters.
 please-enter-a-unique-id=Please enter a unique ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes.
 please-enter-a-valid-id=Please enter a valid ID.
 please-enter-a-valid-script=Please enter a valid script.
 please-enter-a-valid-target-layout-friendly-url=Please enter a valid target page friendly URL.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_ar.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=يرجى إضافة قالب لع
 please-add-at-least-one-field=يُرجى إضافة حقل واحد على الأقل.
 please-enter-a-title-with-fewer-than-x-characters=يُرجى إدخال عنوان يحتوي على أحرف أقل من {0}.
 please-enter-a-unique-id=الرجاء إدخال رمز تعريفي مميّز.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=الرجاء إدخال رمز تعريفي صحيح.
 please-enter-a-valid-script=الرجاء إدخال نص برمجي صحيح.
 please-enter-a-valid-target-layout-friendly-url=يرجى إدخال رابط صالح لصفحة الهدف الودية.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_bg.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Моля, въведете уникално ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Моля, въведете валидно ID.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Моля, въведете валиден приятелски URL адрес на целевия изглед.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_ca.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Afegiu una plantilla per renderit
 please-add-at-least-one-field=Afegiu almenys un camp.
 please-enter-a-title-with-fewer-than-x-characters=Introduïu un títol amb menys de {0} caràcters.
 please-enter-a-unique-id=Introduïu un ID únic.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Introduïu un ID vàlid.
 please-enter-a-valid-script=Introduïu un script vàlid.
 please-enter-a-valid-target-layout-friendly-url=Introduïu una URL amigable vàlida.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_cs.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Přidejte prosím šablonu podle 
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Zadejte prosím unikátní ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Zadejte prosím platné ID.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Zadejte prosím platné přívětivé URL cílové stránky.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_da.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Please enter a valid XML url.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Please enter a valid XML url.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Please enter a valid target page friendly URL. (Automatic Copy)

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_de.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Bitte fügen Sie ein Template hin
 please-add-at-least-one-field=Bitte fügen Sie mindestens ein Feld hinzu.
 please-enter-a-title-with-fewer-than-x-characters=Bitte geben Sie einen Titel mit weniger als {0} Zeichen ein.
 please-enter-a-unique-id=Bitte geben Sie eine eindeutige ID ein.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Bitte geben Sie eine gültige ID ein.
 please-enter-a-valid-script=Bitte geben Sie ein gültiges Script an.
 please-enter-a-valid-target-layout-friendly-url=Bitte geben Sie eine benutzerfreundliche URL für die Zielseite ein.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_el.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Παρακαλώ προσθέστ
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Παρακαλώ δώστε μια μοναδική ταυτότητα.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Παρακαλώ δώστε μια έγκυρη ταυτότητα.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Παρακαλώ δώστε ένα έγκυρο φιλικό URL της σελίδας-στόχου.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_en.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field.
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters.
 please-enter-a-unique-id=Please enter a unique ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes.
 please-enter-a-valid-id=Please enter a valid ID.
 please-enter-a-valid-script=Please enter a valid script.
 please-enter-a-valid-target-layout-friendly-url=Please enter a valid target page friendly URL.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_en_AU.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Please enter a unique ID. (Automatic Copy)
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Please enter a valid ID. (Automatic Copy)
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Please enter a valid target page friendly URL. (Automatic Copy)

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_en_GB.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Please enter a unique ID. (Automatic Copy)
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Please enter a valid ID. (Automatic Copy)
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Please enter a valid target page friendly URL. (Automatic Copy)

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_es.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Por favor añada una plantilla pa
 please-add-at-least-one-field=Añada como mínimo un campo.
 please-enter-a-title-with-fewer-than-x-characters=Escriba un título con menos de {0} caracteres.
 please-enter-a-unique-id=Por favor, introduzca un identificador que no esté siendo usado.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Por favor, introduzca un identificador válido.
 please-enter-a-valid-script=Especifique un script válido.
 please-enter-a-valid-target-layout-friendly-url=Por favor, introduzca una URL amigable destino válida.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_et.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Sisesta unikaalne ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Sisesta korrektne ID.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Sisesta korrektne kasutajasõbralik URL.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_eu.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Mesedez gehitu txantiloi bat egit
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Mesedez, sartu identifikatzaile bakarra.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Mesedez, sartu baliozko identifikatzaile bat.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Mesedez, sartu helmugako baliozko URL erabilerraz bat.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_fa.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=لطفا یک الگو به نم�
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=لطفا یک شناسه کاربری منحصر به فرد وارد کنید.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=لطفا یک شناسه مجاز وارد کنید.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=لطفا یک آدرس معتبر وارد نمایید.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_fi.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Lisää mallinne tämän rakentee
 please-add-at-least-one-field=Lisää ainakin yksi kenttä.
 please-enter-a-title-with-fewer-than-x-characters=Anna otsikko, jossa on alle {0} merkkiä.
 please-enter-a-unique-id=Syötä yksilöllinen ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Syötä kelvollinen ID.
 please-enter-a-valid-script=Anna kelvollinen skripti.
 please-enter-a-valid-target-layout-friendly-url=Syötä kelvollinen kohdesivun käyttäjäystävällinen URL-osoite.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_fr.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Veuillez ajouter un calibre pour 
 please-add-at-least-one-field=Veuillez ajouter au moins un autre champ.
 please-enter-a-title-with-fewer-than-x-characters=Veuillez saisir un titre contenant moins de {0} caractères.
 please-enter-a-unique-id=Veuillez entrer un identifiant unique.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Veuillez entrer un identifiant valide.
 please-enter-a-valid-script=Veuillez saisir un script valide.
 please-enter-a-valid-target-layout-friendly-url=Veuillez entrer un URL simplifié de page cible valide.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_fr_CA.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Please enter a unique ID. (Automatic Copy)
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Please enter a valid ID. (Automatic Copy)
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Please enter a valid target page friendly URL. (Automatic Copy)

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_gl.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Por favor, engade un modelo para 
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Por favor, introduce un ID que non estea sendo usado.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Por favor, introduce un ID válido.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Por favor, introduce unha URL amigable destino válida.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_hi_IN.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=कृपया एक यूनीक ID एंटर करे
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=कृपया एक ठीक ID दर्ज करे
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=कृपया एक ठीक target page friendly URL दर्ज करे.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_hr.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Molimo vas dodajte predložak za 
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Molimo, unesite jedinstveni ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Molimo, unesite ispravan ID.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Molimo, unesite ispravan prijateljski URL ciljane stranice.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_hu.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Adj egy sablont struktúra megjel
 please-add-at-least-one-field=Adjon meg legalább egy mezőt.
 please-enter-a-title-with-fewer-than-x-characters=Adjon meg egy címet kevesebb, mint {0} karakterrel.
 please-enter-a-unique-id=Adj meg egy egyedi azonosítót.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Adj meg egy érvényes azonosítót.
 please-enter-a-valid-script=Érvényes szkript szükséges.
 please-enter-a-valid-target-layout-friendly-url=Adj meg egy érvényes egyszerű URL-t a céloldalnak.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_in.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Harap tambahkan sebuah template u
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Masukkan ID yang unik.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Harap masukkan ID yang valid.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Silakan masukkan halaman target friendly URL yang berlaku.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_it.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Aggiungere un modello per la visu
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Inserisci un ID univoco.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Inserisci un ID valido.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Inserisci una friendly URL valida per la pagina di destinazione.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_iw.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=אנא הוסף תבנית לרנ
 please-add-at-least-one-field=אנא הוסף שדה אחד לפחות.
 please-enter-a-title-with-fewer-than-x-characters=אנא הזן כותרת עם פחות מ-{0} תווים.
 please-enter-a-unique-id=אנא הזן מזהה ייחודי.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=אנא הזן מזהה חוקי.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=אנא הזן כתובת URL ידידותית של דף יעד תקף.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_ja.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=ストラクチャーを利用す
 please-add-at-least-one-field=少なくとも1つのフィールドを追加してください。
 please-enter-a-title-with-fewer-than-x-characters={0} 文字未満でタイトルを入力してください。
 please-enter-a-unique-id=重複しないIDを入力してください。
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=IDを正しく入力してください。
 please-enter-a-valid-script=有効なスクリプトを入力してください。
 please-enter-a-valid-target-layout-friendly-url=フレンドリ URL を正しく入力してください。

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_kk.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Please enter a unique ID. (Automatic Copy)
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Please enter a valid ID. (Automatic Copy)
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Please enter a valid target page friendly URL. (Automatic Copy)

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_ko.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=유일한i.d에 들어가십시요.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=유효한 식별에 들어가십시요.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=유효한 표적 페이지 친절한URL에 들어가십시요.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_lo.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=ກະລຸນາເພີມແ
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=ກະລຸນາປ້ອນໄອດີທີ່ເປັນໜື່ງດຽວ
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=ກະລຸນາປ້ອນ ໄອດີທີ່ເໝາະສົມ
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=ກະລຸນາປ້ອນໜ້າເປົ້າໝາຍ URL ທີ່ເໝາະສົມ

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_lt.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Please enter a unique ID. (Automatic Copy)
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Please enter a valid ID. (Automatic Copy)
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Please enter a valid target page friendly URL. (Automatic Copy)

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_ms.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Sila tambah templat untuk menjadi
 please-add-at-least-one-field=Sila tambah sekurang-kurangnya satu medan. (Automatic Translation)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Sila masukkan ID unik. (Automatic Translation)
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Sila masukkan dokumen pengenalan diri yang sah. (Automatic Translation)
 please-enter-a-valid-script=Sila masukkan skrip yang sah. (Automatic Translation)
 please-enter-a-valid-target-layout-friendly-url=Sila masukkan URL mesra halaman sasaran yang sah. (Automatic Translation)

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_nb.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Vennligst legg til en sidemal for
 please-add-at-least-one-field=Vennligst legg til minst et felt.
 please-enter-a-title-with-fewer-than-x-characters=Vennligst angi en tittel med mindre enn {0} tegn.
 please-enter-a-unique-id=Vennligst angi en unik ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Vennligst angi en gyldig ID.
 please-enter-a-valid-script=Vennligst angi et gyldig skript.
 please-enter-a-valid-target-layout-friendly-url=Vennligst angi en gyldig menneskelesbar URL til målsiden.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_nl.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Voeg een sjabloon toe om deze str
 please-add-at-least-one-field=Voeg minstens één veld toe.
 please-enter-a-title-with-fewer-than-x-characters=Voer een titel in met minder dan {0} tekens.
 please-enter-a-unique-id=Voer een unieke ID in.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Voer een geldige ID in.
 please-enter-a-valid-script=Voer een geldig script in.
 please-enter-a-valid-target-layout-friendly-url=Voer een geldige gebruiksvriendelijke URL voor de doelpagina in.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_nl_BE.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Template toevoegen om deze struct
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Voer een uniek ID in.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Voer een geldige ID in.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Voer een geldige doelpagina met gebruiksvriendelijke URL in.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_pl.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Dodaj szablon aby renderować tą
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Wprowadź niepowtarzalne ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Wprowadź prawidłowe ID.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Wprowadź prawidłowy przyjazny URL strony docelowej.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_pt_BR.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Por favor, adicione um modelo par
 please-add-at-least-one-field=Por favor, adicione pelo menos um campo.
 please-enter-a-title-with-fewer-than-x-characters=Por favor, insira um título com menos de {0} caracteres.
 please-enter-a-unique-id=Por favor, insira um ID único.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Por favor, insira um ID válido.
 please-enter-a-valid-script=Por favor, insira um script válido.
 please-enter-a-valid-target-layout-friendly-url=Por favor, insira uma URL amigável do layout alvo válida.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_pt_PT.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Por favor, adicione um template p
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Por favor, insira um ID único.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Por favor, insira um ID válido.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Por favor, insira um URL amigável válido para o layout pretendido.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_ro.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Te rog adauga un sablon pentru a 
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Te rog introdu un ID unic.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Te rog introdu un ID valid.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Te rog introdu un URL valid de pagina tinta.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_ru.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Пожалуйста, добав�
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Пожалуйста введите уникальный ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Пожалуйста, введите правильный ID.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Пожалуйста, введите удобный URL целевой страницы.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_sk.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Pridajte, prosím, šablónu na v
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Zadajte, prosím, jedinečné ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Zadajte, prosím, platné ID.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Zadajte, prosím, platnú "friendly URL" cieľovej stránky.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_sl.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Vnesite edinstven ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Vnesite pravilen ID.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Vnesite veljaven spletni naslov ciljne strani.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_sr_RS.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Молимо додајте те�
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Молимо Вас да унесете јединствени ИД.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Молимо Вас да унесете важећи ИД.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Молимо Вас да унесете важећи циљни пријатељски УРЛ странице.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Molimo dodajte templejt da prođe
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Molimo Vas da unesete jedinstveni ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Molimo Vas da unesete važeći ID.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Molimo Vas da unesete važeći ciljni prijateljski URL stranice.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_sv.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Var god ange mall som beskriver h
 please-add-at-least-one-field=Lägg till minst ett fält.
 please-enter-a-title-with-fewer-than-x-characters=Ange en titel med färre än {0} tecken.
 please-enter-a-unique-id=Var vänlig och skriv in ett unikt ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Var vänlig och skriv in ett giltigt ID.
 please-enter-a-valid-script=Ange ett giltigt skript.
 please-enter-a-valid-target-layout-friendly-url=Var vänlig och skriv in en giltigt URL för målsidan.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_ta_IN.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=இந்த ஸ்டெக்�
 please-add-at-least-one-field=குறைந்தபட்சம் ஒரு புலத்தைச் சேர்க்கவும்.
 please-enter-a-title-with-fewer-than-x-characters=தயவுசெய்து {0} எழுத்துக்களைக் காட்டிலும் குறைவான தலைப்பை உள்ளிடுக.
 please-enter-a-unique-id=ஒரு தனிப்பட்ட ஐடியை என்டர் செய்யவும்.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=ஒரு சரியான ஐடியை என்டர் செய்யவும்.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=ஒரு சரியான page friendly URL-யை என்டர் செய்யவும்.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_th.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=กรุณาเพิ่มเ
 please-add-at-least-one-field=กรุณาเพิ่มอย่างน้อยหนึ่งฟิลด์
 please-enter-a-title-with-fewer-than-x-characters=กรุณาใส่ชื่อหัวข้อที่มีความยาวน้อยกว่า {0} ตัว
 please-enter-a-unique-id=กรุณาใส่ไอดีที่ไม่ซ้ำ
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=กรุณาใส่ไอดีที่ถูกต้อง
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=กรุณาใส่ URL ที่จำง่ายของหน้าเป้าหมายที่ถูกต้อง

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_tr.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Lütfen benzersiz bir ID girin.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Lütfen geçerli bir ID giriniz.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Lütfen geçerli bir kullanıcı dostu URL giriniz.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_uk.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Please add a template to render t
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Будь ласка введіть унікальний ID.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Будь ласка введіть правильний ID.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Будь ласка введіть зручний URL цільової сторінки.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_vi.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=Vui lòng thêm một biểu mẫ
 please-add-at-least-one-field=Please add at least one field. (Automatic Copy)
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=Số định danh(ID) phải duy nhất.
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=Nhập đúng ID.
 please-enter-a-valid-script=Please enter a valid script. (Automatic Copy)
 please-enter-a-valid-target-layout-friendly-url=Vui lòng nhập URL liên kết bạn bè hợp lệ.

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_zh_CN.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=请添加一个模板来呈现此
 please-add-at-least-one-field=请至少添加一个字段。
 please-enter-a-title-with-fewer-than-x-characters=请输入一个不少于 {0} 个字符的标题。
 please-enter-a-unique-id=请输入唯一的ID。
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=请输入有效ID。
 please-enter-a-valid-script=请输入有效的脚本。
 please-enter-a-valid-target-layout-friendly-url=请输入有效目标页面的URL。

--- a/modules/apps/journal/journal-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/journal/journal-lang/src/main/resources/content/Language_zh_TW.properties
@@ -196,6 +196,7 @@ please-add-a-template-to-render-this-structure=請增加一個版型去呈現這
 please-add-at-least-one-field=請至少增加一個欄位。
 please-enter-a-title-with-fewer-than-x-characters=Please enter a title with fewer than {0} characters. (Automatic Copy)
 please-enter-a-unique-id=請輸入一個唯一的ID。
+please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes=Please enter a valid friendly URL. It must not contain any slashes. (Automatic Copy)
 please-enter-a-valid-id=請輸入一個正確的ID。
 please-enter-a-valid-script=請輸入一個有效的Script。
 please-enter-a-valid-target-layout-friendly-url=請輸入一個正確的目標頁面友善網址。

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -80,6 +80,7 @@ import com.liferay.journal.util.comparator.ArticleVersionComparator;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
+import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.petra.xml.XMLUtil;
@@ -418,6 +419,8 @@ public class JournalArticleLocalServiceImpl
 				throw exportImportContentValidationException;
 			}
 		}
+
+		_validateFriendlyURLMap(friendlyURLMap);
 
 		serviceContext.setAttribute("articleId", articleId);
 
@@ -5644,6 +5647,8 @@ public class JournalArticleLocalServiceImpl
 			}
 		}
 
+		_validateFriendlyURLMap(friendlyURLMap);
+
 		if (addNewVersion) {
 			long id = counterLocalService.increment();
 
@@ -5688,7 +5693,8 @@ public class JournalArticleLocalServiceImpl
 			(classNameLocalService.getClassNameId(DDMStructure.class) !=
 				article.getClassNameId())) {
 
-			throw new ArticleFriendlyURLException();
+			throw new ArticleFriendlyURLException.
+				MustDefineDefaultLanguageFriendlyURL();
 		}
 
 		article.setFolderId(folderId);
@@ -9145,6 +9151,21 @@ public class JournalArticleLocalServiceImpl
 
 		return journalArticleLocalizationPersistence.update(
 			journalArticleLocalization);
+	}
+
+	private void _validateFriendlyURLMap(Map<Locale, String> friendlyURLMap)
+		throws PortalException {
+
+		for (Map.Entry<Locale, String> entry : friendlyURLMap.entrySet()) {
+			String value = entry.getValue();
+
+			if (Validator.isNotNull(value) &&
+				(value.indexOf(CharPool.SLASH) != -1)) {
+
+				throw new ArticleFriendlyURLException.
+					MustNotContainInvalidCharacters();
+			}
+		}
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -146,7 +146,9 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 
 			<liferay-ui:error exception="<%= ArticleContentException.class %>" message="please-enter-valid-content" />
 			<liferay-ui:error exception="<%= ArticleContentSizeException.class %>" message="you-have-exceeded-the-maximum-web-content-size-allowed" />
-			<liferay-ui:error exception="<%= ArticleFriendlyURLException.class %>" message="you-must-define-a-friendly-url-for-the-default-language" />
+			<liferay-ui:error exception="<%= ArticleFriendlyURLException.MustDefineDefaultLanguageFriendlyURL.class %>" message="you-must-define-a-friendly-url-for-the-default-language" />
+			<liferay-ui:error exception="<%= ArticleFriendlyURLException.MustNotContainInvalidCharacters.class %>" message="please-enter-a-valid-friendly-url-.-it-must-not-contain-any-slashes" />
+
 			<liferay-ui:error exception="<%= ArticleIdException.class %>" message="please-enter-a-valid-id" />
 
 			<liferay-ui:error exception="<%= ArticleTitleException.class %>">


### PR DESCRIPTION
Hey @liferay-echo 

Slashes cannot be allowed in friendly URLs, as the display page friendly URL resolver assumes that the second component of an URL is the version ID (see BaseAssetDisplayPageFriendlyURLResolver#_getVersionClassPK)

Thanks!