### PR TITLE
LPS-129685

### DIFF
--- a/modules/apps/asset/asset-list-api/bnd.bnd
+++ b/modules/apps/asset/asset-list-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset List API
 Bundle-SymbolicName: com.liferay.asset.list.api
-Bundle-Version: 3.0.1
+Bundle-Version: 3.1.0
 Export-Package:\
 	com.liferay.asset.list.asset.entry.provider,\
 	com.liferay.asset.list.asset.entry.query.processor,\

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/constants/AssetListEntryUsageConstants.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/constants/AssetListEntryUsageConstants.java
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.list.constants;
+
+/**
+ * @author Víctor Galán
+ */
+public class AssetListEntryUsageConstants {
+
+	public static final int TYPE_DEFAULT = 0;
+
+	public static final int TYPE_DISPLAY_PAGE_TEMPLATE = 1;
+
+	public static final int TYPE_LAYOUT = 2;
+
+	public static final int TYPE_PAGE_TEMPLATE = 3;
+
+}

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/model/AssetListEntryUsageModel.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/model/AssetListEntryUsageModel.java
@@ -298,6 +298,64 @@ public interface AssetListEntryUsageModel
 	public void setClassPK(long classPK);
 
 	/**
+	 * Returns the container key of this asset list entry usage.
+	 *
+	 * @return the container key of this asset list entry usage
+	 */
+	@AutoEscape
+	public String getContainerKey();
+
+	/**
+	 * Sets the container key of this asset list entry usage.
+	 *
+	 * @param containerKey the container key of this asset list entry usage
+	 */
+	public void setContainerKey(String containerKey);
+
+	/**
+	 * Returns the container type of this asset list entry usage.
+	 *
+	 * @return the container type of this asset list entry usage
+	 */
+	public long getContainerType();
+
+	/**
+	 * Sets the container type of this asset list entry usage.
+	 *
+	 * @param containerType the container type of this asset list entry usage
+	 */
+	public void setContainerType(long containerType);
+
+	/**
+	 * Returns the key of this asset list entry usage.
+	 *
+	 * @return the key of this asset list entry usage
+	 */
+	@AutoEscape
+	public String getKey();
+
+	/**
+	 * Sets the key of this asset list entry usage.
+	 *
+	 * @param key the key of this asset list entry usage
+	 */
+	public void setKey(String key);
+
+	/**
+	 * Returns the plid of this asset list entry usage.
+	 *
+	 * @return the plid of this asset list entry usage
+	 */
+	public long getPlid();
+
+	/**
+	 * Sets the plid of this asset list entry usage.
+	 *
+	 * @param plid the plid of this asset list entry usage
+	 */
+	public void setPlid(long plid);
+
+	/**
 	 * Returns the portlet ID of this asset list entry usage.
 	 *
 	 * @return the portlet ID of this asset list entry usage
@@ -311,6 +369,20 @@ public interface AssetListEntryUsageModel
 	 * @param portletId the portlet ID of this asset list entry usage
 	 */
 	public void setPortletId(String portletId);
+
+	/**
+	 * Returns the type of this asset list entry usage.
+	 *
+	 * @return the type of this asset list entry usage
+	 */
+	public int getType();
+
+	/**
+	 * Sets the type of this asset list entry usage.
+	 *
+	 * @param type the type of this asset list entry usage
+	 */
+	public void setType(int type);
 
 	/**
 	 * Returns the last publish date of this asset list entry usage.

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/model/AssetListEntryUsageSoap.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/model/AssetListEntryUsageSoap.java
@@ -48,7 +48,12 @@ public class AssetListEntryUsageSoap implements Serializable {
 		soapModel.setAssetListEntryId(model.getAssetListEntryId());
 		soapModel.setClassNameId(model.getClassNameId());
 		soapModel.setClassPK(model.getClassPK());
+		soapModel.setContainerKey(model.getContainerKey());
+		soapModel.setContainerType(model.getContainerType());
+		soapModel.setKey(model.getKey());
+		soapModel.setPlid(model.getPlid());
 		soapModel.setPortletId(model.getPortletId());
+		soapModel.setType(model.getType());
 		soapModel.setLastPublishDate(model.getLastPublishDate());
 
 		return soapModel;
@@ -216,12 +221,52 @@ public class AssetListEntryUsageSoap implements Serializable {
 		_classPK = classPK;
 	}
 
+	public String getContainerKey() {
+		return _containerKey;
+	}
+
+	public void setContainerKey(String containerKey) {
+		_containerKey = containerKey;
+	}
+
+	public long getContainerType() {
+		return _containerType;
+	}
+
+	public void setContainerType(long containerType) {
+		_containerType = containerType;
+	}
+
+	public String getKey() {
+		return _key;
+	}
+
+	public void setKey(String key) {
+		_key = key;
+	}
+
+	public long getPlid() {
+		return _plid;
+	}
+
+	public void setPlid(long plid) {
+		_plid = plid;
+	}
+
 	public String getPortletId() {
 		return _portletId;
 	}
 
 	public void setPortletId(String portletId) {
 		_portletId = portletId;
+	}
+
+	public int getType() {
+		return _type;
+	}
+
+	public void setType(int type) {
+		_type = type;
 	}
 
 	public Date getLastPublishDate() {
@@ -245,7 +290,12 @@ public class AssetListEntryUsageSoap implements Serializable {
 	private long _assetListEntryId;
 	private long _classNameId;
 	private long _classPK;
+	private String _containerKey;
+	private long _containerType;
+	private String _key;
+	private long _plid;
 	private String _portletId;
+	private int _type;
 	private Date _lastPublishDate;
 
 }

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/model/AssetListEntryUsageTable.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/model/AssetListEntryUsageTable.java
@@ -70,9 +70,21 @@ public class AssetListEntryUsageTable
 			"classNameId", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<AssetListEntryUsageTable, Long> classPK = createColumn(
 		"classPK", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<AssetListEntryUsageTable, String> containerKey =
+		createColumn(
+			"containerKey", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<AssetListEntryUsageTable, Long> containerType =
+		createColumn(
+			"containerType", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
+	public final Column<AssetListEntryUsageTable, String> key = createColumn(
+		"key_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<AssetListEntryUsageTable, Long> plid = createColumn(
+		"plid", Long.class, Types.BIGINT, Column.FLAG_DEFAULT);
 	public final Column<AssetListEntryUsageTable, String> portletId =
 		createColumn(
 			"portletId", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<AssetListEntryUsageTable, Integer> type = createColumn(
+		"type_", Integer.class, Types.INTEGER, Column.FLAG_DEFAULT);
 	public final Column<AssetListEntryUsageTable, Date> lastPublishDate =
 		createColumn(
 			"lastPublishDate", Date.class, Types.TIMESTAMP,

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/model/AssetListEntryUsageWrapper.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/model/AssetListEntryUsageWrapper.java
@@ -58,7 +58,12 @@ public class AssetListEntryUsageWrapper
 		attributes.put("assetListEntryId", getAssetListEntryId());
 		attributes.put("classNameId", getClassNameId());
 		attributes.put("classPK", getClassPK());
+		attributes.put("containerKey", getContainerKey());
+		attributes.put("containerType", getContainerType());
+		attributes.put("key", getKey());
+		attributes.put("plid", getPlid());
 		attributes.put("portletId", getPortletId());
+		attributes.put("type", getType());
 		attributes.put("lastPublishDate", getLastPublishDate());
 
 		return attributes;
@@ -145,10 +150,40 @@ public class AssetListEntryUsageWrapper
 			setClassPK(classPK);
 		}
 
+		String containerKey = (String)attributes.get("containerKey");
+
+		if (containerKey != null) {
+			setContainerKey(containerKey);
+		}
+
+		Long containerType = (Long)attributes.get("containerType");
+
+		if (containerType != null) {
+			setContainerType(containerType);
+		}
+
+		String key = (String)attributes.get("key");
+
+		if (key != null) {
+			setKey(key);
+		}
+
+		Long plid = (Long)attributes.get("plid");
+
+		if (plid != null) {
+			setPlid(plid);
+		}
+
 		String portletId = (String)attributes.get("portletId");
 
 		if (portletId != null) {
 			setPortletId(portletId);
+		}
+
+		Integer type = (Integer)attributes.get("type");
+
+		if (type != null) {
+			setType(type);
 		}
 
 		Date lastPublishDate = (Date)attributes.get("lastPublishDate");
@@ -219,6 +254,26 @@ public class AssetListEntryUsageWrapper
 	}
 
 	/**
+	 * Returns the container key of this asset list entry usage.
+	 *
+	 * @return the container key of this asset list entry usage
+	 */
+	@Override
+	public String getContainerKey() {
+		return model.getContainerKey();
+	}
+
+	/**
+	 * Returns the container type of this asset list entry usage.
+	 *
+	 * @return the container type of this asset list entry usage
+	 */
+	@Override
+	public long getContainerType() {
+		return model.getContainerType();
+	}
+
+	/**
 	 * Returns the create date of this asset list entry usage.
 	 *
 	 * @return the create date of this asset list entry usage
@@ -246,6 +301,16 @@ public class AssetListEntryUsageWrapper
 	@Override
 	public long getGroupId() {
 		return model.getGroupId();
+	}
+
+	/**
+	 * Returns the key of this asset list entry usage.
+	 *
+	 * @return the key of this asset list entry usage
+	 */
+	@Override
+	public String getKey() {
+		return model.getKey();
 	}
 
 	/**
@@ -279,6 +344,16 @@ public class AssetListEntryUsageWrapper
 	}
 
 	/**
+	 * Returns the plid of this asset list entry usage.
+	 *
+	 * @return the plid of this asset list entry usage
+	 */
+	@Override
+	public long getPlid() {
+		return model.getPlid();
+	}
+
+	/**
 	 * Returns the portlet ID of this asset list entry usage.
 	 *
 	 * @return the portlet ID of this asset list entry usage
@@ -296,6 +371,16 @@ public class AssetListEntryUsageWrapper
 	@Override
 	public long getPrimaryKey() {
 		return model.getPrimaryKey();
+	}
+
+	/**
+	 * Returns the type of this asset list entry usage.
+	 *
+	 * @return the type of this asset list entry usage
+	 */
+	@Override
+	public int getType() {
+		return model.getType();
 	}
 
 	/**
@@ -399,6 +484,26 @@ public class AssetListEntryUsageWrapper
 	}
 
 	/**
+	 * Sets the container key of this asset list entry usage.
+	 *
+	 * @param containerKey the container key of this asset list entry usage
+	 */
+	@Override
+	public void setContainerKey(String containerKey) {
+		model.setContainerKey(containerKey);
+	}
+
+	/**
+	 * Sets the container type of this asset list entry usage.
+	 *
+	 * @param containerType the container type of this asset list entry usage
+	 */
+	@Override
+	public void setContainerType(long containerType) {
+		model.setContainerType(containerType);
+	}
+
+	/**
 	 * Sets the create date of this asset list entry usage.
 	 *
 	 * @param createDate the create date of this asset list entry usage
@@ -426,6 +531,16 @@ public class AssetListEntryUsageWrapper
 	@Override
 	public void setGroupId(long groupId) {
 		model.setGroupId(groupId);
+	}
+
+	/**
+	 * Sets the key of this asset list entry usage.
+	 *
+	 * @param key the key of this asset list entry usage
+	 */
+	@Override
+	public void setKey(String key) {
+		model.setKey(key);
 	}
 
 	/**
@@ -459,6 +574,16 @@ public class AssetListEntryUsageWrapper
 	}
 
 	/**
+	 * Sets the plid of this asset list entry usage.
+	 *
+	 * @param plid the plid of this asset list entry usage
+	 */
+	@Override
+	public void setPlid(long plid) {
+		model.setPlid(plid);
+	}
+
+	/**
 	 * Sets the portlet ID of this asset list entry usage.
 	 *
 	 * @param portletId the portlet ID of this asset list entry usage
@@ -476,6 +601,16 @@ public class AssetListEntryUsageWrapper
 	@Override
 	public void setPrimaryKey(long primaryKey) {
 		model.setPrimaryKey(primaryKey);
+	}
+
+	/**
+	 * Sets the type of this asset list entry usage.
+	 *
+	 * @param type the type of this asset list entry usage
+	 */
+	@Override
+	public void setType(int type) {
+		model.setType(type);
 	}
 
 	/**

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryUsageLocalService.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryUsageLocalService.java
@@ -91,6 +91,18 @@ public interface AssetListEntryUsageLocalService
 		throws PortalException;
 
 	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addAssetListEntryUsage(long, long, long, long, long, String,
+	 ServiceContext)}
+	 */
+	@Deprecated
+	public AssetListEntryUsage addAssetListEntryUsage(
+			long userId, long groupId, long classNameId, String key,
+			long containerType, String containerKey, long plid,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	/**
 	 * Creates a new asset list entry usage with the primary key. Does not add the asset list entry usage to the database.
 	 *
 	 * @param assetListEntryUsageId the primary key for the new asset list entry usage
@@ -216,9 +228,18 @@ public interface AssetListEntryUsageLocalService
 	public AssetListEntryUsage fetchAssetListEntryUsage(
 		long assetListEntryUsageId);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #fetchAssetListEntryUsage(String, long, long)}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public AssetListEntryUsage fetchAssetListEntryUsage(
 		long classNameId, long classPK, String portletId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<AssetListEntryUsage> fetchAssetListEntryUsage(
+		String containerKey, long containerType, long plid);
 
 	/**
 	 * Returns the asset list entry usage matching the UUID and group.
@@ -274,22 +295,62 @@ public interface AssetListEntryUsageLocalService
 	public List<AssetListEntryUsage> getAssetListEntryUsages(
 		int start, int end);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsages(long, long, String)}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsages(long, long, String, int, int,
+	 OrderByComparator)}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId, int start, int end,
 		OrderByComparator<AssetListEntryUsage> orderByComparator);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsages(long, long, String, int)}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId, long classNameId);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsages(long, long, String, int, int, int,
+	 OrderByComparator)}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId, long classNameId, int start, int end,
+		OrderByComparator<AssetListEntryUsage> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key, int type);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key, int type, int start,
+		int end, OrderByComparator<AssetListEntryUsage> orderByComparator);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key, int start, int end,
 		OrderByComparator<AssetListEntryUsage> orderByComparator);
 
 	/**
@@ -326,12 +387,30 @@ public interface AssetListEntryUsageLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getAssetListEntryUsagesCount();
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsagesCount(long, long, String)}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getAssetListEntryUsagesCount(long assetListEntryId);
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsagesCount(long, long, String, int)}
+	 */
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getAssetListEntryUsagesCount(
 		long assetListEntryId, long classNameId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getAssetListEntryUsagesCount(
+		long groupId, long classNameId, String key);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getAssetListEntryUsagesCount(
+		long groupId, long classNameId, String key, int type);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ExportActionableDynamicQuery getExportActionableDynamicQuery(

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryUsageLocalServiceUtil.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryUsageLocalServiceUtil.java
@@ -73,6 +73,23 @@ public class AssetListEntryUsageLocalServiceUtil {
 	}
 
 	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addAssetListEntryUsage(long, long, long, long, long, String,
+	 ServiceContext)}
+	 */
+	@Deprecated
+	public static AssetListEntryUsage addAssetListEntryUsage(
+			long userId, long groupId, long classNameId, String key,
+			long containerType, String containerKey, long plid,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addAssetListEntryUsage(
+			userId, groupId, classNameId, key, containerType, containerKey,
+			plid, serviceContext);
+	}
+
+	/**
 	 * Creates a new asset list entry usage with the primary key. Does not add the asset list entry usage to the database.
 	 *
 	 * @param assetListEntryUsageId the primary key for the new asset list entry usage
@@ -225,11 +242,23 @@ public class AssetListEntryUsageLocalServiceUtil {
 		return getService().fetchAssetListEntryUsage(assetListEntryUsageId);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #fetchAssetListEntryUsage(String, long, long)}
+	 */
+	@Deprecated
 	public static AssetListEntryUsage fetchAssetListEntryUsage(
 		long classNameId, long classPK, String portletId) {
 
 		return getService().fetchAssetListEntryUsage(
 			classNameId, classPK, portletId);
+	}
+
+	public static List<AssetListEntryUsage> fetchAssetListEntryUsage(
+		String containerKey, long containerType, long plid) {
+
+		return getService().fetchAssetListEntryUsage(
+			containerKey, containerType, plid);
 	}
 
 	/**
@@ -299,12 +328,23 @@ public class AssetListEntryUsageLocalServiceUtil {
 		return getService().getAssetListEntryUsages(start, end);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsages(long, long, String)}
+	 */
+	@Deprecated
 	public static List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId) {
 
 		return getService().getAssetListEntryUsages(assetListEntryId);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsages(long, long, String, int, int,
+	 OrderByComparator)}
+	 */
+	@Deprecated
 	public static List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId, int start, int end,
 		OrderByComparator<AssetListEntryUsage> orderByComparator) {
@@ -313,6 +353,11 @@ public class AssetListEntryUsageLocalServiceUtil {
 			assetListEntryId, start, end, orderByComparator);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsages(long, long, String, int)}
+	 */
+	@Deprecated
 	public static List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId, long classNameId) {
 
@@ -320,12 +365,47 @@ public class AssetListEntryUsageLocalServiceUtil {
 			assetListEntryId, classNameId);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsages(long, long, String, int, int, int,
+	 OrderByComparator)}
+	 */
+	@Deprecated
 	public static List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId, long classNameId, int start, int end,
 		OrderByComparator<AssetListEntryUsage> orderByComparator) {
 
 		return getService().getAssetListEntryUsages(
 			assetListEntryId, classNameId, start, end, orderByComparator);
+	}
+
+	public static List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key) {
+
+		return getService().getAssetListEntryUsages(groupId, classNameId, key);
+	}
+
+	public static List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key, int type) {
+
+		return getService().getAssetListEntryUsages(
+			groupId, classNameId, key, type);
+	}
+
+	public static List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key, int type, int start,
+		int end, OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return getService().getAssetListEntryUsages(
+			groupId, classNameId, key, type, start, end, orderByComparator);
+	}
+
+	public static List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key, int start, int end,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return getService().getAssetListEntryUsages(
+			groupId, classNameId, key, start, end, orderByComparator);
 	}
 
 	/**
@@ -370,15 +450,39 @@ public class AssetListEntryUsageLocalServiceUtil {
 		return getService().getAssetListEntryUsagesCount();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsagesCount(long, long, String)}
+	 */
+	@Deprecated
 	public static int getAssetListEntryUsagesCount(long assetListEntryId) {
 		return getService().getAssetListEntryUsagesCount(assetListEntryId);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsagesCount(long, long, String, int)}
+	 */
+	@Deprecated
 	public static int getAssetListEntryUsagesCount(
 		long assetListEntryId, long classNameId) {
 
 		return getService().getAssetListEntryUsagesCount(
 			assetListEntryId, classNameId);
+	}
+
+	public static int getAssetListEntryUsagesCount(
+		long groupId, long classNameId, String key) {
+
+		return getService().getAssetListEntryUsagesCount(
+			groupId, classNameId, key);
+	}
+
+	public static int getAssetListEntryUsagesCount(
+		long groupId, long classNameId, String key, int type) {
+
+		return getService().getAssetListEntryUsagesCount(
+			groupId, classNameId, key, type);
 	}
 
 	public static com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryUsageLocalServiceWrapper.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/AssetListEntryUsageLocalServiceWrapper.java
@@ -67,6 +67,24 @@ public class AssetListEntryUsageLocalServiceWrapper
 	}
 
 	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #addAssetListEntryUsage(long, long, long, long, long, String,
+	 ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public AssetListEntryUsage addAssetListEntryUsage(
+			long userId, long groupId, long classNameId, String key,
+			long containerType, String containerKey, long plid,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _assetListEntryUsageLocalService.addAssetListEntryUsage(
+			userId, groupId, classNameId, key, containerType, containerKey,
+			plid, serviceContext);
+	}
+
+	/**
 	 * Creates a new asset list entry usage with the primary key. Does not add the asset list entry usage to the database.
 	 *
 	 * @param assetListEntryUsageId the primary key for the new asset list entry usage
@@ -246,12 +264,25 @@ public class AssetListEntryUsageLocalServiceWrapper
 			assetListEntryUsageId);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #fetchAssetListEntryUsage(String, long, long)}
+	 */
+	@Deprecated
 	@Override
 	public AssetListEntryUsage fetchAssetListEntryUsage(
 		long classNameId, long classPK, String portletId) {
 
 		return _assetListEntryUsageLocalService.fetchAssetListEntryUsage(
 			classNameId, classPK, portletId);
+	}
+
+	@Override
+	public java.util.List<AssetListEntryUsage> fetchAssetListEntryUsage(
+		String containerKey, long containerType, long plid) {
+
+		return _assetListEntryUsageLocalService.fetchAssetListEntryUsage(
+			containerKey, containerType, plid);
 	}
 
 	/**
@@ -328,6 +359,11 @@ public class AssetListEntryUsageLocalServiceWrapper
 			start, end);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsages(long, long, String)}
+	 */
+	@Deprecated
 	@Override
 	public java.util.List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId) {
@@ -336,6 +372,12 @@ public class AssetListEntryUsageLocalServiceWrapper
 			assetListEntryId);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsages(long, long, String, int, int,
+	 OrderByComparator)}
+	 */
+	@Deprecated
 	@Override
 	public java.util.List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId, int start, int end,
@@ -346,6 +388,11 @@ public class AssetListEntryUsageLocalServiceWrapper
 			assetListEntryId, start, end, orderByComparator);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsages(long, long, String, int)}
+	 */
+	@Deprecated
 	@Override
 	public java.util.List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId, long classNameId) {
@@ -354,6 +401,12 @@ public class AssetListEntryUsageLocalServiceWrapper
 			assetListEntryId, classNameId);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsages(long, long, String, int, int, int,
+	 OrderByComparator)}
+	 */
+	@Deprecated
 	@Override
 	public java.util.List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId, long classNameId, int start, int end,
@@ -362,6 +415,43 @@ public class AssetListEntryUsageLocalServiceWrapper
 
 		return _assetListEntryUsageLocalService.getAssetListEntryUsages(
 			assetListEntryId, classNameId, start, end, orderByComparator);
+	}
+
+	@Override
+	public java.util.List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key) {
+
+		return _assetListEntryUsageLocalService.getAssetListEntryUsages(
+			groupId, classNameId, key);
+	}
+
+	@Override
+	public java.util.List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key, int type) {
+
+		return _assetListEntryUsageLocalService.getAssetListEntryUsages(
+			groupId, classNameId, key, type);
+	}
+
+	@Override
+	public java.util.List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key, int type, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator) {
+
+		return _assetListEntryUsageLocalService.getAssetListEntryUsages(
+			groupId, classNameId, key, type, start, end, orderByComparator);
+	}
+
+	@Override
+	public java.util.List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator) {
+
+		return _assetListEntryUsageLocalService.getAssetListEntryUsages(
+			groupId, classNameId, key, start, end, orderByComparator);
 	}
 
 	/**
@@ -411,18 +501,44 @@ public class AssetListEntryUsageLocalServiceWrapper
 		return _assetListEntryUsageLocalService.getAssetListEntryUsagesCount();
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsagesCount(long, long, String)}
+	 */
+	@Deprecated
 	@Override
 	public int getAssetListEntryUsagesCount(long assetListEntryId) {
 		return _assetListEntryUsageLocalService.getAssetListEntryUsagesCount(
 			assetListEntryId);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 #getAssetListEntryUsagesCount(long, long, String, int)}
+	 */
+	@Deprecated
 	@Override
 	public int getAssetListEntryUsagesCount(
 		long assetListEntryId, long classNameId) {
 
 		return _assetListEntryUsageLocalService.getAssetListEntryUsagesCount(
 			assetListEntryId, classNameId);
+	}
+
+	@Override
+	public int getAssetListEntryUsagesCount(
+		long groupId, long classNameId, String key) {
+
+		return _assetListEntryUsageLocalService.getAssetListEntryUsagesCount(
+			groupId, classNameId, key);
+	}
+
+	@Override
+	public int getAssetListEntryUsagesCount(
+		long groupId, long classNameId, String key, int type) {
+
+		return _assetListEntryUsageLocalService.getAssetListEntryUsagesCount(
+			groupId, classNameId, key, type);
 	}
 
 	@Override

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/persistence/AssetListEntryUsagePersistence.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/persistence/AssetListEntryUsagePersistence.java
@@ -691,6 +691,173 @@ public interface AssetListEntryUsagePersistence
 	public int countByA_C(long assetListEntryId, long classNameId);
 
 	/**
+	 * Returns all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @return the matching asset list entry usages
+	 */
+	public java.util.List<AssetListEntryUsage> findByG_C_K(
+		long groupId, long classNameId, String key);
+
+	/**
+	 * Returns a range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @return the range of matching asset list entry usages
+	 */
+	public java.util.List<AssetListEntryUsage> findByG_C_K(
+		long groupId, long classNameId, String key, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	public java.util.List<AssetListEntryUsage> findByG_C_K(
+		long groupId, long classNameId, String key, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	public java.util.List<AssetListEntryUsage> findByG_C_K(
+		long groupId, long classNameId, String key, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	public AssetListEntryUsage findByG_C_K_First(
+			long groupId, long classNameId, String key,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException;
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	public AssetListEntryUsage fetchByG_C_K_First(
+		long groupId, long classNameId, String key,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator);
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	public AssetListEntryUsage findByG_C_K_Last(
+			long groupId, long classNameId, String key,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException;
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	public AssetListEntryUsage fetchByG_C_K_Last(
+		long groupId, long classNameId, String key,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator);
+
+	/**
+	 * Returns the asset list entry usages before and after the current asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param assetListEntryUsageId the primary key of the current asset list entry usage
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset list entry usage
+	 * @throws NoSuchEntryUsageException if a asset list entry usage with the primary key could not be found
+	 */
+	public AssetListEntryUsage[] findByG_C_K_PrevAndNext(
+			long assetListEntryUsageId, long groupId, long classNameId,
+			String key,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException;
+
+	/**
+	 * Removes all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 */
+	public void removeByG_C_K(long groupId, long classNameId, String key);
+
+	/**
+	 * Returns the number of asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @return the number of matching asset list entry usages
+	 */
+	public int countByG_C_K(long groupId, long classNameId, String key);
+
+	/**
 	 * Returns the asset list entry usage where classNameId = &#63; and classPK = &#63; and portletId = &#63; or throws a <code>NoSuchEntryUsageException</code> if it could not be found.
 	 *
 	 * @param classNameId the class name ID
@@ -748,6 +915,358 @@ public interface AssetListEntryUsagePersistence
 	 * @return the number of matching asset list entry usages
 	 */
 	public int countByC_C_P(long classNameId, long classPK, String portletId);
+
+	/**
+	 * Returns all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @return the matching asset list entry usages
+	 */
+	public java.util.List<AssetListEntryUsage> findByCK_CT_P(
+		String containerKey, long containerType, long plid);
+
+	/**
+	 * Returns a range of all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @return the range of matching asset list entry usages
+	 */
+	public java.util.List<AssetListEntryUsage> findByCK_CT_P(
+		String containerKey, long containerType, long plid, int start, int end);
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	public java.util.List<AssetListEntryUsage> findByCK_CT_P(
+		String containerKey, long containerType, long plid, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	public java.util.List<AssetListEntryUsage> findByCK_CT_P(
+		String containerKey, long containerType, long plid, int start, int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	public AssetListEntryUsage findByCK_CT_P_First(
+			String containerKey, long containerType, long plid,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException;
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	public AssetListEntryUsage fetchByCK_CT_P_First(
+		String containerKey, long containerType, long plid,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator);
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	public AssetListEntryUsage findByCK_CT_P_Last(
+			String containerKey, long containerType, long plid,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException;
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	public AssetListEntryUsage fetchByCK_CT_P_Last(
+		String containerKey, long containerType, long plid,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator);
+
+	/**
+	 * Returns the asset list entry usages before and after the current asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param assetListEntryUsageId the primary key of the current asset list entry usage
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset list entry usage
+	 * @throws NoSuchEntryUsageException if a asset list entry usage with the primary key could not be found
+	 */
+	public AssetListEntryUsage[] findByCK_CT_P_PrevAndNext(
+			long assetListEntryUsageId, String containerKey, long containerType,
+			long plid,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException;
+
+	/**
+	 * Removes all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63; from the database.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 */
+	public void removeByCK_CT_P(
+		String containerKey, long containerType, long plid);
+
+	/**
+	 * Returns the number of asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @return the number of matching asset list entry usages
+	 */
+	public int countByCK_CT_P(
+		String containerKey, long containerType, long plid);
+
+	/**
+	 * Returns all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @return the matching asset list entry usages
+	 */
+	public java.util.List<AssetListEntryUsage> findByG_C_K_T(
+		long groupId, long classNameId, String key, int type);
+
+	/**
+	 * Returns a range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @return the range of matching asset list entry usages
+	 */
+	public java.util.List<AssetListEntryUsage> findByG_C_K_T(
+		long groupId, long classNameId, String key, int type, int start,
+		int end);
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	public java.util.List<AssetListEntryUsage> findByG_C_K_T(
+		long groupId, long classNameId, String key, int type, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator);
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	public java.util.List<AssetListEntryUsage> findByG_C_K_T(
+		long groupId, long classNameId, String key, int type, int start,
+		int end,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator,
+		boolean useFinderCache);
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	public AssetListEntryUsage findByG_C_K_T_First(
+			long groupId, long classNameId, String key, int type,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException;
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	public AssetListEntryUsage fetchByG_C_K_T_First(
+		long groupId, long classNameId, String key, int type,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator);
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	public AssetListEntryUsage findByG_C_K_T_Last(
+			long groupId, long classNameId, String key, int type,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException;
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	public AssetListEntryUsage fetchByG_C_K_T_Last(
+		long groupId, long classNameId, String key, int type,
+		com.liferay.portal.kernel.util.OrderByComparator<AssetListEntryUsage>
+			orderByComparator);
+
+	/**
+	 * Returns the asset list entry usages before and after the current asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param assetListEntryUsageId the primary key of the current asset list entry usage
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset list entry usage
+	 * @throws NoSuchEntryUsageException if a asset list entry usage with the primary key could not be found
+	 */
+	public AssetListEntryUsage[] findByG_C_K_T_PrevAndNext(
+			long assetListEntryUsageId, long groupId, long classNameId,
+			String key, int type,
+			com.liferay.portal.kernel.util.OrderByComparator
+				<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException;
+
+	/**
+	 * Removes all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 */
+	public void removeByG_C_K_T(
+		long groupId, long classNameId, String key, int type);
+
+	/**
+	 * Returns the number of asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @return the number of matching asset list entry usages
+	 */
+	public int countByG_C_K_T(
+		long groupId, long classNameId, String key, int type);
 
 	/**
 	 * Caches the asset list entry usage in the entity cache if it is enabled.

--- a/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/persistence/AssetListEntryUsageUtil.java
+++ b/modules/apps/asset/asset-list-api/src/main/java/com/liferay/asset/list/service/persistence/AssetListEntryUsageUtil.java
@@ -907,6 +907,209 @@ public class AssetListEntryUsageUtil {
 	}
 
 	/**
+	 * Returns all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @return the matching asset list entry usages
+	 */
+	public static List<AssetListEntryUsage> findByG_C_K(
+		long groupId, long classNameId, String key) {
+
+		return getPersistence().findByG_C_K(groupId, classNameId, key);
+	}
+
+	/**
+	 * Returns a range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @return the range of matching asset list entry usages
+	 */
+	public static List<AssetListEntryUsage> findByG_C_K(
+		long groupId, long classNameId, String key, int start, int end) {
+
+		return getPersistence().findByG_C_K(
+			groupId, classNameId, key, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	public static List<AssetListEntryUsage> findByG_C_K(
+		long groupId, long classNameId, String key, int start, int end,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return getPersistence().findByG_C_K(
+			groupId, classNameId, key, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	public static List<AssetListEntryUsage> findByG_C_K(
+		long groupId, long classNameId, String key, int start, int end,
+		OrderByComparator<AssetListEntryUsage> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_C_K(
+			groupId, classNameId, key, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	public static AssetListEntryUsage findByG_C_K_First(
+			long groupId, long classNameId, String key,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws com.liferay.asset.list.exception.NoSuchEntryUsageException {
+
+		return getPersistence().findByG_C_K_First(
+			groupId, classNameId, key, orderByComparator);
+	}
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	public static AssetListEntryUsage fetchByG_C_K_First(
+		long groupId, long classNameId, String key,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return getPersistence().fetchByG_C_K_First(
+			groupId, classNameId, key, orderByComparator);
+	}
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	public static AssetListEntryUsage findByG_C_K_Last(
+			long groupId, long classNameId, String key,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws com.liferay.asset.list.exception.NoSuchEntryUsageException {
+
+		return getPersistence().findByG_C_K_Last(
+			groupId, classNameId, key, orderByComparator);
+	}
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	public static AssetListEntryUsage fetchByG_C_K_Last(
+		long groupId, long classNameId, String key,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return getPersistence().fetchByG_C_K_Last(
+			groupId, classNameId, key, orderByComparator);
+	}
+
+	/**
+	 * Returns the asset list entry usages before and after the current asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param assetListEntryUsageId the primary key of the current asset list entry usage
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset list entry usage
+	 * @throws NoSuchEntryUsageException if a asset list entry usage with the primary key could not be found
+	 */
+	public static AssetListEntryUsage[] findByG_C_K_PrevAndNext(
+			long assetListEntryUsageId, long groupId, long classNameId,
+			String key,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws com.liferay.asset.list.exception.NoSuchEntryUsageException {
+
+		return getPersistence().findByG_C_K_PrevAndNext(
+			assetListEntryUsageId, groupId, classNameId, key,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 */
+	public static void removeByG_C_K(
+		long groupId, long classNameId, String key) {
+
+		getPersistence().removeByG_C_K(groupId, classNameId, key);
+	}
+
+	/**
+	 * Returns the number of asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @return the number of matching asset list entry usages
+	 */
+	public static int countByG_C_K(long groupId, long classNameId, String key) {
+		return getPersistence().countByG_C_K(groupId, classNameId, key);
+	}
+
+	/**
 	 * Returns the asset list entry usage where classNameId = &#63; and classPK = &#63; and portletId = &#63; or throws a <code>NoSuchEntryUsageException</code> if it could not be found.
 	 *
 	 * @param classNameId the class name ID
@@ -980,6 +1183,430 @@ public class AssetListEntryUsageUtil {
 		long classNameId, long classPK, String portletId) {
 
 		return getPersistence().countByC_C_P(classNameId, classPK, portletId);
+	}
+
+	/**
+	 * Returns all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @return the matching asset list entry usages
+	 */
+	public static List<AssetListEntryUsage> findByCK_CT_P(
+		String containerKey, long containerType, long plid) {
+
+		return getPersistence().findByCK_CT_P(
+			containerKey, containerType, plid);
+	}
+
+	/**
+	 * Returns a range of all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @return the range of matching asset list entry usages
+	 */
+	public static List<AssetListEntryUsage> findByCK_CT_P(
+		String containerKey, long containerType, long plid, int start,
+		int end) {
+
+		return getPersistence().findByCK_CT_P(
+			containerKey, containerType, plid, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	public static List<AssetListEntryUsage> findByCK_CT_P(
+		String containerKey, long containerType, long plid, int start, int end,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return getPersistence().findByCK_CT_P(
+			containerKey, containerType, plid, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	public static List<AssetListEntryUsage> findByCK_CT_P(
+		String containerKey, long containerType, long plid, int start, int end,
+		OrderByComparator<AssetListEntryUsage> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByCK_CT_P(
+			containerKey, containerType, plid, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	public static AssetListEntryUsage findByCK_CT_P_First(
+			String containerKey, long containerType, long plid,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws com.liferay.asset.list.exception.NoSuchEntryUsageException {
+
+		return getPersistence().findByCK_CT_P_First(
+			containerKey, containerType, plid, orderByComparator);
+	}
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	public static AssetListEntryUsage fetchByCK_CT_P_First(
+		String containerKey, long containerType, long plid,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return getPersistence().fetchByCK_CT_P_First(
+			containerKey, containerType, plid, orderByComparator);
+	}
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	public static AssetListEntryUsage findByCK_CT_P_Last(
+			String containerKey, long containerType, long plid,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws com.liferay.asset.list.exception.NoSuchEntryUsageException {
+
+		return getPersistence().findByCK_CT_P_Last(
+			containerKey, containerType, plid, orderByComparator);
+	}
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	public static AssetListEntryUsage fetchByCK_CT_P_Last(
+		String containerKey, long containerType, long plid,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return getPersistence().fetchByCK_CT_P_Last(
+			containerKey, containerType, plid, orderByComparator);
+	}
+
+	/**
+	 * Returns the asset list entry usages before and after the current asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param assetListEntryUsageId the primary key of the current asset list entry usage
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset list entry usage
+	 * @throws NoSuchEntryUsageException if a asset list entry usage with the primary key could not be found
+	 */
+	public static AssetListEntryUsage[] findByCK_CT_P_PrevAndNext(
+			long assetListEntryUsageId, String containerKey, long containerType,
+			long plid, OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws com.liferay.asset.list.exception.NoSuchEntryUsageException {
+
+		return getPersistence().findByCK_CT_P_PrevAndNext(
+			assetListEntryUsageId, containerKey, containerType, plid,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63; from the database.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 */
+	public static void removeByCK_CT_P(
+		String containerKey, long containerType, long plid) {
+
+		getPersistence().removeByCK_CT_P(containerKey, containerType, plid);
+	}
+
+	/**
+	 * Returns the number of asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @return the number of matching asset list entry usages
+	 */
+	public static int countByCK_CT_P(
+		String containerKey, long containerType, long plid) {
+
+		return getPersistence().countByCK_CT_P(
+			containerKey, containerType, plid);
+	}
+
+	/**
+	 * Returns all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @return the matching asset list entry usages
+	 */
+	public static List<AssetListEntryUsage> findByG_C_K_T(
+		long groupId, long classNameId, String key, int type) {
+
+		return getPersistence().findByG_C_K_T(groupId, classNameId, key, type);
+	}
+
+	/**
+	 * Returns a range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @return the range of matching asset list entry usages
+	 */
+	public static List<AssetListEntryUsage> findByG_C_K_T(
+		long groupId, long classNameId, String key, int type, int start,
+		int end) {
+
+		return getPersistence().findByG_C_K_T(
+			groupId, classNameId, key, type, start, end);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	public static List<AssetListEntryUsage> findByG_C_K_T(
+		long groupId, long classNameId, String key, int type, int start,
+		int end, OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return getPersistence().findByG_C_K_T(
+			groupId, classNameId, key, type, start, end, orderByComparator);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	public static List<AssetListEntryUsage> findByG_C_K_T(
+		long groupId, long classNameId, String key, int type, int start,
+		int end, OrderByComparator<AssetListEntryUsage> orderByComparator,
+		boolean useFinderCache) {
+
+		return getPersistence().findByG_C_K_T(
+			groupId, classNameId, key, type, start, end, orderByComparator,
+			useFinderCache);
+	}
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	public static AssetListEntryUsage findByG_C_K_T_First(
+			long groupId, long classNameId, String key, int type,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws com.liferay.asset.list.exception.NoSuchEntryUsageException {
+
+		return getPersistence().findByG_C_K_T_First(
+			groupId, classNameId, key, type, orderByComparator);
+	}
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	public static AssetListEntryUsage fetchByG_C_K_T_First(
+		long groupId, long classNameId, String key, int type,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return getPersistence().fetchByG_C_K_T_First(
+			groupId, classNameId, key, type, orderByComparator);
+	}
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	public static AssetListEntryUsage findByG_C_K_T_Last(
+			long groupId, long classNameId, String key, int type,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws com.liferay.asset.list.exception.NoSuchEntryUsageException {
+
+		return getPersistence().findByG_C_K_T_Last(
+			groupId, classNameId, key, type, orderByComparator);
+	}
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	public static AssetListEntryUsage fetchByG_C_K_T_Last(
+		long groupId, long classNameId, String key, int type,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return getPersistence().fetchByG_C_K_T_Last(
+			groupId, classNameId, key, type, orderByComparator);
+	}
+
+	/**
+	 * Returns the asset list entry usages before and after the current asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param assetListEntryUsageId the primary key of the current asset list entry usage
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset list entry usage
+	 * @throws NoSuchEntryUsageException if a asset list entry usage with the primary key could not be found
+	 */
+	public static AssetListEntryUsage[] findByG_C_K_T_PrevAndNext(
+			long assetListEntryUsageId, long groupId, long classNameId,
+			String key, int type,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws com.liferay.asset.list.exception.NoSuchEntryUsageException {
+
+		return getPersistence().findByG_C_K_T_PrevAndNext(
+			assetListEntryUsageId, groupId, classNameId, key, type,
+			orderByComparator);
+	}
+
+	/**
+	 * Removes all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 */
+	public static void removeByG_C_K_T(
+		long groupId, long classNameId, String key, int type) {
+
+		getPersistence().removeByG_C_K_T(groupId, classNameId, key, type);
+	}
+
+	/**
+	 * Returns the number of asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @return the number of matching asset list entry usages
+	 */
+	public static int countByG_C_K_T(
+		long groupId, long classNameId, String key, int type) {
+
+		return getPersistence().countByG_C_K_T(groupId, classNameId, key, type);
 	}
 
 	/**

--- a/modules/apps/asset/asset-list-api/src/main/resources/com/liferay/asset/list/constants/packageinfo
+++ b/modules/apps/asset/asset-list-api/src/main/resources/com/liferay/asset/list/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/asset/asset-list-api/src/main/resources/com/liferay/asset/list/model/packageinfo
+++ b/modules/apps/asset/asset-list-api/src/main/resources/com/liferay/asset/list/model/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.6.0

--- a/modules/apps/asset/asset-list-api/src/main/resources/com/liferay/asset/list/service/packageinfo
+++ b/modules/apps/asset/asset-list-api/src/main/resources/com/liferay/asset/list/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 1.6.0

--- a/modules/apps/asset/asset-list-api/src/main/resources/com/liferay/asset/list/service/persistence/packageinfo
+++ b/modules/apps/asset/asset-list-api/src/main/resources/com/liferay/asset/list/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/asset/asset-list-service/bnd.bnd
+++ b/modules/apps/asset/asset-list-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset List Service
 Bundle-SymbolicName: com.liferay.asset.list.service
 Bundle-Version: 3.0.1
-Liferay-Require-SchemaVersion: 1.3.0
+Liferay-Require-SchemaVersion: 1.4.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/asset/asset-list-service/build.gradle
+++ b/modules/apps/asset/asset-list-service/build.gradle
@@ -12,11 +12,14 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.3.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:asset:asset-api")
+	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:asset:asset-entry-rel-api")
 	compileOnly project(":apps:asset:asset-list-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:export-import:export-import-api")
+	compileOnly project(":apps:layout:layout-api")
+	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:segments:segments-api")

--- a/modules/apps/asset/asset-list-service/service.xml
+++ b/modules/apps/asset/asset-list-service/service.xml
@@ -200,7 +200,12 @@
 		<column name="assetListEntryId" type="long" />
 		<column name="classNameId" type="long" />
 		<column name="classPK" type="long" />
+		<column name="containerKey" type="String" />
+		<column name="containerType" type="long" />
+		<column name="key" type="String" />
+		<column name="plid" type="long" />
 		<column name="portletId" type="String" />
+		<column name="type" type="int" />
 		<column name="lastPublishDate" type="Date" />
 
 		<!-- Finder methods -->

--- a/modules/apps/asset/asset-list-service/service.xml
+++ b/modules/apps/asset/asset-list-service/service.xml
@@ -217,10 +217,26 @@
 			<finder-column name="assetListEntryId" />
 			<finder-column name="classNameId" />
 		</finder>
+		<finder name="G_C_K" return-type="Collection">
+			<finder-column name="groupId" />
+			<finder-column name="classNameId" />
+			<finder-column name="key" />
+		</finder>
 		<finder name="C_C_P" return-type="AssetListEntryUsage" unique="true">
 			<finder-column name="classNameId" />
 			<finder-column name="classPK" />
 			<finder-column name="portletId" />
+		</finder>
+		<finder db-index="false" name="CK_CT_P" return-type="Collection">
+			<finder-column name="containerKey" />
+			<finder-column name="containerType" />
+			<finder-column name="plid" />
+		</finder>
+		<finder name="G_C_K_T" return-type="Collection">
+			<finder-column name="groupId" />
+			<finder-column name="classNameId" />
+			<finder-column name="key" />
+			<finder-column name="type" />
 		</finder>
 
 		<!-- References -->

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/upgrade/AssetListServiceUpgrade.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/upgrade/AssetListServiceUpgrade.java
@@ -15,6 +15,7 @@
 package com.liferay.asset.list.internal.upgrade;
 
 import com.liferay.asset.list.internal.upgrade.v1_3_0.AssetListEntryUpgradeProcess;
+import com.liferay.asset.list.internal.upgrade.v1_4_0.AssetListEntryUsageUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.UpgradeCTModel;
 import com.liferay.portal.kernel.upgrade.UpgradeMVCCVersion;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
@@ -50,6 +51,9 @@ public class AssetListServiceUpgrade implements UpgradeStepRegistrator {
 				"AssetListEntrySegmentsEntryRel", "AssetListEntryUsage"));
 
 		registry.register("1.2.0", "1.3.0", new AssetListEntryUpgradeProcess());
+
+		registry.register(
+			"1.3.0", "1.4.0", new AssetListEntryUsageUpgradeProcess());
 	}
 
 }

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/upgrade/v1_4_0/AssetListEntryUsageUpgradeProcess.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/upgrade/v1_4_0/AssetListEntryUsageUpgradeProcess.java
@@ -1,0 +1,81 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.list.internal.upgrade.v1_4_0;
+
+import com.liferay.asset.list.constants.AssetListEntryUsageConstants;
+import com.liferay.asset.list.internal.upgrade.v1_4_0.util.AssetListEntryUsageTable;
+import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Víctor Galán
+ */
+public class AssetListEntryUsageUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		upgradeSchema();
+	}
+
+	protected void upgradeSchema() throws Exception {
+		alter(
+			AssetListEntryUsageTable.class,
+			new AlterTableAddColumn("containerKey", "VARCHAR(255) null"),
+			new AlterTableAddColumn("containerType", "LONG"),
+			new AlterTableAddColumn("key_", "VARCHAR(255) null"),
+			new AlterTableAddColumn("plid", "LONG"),
+			new AlterTableAddColumn("type_", "INTEGER"));
+
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			try (PreparedStatement ps1 = connection.prepareStatement(
+					"select assetListEntryId, assetListEntryUsageId, classPK," +
+						"portletId from AssetListEntryUsage");
+				PreparedStatement ps2 =
+					AutoBatchPreparedStatementUtil.autoBatch(
+						connection.prepareStatement(
+							StringBundler.concat(
+								"update AssetListEntryUsage set classNameId = ",
+								"?, containerKey = ?, containerType = ?, key_ ",
+								"= ?, plid = ?, type_ = ? where ",
+								"assetListEntryUsageId = ?")));
+				ResultSet rs = ps1.executeQuery()) {
+
+				while (rs.next()) {
+					ps2.setLong(
+						1, PortalUtil.getClassNameId(AssetListEntry.class));
+					ps2.setString(2, String.valueOf(rs.getString(4)));
+					ps2.setLong(3, PortalUtil.getClassNameId(Portlet.class));
+					ps2.setString(4, String.valueOf(rs.getLong(1)));
+					ps2.setLong(5, rs.getLong(3));
+					ps2.setLong(6, AssetListEntryUsageConstants.TYPE_LAYOUT);
+					ps2.setLong(7, rs.getLong(2));
+
+					ps2.addBatch();
+				}
+
+				ps2.executeBatch();
+			}
+		}
+	}
+
+}

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/upgrade/v1_4_0/util/AssetListEntryUsageTable.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/upgrade/v1_4_0/util/AssetListEntryUsageTable.java
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.list.internal.upgrade.v1_4_0.util;
+
+import java.sql.Types;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author	  Víctor Galán
+ * @generated
+ */
+public class AssetListEntryUsageTable {
+
+	public static final String TABLE_NAME = "AssetListEntryUsage";
+
+	public static final Object[][] TABLE_COLUMNS = {
+		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
+		{"uuid_", Types.VARCHAR}, {"assetListEntryUsageId", Types.BIGINT},
+		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
+		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
+		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"assetListEntryId", Types.BIGINT}, {"classNameId", Types.BIGINT},
+		{"classPK", Types.BIGINT}, {"containerKey", Types.VARCHAR},
+		{"containerType", Types.BIGINT}, {"key_", Types.VARCHAR},
+		{"plid", Types.BIGINT}, {"portletId", Types.VARCHAR},
+		{"type_", Types.INTEGER}, {"lastPublishDate", Types.TIMESTAMP}
+	};
+
+	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
+new HashMap<String, Integer>();
+
+static {
+TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("assetListEntryUsageId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("userName", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("createDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("modifiedDate", Types.TIMESTAMP);
+
+TABLE_COLUMNS_MAP.put("assetListEntryId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("classNameId", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("containerKey", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("containerType", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("key_", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("plid", Types.BIGINT);
+
+TABLE_COLUMNS_MAP.put("portletId", Types.VARCHAR);
+
+TABLE_COLUMNS_MAP.put("type_", Types.INTEGER);
+
+TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
+
+}
+	public static final String TABLE_SQL_CREATE =
+"create table AssetListEntryUsage (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,assetListEntryUsageId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,assetListEntryId LONG,classNameId LONG,classPK LONG,containerKey VARCHAR(255) null,containerType LONG,key_ VARCHAR(255) null,plid LONG,portletId VARCHAR(200) null,type_ INTEGER,lastPublishDate DATE null,primary key (assetListEntryUsageId, ctCollectionId))";
+
+	public static final String TABLE_SQL_DROP =
+"drop table AssetListEntryUsage";
+
+	public static final String[] TABLE_SQL_ADD_INDEXES = {
+		"create index IX_76643456 on AssetListEntryUsage (assetListEntryId, classNameId, ctCollectionId)",
+		"create index IX_6E1C4974 on AssetListEntryUsage (assetListEntryId, ctCollectionId)",
+		"create unique index IX_78341F6B on AssetListEntryUsage (classNameId, classPK, portletId[$COLUMN_LENGTH:200$], ctCollectionId)",
+		"create index IX_AF0F2C99 on AssetListEntryUsage (groupId, classNameId, key_[$COLUMN_LENGTH:255$], ctCollectionId)",
+		"create index IX_27D73798 on AssetListEntryUsage (groupId, classNameId, key_[$COLUMN_LENGTH:255$], type_, ctCollectionId)",
+		"create index IX_4B343E95 on AssetListEntryUsage (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId)",
+		"create index IX_1F2615AF on AssetListEntryUsage (uuid_[$COLUMN_LENGTH:75$], ctCollectionId)",
+		"create unique index IX_AE0E22D7 on AssetListEntryUsage (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId)"
+	};
+
+}

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/model/impl/AssetListEntryUsageCacheModel.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/model/impl/AssetListEntryUsageCacheModel.java
@@ -78,7 +78,7 @@ public class AssetListEntryUsageCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(31);
+		StringBundler sb = new StringBundler(41);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -106,8 +106,18 @@ public class AssetListEntryUsageCacheModel
 		sb.append(classNameId);
 		sb.append(", classPK=");
 		sb.append(classPK);
+		sb.append(", containerKey=");
+		sb.append(containerKey);
+		sb.append(", containerType=");
+		sb.append(containerType);
+		sb.append(", key=");
+		sb.append(key);
+		sb.append(", plid=");
+		sb.append(plid);
 		sb.append(", portletId=");
 		sb.append(portletId);
+		sb.append(", type=");
+		sb.append(type);
 		sb.append(", lastPublishDate=");
 		sb.append(lastPublishDate);
 		sb.append("}");
@@ -160,12 +170,32 @@ public class AssetListEntryUsageCacheModel
 		assetListEntryUsageImpl.setClassNameId(classNameId);
 		assetListEntryUsageImpl.setClassPK(classPK);
 
+		if (containerKey == null) {
+			assetListEntryUsageImpl.setContainerKey("");
+		}
+		else {
+			assetListEntryUsageImpl.setContainerKey(containerKey);
+		}
+
+		assetListEntryUsageImpl.setContainerType(containerType);
+
+		if (key == null) {
+			assetListEntryUsageImpl.setKey("");
+		}
+		else {
+			assetListEntryUsageImpl.setKey(key);
+		}
+
+		assetListEntryUsageImpl.setPlid(plid);
+
 		if (portletId == null) {
 			assetListEntryUsageImpl.setPortletId("");
 		}
 		else {
 			assetListEntryUsageImpl.setPortletId(portletId);
 		}
+
+		assetListEntryUsageImpl.setType(type);
 
 		if (lastPublishDate == Long.MIN_VALUE) {
 			assetListEntryUsageImpl.setLastPublishDate(null);
@@ -203,7 +233,15 @@ public class AssetListEntryUsageCacheModel
 		classNameId = objectInput.readLong();
 
 		classPK = objectInput.readLong();
+		containerKey = objectInput.readUTF();
+
+		containerType = objectInput.readLong();
+		key = objectInput.readUTF();
+
+		plid = objectInput.readLong();
 		portletId = objectInput.readUTF();
+
+		type = objectInput.readInt();
 		lastPublishDate = objectInput.readLong();
 	}
 
@@ -244,6 +282,24 @@ public class AssetListEntryUsageCacheModel
 
 		objectOutput.writeLong(classPK);
 
+		if (containerKey == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(containerKey);
+		}
+
+		objectOutput.writeLong(containerType);
+
+		if (key == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(key);
+		}
+
+		objectOutput.writeLong(plid);
+
 		if (portletId == null) {
 			objectOutput.writeUTF("");
 		}
@@ -251,6 +307,7 @@ public class AssetListEntryUsageCacheModel
 			objectOutput.writeUTF(portletId);
 		}
 
+		objectOutput.writeInt(type);
 		objectOutput.writeLong(lastPublishDate);
 	}
 
@@ -267,7 +324,12 @@ public class AssetListEntryUsageCacheModel
 	public long assetListEntryId;
 	public long classNameId;
 	public long classPK;
+	public String containerKey;
+	public long containerType;
+	public String key;
+	public long plid;
 	public String portletId;
+	public int type;
 	public long lastPublishDate;
 
 }

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/model/impl/AssetListEntryUsageImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/model/impl/AssetListEntryUsageImpl.java
@@ -14,12 +14,30 @@
 
 package com.liferay.asset.list.model.impl;
 
+import com.liferay.portal.kernel.util.GetterUtil;
+
 /**
  * @author Brian Wing Shun Chan
  */
 public class AssetListEntryUsageImpl extends AssetListEntryUsageBaseImpl {
 
 	public AssetListEntryUsageImpl() {
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #getKey()}
+	 */
+	@Deprecated
+	public long getClassPK() {
+		return GetterUtil.getLong(getKey());
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link #setKey(String)}
+	 */
+	@Deprecated
+	public void setClassPK(long classPK) {
+		setKey(String.valueOf(classPK));
 	}
 
 }

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/model/impl/AssetListEntryUsageModelImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/model/impl/AssetListEntryUsageModelImpl.java
@@ -77,8 +77,10 @@ public class AssetListEntryUsageModelImpl
 		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
 		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
 		{"assetListEntryId", Types.BIGINT}, {"classNameId", Types.BIGINT},
-		{"classPK", Types.BIGINT}, {"portletId", Types.VARCHAR},
-		{"lastPublishDate", Types.TIMESTAMP}
+		{"classPK", Types.BIGINT}, {"containerKey", Types.VARCHAR},
+		{"containerType", Types.BIGINT}, {"key_", Types.VARCHAR},
+		{"plid", Types.BIGINT}, {"portletId", Types.VARCHAR},
+		{"type_", Types.INTEGER}, {"lastPublishDate", Types.TIMESTAMP}
 	};
 
 	public static final Map<String, Integer> TABLE_COLUMNS_MAP =
@@ -98,12 +100,17 @@ public class AssetListEntryUsageModelImpl
 		TABLE_COLUMNS_MAP.put("assetListEntryId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("classNameId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("classPK", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("containerKey", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("containerType", Types.BIGINT);
+		TABLE_COLUMNS_MAP.put("key_", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("plid", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("portletId", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("type_", Types.INTEGER);
 		TABLE_COLUMNS_MAP.put("lastPublishDate", Types.TIMESTAMP);
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table AssetListEntryUsage (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,assetListEntryUsageId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,assetListEntryId LONG,classNameId LONG,classPK LONG,portletId VARCHAR(200) null,lastPublishDate DATE null,primary key (assetListEntryUsageId, ctCollectionId))";
+		"create table AssetListEntryUsage (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,assetListEntryUsageId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,assetListEntryId LONG,classNameId LONG,classPK LONG,containerKey VARCHAR(255) null,containerType LONG,key_ VARCHAR(255) null,plid LONG,portletId VARCHAR(200) null,type_ INTEGER,lastPublishDate DATE null,primary key (assetListEntryUsageId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table AssetListEntryUsage";
@@ -148,26 +155,56 @@ public class AssetListEntryUsageModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 16L;
+	public static final long CONTAINERKEY_COLUMN_BITMASK = 16L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long PORTLETID_COLUMN_BITMASK = 32L;
+	public static final long CONTAINERTYPE_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 64L;
+	public static final long GROUPID_COLUMN_BITMASK = 64L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long KEY_COLUMN_BITMASK = 128L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long PLID_COLUMN_BITMASK = 256L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long PORTLETID_COLUMN_BITMASK = 512L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long TYPE_COLUMN_BITMASK = 1024L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 2048L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
 	 *		#getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long ASSETLISTENTRYUSAGEID_COLUMN_BITMASK = 128L;
+	public static final long ASSETLISTENTRYUSAGEID_COLUMN_BITMASK = 4096L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -388,11 +425,38 @@ public class AssetListEntryUsageModelImpl
 			(BiConsumer<AssetListEntryUsage, Long>)
 				AssetListEntryUsage::setClassPK);
 		attributeGetterFunctions.put(
+			"containerKey", AssetListEntryUsage::getContainerKey);
+		attributeSetterBiConsumers.put(
+			"containerKey",
+			(BiConsumer<AssetListEntryUsage, String>)
+				AssetListEntryUsage::setContainerKey);
+		attributeGetterFunctions.put(
+			"containerType", AssetListEntryUsage::getContainerType);
+		attributeSetterBiConsumers.put(
+			"containerType",
+			(BiConsumer<AssetListEntryUsage, Long>)
+				AssetListEntryUsage::setContainerType);
+		attributeGetterFunctions.put("key", AssetListEntryUsage::getKey);
+		attributeSetterBiConsumers.put(
+			"key",
+			(BiConsumer<AssetListEntryUsage, String>)
+				AssetListEntryUsage::setKey);
+		attributeGetterFunctions.put("plid", AssetListEntryUsage::getPlid);
+		attributeSetterBiConsumers.put(
+			"plid",
+			(BiConsumer<AssetListEntryUsage, Long>)
+				AssetListEntryUsage::setPlid);
+		attributeGetterFunctions.put(
 			"portletId", AssetListEntryUsage::getPortletId);
 		attributeSetterBiConsumers.put(
 			"portletId",
 			(BiConsumer<AssetListEntryUsage, String>)
 				AssetListEntryUsage::setPortletId);
+		attributeGetterFunctions.put("type", AssetListEntryUsage::getType);
+		attributeSetterBiConsumers.put(
+			"type",
+			(BiConsumer<AssetListEntryUsage, Integer>)
+				AssetListEntryUsage::setType);
 		attributeGetterFunctions.put(
 			"lastPublishDate", AssetListEntryUsage::getLastPublishDate);
 		attributeSetterBiConsumers.put(
@@ -698,6 +762,109 @@ public class AssetListEntryUsageModelImpl
 	}
 
 	@Override
+	public String getContainerKey() {
+		if (_containerKey == null) {
+			return "";
+		}
+		else {
+			return _containerKey;
+		}
+	}
+
+	@Override
+	public void setContainerKey(String containerKey) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_containerKey = containerKey;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalContainerKey() {
+		return getColumnOriginalValue("containerKey");
+	}
+
+	@Override
+	public long getContainerType() {
+		return _containerType;
+	}
+
+	@Override
+	public void setContainerType(long containerType) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_containerType = containerType;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public long getOriginalContainerType() {
+		return GetterUtil.getLong(
+			this.<Long>getColumnOriginalValue("containerType"));
+	}
+
+	@Override
+	public String getKey() {
+		if (_key == null) {
+			return "";
+		}
+		else {
+			return _key;
+		}
+	}
+
+	@Override
+	public void setKey(String key) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_key = key;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalKey() {
+		return getColumnOriginalValue("key_");
+	}
+
+	@Override
+	public long getPlid() {
+		return _plid;
+	}
+
+	@Override
+	public void setPlid(long plid) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_plid = plid;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public long getOriginalPlid() {
+		return GetterUtil.getLong(this.<Long>getColumnOriginalValue("plid"));
+	}
+
+	@Override
 	public String getPortletId() {
 		if (_portletId == null) {
 			return "";
@@ -723,6 +890,30 @@ public class AssetListEntryUsageModelImpl
 	@Deprecated
 	public String getOriginalPortletId() {
 		return getColumnOriginalValue("portletId");
+	}
+
+	@Override
+	public int getType() {
+		return _type;
+	}
+
+	@Override
+	public void setType(int type) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_type = type;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public int getOriginalType() {
+		return GetterUtil.getInteger(
+			this.<Integer>getColumnOriginalValue("type_"));
 	}
 
 	@Override
@@ -816,7 +1007,12 @@ public class AssetListEntryUsageModelImpl
 		assetListEntryUsageImpl.setAssetListEntryId(getAssetListEntryId());
 		assetListEntryUsageImpl.setClassNameId(getClassNameId());
 		assetListEntryUsageImpl.setClassPK(getClassPK());
+		assetListEntryUsageImpl.setContainerKey(getContainerKey());
+		assetListEntryUsageImpl.setContainerType(getContainerType());
+		assetListEntryUsageImpl.setKey(getKey());
+		assetListEntryUsageImpl.setPlid(getPlid());
 		assetListEntryUsageImpl.setPortletId(getPortletId());
+		assetListEntryUsageImpl.setType(getType());
 		assetListEntryUsageImpl.setLastPublishDate(getLastPublishDate());
 
 		assetListEntryUsageImpl.resetOriginalValues();
@@ -951,6 +1147,26 @@ public class AssetListEntryUsageModelImpl
 
 		assetListEntryUsageCacheModel.classPK = getClassPK();
 
+		assetListEntryUsageCacheModel.containerKey = getContainerKey();
+
+		String containerKey = assetListEntryUsageCacheModel.containerKey;
+
+		if ((containerKey != null) && (containerKey.length() == 0)) {
+			assetListEntryUsageCacheModel.containerKey = null;
+		}
+
+		assetListEntryUsageCacheModel.containerType = getContainerType();
+
+		assetListEntryUsageCacheModel.key = getKey();
+
+		String key = assetListEntryUsageCacheModel.key;
+
+		if ((key != null) && (key.length() == 0)) {
+			assetListEntryUsageCacheModel.key = null;
+		}
+
+		assetListEntryUsageCacheModel.plid = getPlid();
+
 		assetListEntryUsageCacheModel.portletId = getPortletId();
 
 		String portletId = assetListEntryUsageCacheModel.portletId;
@@ -958,6 +1174,8 @@ public class AssetListEntryUsageModelImpl
 		if ((portletId != null) && (portletId.length() == 0)) {
 			assetListEntryUsageCacheModel.portletId = null;
 		}
+
+		assetListEntryUsageCacheModel.type = getType();
 
 		Date lastPublishDate = getLastPublishDate();
 
@@ -1056,7 +1274,12 @@ public class AssetListEntryUsageModelImpl
 	private long _assetListEntryId;
 	private long _classNameId;
 	private long _classPK;
+	private String _containerKey;
+	private long _containerType;
+	private String _key;
+	private long _plid;
 	private String _portletId;
+	private int _type;
 	private Date _lastPublishDate;
 
 	public <T> T getColumnValue(String columnName) {
@@ -1102,7 +1325,12 @@ public class AssetListEntryUsageModelImpl
 		_columnOriginalValues.put("assetListEntryId", _assetListEntryId);
 		_columnOriginalValues.put("classNameId", _classNameId);
 		_columnOriginalValues.put("classPK", _classPK);
+		_columnOriginalValues.put("containerKey", _containerKey);
+		_columnOriginalValues.put("containerType", _containerType);
+		_columnOriginalValues.put("key_", _key);
+		_columnOriginalValues.put("plid", _plid);
 		_columnOriginalValues.put("portletId", _portletId);
+		_columnOriginalValues.put("type_", _type);
 		_columnOriginalValues.put("lastPublishDate", _lastPublishDate);
 	}
 
@@ -1112,6 +1340,8 @@ public class AssetListEntryUsageModelImpl
 		Map<String, String> attributeNames = new HashMap<>();
 
 		attributeNames.put("uuid_", "uuid");
+		attributeNames.put("key_", "key");
+		attributeNames.put("type_", "type");
 
 		_attributeNames = Collections.unmodifiableMap(attributeNames);
 	}
@@ -1153,9 +1383,19 @@ public class AssetListEntryUsageModelImpl
 
 		columnBitmasks.put("classPK", 4096L);
 
-		columnBitmasks.put("portletId", 8192L);
+		columnBitmasks.put("containerKey", 8192L);
 
-		columnBitmasks.put("lastPublishDate", 16384L);
+		columnBitmasks.put("containerType", 16384L);
+
+		columnBitmasks.put("key_", 32768L);
+
+		columnBitmasks.put("plid", 65536L);
+
+		columnBitmasks.put("portletId", 131072L);
+
+		columnBitmasks.put("type_", 262144L);
+
+		columnBitmasks.put("lastPublishDate", 524288L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryUsageLocalServiceImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/impl/AssetListEntryUsageLocalServiceImpl.java
@@ -14,18 +14,32 @@
 
 package com.liferay.asset.list.service.impl;
 
+import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
+import com.liferay.asset.list.constants.AssetListEntryUsageConstants;
+import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.model.AssetListEntryUsage;
+import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.asset.list.service.base.AssetListEntryUsageLocalServiceBaseImpl;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.OrderByComparator;
+import com.liferay.portal.kernel.util.Portal;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Pavel Savinov
@@ -41,6 +55,26 @@ public class AssetListEntryUsageLocalServiceImpl
 	public AssetListEntryUsage addAssetListEntryUsage(
 			long userId, long groupId, long assetListEntryId, long classNameId,
 			long classPK, String portletId, ServiceContext serviceContext)
+		throws PortalException {
+
+		return addAssetListEntryUsage(
+			userId, groupId, _portal.getClassNameId(AssetListEntry.class),
+			String.valueOf(assetListEntryId),
+			_portal.getClassNameId(Portlet.class), portletId, classPK,
+			serviceContext);
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #addAssetListEntryUsage(long, long, long, long, long, String,
+	 *             ServiceContext)}
+	 */
+	@Deprecated
+	@Override
+	public AssetListEntryUsage addAssetListEntryUsage(
+			long userId, long groupId, long classNameId, String key,
+			long containerType, String containerKey, long plid,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		User user = userLocalService.getUser(userId);
@@ -59,68 +93,263 @@ public class AssetListEntryUsageLocalServiceImpl
 			serviceContext.getCreateDate(new Date()));
 		assetListEntryUsage.setModifiedDate(
 			serviceContext.getModifiedDate(new Date()));
-		assetListEntryUsage.setAssetListEntryId(assetListEntryId);
 		assetListEntryUsage.setClassNameId(classNameId);
-		assetListEntryUsage.setClassPK(classPK);
-		assetListEntryUsage.setPortletId(portletId);
+		assetListEntryUsage.setContainerKey(containerKey);
+		assetListEntryUsage.setContainerType(containerType);
+		assetListEntryUsage.setKey(key);
+		assetListEntryUsage.setPlid(plid);
+		assetListEntryUsage.setType(_getType(plid));
 
 		return assetListEntryUsagePersistence.update(assetListEntryUsage);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #fetchAssetListEntryUsage(String, long, long)}
+	 */
+	@Deprecated
 	@Override
 	public AssetListEntryUsage fetchAssetListEntryUsage(
 		long classNameId, long classPK, String portletId) {
 
-		return assetListEntryUsagePersistence.fetchByC_C_P(
-			classNameId, classPK, portletId);
+		List<AssetListEntryUsage> assetListEntryUsages =
+			fetchAssetListEntryUsage(
+				portletId, _portal.getClassNameId(Portlet.class), classPK);
+
+		if (!assetListEntryUsages.isEmpty()) {
+			return assetListEntryUsages.get(0);
+		}
+
+		return null;
 	}
 
+	@Override
+	public List<AssetListEntryUsage> fetchAssetListEntryUsage(
+		String containerKey, long containerType, long plid) {
+
+		return assetListEntryUsagePersistence.findByCK_CT_P(
+			containerKey, containerType, plid);
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #getAssetListEntryUsages(long, long, String)}
+	 */
+	@Deprecated
 	@Override
 	public List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId) {
 
-		return assetListEntryUsagePersistence.findByAssetListEntryId(
-			assetListEntryId);
+		return getAssetListEntryUsages(
+			GroupThreadLocal.getGroupId(),
+			_portal.getClassNameId(AssetListEntry.class),
+			String.valueOf(assetListEntryId));
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #getAssetListEntryUsages(long, long, String, int, int,
+	 *             OrderByComparator)}
+	 */
+	@Deprecated
 	@Override
 	public List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId, int start, int end,
 		OrderByComparator<AssetListEntryUsage> orderByComparator) {
 
-		return assetListEntryUsagePersistence.findByAssetListEntryId(
-			assetListEntryId, start, end, orderByComparator);
+		return getAssetListEntryUsages(
+			_getGroupId(assetListEntryId),
+			_portal.getClassNameId(AssetListEntry.class),
+			String.valueOf(assetListEntryId), start, end, orderByComparator);
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #getAssetListEntryUsages(long, long, String, int)}
+	 */
+	@Deprecated
 	@Override
 	public List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId, long classNameId) {
 
-		return assetListEntryUsagePersistence.findByA_C(
-			assetListEntryId, classNameId);
+		return getAssetListEntryUsages(
+			_getGroupId(assetListEntryId),
+			_portal.getClassNameId(AssetListEntry.class),
+			String.valueOf(assetListEntryId), _toType(classNameId));
 	}
 
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #getAssetListEntryUsages(long, long, String, int, int, int,
+	 *             OrderByComparator)}
+	 */
+	@Deprecated
 	@Override
 	public List<AssetListEntryUsage> getAssetListEntryUsages(
 		long assetListEntryId, long classNameId, int start, int end,
 		OrderByComparator<AssetListEntryUsage> orderByComparator) {
 
-		return assetListEntryUsagePersistence.findByA_C(
-			assetListEntryId, classNameId, start, end, orderByComparator);
+		return getAssetListEntryUsages(
+			_getGroupId(assetListEntryId),
+			_portal.getClassNameId(AssetListEntry.class),
+			String.valueOf(assetListEntryId), _toType(classNameId), start, end,
+			orderByComparator);
 	}
 
 	@Override
-	public int getAssetListEntryUsagesCount(long assetListEntryId) {
-		return assetListEntryUsagePersistence.countByAssetListEntryId(
-			assetListEntryId);
+	public List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key) {
+
+		return assetListEntryUsagePersistence.findByG_C_K(
+			groupId, classNameId, key);
 	}
 
+	@Override
+	public List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key, int type) {
+
+		return assetListEntryUsagePersistence.findByG_C_K_T(
+			groupId, classNameId, key, type);
+	}
+
+	@Override
+	public List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key, int type, int start,
+		int end, OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return assetListEntryUsagePersistence.findByG_C_K_T(
+			groupId, classNameId, key, type, start, end, orderByComparator);
+	}
+
+	@Override
+	public List<AssetListEntryUsage> getAssetListEntryUsages(
+		long groupId, long classNameId, String key, int start, int end,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return assetListEntryUsagePersistence.findByG_C_K(
+			groupId, classNameId, key, start, end, orderByComparator);
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #getAssetListEntryUsagesCount(long, long, String)}
+	 */
+	@Deprecated
+	@Override
+	public int getAssetListEntryUsagesCount(long assetListEntryId) {
+		return getAssetListEntryUsagesCount(
+			_getGroupId(assetListEntryId),
+			_portal.getClassNameId(AssetListEntry.class),
+			String.valueOf(assetListEntryId));
+	}
+
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #getAssetListEntryUsagesCount(long, long, String, int)}
+	 */
+	@Deprecated
 	@Override
 	public int getAssetListEntryUsagesCount(
 		long assetListEntryId, long classNameId) {
 
-		return assetListEntryUsagePersistence.countByA_C(
-			assetListEntryId, classNameId);
+		return getAssetListEntryUsagesCount(
+			_getGroupId(assetListEntryId),
+			_portal.getClassNameId(AssetListEntry.class),
+			String.valueOf(assetListEntryId), _toType(classNameId));
 	}
+
+	@Override
+	public int getAssetListEntryUsagesCount(
+		long groupId, long classNameId, String key) {
+
+		return assetListEntryUsagePersistence.countByG_C_K(
+			groupId, classNameId, key);
+	}
+
+	@Override
+	public int getAssetListEntryUsagesCount(
+		long groupId, long classNameId, String key, int type) {
+
+		return assetListEntryUsagePersistence.countByG_C_K_T(
+			groupId, classNameId, key, type);
+	}
+
+	private long _getGroupId(long assetListEntryId) {
+		AssetListEntry assetListEntry =
+			_assetListEntryLocalService.fetchAssetListEntry(assetListEntryId);
+
+		if (assetListEntry != null) {
+			return assetListEntry.getGroupId();
+		}
+
+		return 0L;
+	}
+
+	private int _getType(long plid) {
+		if (plid <= 0) {
+			return AssetListEntryUsageConstants.TYPE_DEFAULT;
+		}
+
+		Layout layout = _layoutLocalService.fetchLayout(plid);
+
+		if (layout == null) {
+			return AssetListEntryUsageConstants.TYPE_DEFAULT;
+		}
+
+		if ((layout.getClassNameId() > 0) && (layout.getClassPK() > 0)) {
+			plid = layout.getClassPK();
+		}
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.
+				fetchLayoutPageTemplateEntryByPlid(plid);
+
+		if (layoutPageTemplateEntry == null) {
+			return AssetListEntryUsageConstants.TYPE_LAYOUT;
+		}
+
+		if (layoutPageTemplateEntry.getType() ==
+				LayoutPageTemplateEntryTypeConstants.TYPE_DISPLAY_PAGE) {
+
+			return AssetListEntryUsageConstants.TYPE_DISPLAY_PAGE_TEMPLATE;
+		}
+
+		return AssetListEntryUsageConstants.TYPE_PAGE_TEMPLATE;
+	}
+
+	private int _toType(long classNameId) {
+		if (Objects.equals(classNameId, _portal.getClassNameId(Layout.class))) {
+			return AssetListEntryUsageConstants.TYPE_LAYOUT;
+		}
+
+		if (Objects.equals(
+				classNameId,
+				_portal.getClassNameId(LayoutPageTemplateEntry.class))) {
+
+			return AssetListEntryUsageConstants.TYPE_PAGE_TEMPLATE;
+		}
+
+		if (Objects.equals(
+				classNameId,
+				_portal.getClassNameId(AssetDisplayPageEntry.class))) {
+
+			return AssetListEntryUsageConstants.TYPE_DISPLAY_PAGE_TEMPLATE;
+		}
+
+		return AssetListEntryUsageConstants.TYPE_DEFAULT;
+	}
+
+	@Reference
+	private AssetListEntryLocalService _assetListEntryLocalService;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/persistence/impl/AssetListEntryUsagePersistenceImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/service/persistence/impl/AssetListEntryUsagePersistenceImpl.java
@@ -2615,6 +2615,642 @@ public class AssetListEntryUsagePersistenceImpl
 	private static final String _FINDER_COLUMN_A_C_CLASSNAMEID_2 =
 		"assetListEntryUsage.classNameId = ?";
 
+	private FinderPath _finderPathWithPaginationFindByG_C_K;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_K;
+	private FinderPath _finderPathCountByG_C_K;
+
+	/**
+	 * Returns all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @return the matching asset list entry usages
+	 */
+	@Override
+	public List<AssetListEntryUsage> findByG_C_K(
+		long groupId, long classNameId, String key) {
+
+		return findByG_C_K(
+			groupId, classNameId, key, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+			null);
+	}
+
+	/**
+	 * Returns a range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @return the range of matching asset list entry usages
+	 */
+	@Override
+	public List<AssetListEntryUsage> findByG_C_K(
+		long groupId, long classNameId, String key, int start, int end) {
+
+		return findByG_C_K(groupId, classNameId, key, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	@Override
+	public List<AssetListEntryUsage> findByG_C_K(
+		long groupId, long classNameId, String key, int start, int end,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return findByG_C_K(
+			groupId, classNameId, key, start, end, orderByComparator, true);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	@Override
+	public List<AssetListEntryUsage> findByG_C_K(
+		long groupId, long classNameId, String key, int start, int end,
+		OrderByComparator<AssetListEntryUsage> orderByComparator,
+		boolean useFinderCache) {
+
+		key = Objects.toString(key, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			AssetListEntryUsage.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache && productionMode) {
+				finderPath = _finderPathWithoutPaginationFindByG_C_K;
+				finderArgs = new Object[] {groupId, classNameId, key};
+			}
+		}
+		else if (useFinderCache && productionMode) {
+			finderPath = _finderPathWithPaginationFindByG_C_K;
+			finderArgs = new Object[] {
+				groupId, classNameId, key, start, end, orderByComparator
+			};
+		}
+
+		List<AssetListEntryUsage> list = null;
+
+		if (useFinderCache && productionMode) {
+			list = (List<AssetListEntryUsage>)finderCache.getResult(
+				finderPath, finderArgs);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (AssetListEntryUsage assetListEntryUsage : list) {
+					if ((groupId != assetListEntryUsage.getGroupId()) ||
+						(classNameId != assetListEntryUsage.getClassNameId()) ||
+						!key.equals(assetListEntryUsage.getKey())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					5 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(5);
+			}
+
+			sb.append(_SQL_SELECT_ASSETLISTENTRYUSAGE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_C_K_GROUPID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_K_CLASSNAMEID_2);
+
+			boolean bindKey = false;
+
+			if (key.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_K_KEY_3);
+			}
+			else {
+				bindKey = true;
+
+				sb.append(_FINDER_COLUMN_G_C_K_KEY_2);
+			}
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(AssetListEntryUsageModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				queryPos.add(classNameId);
+
+				if (bindKey) {
+					queryPos.add(key);
+				}
+
+				list = (List<AssetListEntryUsage>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache && productionMode) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	@Override
+	public AssetListEntryUsage findByG_C_K_First(
+			long groupId, long classNameId, String key,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException {
+
+		AssetListEntryUsage assetListEntryUsage = fetchByG_C_K_First(
+			groupId, classNameId, key, orderByComparator);
+
+		if (assetListEntryUsage != null) {
+			return assetListEntryUsage;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append(", key=");
+		sb.append(key);
+
+		sb.append("}");
+
+		throw new NoSuchEntryUsageException(sb.toString());
+	}
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	@Override
+	public AssetListEntryUsage fetchByG_C_K_First(
+		long groupId, long classNameId, String key,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		List<AssetListEntryUsage> list = findByG_C_K(
+			groupId, classNameId, key, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	@Override
+	public AssetListEntryUsage findByG_C_K_Last(
+			long groupId, long classNameId, String key,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException {
+
+		AssetListEntryUsage assetListEntryUsage = fetchByG_C_K_Last(
+			groupId, classNameId, key, orderByComparator);
+
+		if (assetListEntryUsage != null) {
+			return assetListEntryUsage;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append(", key=");
+		sb.append(key);
+
+		sb.append("}");
+
+		throw new NoSuchEntryUsageException(sb.toString());
+	}
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	@Override
+	public AssetListEntryUsage fetchByG_C_K_Last(
+		long groupId, long classNameId, String key,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		int count = countByG_C_K(groupId, classNameId, key);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<AssetListEntryUsage> list = findByG_C_K(
+			groupId, classNameId, key, count - 1, count, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the asset list entry usages before and after the current asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param assetListEntryUsageId the primary key of the current asset list entry usage
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset list entry usage
+	 * @throws NoSuchEntryUsageException if a asset list entry usage with the primary key could not be found
+	 */
+	@Override
+	public AssetListEntryUsage[] findByG_C_K_PrevAndNext(
+			long assetListEntryUsageId, long groupId, long classNameId,
+			String key,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException {
+
+		key = Objects.toString(key, "");
+
+		AssetListEntryUsage assetListEntryUsage = findByPrimaryKey(
+			assetListEntryUsageId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			AssetListEntryUsage[] array = new AssetListEntryUsageImpl[3];
+
+			array[0] = getByG_C_K_PrevAndNext(
+				session, assetListEntryUsage, groupId, classNameId, key,
+				orderByComparator, true);
+
+			array[1] = assetListEntryUsage;
+
+			array[2] = getByG_C_K_PrevAndNext(
+				session, assetListEntryUsage, groupId, classNameId, key,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected AssetListEntryUsage getByG_C_K_PrevAndNext(
+		Session session, AssetListEntryUsage assetListEntryUsage, long groupId,
+		long classNameId, String key,
+		OrderByComparator<AssetListEntryUsage> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		sb.append(_SQL_SELECT_ASSETLISTENTRYUSAGE_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_C_K_GROUPID_2);
+
+		sb.append(_FINDER_COLUMN_G_C_K_CLASSNAMEID_2);
+
+		boolean bindKey = false;
+
+		if (key.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_C_K_KEY_3);
+		}
+		else {
+			bindKey = true;
+
+			sb.append(_FINDER_COLUMN_G_C_K_KEY_2);
+		}
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(AssetListEntryUsageModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		queryPos.add(classNameId);
+
+		if (bindKey) {
+			queryPos.add(key);
+		}
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						assetListEntryUsage)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<AssetListEntryUsage> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 */
+	@Override
+	public void removeByG_C_K(long groupId, long classNameId, String key) {
+		for (AssetListEntryUsage assetListEntryUsage :
+				findByG_C_K(
+					groupId, classNameId, key, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(assetListEntryUsage);
+		}
+	}
+
+	/**
+	 * Returns the number of asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @return the number of matching asset list entry usages
+	 */
+	@Override
+	public int countByG_C_K(long groupId, long classNameId, String key) {
+		key = Objects.toString(key, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			AssetListEntryUsage.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByG_C_K;
+
+			finderArgs = new Object[] {groupId, classNameId, key};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_SQL_COUNT_ASSETLISTENTRYUSAGE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_C_K_GROUPID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_K_CLASSNAMEID_2);
+
+			boolean bindKey = false;
+
+			if (key.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_K_KEY_3);
+			}
+			else {
+				bindKey = true;
+
+				sb.append(_FINDER_COLUMN_G_C_K_KEY_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				queryPos.add(classNameId);
+
+				if (bindKey) {
+					queryPos.add(key);
+				}
+
+				count = (Long)query.uniqueResult();
+
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_G_C_K_GROUPID_2 =
+		"assetListEntryUsage.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_K_CLASSNAMEID_2 =
+		"assetListEntryUsage.classNameId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_K_KEY_2 =
+		"assetListEntryUsage.key = ?";
+
+	private static final String _FINDER_COLUMN_G_C_K_KEY_3 =
+		"(assetListEntryUsage.key IS NULL OR assetListEntryUsage.key = '')";
+
 	private FinderPath _finderPathFetchByC_C_P;
 	private FinderPath _finderPathCountByC_C_P;
 
@@ -2906,10 +3542,1333 @@ public class AssetListEntryUsagePersistenceImpl
 	private static final String _FINDER_COLUMN_C_C_P_PORTLETID_3 =
 		"(assetListEntryUsage.portletId IS NULL OR assetListEntryUsage.portletId = '')";
 
+	private FinderPath _finderPathWithPaginationFindByCK_CT_P;
+	private FinderPath _finderPathWithoutPaginationFindByCK_CT_P;
+	private FinderPath _finderPathCountByCK_CT_P;
+
+	/**
+	 * Returns all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @return the matching asset list entry usages
+	 */
+	@Override
+	public List<AssetListEntryUsage> findByCK_CT_P(
+		String containerKey, long containerType, long plid) {
+
+		return findByCK_CT_P(
+			containerKey, containerType, plid, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @return the range of matching asset list entry usages
+	 */
+	@Override
+	public List<AssetListEntryUsage> findByCK_CT_P(
+		String containerKey, long containerType, long plid, int start,
+		int end) {
+
+		return findByCK_CT_P(
+			containerKey, containerType, plid, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	@Override
+	public List<AssetListEntryUsage> findByCK_CT_P(
+		String containerKey, long containerType, long plid, int start, int end,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return findByCK_CT_P(
+			containerKey, containerType, plid, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	@Override
+	public List<AssetListEntryUsage> findByCK_CT_P(
+		String containerKey, long containerType, long plid, int start, int end,
+		OrderByComparator<AssetListEntryUsage> orderByComparator,
+		boolean useFinderCache) {
+
+		containerKey = Objects.toString(containerKey, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			AssetListEntryUsage.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache && productionMode) {
+				finderPath = _finderPathWithoutPaginationFindByCK_CT_P;
+				finderArgs = new Object[] {containerKey, containerType, plid};
+			}
+		}
+		else if (useFinderCache && productionMode) {
+			finderPath = _finderPathWithPaginationFindByCK_CT_P;
+			finderArgs = new Object[] {
+				containerKey, containerType, plid, start, end, orderByComparator
+			};
+		}
+
+		List<AssetListEntryUsage> list = null;
+
+		if (useFinderCache && productionMode) {
+			list = (List<AssetListEntryUsage>)finderCache.getResult(
+				finderPath, finderArgs);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (AssetListEntryUsage assetListEntryUsage : list) {
+					if (!containerKey.equals(
+							assetListEntryUsage.getContainerKey()) ||
+						(containerType !=
+							assetListEntryUsage.getContainerType()) ||
+						(plid != assetListEntryUsage.getPlid())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					5 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(5);
+			}
+
+			sb.append(_SQL_SELECT_ASSETLISTENTRYUSAGE_WHERE);
+
+			boolean bindContainerKey = false;
+
+			if (containerKey.isEmpty()) {
+				sb.append(_FINDER_COLUMN_CK_CT_P_CONTAINERKEY_3);
+			}
+			else {
+				bindContainerKey = true;
+
+				sb.append(_FINDER_COLUMN_CK_CT_P_CONTAINERKEY_2);
+			}
+
+			sb.append(_FINDER_COLUMN_CK_CT_P_CONTAINERTYPE_2);
+
+			sb.append(_FINDER_COLUMN_CK_CT_P_PLID_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(AssetListEntryUsageModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				if (bindContainerKey) {
+					queryPos.add(containerKey);
+				}
+
+				queryPos.add(containerType);
+
+				queryPos.add(plid);
+
+				list = (List<AssetListEntryUsage>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache && productionMode) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	@Override
+	public AssetListEntryUsage findByCK_CT_P_First(
+			String containerKey, long containerType, long plid,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException {
+
+		AssetListEntryUsage assetListEntryUsage = fetchByCK_CT_P_First(
+			containerKey, containerType, plid, orderByComparator);
+
+		if (assetListEntryUsage != null) {
+			return assetListEntryUsage;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("containerKey=");
+		sb.append(containerKey);
+
+		sb.append(", containerType=");
+		sb.append(containerType);
+
+		sb.append(", plid=");
+		sb.append(plid);
+
+		sb.append("}");
+
+		throw new NoSuchEntryUsageException(sb.toString());
+	}
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	@Override
+	public AssetListEntryUsage fetchByCK_CT_P_First(
+		String containerKey, long containerType, long plid,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		List<AssetListEntryUsage> list = findByCK_CT_P(
+			containerKey, containerType, plid, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	@Override
+	public AssetListEntryUsage findByCK_CT_P_Last(
+			String containerKey, long containerType, long plid,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException {
+
+		AssetListEntryUsage assetListEntryUsage = fetchByCK_CT_P_Last(
+			containerKey, containerType, plid, orderByComparator);
+
+		if (assetListEntryUsage != null) {
+			return assetListEntryUsage;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("containerKey=");
+		sb.append(containerKey);
+
+		sb.append(", containerType=");
+		sb.append(containerType);
+
+		sb.append(", plid=");
+		sb.append(plid);
+
+		sb.append("}");
+
+		throw new NoSuchEntryUsageException(sb.toString());
+	}
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	@Override
+	public AssetListEntryUsage fetchByCK_CT_P_Last(
+		String containerKey, long containerType, long plid,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		int count = countByCK_CT_P(containerKey, containerType, plid);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<AssetListEntryUsage> list = findByCK_CT_P(
+			containerKey, containerType, plid, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the asset list entry usages before and after the current asset list entry usage in the ordered set where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param assetListEntryUsageId the primary key of the current asset list entry usage
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset list entry usage
+	 * @throws NoSuchEntryUsageException if a asset list entry usage with the primary key could not be found
+	 */
+	@Override
+	public AssetListEntryUsage[] findByCK_CT_P_PrevAndNext(
+			long assetListEntryUsageId, String containerKey, long containerType,
+			long plid, OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException {
+
+		containerKey = Objects.toString(containerKey, "");
+
+		AssetListEntryUsage assetListEntryUsage = findByPrimaryKey(
+			assetListEntryUsageId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			AssetListEntryUsage[] array = new AssetListEntryUsageImpl[3];
+
+			array[0] = getByCK_CT_P_PrevAndNext(
+				session, assetListEntryUsage, containerKey, containerType, plid,
+				orderByComparator, true);
+
+			array[1] = assetListEntryUsage;
+
+			array[2] = getByCK_CT_P_PrevAndNext(
+				session, assetListEntryUsage, containerKey, containerType, plid,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected AssetListEntryUsage getByCK_CT_P_PrevAndNext(
+		Session session, AssetListEntryUsage assetListEntryUsage,
+		String containerKey, long containerType, long plid,
+		OrderByComparator<AssetListEntryUsage> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				6 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(5);
+		}
+
+		sb.append(_SQL_SELECT_ASSETLISTENTRYUSAGE_WHERE);
+
+		boolean bindContainerKey = false;
+
+		if (containerKey.isEmpty()) {
+			sb.append(_FINDER_COLUMN_CK_CT_P_CONTAINERKEY_3);
+		}
+		else {
+			bindContainerKey = true;
+
+			sb.append(_FINDER_COLUMN_CK_CT_P_CONTAINERKEY_2);
+		}
+
+		sb.append(_FINDER_COLUMN_CK_CT_P_CONTAINERTYPE_2);
+
+		sb.append(_FINDER_COLUMN_CK_CT_P_PLID_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(AssetListEntryUsageModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		if (bindContainerKey) {
+			queryPos.add(containerKey);
+		}
+
+		queryPos.add(containerType);
+
+		queryPos.add(plid);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						assetListEntryUsage)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<AssetListEntryUsage> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63; from the database.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 */
+	@Override
+	public void removeByCK_CT_P(
+		String containerKey, long containerType, long plid) {
+
+		for (AssetListEntryUsage assetListEntryUsage :
+				findByCK_CT_P(
+					containerKey, containerType, plid, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(assetListEntryUsage);
+		}
+	}
+
+	/**
+	 * Returns the number of asset list entry usages where containerKey = &#63; and containerType = &#63; and plid = &#63;.
+	 *
+	 * @param containerKey the container key
+	 * @param containerType the container type
+	 * @param plid the plid
+	 * @return the number of matching asset list entry usages
+	 */
+	@Override
+	public int countByCK_CT_P(
+		String containerKey, long containerType, long plid) {
+
+		containerKey = Objects.toString(containerKey, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			AssetListEntryUsage.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByCK_CT_P;
+
+			finderArgs = new Object[] {containerKey, containerType, plid};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_SQL_COUNT_ASSETLISTENTRYUSAGE_WHERE);
+
+			boolean bindContainerKey = false;
+
+			if (containerKey.isEmpty()) {
+				sb.append(_FINDER_COLUMN_CK_CT_P_CONTAINERKEY_3);
+			}
+			else {
+				bindContainerKey = true;
+
+				sb.append(_FINDER_COLUMN_CK_CT_P_CONTAINERKEY_2);
+			}
+
+			sb.append(_FINDER_COLUMN_CK_CT_P_CONTAINERTYPE_2);
+
+			sb.append(_FINDER_COLUMN_CK_CT_P_PLID_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				if (bindContainerKey) {
+					queryPos.add(containerKey);
+				}
+
+				queryPos.add(containerType);
+
+				queryPos.add(plid);
+
+				count = (Long)query.uniqueResult();
+
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_CK_CT_P_CONTAINERKEY_2 =
+		"assetListEntryUsage.containerKey = ? AND ";
+
+	private static final String _FINDER_COLUMN_CK_CT_P_CONTAINERKEY_3 =
+		"(assetListEntryUsage.containerKey IS NULL OR assetListEntryUsage.containerKey = '') AND ";
+
+	private static final String _FINDER_COLUMN_CK_CT_P_CONTAINERTYPE_2 =
+		"assetListEntryUsage.containerType = ? AND ";
+
+	private static final String _FINDER_COLUMN_CK_CT_P_PLID_2 =
+		"assetListEntryUsage.plid = ?";
+
+	private FinderPath _finderPathWithPaginationFindByG_C_K_T;
+	private FinderPath _finderPathWithoutPaginationFindByG_C_K_T;
+	private FinderPath _finderPathCountByG_C_K_T;
+
+	/**
+	 * Returns all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @return the matching asset list entry usages
+	 */
+	@Override
+	public List<AssetListEntryUsage> findByG_C_K_T(
+		long groupId, long classNameId, String key, int type) {
+
+		return findByG_C_K_T(
+			groupId, classNameId, key, type, QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS, null);
+	}
+
+	/**
+	 * Returns a range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @return the range of matching asset list entry usages
+	 */
+	@Override
+	public List<AssetListEntryUsage> findByG_C_K_T(
+		long groupId, long classNameId, String key, int type, int start,
+		int end) {
+
+		return findByG_C_K_T(groupId, classNameId, key, type, start, end, null);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	@Override
+	public List<AssetListEntryUsage> findByG_C_K_T(
+		long groupId, long classNameId, String key, int type, int start,
+		int end, OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		return findByG_C_K_T(
+			groupId, classNameId, key, type, start, end, orderByComparator,
+			true);
+	}
+
+	/**
+	 * Returns an ordered range of all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * <p>
+	 * Useful when paginating results. Returns a maximum of <code>end - start</code> instances. <code>start</code> and <code>end</code> are not primary keys, they are indexes in the result set. Thus, <code>0</code> refers to the first result in the set. Setting both <code>start</code> and <code>end</code> to <code>QueryUtil#ALL_POS</code> will return the full result set. If <code>orderByComparator</code> is specified, then the query will include the given ORDER BY logic. If <code>orderByComparator</code> is absent, then the query will include the default ORDER BY logic from <code>AssetListEntryUsageModelImpl</code>.
+	 * </p>
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param start the lower bound of the range of asset list entry usages
+	 * @param end the upper bound of the range of asset list entry usages (not inclusive)
+	 * @param orderByComparator the comparator to order the results by (optionally <code>null</code>)
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the ordered range of matching asset list entry usages
+	 */
+	@Override
+	public List<AssetListEntryUsage> findByG_C_K_T(
+		long groupId, long classNameId, String key, int type, int start,
+		int end, OrderByComparator<AssetListEntryUsage> orderByComparator,
+		boolean useFinderCache) {
+
+		key = Objects.toString(key, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			AssetListEntryUsage.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		if ((start == QueryUtil.ALL_POS) && (end == QueryUtil.ALL_POS) &&
+			(orderByComparator == null)) {
+
+			if (useFinderCache && productionMode) {
+				finderPath = _finderPathWithoutPaginationFindByG_C_K_T;
+				finderArgs = new Object[] {groupId, classNameId, key, type};
+			}
+		}
+		else if (useFinderCache && productionMode) {
+			finderPath = _finderPathWithPaginationFindByG_C_K_T;
+			finderArgs = new Object[] {
+				groupId, classNameId, key, type, start, end, orderByComparator
+			};
+		}
+
+		List<AssetListEntryUsage> list = null;
+
+		if (useFinderCache && productionMode) {
+			list = (List<AssetListEntryUsage>)finderCache.getResult(
+				finderPath, finderArgs);
+
+			if ((list != null) && !list.isEmpty()) {
+				for (AssetListEntryUsage assetListEntryUsage : list) {
+					if ((groupId != assetListEntryUsage.getGroupId()) ||
+						(classNameId != assetListEntryUsage.getClassNameId()) ||
+						!key.equals(assetListEntryUsage.getKey()) ||
+						(type != assetListEntryUsage.getType())) {
+
+						list = null;
+
+						break;
+					}
+				}
+			}
+		}
+
+		if (list == null) {
+			StringBundler sb = null;
+
+			if (orderByComparator != null) {
+				sb = new StringBundler(
+					6 + (orderByComparator.getOrderByFields().length * 2));
+			}
+			else {
+				sb = new StringBundler(6);
+			}
+
+			sb.append(_SQL_SELECT_ASSETLISTENTRYUSAGE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_C_K_T_GROUPID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_K_T_CLASSNAMEID_2);
+
+			boolean bindKey = false;
+
+			if (key.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_K_T_KEY_3);
+			}
+			else {
+				bindKey = true;
+
+				sb.append(_FINDER_COLUMN_G_C_K_T_KEY_2);
+			}
+
+			sb.append(_FINDER_COLUMN_G_C_K_T_TYPE_2);
+
+			if (orderByComparator != null) {
+				appendOrderByComparator(
+					sb, _ORDER_BY_ENTITY_ALIAS, orderByComparator);
+			}
+			else {
+				sb.append(AssetListEntryUsageModelImpl.ORDER_BY_JPQL);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				queryPos.add(classNameId);
+
+				if (bindKey) {
+					queryPos.add(key);
+				}
+
+				queryPos.add(type);
+
+				list = (List<AssetListEntryUsage>)QueryUtil.list(
+					query, getDialect(), start, end);
+
+				cacheResult(list);
+
+				if (useFinderCache && productionMode) {
+					finderCache.putResult(finderPath, finderArgs, list);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return list;
+	}
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	@Override
+	public AssetListEntryUsage findByG_C_K_T_First(
+			long groupId, long classNameId, String key, int type,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException {
+
+		AssetListEntryUsage assetListEntryUsage = fetchByG_C_K_T_First(
+			groupId, classNameId, key, type, orderByComparator);
+
+		if (assetListEntryUsage != null) {
+			return assetListEntryUsage;
+		}
+
+		StringBundler sb = new StringBundler(10);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append(", key=");
+		sb.append(key);
+
+		sb.append(", type=");
+		sb.append(type);
+
+		sb.append("}");
+
+		throw new NoSuchEntryUsageException(sb.toString());
+	}
+
+	/**
+	 * Returns the first asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the first matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	@Override
+	public AssetListEntryUsage fetchByG_C_K_T_First(
+		long groupId, long classNameId, String key, int type,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		List<AssetListEntryUsage> list = findByG_C_K_T(
+			groupId, classNameId, key, type, 0, 1, orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage
+	 * @throws NoSuchEntryUsageException if a matching asset list entry usage could not be found
+	 */
+	@Override
+	public AssetListEntryUsage findByG_C_K_T_Last(
+			long groupId, long classNameId, String key, int type,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException {
+
+		AssetListEntryUsage assetListEntryUsage = fetchByG_C_K_T_Last(
+			groupId, classNameId, key, type, orderByComparator);
+
+		if (assetListEntryUsage != null) {
+			return assetListEntryUsage;
+		}
+
+		StringBundler sb = new StringBundler(10);
+
+		sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+		sb.append("groupId=");
+		sb.append(groupId);
+
+		sb.append(", classNameId=");
+		sb.append(classNameId);
+
+		sb.append(", key=");
+		sb.append(key);
+
+		sb.append(", type=");
+		sb.append(type);
+
+		sb.append("}");
+
+		throw new NoSuchEntryUsageException(sb.toString());
+	}
+
+	/**
+	 * Returns the last asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the last matching asset list entry usage, or <code>null</code> if a matching asset list entry usage could not be found
+	 */
+	@Override
+	public AssetListEntryUsage fetchByG_C_K_T_Last(
+		long groupId, long classNameId, String key, int type,
+		OrderByComparator<AssetListEntryUsage> orderByComparator) {
+
+		int count = countByG_C_K_T(groupId, classNameId, key, type);
+
+		if (count == 0) {
+			return null;
+		}
+
+		List<AssetListEntryUsage> list = findByG_C_K_T(
+			groupId, classNameId, key, type, count - 1, count,
+			orderByComparator);
+
+		if (!list.isEmpty()) {
+			return list.get(0);
+		}
+
+		return null;
+	}
+
+	/**
+	 * Returns the asset list entry usages before and after the current asset list entry usage in the ordered set where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param assetListEntryUsageId the primary key of the current asset list entry usage
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @param orderByComparator the comparator to order the set by (optionally <code>null</code>)
+	 * @return the previous, current, and next asset list entry usage
+	 * @throws NoSuchEntryUsageException if a asset list entry usage with the primary key could not be found
+	 */
+	@Override
+	public AssetListEntryUsage[] findByG_C_K_T_PrevAndNext(
+			long assetListEntryUsageId, long groupId, long classNameId,
+			String key, int type,
+			OrderByComparator<AssetListEntryUsage> orderByComparator)
+		throws NoSuchEntryUsageException {
+
+		key = Objects.toString(key, "");
+
+		AssetListEntryUsage assetListEntryUsage = findByPrimaryKey(
+			assetListEntryUsageId);
+
+		Session session = null;
+
+		try {
+			session = openSession();
+
+			AssetListEntryUsage[] array = new AssetListEntryUsageImpl[3];
+
+			array[0] = getByG_C_K_T_PrevAndNext(
+				session, assetListEntryUsage, groupId, classNameId, key, type,
+				orderByComparator, true);
+
+			array[1] = assetListEntryUsage;
+
+			array[2] = getByG_C_K_T_PrevAndNext(
+				session, assetListEntryUsage, groupId, classNameId, key, type,
+				orderByComparator, false);
+
+			return array;
+		}
+		catch (Exception exception) {
+			throw processException(exception);
+		}
+		finally {
+			closeSession(session);
+		}
+	}
+
+	protected AssetListEntryUsage getByG_C_K_T_PrevAndNext(
+		Session session, AssetListEntryUsage assetListEntryUsage, long groupId,
+		long classNameId, String key, int type,
+		OrderByComparator<AssetListEntryUsage> orderByComparator,
+		boolean previous) {
+
+		StringBundler sb = null;
+
+		if (orderByComparator != null) {
+			sb = new StringBundler(
+				7 + (orderByComparator.getOrderByConditionFields().length * 3) +
+					(orderByComparator.getOrderByFields().length * 3));
+		}
+		else {
+			sb = new StringBundler(6);
+		}
+
+		sb.append(_SQL_SELECT_ASSETLISTENTRYUSAGE_WHERE);
+
+		sb.append(_FINDER_COLUMN_G_C_K_T_GROUPID_2);
+
+		sb.append(_FINDER_COLUMN_G_C_K_T_CLASSNAMEID_2);
+
+		boolean bindKey = false;
+
+		if (key.isEmpty()) {
+			sb.append(_FINDER_COLUMN_G_C_K_T_KEY_3);
+		}
+		else {
+			bindKey = true;
+
+			sb.append(_FINDER_COLUMN_G_C_K_T_KEY_2);
+		}
+
+		sb.append(_FINDER_COLUMN_G_C_K_T_TYPE_2);
+
+		if (orderByComparator != null) {
+			String[] orderByConditionFields =
+				orderByComparator.getOrderByConditionFields();
+
+			if (orderByConditionFields.length > 0) {
+				sb.append(WHERE_AND);
+			}
+
+			for (int i = 0; i < orderByConditionFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByConditionFields[i]);
+
+				if ((i + 1) < orderByConditionFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN_HAS_NEXT);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(WHERE_GREATER_THAN);
+					}
+					else {
+						sb.append(WHERE_LESSER_THAN);
+					}
+				}
+			}
+
+			sb.append(ORDER_BY_CLAUSE);
+
+			String[] orderByFields = orderByComparator.getOrderByFields();
+
+			for (int i = 0; i < orderByFields.length; i++) {
+				sb.append(_ORDER_BY_ENTITY_ALIAS);
+				sb.append(orderByFields[i]);
+
+				if ((i + 1) < orderByFields.length) {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC_HAS_NEXT);
+					}
+					else {
+						sb.append(ORDER_BY_DESC_HAS_NEXT);
+					}
+				}
+				else {
+					if (orderByComparator.isAscending() ^ previous) {
+						sb.append(ORDER_BY_ASC);
+					}
+					else {
+						sb.append(ORDER_BY_DESC);
+					}
+				}
+			}
+		}
+		else {
+			sb.append(AssetListEntryUsageModelImpl.ORDER_BY_JPQL);
+		}
+
+		String sql = sb.toString();
+
+		Query query = session.createQuery(sql);
+
+		query.setFirstResult(0);
+		query.setMaxResults(2);
+
+		QueryPos queryPos = QueryPos.getInstance(query);
+
+		queryPos.add(groupId);
+
+		queryPos.add(classNameId);
+
+		if (bindKey) {
+			queryPos.add(key);
+		}
+
+		queryPos.add(type);
+
+		if (orderByComparator != null) {
+			for (Object orderByConditionValue :
+					orderByComparator.getOrderByConditionValues(
+						assetListEntryUsage)) {
+
+				queryPos.add(orderByConditionValue);
+			}
+		}
+
+		List<AssetListEntryUsage> list = query.list();
+
+		if (list.size() == 2) {
+			return list.get(1);
+		}
+		else {
+			return null;
+		}
+	}
+
+	/**
+	 * Removes all the asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 */
+	@Override
+	public void removeByG_C_K_T(
+		long groupId, long classNameId, String key, int type) {
+
+		for (AssetListEntryUsage assetListEntryUsage :
+				findByG_C_K_T(
+					groupId, classNameId, key, type, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			remove(assetListEntryUsage);
+		}
+	}
+
+	/**
+	 * Returns the number of asset list entry usages where groupId = &#63; and classNameId = &#63; and key = &#63; and type = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param key the key
+	 * @param type the type
+	 * @return the number of matching asset list entry usages
+	 */
+	@Override
+	public int countByG_C_K_T(
+		long groupId, long classNameId, String key, int type) {
+
+		key = Objects.toString(key, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			AssetListEntryUsage.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByG_C_K_T;
+
+			finderArgs = new Object[] {groupId, classNameId, key, type};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs);
+		}
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(5);
+
+			sb.append(_SQL_COUNT_ASSETLISTENTRYUSAGE_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_C_K_T_GROUPID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_K_T_CLASSNAMEID_2);
+
+			boolean bindKey = false;
+
+			if (key.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_K_T_KEY_3);
+			}
+			else {
+				bindKey = true;
+
+				sb.append(_FINDER_COLUMN_G_C_K_T_KEY_2);
+			}
+
+			sb.append(_FINDER_COLUMN_G_C_K_T_TYPE_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				queryPos.add(classNameId);
+
+				if (bindKey) {
+					queryPos.add(key);
+				}
+
+				queryPos.add(type);
+
+				count = (Long)query.uniqueResult();
+
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_G_C_K_T_GROUPID_2 =
+		"assetListEntryUsage.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_K_T_CLASSNAMEID_2 =
+		"assetListEntryUsage.classNameId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_K_T_KEY_2 =
+		"assetListEntryUsage.key = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_K_T_KEY_3 =
+		"(assetListEntryUsage.key IS NULL OR assetListEntryUsage.key = '') AND ";
+
+	private static final String _FINDER_COLUMN_G_C_K_T_TYPE_2 =
+		"assetListEntryUsage.type = ?";
+
 	public AssetListEntryUsagePersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
 		dbColumnNames.put("uuid", "uuid_");
+		dbColumnNames.put("key", "key_");
+		dbColumnNames.put("type", "type_");
 
 		setDBColumnNames(dbColumnNames);
 
@@ -3691,7 +5650,12 @@ public class AssetListEntryUsagePersistenceImpl
 		ctStrictColumnNames.add("assetListEntryId");
 		ctStrictColumnNames.add("classNameId");
 		ctStrictColumnNames.add("classPK");
+		ctStrictColumnNames.add("containerKey");
+		ctStrictColumnNames.add("containerType");
+		ctStrictColumnNames.add("key_");
+		ctStrictColumnNames.add("plid");
 		ctStrictColumnNames.add("portletId");
+		ctStrictColumnNames.add("type_");
 		ctStrictColumnNames.add("lastPublishDate");
 
 		_ctColumnNamesMap.put(
@@ -3819,6 +5783,31 @@ public class AssetListEntryUsagePersistenceImpl
 			new String[] {Long.class.getName(), Long.class.getName()},
 			new String[] {"assetListEntryId", "classNameId"}, false);
 
+		_finderPathWithPaginationFindByG_C_K = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_K",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "key_"}, true);
+
+		_finderPathWithoutPaginationFindByG_C_K = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_K",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "key_"}, true);
+
+		_finderPathCountByG_C_K = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_K",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "key_"}, false);
+
 		_finderPathFetchByC_C_P = new FinderPath(
 			FINDER_CLASS_NAME_ENTITY, "fetchByC_C_P",
 			new String[] {
@@ -3834,6 +5823,57 @@ public class AssetListEntryUsagePersistenceImpl
 				String.class.getName()
 			},
 			new String[] {"classNameId", "classPK", "portletId"}, false);
+
+		_finderPathWithPaginationFindByCK_CT_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByCK_CT_P",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Long.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), OrderByComparator.class.getName()
+			},
+			new String[] {"containerKey", "containerType", "plid"}, true);
+
+		_finderPathWithoutPaginationFindByCK_CT_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByCK_CT_P",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Long.class.getName()
+			},
+			new String[] {"containerKey", "containerType", "plid"}, true);
+
+		_finderPathCountByCK_CT_P = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByCK_CT_P",
+			new String[] {
+				String.class.getName(), Long.class.getName(),
+				Long.class.getName()
+			},
+			new String[] {"containerKey", "containerType", "plid"}, false);
+
+		_finderPathWithPaginationFindByG_C_K_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_K_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), Integer.class.getName(),
+				Integer.class.getName(), Integer.class.getName(),
+				OrderByComparator.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "key_", "type_"}, true);
+
+		_finderPathWithoutPaginationFindByG_C_K_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "findByG_C_K_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), Integer.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "key_", "type_"}, true);
+
+		_finderPathCountByG_C_K_T = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_K_T",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), Integer.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "key_", "type_"}, false);
 	}
 
 	@Deactivate
@@ -3904,7 +5944,7 @@ public class AssetListEntryUsagePersistenceImpl
 		AssetListEntryUsagePersistenceImpl.class);
 
 	private static final Set<String> _badColumnNames = SetUtil.fromArray(
-		new String[] {"uuid"});
+		new String[] {"uuid", "key", "type"});
 
 	@Override
 	protected FinderCache getFinderCache() {

--- a/modules/apps/asset/asset-list-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/asset/asset-list-service/src/main/resources/META-INF/module-hbm.xml
@@ -79,7 +79,12 @@
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="assetListEntryId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="classNameId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="classPK" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="containerKey" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="containerType" type="com.liferay.portal.dao.orm.hibernate.LongType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" column="key_" name="key" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="plid" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="portletId" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" column="type_" name="type" type="com.liferay.portal.dao.orm.hibernate.IntegerType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.LiferayPropertyAccessor" name="lastPublishDate" type="org.hibernate.type.TimestampType" />
 	</class>
 </hibernate-mapping>

--- a/modules/apps/asset/asset-list-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/asset/asset-list-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -72,9 +72,18 @@
 		<field name="assetListEntryId" type="long" />
 		<field name="classNameId" type="long" />
 		<field name="classPK" type="long" />
+		<field name="containerKey" type="String">
+			<hint name="max-length">255</hint>
+		</field>
+		<field name="containerType" type="long" />
+		<field name="key" type="String">
+			<hint name="max-length">255</hint>
+		</field>
+		<field name="plid" type="long" />
 		<field name="portletId" type="String">
 			<hint name="max-length">200</hint>
 		</field>
+		<field name="type" type="int" />
 		<field name="lastPublishDate" type="Date" />
 	</model>
 </model-hints>

--- a/modules/apps/asset/asset-list-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/asset/asset-list-service/src/main/resources/META-INF/sql/indexes.sql
@@ -27,6 +27,8 @@ create unique index IX_29F4FD05 on AssetListEntrySegmentsEntryRel (uuid_[$COLUMN
 create index IX_76643456 on AssetListEntryUsage (assetListEntryId, classNameId, ctCollectionId);
 create index IX_6E1C4974 on AssetListEntryUsage (assetListEntryId, ctCollectionId);
 create unique index IX_78341F6B on AssetListEntryUsage (classNameId, classPK, portletId[$COLUMN_LENGTH:200$], ctCollectionId);
+create index IX_AF0F2C99 on AssetListEntryUsage (groupId, classNameId, key_[$COLUMN_LENGTH:255$], ctCollectionId);
+create index IX_27D73798 on AssetListEntryUsage (groupId, classNameId, key_[$COLUMN_LENGTH:255$], type_, ctCollectionId);
 create index IX_4B343E95 on AssetListEntryUsage (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId);
 create index IX_1F2615AF on AssetListEntryUsage (uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 create unique index IX_AE0E22D7 on AssetListEntryUsage (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);

--- a/modules/apps/asset/asset-list-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/asset/asset-list-service/src/main/resources/META-INF/sql/tables.sql
@@ -69,7 +69,12 @@ create table AssetListEntryUsage (
 	assetListEntryId LONG,
 	classNameId LONG,
 	classPK LONG,
+	containerKey VARCHAR(255) null,
+	containerType LONG,
+	key_ VARCHAR(255) null,
+	plid LONG,
 	portletId VARCHAR(200) null,
+	type_ INTEGER,
 	lastPublishDate DATE null,
 	primary key (assetListEntryUsageId, ctCollectionId)
 );

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryUsagePersistenceTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/service/persistence/test/AssetListEntryUsagePersistenceTest.java
@@ -150,7 +150,17 @@ public class AssetListEntryUsagePersistenceTest {
 
 		newAssetListEntryUsage.setClassPK(RandomTestUtil.nextLong());
 
+		newAssetListEntryUsage.setContainerKey(RandomTestUtil.randomString());
+
+		newAssetListEntryUsage.setContainerType(RandomTestUtil.nextLong());
+
+		newAssetListEntryUsage.setKey(RandomTestUtil.randomString());
+
+		newAssetListEntryUsage.setPlid(RandomTestUtil.nextLong());
+
 		newAssetListEntryUsage.setPortletId(RandomTestUtil.randomString());
+
+		newAssetListEntryUsage.setType(RandomTestUtil.nextInt());
 
 		newAssetListEntryUsage.setLastPublishDate(RandomTestUtil.nextDate());
 
@@ -201,8 +211,23 @@ public class AssetListEntryUsagePersistenceTest {
 			existingAssetListEntryUsage.getClassPK(),
 			newAssetListEntryUsage.getClassPK());
 		Assert.assertEquals(
+			existingAssetListEntryUsage.getContainerKey(),
+			newAssetListEntryUsage.getContainerKey());
+		Assert.assertEquals(
+			existingAssetListEntryUsage.getContainerType(),
+			newAssetListEntryUsage.getContainerType());
+		Assert.assertEquals(
+			existingAssetListEntryUsage.getKey(),
+			newAssetListEntryUsage.getKey());
+		Assert.assertEquals(
+			existingAssetListEntryUsage.getPlid(),
+			newAssetListEntryUsage.getPlid());
+		Assert.assertEquals(
 			existingAssetListEntryUsage.getPortletId(),
 			newAssetListEntryUsage.getPortletId());
+		Assert.assertEquals(
+			existingAssetListEntryUsage.getType(),
+			newAssetListEntryUsage.getType());
 		Assert.assertEquals(
 			Time.getShortTimestamp(
 				existingAssetListEntryUsage.getLastPublishDate()),
@@ -253,6 +278,16 @@ public class AssetListEntryUsagePersistenceTest {
 	}
 
 	@Test
+	public void testCountByG_C_K() throws Exception {
+		_persistence.countByG_C_K(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "");
+
+		_persistence.countByG_C_K(0L, 0L, "null");
+
+		_persistence.countByG_C_K(0L, 0L, (String)null);
+	}
+
+	@Test
 	public void testCountByC_C_P() throws Exception {
 		_persistence.countByC_C_P(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "");
@@ -260,6 +295,27 @@ public class AssetListEntryUsagePersistenceTest {
 		_persistence.countByC_C_P(0L, 0L, "null");
 
 		_persistence.countByC_C_P(0L, 0L, (String)null);
+	}
+
+	@Test
+	public void testCountByCK_CT_P() throws Exception {
+		_persistence.countByCK_CT_P(
+			"", RandomTestUtil.nextLong(), RandomTestUtil.nextLong());
+
+		_persistence.countByCK_CT_P("null", 0L, 0L);
+
+		_persistence.countByCK_CT_P((String)null, 0L, 0L);
+	}
+
+	@Test
+	public void testCountByG_C_K_T() throws Exception {
+		_persistence.countByG_C_K_T(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "",
+			RandomTestUtil.nextInt());
+
+		_persistence.countByG_C_K_T(0L, 0L, "null", 0);
+
+		_persistence.countByG_C_K_T(0L, 0L, (String)null, 0);
 	}
 
 	@Test
@@ -293,7 +349,9 @@ public class AssetListEntryUsagePersistenceTest {
 			"uuid", true, "assetListEntryUsageId", true, "groupId", true,
 			"companyId", true, "userId", true, "userName", true, "createDate",
 			true, "modifiedDate", true, "assetListEntryId", true, "classNameId",
-			true, "classPK", true, "portletId", true, "lastPublishDate", true);
+			true, "classPK", true, "containerKey", true, "containerType", true,
+			"key", true, "plid", true, "portletId", true, "type", true,
+			"lastPublishDate", true);
 	}
 
 	@Test
@@ -633,7 +691,17 @@ public class AssetListEntryUsagePersistenceTest {
 
 		assetListEntryUsage.setClassPK(RandomTestUtil.nextLong());
 
+		assetListEntryUsage.setContainerKey(RandomTestUtil.randomString());
+
+		assetListEntryUsage.setContainerType(RandomTestUtil.nextLong());
+
+		assetListEntryUsage.setKey(RandomTestUtil.randomString());
+
+		assetListEntryUsage.setPlid(RandomTestUtil.nextLong());
+
 		assetListEntryUsage.setPortletId(RandomTestUtil.randomString());
+
+		assetListEntryUsage.setType(RandomTestUtil.nextInt());
 
 		assetListEntryUsage.setLastPublishDate(RandomTestUtil.nextDate());
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/ContentUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/ContentUtil.java
@@ -572,15 +572,15 @@ public class ContentUtil {
 					layoutClassedModelUsage.getClassPK()));
 
 		return mappedContentJSONObject.put(
-			"name",
-			ResourceActionsUtil.getModelResource(
-				themeDisplay.getLocale(),
-				layoutClassedModelUsage.getClassName())
-		).put(
 			"status", _getStatusJSONObject(layoutClassedModelUsage)
 		).put(
 			"title",
 			layoutDisplayPageObjectProvider.getTitle(themeDisplay.getLocale())
+		).put(
+			"type",
+			ResourceActionsUtil.getModelResource(
+				themeDisplay.getLocale(),
+				layoutClassedModelUsage.getClassName())
 		).put(
 			"usagesCount",
 			LayoutClassedModelUsageLocalServiceUtil.

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/contents/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/contents/components/PageContent.js
@@ -92,7 +92,7 @@ export default function PageContent(props) {
 						{props.title}
 					</strong>
 
-					<span className="small text-secondary">{props.name}</span>
+					<span className="small text-secondary">{props.type}</span>
 
 					<span className="small text-secondary">
 						{props.usagesCount === 1


### PR DESCRIPTION
⚠️ The idea is just to review my progress so far, to see that all that I've done make senses and I haven't done any mistake ⚠️ 
Once the review is complete we can just close the pr :) 

### What is included in the PR:

* Adaptation of the AssetEntryListUsage for saving collection and collection provider usages. 
    - assetEntryListId and classPK are no longer needed 
    - Key, containerKey, containerType, type and plid fields added (basically to work like the LayoutClassedModelUsage table)
* LocalServiceImpl updated so that all the current methods are deprecated and new ones has been added. We'll probably need more, but I'd prefer doing it once the necessity arises
* Upgrade process

### Questions
1. I am not sure how to deprecate class fields properly, I have tried adding the deprecated annotation in the AssetListEntryUsageImpl, but it is not propagated to the interface therefore users cannot notice that is deprecated
2. I have to add `db-index="false"` to the `CK_CT_P` because an exception was thrown if two entities with the same combination of containerKey, containerType, plid were added. I assume this make sense, but not sure if this is the correct way to avoid the error.

### Pending taks

* Update current usages to use the new fields
* Adds Listeners for saving the usages when something in a page change