### PR TITLE
LPS-121913 Migrate v2 usages in site/site-my-sites-web

### DIFF
--- a/modules/apps/site/site-my-sites-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-my-sites-web/src/main/resources/META-INF/resources/view.jsp
@@ -24,8 +24,8 @@
 	navigationItems="<%= siteMySitesDisplayContext.getNavigationItems() %>"
 />
 
-<clay:management-toolbar-v2
-	displayContext="<%= new SiteMySitesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, siteMySitesDisplayContext) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new SiteMySitesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, siteMySitesDisplayContext) %>"
 />
 
 <aui:form action="<%= siteMySitesDisplayContext.getPortletURL() %>" cssClass="container-fluid container-fluid-max-xl" method="get" name="fm">


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

![](https://user-images.githubusercontent.com/5572/109522900-111e5c80-7aaf-11eb-938b-7e14f3e55488.gif)


**Test plan**:
- Click the Avatar on the top right of the page
- Select *My Dashboard**
- Assert that you can view and filter your sites