### PR TITLE
LPS-121861 Migrate v2 usages in asset/asset-taglib

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_entry_usages/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_entry_usages/page.jsp
@@ -119,8 +119,8 @@ AssetEntryUsagesDisplayContext assetEntryUsagesDisplayContext = new AssetEntryUs
 					</c:choose>
 				</h3>
 
-				<clay:management-toolbar-v2
-					displayContext="<%= new AssetEntryUsagesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetEntryUsagesDisplayContext.getSearchContainer()) %>"
+				<clay:management-toolbar
+					managementToolbarDisplayContext="<%= new AssetEntryUsagesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetEntryUsagesDisplayContext.getSearchContainer()) %>"
 				/>
 
 				<liferay-ui:search-container


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

**Test plan**:

Since this tag is no longer used and was replaced with the
`<liferay-layout:layout-classed-model-usages-admin />` tag in
[https://github.com/liferay/liferay-portal/commit/1bb7fde](https://github.com/liferay/liferay-portal/commit/1bb7fdefbbf3b4d595252fc4134f481d8db075e7), you can:

- Edit [`view_asset_entry_usages.jsp`](https://github.com/liferay/liferay-portal/blob/c724841cf6f0b0baff32e5aa3fca17b799583427/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_asset_entry_usages.jsp)
- Replace `<liferay-layout:layout-classed-model-usages-admin />` 
  with `<liferay-asset:asset-entry-usages />`
- Follow the original test plan described [here](https://github.com/liferay-echo/liferay-portal/pull/3898#issue-584082311)