### PR TITLE
LPS-121881 Migrate v2 usages in journal-web

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalSelectArticleTranslationsManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalSelectArticleTranslationsManagementToolbarDisplayContext.java
@@ -87,6 +87,11 @@ public class JournalSelectArticleTranslationsManagementToolbarDisplayContext
 	}
 
 	@Override
+	public String getSortingURL() {
+		return null;
+	}
+
+	@Override
 	protected String[] getDisplayViews() {
 		return new String[] {"list"};
 	}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_article_translations.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_article_translations.jsp
@@ -16,8 +16,8 @@
 
 <%@ include file="/init.jsp" %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= new JournalSelectArticleTranslationsManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, journalDisplayContext) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new JournalSelectArticleTranslationsManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, journalDisplayContext) %>"
 />
 
 <aui:form cssClass="container-fluid container-fluid-max-xl" name="fm">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_structure.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_structure.jsp
@@ -22,8 +22,8 @@ JournalSelectDDMStructureDisplayContext journalSelectDDMStructureDisplayContext 
 SearchContainer<DDMStructure> ddmStructureSearch = journalSelectDDMStructureDisplayContext.getDDMStructureSearch();
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= new JournalSelectDDMStructureManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, journalSelectDDMStructureDisplayContext) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new JournalSelectDDMStructureManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, journalSelectDDMStructureDisplayContext) %>"
 />
 
 <aui:form cssClass="container-fluid container-fluid-max-xl" method="post" name="selectDDMStructureFm">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_template.jsp
@@ -20,8 +20,8 @@
 JournalSelectDDMTemplateDisplayContext journalSelectDDMTemplateDisplayContext = new JournalSelectDDMTemplateDisplayContext(renderRequest, renderResponse);
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= new JournalSelectDDMTemplateManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, journalSelectDDMTemplateDisplayContext) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new JournalSelectDDMTemplateManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, journalSelectDDMTemplateDisplayContext) %>"
 />
 
 <aui:form cssClass="container-fluid container-fluid-max-xl" method="post" name="selectDDMTemplateFm">


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

**Test plan for each of the jsps changed:** 

`select_article_translations.jsp`
1. Go to Web Content and add a web content article
2. Click on the three dots on "Delete translations" => modal is opened with the new management toolbar

`select_ddm_template.jsp`
1. Go to Web content and create or edit a web content article. 
2. On the right panel, in "Default Template" section, click on "select" button => modal is opened with the new management toolbar. 

`select_ddm_structure.jsp`
1. Go to Web Content > Templates and create or edit a template
2. On the right panel, in "Basic information" section, click on "select" button => modal is opened with the new management toolbar

Everything should work like before. 

/cc @julien @markocikos @jonmak08