### PR TITLE
LPS-129552 Can not link to a public page when adding a link in Rich Text

### DIFF
--- a/modules/apps/layout/layout-item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -24,8 +24,7 @@ taglib uri="http://liferay.com/tld/site-navigation" prefix="liferay-site-navigat
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.layout.item.selector.web.internal.constants.LayoutsItemSelectorWebKeys" %><%@
-page import="com.liferay.layout.item.selector.web.internal.display.context.LayoutItemSelectorViewDisplayContext" %><%@
-page import="com.liferay.portal.kernel.util.HtmlUtil" %>
+page import="com.liferay.layout.item.selector.web.internal.display.context.LayoutItemSelectorViewDisplayContext" %>
 
 <liferay-frontend:defineObjects />
 

--- a/modules/apps/layout/layout-item-selector-web/src/main/resources/META-INF/resources/layouts.jsp
+++ b/modules/apps/layout/layout-item-selector-web/src/main/resources/META-INF/resources/layouts.jsp
@@ -30,7 +30,7 @@ LayoutItemSelectorViewDisplayContext layoutItemSelectorViewDisplayContext = (Lay
 	checkDisplayPage="<%= layoutItemSelectorViewDisplayContext.isCheckDisplayPage() %>"
 	enableCurrentPage="<%= layoutItemSelectorViewDisplayContext.isEnableCurrentPage() %>"
 	followURLOnTitleClick="<%= layoutItemSelectorViewDisplayContext.isFollowURLOnTitleClick() %>"
-	itemSelectorSaveEvent="<%= HtmlUtil.escapeJS(layoutItemSelectorViewDisplayContext.getItemSelectedEventName()) %>"
+	itemSelectorSaveEvent="<%= layoutItemSelectorViewDisplayContext.getItemSelectedEventName() %>"
 	multiSelection="<%= layoutItemSelectorViewDisplayContext.isMultiSelection() %>"
 	namespace="<%= liferayPortletResponse.getNamespace() %>"
 	privateLayout="<%= layoutItemSelectorViewDisplayContext.isPrivateLayout() %>"


### PR DESCRIPTION
This is a fix for https://issues.liferay.com/browse/LPS-129552. 

**Steps to reproduce:** 
1. Go to Product Menu > Web Content > Create a new Web Content
2. On the editor, try to add a link(Click Browse Server > Go to Public Pages tab > Select one page)

<img width="825" alt="Screenshot 2021-03-25 at 13 52 06" src="https://user-images.githubusercontent.com/8373764/112475640-54e44900-8d71-11eb-8942-90e836e573da.png">


**Expected result:**
Can select a page to link.
**Actual Result**
Can not select a page to link: Clicking the page can not select it and no save button shows on the Select Item page

