### PR TITLE
LPS-121911 Migrate v2 usages in site/site-item-selector-web

### DIFF
--- a/modules/apps/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
+++ b/modules/apps/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
@@ -27,8 +27,8 @@ GroupItemSelectorCriterion groupItemSelectorCriterion = siteItemSelectorViewDisp
 String target = ParamUtil.getString(request, "target", groupItemSelectorCriterion.getTarget());
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= new SitesItemSelectorViewManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, siteItemSelectorViewDisplayContext) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new SitesItemSelectorViewManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, siteItemSelectorViewDisplayContext) %>"
 />
 
 <aui:form action="<%= siteItemSelectorViewDisplayContext.getPortletURL() %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="selectGroupFm">


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

Switching to a site should work as expected

![](https://user-images.githubusercontent.com/5572/109807253-ec98c080-7c25-11eb-90f3-e8f6851893f4.gif)

**Test plan**:
- Click on the user avatar in the top right hand corner of the home page
- Click on **My Sites**
- Assert that you can switch to another website