### PR TITLE
[TS] LPS-128389 Modified dates of web content previous versions change when expiration date is set in the future

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6571,7 +6571,9 @@ public class JournalArticleLocalServiceImpl
 
 		article = journalArticlePersistence.update(article);
 
-		if (isExpireAllArticleVersions(article.getCompanyId())) {
+		if (isExpireAllArticleVersions(article.getCompanyId()) &&
+			(expirationDate != null) && expirationDate.before(now)) {
+
 			article = setArticlesExpirationDate(article);
 		}
 
@@ -7038,9 +7040,8 @@ public class JournalArticleLocalServiceImpl
 							new ArticleVersionComparator(true));
 
 					for (JournalArticle currentArticle : currentArticles) {
-						if ((currentArticle.getExpirationDate() == null) ||
-							(currentArticle.getVersion() >
-								article.getVersion())) {
+						if (currentArticle.getVersion() >
+								article.getVersion()) {
 
 							continue;
 						}


### PR DESCRIPTION
Hi @liferay-echo,

This is a solution for issue LPS-128389 which tries to maintain the history of modified dates for a web content when the expiration date is set to a date in the future. This history should change when the expiration date arrives (or has past), at which moment all modified dates are updated to the expiration date. (Except if the system setting _Expire All Article Versions Enabled_ is disabled.)

`relevant` and `staging` tests have been triggered in https://github.com/ricardocousolr/liferay-portal/pull/53. Some of the failures are spurious but `LocalFile.Staging#StagingRemoteLiveWebContent` seems consistent. 
I run this test in my local with `run-selenium-test`and I could reproduce it on several occasions, but on others the test finished successfully. 
To make sure it wasn't an existing instability in `master` I ran a placebo pr in https://github.com/ricardocousolr/liferay-portal/pull/51 and the same test fails (alongside others too).

Please let me know if you have any questions.

Thanks!