### PR TITLE
LPS-128826 Migrate v2 usages in asset/asset-list-web

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {openSimpleInputModal} from 'frontend-js-web';
+
+export default function propsTransformer({portletNamespace, ...otherProps}) {
+	return {
+		...otherProps,
+		onActionButtonClick(event, {item}) {
+			const action = item.data?.action;
+
+			if (action === 'deleteSelectedAssetListEntries') {
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-this'
+						)
+					)
+				) {
+					const form = document.getElementById(
+						`${portletNamespace}fm`
+					);
+
+					if (form) {
+						submitForm(form);
+					}
+				}
+			}
+		},
+		onCreationMenuItemClick(event, {item}) {
+			const action = item.data?.action;
+
+			if (action === 'addAssetListEntry') {
+				openSimpleInputModal({
+					dialogTitle: item.data.title,
+					formSubmitURL: item.data.addAssetListEntryURL,
+					mainFieldLabel: Liferay.Language.get('title'),
+					mainFieldName: 'title',
+					mainFieldPlaceholder: Liferay.Language.get('title'),
+					namespace: portletNamespace,
+				});
+			}
+		},
+	};
+}

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view.jsp
@@ -25,8 +25,9 @@ AssetListManagementToolbarDisplayContext assetListManagementToolbarDisplayContex
 	navigationItems='<%= assetListDisplayContext.getNavigationItems("collections") %>'
 />
 
-<clay:management-toolbar-v2
-	displayContext="<%= assetListManagementToolbarDisplayContext %>"
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= assetListManagementToolbarDisplayContext %>"
+	propsTransformer="js/ManagementToolbarPropsTransformer"
 />
 
 <portlet:actionURL name="/asset_list/delete_asset_list_entries" var="deleteAssetListEntryURL">

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_asset_list_entry_usages.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view_asset_list_entry_usages.jsp
@@ -125,8 +125,8 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 					</c:choose>
 				</h3>
 
-				<clay:management-toolbar-v2
-					displayContext="<%= new AssetListEntryUsagesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetListEntryUsagesDisplayContext.getSearchContainer()) %>"
+				<clay:management-toolbar
+					managementToolbarDisplayContext="<%= new AssetListEntryUsagesManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, assetListEntryUsagesDisplayContext.getSearchContainer()) %>"
 				/>
 
 				<liferay-ui:search-container


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

Creating and deleting collections and viewing their usages should work as
expected.

![](https://user-images.githubusercontent.com/5572/110501858-e6f61b80-80fa-11eb-94f8-d7930bb840b9.gif)

**Test plan**:
- Navigate to **Site Builder** > **Collections**
- Click on the **+** button on the right and make sure you can
    - Create a manual collection
    - Create a dynamic collection
- Make sure you can delete a collection
- Navigate to **Content & Data** > **Blogs**
- Create a few blog entries and publish them
- Navigate to **Site Builder** > **Pages**
- Create a new (Content) Page
- Drag and Drop an Asset Publisher widget and configure it display
  your collection
- Make sure you can view their usages