### PR TITLE
LPS-129701 Migrate selection modals in site modules

### DIFF
--- a/modules/apps/site/site-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -116,11 +116,3 @@
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectGroupFm',
-		'<%= HtmlUtil.escapeJS(siteBrowserDisplayContext.getEventName()) %>',
-		<%= siteBrowserDisplayContext.getSelUser() != null %>
-	);
-</aui:script>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarPropsTransformer.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarPropsTransformer.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {openSelectionModal} from 'frontend-js-web';
+import {addParams, openSelectionModal} from 'frontend-js-web';
 
 export default function propsTransformer({portletNamespace, ...otherProps}) {
 	const deleteSelectedUserGroups = () => {
@@ -53,6 +53,20 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 			selectEventName: `${portletNamespace}selectRole`,
 			title: Liferay.Language.get('assign-roles'),
 			url: itemData?.selectRoleURL,
+		});
+	};
+
+	const selectRoles = (itemData) => {
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				location.href = addParams(
+					`${`${portletNamespace}roleId`}=${selectedItem.id}`,
+					itemData.viewRoleURL
+				);
+			},
+			selectEventName: `${portletNamespace}selectRole`,
+			title: Liferay.Language.get('select-role'),
+			url: itemData?.selectRolesURL,
 		});
 	};
 
@@ -107,6 +121,11 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 
 			if (action === 'selectUserGroups') {
 				selectUserGroups(data);
+			}
+		},
+		onFilterDropdownItemClick(event, {item}) {
+			if (item?.data?.action === 'selectRoles') {
+				selectRoles(item?.data);
 			}
 		},
 	};

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserManagementToolbarPropsTransformer.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserManagementToolbarPropsTransformer.js
@@ -56,6 +56,20 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 		});
 	};
 
+	const selectRoles = (itemData) => {
+		openSelectionModal({
+			onSelect: (selectedItem) => {
+				location.href = addParams(
+					`${`${portletNamespace}roleId`}=${selectedItem.id}`,
+					itemData.viewRoleURL
+				);
+			},
+			selectEventName: `${portletNamespace}selectRole`,
+			title: Liferay.Language.get('select-role'),
+			url: itemData?.selectRolesURL,
+		});
+	};
+
 	const selectUsers = (itemData) => {
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
@@ -108,6 +122,11 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 
 			if (data?.action === 'selectUsers') {
 				selectUsers(data);
+			}
+		},
+		onFilterDropdownItemClick(event, {item}) {
+			if (item?.data?.action === 'selectRoles') {
+				selectRoles(item?.data);
 			}
 		},
 	};

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_site_role.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_site_role.jsp
@@ -100,10 +100,3 @@ SelectRolesDisplayContext selectRolesDisplayContext = new SelectRolesDisplayCont
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />fm',
-		'<%= HtmlUtil.escapeJS(selectRolesDisplayContext.getEventName()) %>'
-	);
-</aui:script>

--- a/modules/apps/site/site-taglib/src/main/resources/META-INF/resources/site_browser/page.jsp
+++ b/modules/apps/site/site-taglib/src/main/resources/META-INF/resources/site_browser/page.jsp
@@ -17,7 +17,6 @@
 <%@ include file="/site_browser/init.jsp" %>
 
 <%
-String eventName = GetterUtil.getString(request.getAttribute("liferay-site:site-browser:eventName"));
 long[] selectedGroupIds = GetterUtil.getLongValues(request.getAttribute("liferay-site:site-browser:selectedGroupIds"));
 %>
 
@@ -123,10 +122,3 @@ long[] selectedGroupIds = GetterUtil.getLongValues(request.getAttribute("liferay
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="aui-base">
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectGroupFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>


### PR DESCRIPTION
Part 1 fix of https://issues.liferay.com/browse/LPS-129701.

Here are some of the removals I managed to get done. There are a couple leftover cases that I'll try and fix tomorrow, one of the leftover (not commited) migrations would have to wait for https://github.com/pei-jung/liferay-portal/pull/824 so I just sent this as a part 1 of the task.

We (@victorg1991 and I) also fixed a bug that came up with the Management Toolbar migration via https://github.com/liferay-echo/liferay-portal/commit/f8607cd53a6af4a2997c28fcb594838dc60402c3. 

I've manually tested these and they work, but I can no longer recall the steps to test them individually so I can't write it up for you, sorry.