### PR TITLE
[TS] LPS-129944 Not needed on configuration modal, let JournalContentPortlet handle this

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -625,10 +625,6 @@ public class JournalContentDisplayContext {
 			}
 		}
 
-		_portletRequest.setAttribute(WebKeys.JOURNAL_ARTICLE, getArticle());
-		_portletRequest.setAttribute(
-			WebKeys.JOURNAL_ARTICLE_DISPLAY, getArticleDisplay());
-
 		return _contentMetadataAssetAddonEntries;
 	}
 
@@ -677,10 +673,6 @@ public class JournalContentDisplayContext {
 				_userToolAssetAddonEntries.add(userToolAssetAddonEntry);
 			}
 		}
-
-		_portletRequest.setAttribute(WebKeys.JOURNAL_ARTICLE, getArticle());
-		_portletRequest.setAttribute(
-			WebKeys.JOURNAL_ARTICLE_DISPLAY, getArticleDisplay());
 
 		return _userToolAssetAddonEntries;
 	}


### PR DESCRIPTION
Hit Team,
This is quite similar to https://issues.liferay.com/browse/LPS-127637 in the way that

- when the article's template has a dynamically included JournalContentPortlet
- and creating the articleDisplay on the configuration modal

the template rendering can get into an infinite loop .

Can you please review?
https://issues.liferay.com/browse/LPS-129944

Thanks,
Balázs