### PR TITLE
LPS-121860 Migrate v2 usages in asset/asset-display-page-item-selector-web

### DIFF
--- a/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
+++ b/modules/apps/asset/asset-display-page-item-selector-web/src/main/resources/META-INF/resources/display_pages.jsp
@@ -20,8 +20,8 @@
 AssetDisplayPagesItemSelectorViewDisplayContext assetDisplayPagesItemSelectorViewDisplayContext = (AssetDisplayPagesItemSelectorViewDisplayContext)request.getAttribute(AssetDisplayPageItemSelectorWebKeys.ASSET_DISPLAY_PAGES_ITEM_SELECTOR_VIEW_DISPLAY_CONTEXT);
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= new AssetDisplayPagesItemSelectorViewManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetDisplayPagesItemSelectorViewDisplayContext) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new AssetDisplayPagesItemSelectorViewManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetDisplayPagesItemSelectorViewDisplayContext) %>"
 />
 
 <aui:form cssClass="container-fluid container-fluid-max-xl container-view" name="fm">


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

Selecting a new display page template for a Web Content article should
work as expected

![](https://user-images.githubusercontent.com/5572/109666613-9ff2ae00-7b6f-11eb-9b99-ff9c3084a5f7.gif)

**Test plan**:
- Navigate to **Design** > **Page Templates**
- Select the **Display Page Templates** tab
- Click on the **+** button to create a new **Display Page Template**
- Enter a name
- Select **Web Content Article** under the **Content Type** drop down
menu
- Select **Basic Web Content** under the **Subtype** drop down menu
- Click on **Save**
- Publish your Display Page Template
- Navigate to **Content & Data** > **Web Content**
- Create a new **Basic Web Content**
- In the sidebar on the right, search for **Display Page Template**
- In the drop down menu, select **Specific Display Page Template**
- Click on the **Select** button
- Make sure you can filter the available Display Page Templates
- Select the **Display Page Template** you created