### PR TITLE
[TS] LPS-128652 Only change 1 fragmentEntryLink in the scope of this method

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -700,45 +700,33 @@ public class FragmentEntryLinkLocalServiceImpl
 	public void updateLatestChanges(long fragmentEntryLinkId)
 		throws PortalException {
 
-		FragmentEntryLink oldFragmentEntryLink =
+		FragmentEntryLink fragmentEntryLink =
 			fragmentEntryLinkPersistence.findByPrimaryKey(fragmentEntryLinkId);
 
 		FragmentEntry fragmentEntry = fragmentEntryPersistence.findByPrimaryKey(
-			oldFragmentEntryLink.getFragmentEntryId());
+			fragmentEntryLink.getFragmentEntryId());
 
-		List<FragmentEntryLink> fragmentEntryLinks =
-			fragmentEntryLinkPersistence.findByG_F_C_C(
-				oldFragmentEntryLink.getGroupId(),
-				oldFragmentEntryLink.getFragmentEntryId(),
-				_portal.getClassNameId(Layout.class),
-				oldFragmentEntryLink.getPlid());
-
-		oldFragmentEntryLink.setHtml(fragmentEntry.getHtml());
+		fragmentEntryLink.setHtml(fragmentEntry.getHtml());
 
 		String processedHTML = _getProcessedHTML(
-			oldFragmentEntryLink,
-			ServiceContextThreadLocal.getServiceContext());
+			fragmentEntryLink, ServiceContextThreadLocal.getServiceContext());
 
 		String defaultEditableValues = String.valueOf(
 			_fragmentEntryProcessorRegistry.getDefaultEditableValuesJSONObject(
-				processedHTML, oldFragmentEntryLink.getConfiguration()));
+				processedHTML, fragmentEntryLink.getConfiguration()));
 
-		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
-			fragmentEntryLink.setCss(fragmentEntry.getCss());
-			fragmentEntryLink.setHtml(fragmentEntry.getHtml());
-			fragmentEntryLink.setJs(fragmentEntry.getJs());
-			fragmentEntryLink.setConfiguration(
-				fragmentEntry.getConfiguration());
+		fragmentEntryLink.setCss(fragmentEntry.getCss());
+		fragmentEntryLink.setJs(fragmentEntry.getJs());
+		fragmentEntryLink.setConfiguration(fragmentEntry.getConfiguration());
 
-			String newEditableValues = _mergeEditableValues(
-				defaultEditableValues, fragmentEntryLink.getEditableValues());
+		String newEditableValues = _mergeEditableValues(
+			defaultEditableValues, fragmentEntryLink.getEditableValues());
 
-			fragmentEntryLink.setEditableValues(newEditableValues);
+		fragmentEntryLink.setEditableValues(newEditableValues);
 
-			fragmentEntryLink.setLastPropagationDate(new Date());
+		fragmentEntryLink.setLastPropagationDate(new Date());
 
-			fragmentEntryLinkPersistence.update(fragmentEntryLink);
-		}
+		fragmentEntryLinkPersistence.update(fragmentEntryLink);
 	}
 
 	private String _getProcessedHTML(


### PR DESCRIPTION
Hi Team,

This method is overiterating through fragmentEntryLinks. All calls for this method already handle supplying the correct fragmentEntryLinkIds so we don't need to update every fragmentEntryLink belonging the oldFragmentEntryLink's fragmentEntry.

Apart from performance improvement, defaultEditableValues was never updated to match it to the current fragmentEntryLink of the loop, so the editableValues of 2 different fragmentEntryLinks were merged, causing LPS-128652.

Can you please review?
https://issues.liferay.com/browse/LPS-128652

Thanks,
Balázs