### PR TITLE
LPS-128825 Migrate v2 usages in asset/asset-categories-admin-web

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/npmscripts.config.js
+++ b/modules/apps/asset/asset-categories-admin-web/npmscripts.config.js
@@ -16,7 +16,7 @@ module.exports = {
 	federation: {
 		exposes: [
 			'<inputDir>/js/ActionsComponentPropsTransformer.js',
-			'<inputDir>/js/AssetCategoriesManagementToolbarDefaultEventHandler.es.js',
+			'<inputDir>/js/AssetCategoriesManagementToolbarPropsTransformer.js',
 			'<inputDir>/js/AssetCategoriesSelectorTag.es.js',
 		],
 		mode: 'default',

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/AssetCategoriesManagementToolbarPropsTransformer.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/AssetCategoriesManagementToolbarPropsTransformer.js
@@ -12,44 +12,54 @@
  * details.
  */
 
-import {
-	DefaultEventHandler,
-	addParams,
-	openSelectionModal,
-} from 'frontend-js-web';
+import {addParams, openSelectionModal} from 'frontend-js-web';
 
-class AssetCategoriesManagementToolbarDefaultEventHandler extends DefaultEventHandler {
-	deleteSelectedCategories() {
+export default function propsTransformer({portletNamespace, ...otherProps}) {
+	const deleteSelectedCategories = () => {
 		if (
 			confirm(
 				Liferay.Language.get('are-you-sure-you-want-to-delete-this')
 			)
 		) {
-			submitForm(this.one('#fm'));
+			const form = document.getElementById(`${portletNamespace}fm`);
+
+			if (form) {
+				submitForm(form);
+			}
 		}
-	}
+	};
 
-	selectCategory(itemData) {
-		const namespace = this.namespace;
-
+	const selectCategory = (itemData) => {
 		openSelectionModal({
-			onSelect: (selectedItem) => {
+			onSelect(selectedItem) {
 				const category = selectedItem
 					? selectedItem[Object.keys(selectedItem)[0]]
 					: null;
 
 				if (category) {
 					location.href = addParams(
-						namespace + 'categoryId=' + category.categoryId,
+						`${portletNamespace}categoryId=${category.categoryId}`,
 						itemData.viewCategoriesURL
 					);
 				}
 			},
-			selectEventName: this.ns('selectCategory'),
+			selectEventName: `${portletNamespace}selectCategory`,
 			title: Liferay.Language.get('select-category'),
 			url: itemData.categoriesSelectorURL,
 		});
-	}
-}
+	};
 
-export default AssetCategoriesManagementToolbarDefaultEventHandler;
+	return {
+		...otherProps,
+		onActionButtonClick(event, {item}) {
+			const action = item.data?.action;
+
+			if (action === 'deleteSelectedCategories') {
+				deleteSelectedCategories();
+			}
+			else if (action === 'selectCategory') {
+				selectCategory();
+			}
+		},
+	};
+}

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view_categories.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view_categories.jsp
@@ -20,8 +20,9 @@
 AssetCategoriesManagementToolbarDisplayContext assetCategoriesManagementToolbarDisplayContext = new AssetCategoriesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetCategoriesDisplayContext);
 %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= assetCategoriesManagementToolbarDisplayContext %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= assetCategoriesManagementToolbarDisplayContext %>"
+	propsTransformer="js/AssetCategoriesManagementToolbarPropsTransformer"
 />
 
 <portlet:actionURL name="deleteCategory" var="deleteCategoryURL">
@@ -162,8 +163,3 @@ AssetCategoriesManagementToolbarDisplayContext assetCategoriesManagementToolbarD
 	<aui:input name="parentCategoryId" type="hidden" />
 	<aui:input name="vocabularyId" type="hidden" />
 </aui:form>
-
-<liferay-frontend:component
-	componentId="<%= assetCategoriesManagementToolbarDisplayContext.getDefaultEventHandler() %>"
-	module="js/AssetCategoriesManagementToolbarDefaultEventHandler.es"
-/>

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view_vocabularies.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view_vocabularies.jsp
@@ -16,8 +16,8 @@
 
 <%@ include file="/init.jsp" %>
 
-<clay:management-toolbar-v2
-	displayContext="<%= new AssetVocabulariesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetCategoriesDisplayContext) %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= new AssetVocabulariesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetCategoriesDisplayContext) %>"
 />
 
 <aui:form cssClass="container-fluid container-fluid-max-xl" name="fm">


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

Creating and deleting categories and vocabularies should work as
expected.

![](https://user-images.githubusercontent.com/5572/110474266-c1a7e400-80df-11eb-8e28-0ee8309c01cd.gif)

**Test plan**:
- Navigate to **Categorization** > **Categories**
- Assert that you can create a new Vocabulary
- Assert that you can delete a Vocabulary
- Assert that you can create a new Category inside a Vocabulary
- Assert that you can delete a Category inside a Vocabulary