### PR TITLE
LPS-121909 Migrate v2 usages in site/site-admin-web

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/SiteManagementToolbarPropsTransformer.js
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/SiteManagementToolbarPropsTransformer.js
@@ -12,18 +12,29 @@
  * details.
  */
 
-import {DefaultEventHandler} from 'frontend-js-web';
+export default function propsTransformer({portletNamespace, ...otherProps}) {
+	return {
+		...otherProps,
+		onActionButtonClick(event, {item}) {
+			const action = item.data?.action;
 
-class ManagementToolbarDefaultEventHandler extends DefaultEventHandler {
-	deleteSites() {
-		if (
-			confirm(
-				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
-			)
-		) {
-			submitForm(this.one('#fm'));
-		}
-	}
+			if (action === 'deleteSites') {
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-this'
+						)
+					)
+				) {
+					const form = document.getElementById(
+						`${portletNamespace}fm`
+					);
+
+					if (form) {
+						submitForm(form);
+					}
+				}
+			}
+		},
+	};
 }
-
-export default ManagementToolbarDefaultEventHandler;

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -33,8 +33,9 @@ if (group != null) {
 }
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= siteAdminManagementToolbarDisplayContext %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= siteAdminManagementToolbarDisplayContext %>"
+	propsTransformer="js/SiteManagementToolbarPropsTransformer"
 />
 
 <div class="closed sidenav-container sidenav-right" id="<%= liferayPortletResponse.getNamespace() + "infoPanelId" %>">
@@ -90,8 +91,3 @@ if (group != null) {
 		</clay:container-fluid>
 	</div>
 </div>
-
-<liferay-frontend:component
-	componentId="<%= siteAdminManagementToolbarDisplayContext.getDefaultEventHandler() %>"
-	module="js/ManagementToolbarDefaultEventHandler.es"
-/>


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

Creating, filtering and deleting sites should work as expected

![](https://user-images.githubusercontent.com/5572/109789734-ea783700-7c10-11eb-9191-fa91d7b5f359.gif)

**Test plan**:
- From the Global Menu, select the **Control Panel** tab
- Navigate to **Sites**
- Assert that you can create a **New Site** from the management toolbar
- Assert that you can delete a **Site** from the management toolbar
- Assert that you can create a nested Site in an existing Site
- Assert that you can delete a nested Site in an existing Site