### PR TITLE
LPS-121863 Migrate v2 usages in asset/asset-tags-selector-web

### DIFF
--- a/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/select_single.jsp
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/select_single.jsp
@@ -20,8 +20,8 @@
 assetTagsSelectorDisplayContext = new AssetTagsSelectorDisplayContext(request, renderRequest, renderResponse, false);
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= new AssetTagsSelectorManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetTagsSelectorDisplayContext) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new AssetTagsSelectorManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetTagsSelectorDisplayContext) %>"
 />
 
 <aui:form action="<%= assetTagsSelectorDisplayContext.getPortletURL() %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="selectAssetTagFm">

--- a/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/resources/META-INF/resources/view.jsp
@@ -16,8 +16,8 @@
 
 <%@ include file="/init.jsp" %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= new AssetTagsSelectorManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetTagsSelectorDisplayContext) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new AssetTagsSelectorManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetTagsSelectorDisplayContext) %>"
 />
 
 <clay:container-fluid>


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

Adding tags to Web Content articles and Segments should work as
expected.

**Test plan (1)**:

![](https://user-images.githubusercontent.com/5572/109660880-a41bcd00-7b69-11eb-9271-5150fc3f6380.gif)

- Navigate to **Content & Data** > **Web Content**
- Create a new **Basic Web Content**
- In the sidebar on the right, scroll down and click on the **Tags** button
- In the modal window, make sure you can filter or add tags to your
Basic Web Content

**Test plan (2)**:

![](https://user-images.githubusercontent.com/5572/109660909-ada53500-7b69-11eb-82c4-2de79911af18.gif)

- Navigate to **People** > **Segments**
- Create a new Segment
- Drag and Drop a **Tag** field
- Click on the **Select** button and make sure you can add a tag