### PR TITLE
LPS-129012 Use page's currentURL instead of portlet's currentURL

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_asset_entry_full_content.jsp
@@ -87,7 +87,7 @@ Map<String, Object> fragmentsEditorData = HashMapBuilder.<String, Object>put(
 		<c:if test="<%= !print %>">
 
 			<%
-			String fullContentRedirect = currentURL;
+			String fullContentRedirect = themeDisplay.getURLCurrent();
 
 			if (WorkflowDefinitionLinkLocalServiceUtil.hasWorkflowDefinitionLink(assetEntry.getCompanyId(), assetEntry.getGroupId(), assetEntry.getClassName())) {
 				fullContentRedirect = redirect;


### PR DESCRIPTION
Hi Team,
If we are on a page defined by an asset's friendlyURL, this redirection will not redirect to the asset's friendlyURL, but to the asset publisher's friendlyURL.

Can you please review?
https://issues.liferay.com/browse/LPS-129012

Thanks,
Balázs

ps.: Resent from https://github.com/liferay-echo/liferay-portal/pull/3996 after fixing SF