### PR TITLE
LPS-128765 Make sure that all fragmentEntryLinks referenced in the layout structure are included. If any is not found, just add a dummy for it to avoid frontend errors

### DIFF
--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/LayoutStructure.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/LayoutStructure.java
@@ -401,6 +401,10 @@ public class LayoutStructure {
 		return null;
 	}
 
+	public Map<Long, LayoutStructureItem> getFragmentLayoutStructureItems() {
+		return _fragmentLayoutStructureItems;
+	}
+
 	public LayoutStructureItem getLayoutStructureItem(String itemId) {
 		return _layoutStructureItems.get(itemId);
 	}

--- a/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/util/structure/packageinfo
+++ b/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/util/structure/packageinfo
@@ -1,1 +1,1 @@
-version 1.10.0
+version 1.11.0

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -1573,6 +1573,35 @@ public class ContentPageEditorDisplayContext {
 			themeDisplay.setIsolated(isolated);
 		}
 
+		LayoutStructure layoutStructure = _getLayoutStructure();
+
+		Map<Long, LayoutStructureItem> fragmentLayoutStructureItems =
+			layoutStructure.getFragmentLayoutStructureItems();
+
+		for (long fragmentEntryLinkId : fragmentLayoutStructureItems.keySet()) {
+			if (!fragmentEntryLinksMap.containsKey(
+					String.valueOf(fragmentEntryLinkId))) {
+
+				fragmentEntryLinksMap.put(
+					String.valueOf(fragmentEntryLinkId),
+					JSONUtil.put(
+						"configuration", JSONFactoryUtil.createJSONObject()
+					).put(
+						"content", StringPool.BLANK
+					).put(
+						"defaultConfigurationValues",
+						JSONFactoryUtil.createJSONObject()
+					).put(
+						"editableValues", JSONFactoryUtil.createJSONObject()
+					).put(
+						"error", Boolean.TRUE
+					).put(
+						"fragmentEntryLinkId",
+						String.valueOf(fragmentEntryLinkId)
+					));
+			}
+		}
+
 		_fragmentEntryLinks = fragmentEntryLinksMap;
 
 		return _fragmentEntryLinks;


### PR DESCRIPTION
I have tried several thing in the frontend, but they required to modified several files and also having to take into account this case in future developments. Instead of that I've moved the code to the backend to ensure that we always have a fragmentEntryLink, if that doesn't exist in the database, we'll show an error element that the user can remove 