### PR TITLE
LPS-127955 Fix ImageSourcePanel-EditableLink conflict

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/SaveFragmentCompositionModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/SaveFragmentCompositionModal.js
@@ -20,7 +20,6 @@ import ClayLayout from '@clayui/layout';
 import ClayModal, {useModal} from '@clayui/modal';
 import ClaySticker from '@clayui/sticker';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
-import {openToast} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
 
@@ -89,13 +88,6 @@ const SaveFragmentCompositionModal = ({onCloseModal}) => {
 					onClose();
 				})
 				.catch(() => {
-					openToast({
-						message: Liferay.Language.get(
-							'an-unexpected-error-occurred'
-						),
-						type: 'danger',
-					});
-
 					setLoading(false);
 				});
 		}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/LayoutService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/LayoutService.js
@@ -114,20 +114,14 @@ export default {
 	},
 
 	/**
-	 * @param {string} groupId
-	 * @param {string} layoutId
-	 * @param {boolean} privateLayout
+	 * @param {object} layout
 	 * @returns {Promise<{error: Error, friendlyURL: string}>}
 	 */
-	getLayoutFriendlyURL({groupId, layoutId, privateLayout}) {
+	getLayoutFriendlyURL(layout) {
 		return layoutServiceFetch(
 			config.getLayoutFriendlyURL,
 			{
-				body: {
-					groupId,
-					layoutId,
-					privateLayout,
-				},
+				body: layout,
 			},
 			() => {}
 		);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/editable-value/isMappedToLayout.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/editable-value/isMappedToLayout.js
@@ -13,5 +13,5 @@
  */
 
 export default function isMappedToLayout(editable) {
-	return !!(editable?.layout?.layoutId && editable?.layout?.groupId);
+	return !!editable?.layout;
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/LayoutSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/LayoutSelector.js
@@ -43,11 +43,6 @@ export const LayoutSelector = ({mappedLayout, onLayoutSelect}) => {
 };
 
 LayoutSelector.propTypes = {
-	mappedLayout: PropTypes.shape({
-		groupId: PropTypes.string.isRequired,
-		layoutId: PropTypes.string.isRequired,
-		name: PropTypes.string.isRequired,
-		privateLayout: PropTypes.bool.isRequired,
-	}),
+	mappedLayout: PropTypes.shape({name: PropTypes.string.isRequired}),
 	onLayoutSelect: PropTypes.func.isRequired,
 };

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/EditableLinkPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/EditableLinkPanel.js
@@ -76,10 +76,15 @@ export default function EditableLinkPanel({item}) {
 			setLinkValue({
 				...linkConfig,
 				href:
-					linkConfig[languageId] ||
-					linkConfig[config.defaultLanguageId] ||
+					linkConfig.href ||
+					linkConfig[languageId]?.href ||
+					linkConfig[config.defaultLanguageId]?.href ||
 					'',
-				target: linkConfig.target || '',
+				target:
+					linkConfig.target ||
+					linkConfig[languageId]?.target ||
+					linkConfig[config.defaultLanguageId]?.target ||
+					'',
 			});
 		}
 		else {
@@ -99,8 +104,10 @@ export default function EditableLinkPanel({item}) {
 			nextConfig = {
 				...imageConfig,
 				...(linkConfig || {}),
-				[languageId]: nextLinkConfig.href,
-				target: nextLinkConfig.target || '',
+				[languageId]: {
+					href: nextLinkConfig.href,
+					target: nextLinkConfig.target || '',
+				},
 			};
 		}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/EditableLinkPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/EditableLinkPanel.js
@@ -64,8 +64,8 @@ export default function EditableLinkPanel({item}) {
 
 		if (Object.keys(linkConfig).length > 0) {
 			setImageConfig({
-				alt: linkConfig.alt,
-				imageConfiguration: linkConfig.imageConfiguration,
+				alt: linkConfig.alt || '',
+				imageConfiguration: linkConfig.imageConfiguration || {},
 			});
 
 			delete linkConfig.alt;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/ImageSourcePanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-structure/components/item-configuration-panels/ImageSourcePanel.js
@@ -201,6 +201,14 @@ function DirectImagePanel({item}) {
 			}
 		}
 
+		if (!nextEditableValue.config?.imageConfiguration) {
+			nextEditableValue = setIn(
+				nextEditableValue,
+				['config', 'imageConfiguration'],
+				{}
+			);
+		}
+
 		dispatch(
 			updateEditableValuesThunk({
 				editableValues: setIn(

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/EditableLinkPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page-structure/components/item-configuration-panels/EditableLinkPanel.test.js
@@ -244,7 +244,11 @@ describe('EditableLinkPanel', () => {
 			});
 		});
 
-		expect(editableConfig).toEqual({});
+		expect(editableConfig).toEqual({
+			alt: '',
+			imageConfiguration: {},
+			mapperType: 'link',
+		});
 
 		expect(getByLabelText(document.body, 'url')).toHaveValue('');
 		expect(
@@ -273,12 +277,13 @@ describe('EditableLinkPanel', () => {
 		expect(editableConfig).toEqual({
 			en_US: {
 				href: 'http://google.com',
+				target: '',
 			},
 			mapperType: 'link',
 		});
 	});
 
-	it('calls dispatch withouth mapperType when editable type is link', async () => {
+	it('calls dispatch without mapperType when editable type is link', async () => {
 		let editableConfig;
 		updateEditableValues.mockImplementation(({editableValues}) => {
 			editableConfig = getEditableConfig(editableValues);
@@ -300,6 +305,7 @@ describe('EditableLinkPanel', () => {
 		expect(editableConfig).toEqual({
 			en_US: {
 				href: 'http://google.com',
+				target: '',
 			},
 		});
 	});


### PR DESCRIPTION
@ruben-pulido this should fix link-image conflicts

This is the editableValue shape that we have in portal:

```js
{
  "defaultValue": "data:image/png;base64,iVBORw0KGgoA=",
  "config": {
    /* Image description, this configuration can be translated but not mapped */
    "alt": {
      "es_ES": "Spanish image description",
      "en_US": "English image description"
    },

    /* Image size, this configuration cannot be translated nor mapped */
    "imageConfiguration": {
      "desktop": "Thumbnail-300x300"
    },

    /* Link href and target, these values appear here if they have been mapped  */
    "target": "_blank",
    "href": "https://google.mapped",

    /* It looks like backend services need this "flat" for link configuration */
    "mapperType": "link",

    /* Link href, this configuration can be translated and mapped */
    "es_ES": { href: "https://google.es", target: "_blank" },
    "en_US": { href: "https://google.us", target: "_blank" }
  },

  /* Editable content */
  "en_US": {
    "fileEntryId": "38684",
    "title": "samurai.jpg",
    "url": "/documents/20124/0/samurai.jpg/59d01c97-2563-4e81-a0d1-583876c799e8?t=1614673849293&download=true"
  },
  "es_ES": {
    "fileEntryId": "38695",
    "title": "tetris-minimal.jpg",
    "url": "/documents/20124/0/tetris-minimal.jpg/90f9dd03-9f69-b951-ea56-ae3908ade75a?t=1614673887980&download=true"
  }
}
```

In a near future, we should move editable link configuration to somewhere like `config > link > { href, target }`. Currently this information is embeded inside `editableValue > config`, which causes lots of headaches, and force us to take care of link-image configuration conflicts.

I would refactor editableValues into something like this:

```js
{
  /* Image description, this configuration can be translated but not mapped */
  "imageDescription": {
    "es_ES": "Spanish image description",
    "en_US": "English image description"
  },

  /* Image size, this configuration cannot be translated nor mapped */
  "imageSize": {
    "desktop": "Thumbnail-300x300"
  },

  /* Link target, this configuration cannot be translated nor mapped */
  "linkTarget": "_blank",

  /* Link href, this configuration can be translated and mapped */
  "linkHref": {
    "es_ES": "https://google.es",
    "en_US": "https://google.us"
  },

  /* Default value, cannot be translated nor mapped */
  "defaultValue": {
    url: "data:image/png;base64,iVBORw0KGgoA="
  },

  /* Editable content, can be translated or mapped */
  "content": {
      "en_US": {
        "fileEntryId": "38684",
        "title": "samurai.jpg",
        "url": "/documents/20124/0/samurai.jpg/59d01c97-2563-4e81-a0d1-583876c799e8?t=1614673849293&download=true"
      },
      "es_ES": {
        "fileEntryId": "38695",
        "title": "tetris-minimal.jpg",
        "url": "/documents/20124/0/tetris-minimal.jpg/90f9dd03-9f69-b951-ea56-ae3908ade75a?t=1614673887980&download=true"
      }
   }
}
```

```ts
type LanguageId = "en_US" | "es_ES";
type ViewportSize = "desktop" | "mobile";

type EditableValueRawEntry<T> = T;
type EditableValueTranslatedEntry<T> = Record<LanguageId, T>;
type EditableValueMappedEntry = { name: string };

type DefaultEditable<T> = {
  defaultValue: EditableValueRawEntry<T>,
  content: EditableValueTranslatedEntry<T> | EditableValueMappedEntry,
};

type LinkableEditable = {
  linkHref: EditableValueTranslatedEntry<string> | EditableValueMappedEntry,
  linkTarget: EditableValueRawEntry<string>,
};

type EditableImage = DefaultEditable<{ title: string, url: string }> &
  LinkableEditable & {
    imageDescription: EditableValueTranslatedEntry<string>,
    imageSize: EditableValueRawEntry<Record<ViewportSize, string>>,
  };
```

Which will allow us to add extra configuration in the future without modifying existing configuration panels. This will imply an upgrade process (or at least a lazy upgrade of all editables). For more information please check [my original post](http://www.cervantesvirtual.com/obra-visor/el-ingenioso-hidalgo-don-quijote-de-la-mancha-6/html/05f86699-4b53-4d9b-8ab8-b40ab63fb0b3_2.html#I_2_) at cervantesvirtual.com.