### PR TITLE
LPS-121910 Migrate v2 usages in site/site-browser-web

### DIFF
--- a/modules/apps/site/site-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -20,8 +20,8 @@
 	navigationItems="<%= siteBrowserDisplayContext.getNavigationItems() %>"
 />
 
-<clay:management-toolbar-v2
-	displayContext="<%= new SiteBrowserManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, siteBrowserDisplayContext) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new SiteBrowserManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, siteBrowserDisplayContext) %>"
 />
 
 <aui:form action="<%= siteBrowserDisplayContext.getPortletURL() %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="selectGroupFm">


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

![](https://user-images.githubusercontent.com/5572/109677313-d33a3a80-7b79-11eb-83a7-393652da79b8.gif)

**Test plan**:
- Navigate to **Configuration** > **Site Settings**
- Scroll down and search for the **Parent Site** section
- Click on the **Select Button**
- Assert that you can filter and choose a parent site