### PR TITLE
LPS-121859 Migrate v2 usages in asset/asset-browser-web

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -16,8 +16,8 @@
 
 <%@ include file="/init.jsp" %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= new AssetBrowserManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetBrowserDisplayContext) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new AssetBrowserManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetBrowserDisplayContext) %>"
 />
 
 <aui:form action="<%= assetBrowserDisplayContext.getPortletURL() %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="selectAssetFm">


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

![](https://user-images.githubusercontent.com/5572/109642239-fb627300-7b52-11eb-9b8f-8bf106a3d204.gif)

**Test plan**:
- Navigate to **Content & Data** > **Blogs**
- Create a new Blog Entry and publish it
- Navigate to **Content & Data** > **Web Content**
- Create a new Web Content
- In the sidebar on the right, scroll down and click on the **Related
Assets** button, and select **Blog Entry**
- In the modal window, select the Blog Entry you created previously
- Assert that the Blog Entry you selected is visible in the **Related
Assets** section