### PR TITLE
LPS-129497 Removes unnecessary taglib call since ManagementToolbarDefaultEventHandler doesn't exist

### DIFF
--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view.jsp
@@ -290,8 +290,3 @@ TrashManagementToolbarDisplayContext trashManagementToolbarDisplayContext = new 
 		</clay:container-fluid>
 	</div>
 </div>
-
-<liferay-frontend:component
-	componentId="<%= trashManagementToolbarDisplayContext.getDefaultEventHandler() %>"
-	module="js/ManagementToolbarDefaultEventHandler.es"
-/>


### PR DESCRIPTION
forward