### PR TITLE
LPS-129599 Remove selectEntityHandler usages as part of migration to openSelectionModal

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content_template.jsp
@@ -88,9 +88,4 @@ JournalArticleDisplay articleDisplay = journalPreviewArticleContentTemplateDispl
 			'<%= journalPreviewArticleContentTemplateDisplayContext.getPortletURL() %>'
 		);
 	}
-
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />previewFm',
-		'<%= HtmlUtil.escapeJS(journalPreviewArticleContentTemplateDisplayContext.getEventName()) %>'
-	);
 </script>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_structure.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_structure.jsp
@@ -87,12 +87,3 @@ SearchContainer<DDMStructure> ddmStructureSearch = journalSelectDDMStructureDisp
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	document.addEventListener('DOMContentLoaded', () => {
-		Liferay.Util.selectEntityHandler(
-			'#<portlet:namespace />selectDDMStructureFm',
-			'<%= HtmlUtil.escapeJS(journalSelectDDMStructureDisplayContext.getEventName()) %>'
-		);
-	});
-</aui:script>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_ddm_template.jsp
@@ -94,12 +94,3 @@ JournalSelectDDMTemplateDisplayContext journalSelectDDMTemplateDisplayContext = 
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	document.addEventListener('DOMContentLoaded', () => {
-		Liferay.Util.selectEntityHandler(
-			'#<portlet:namespace />selectDDMTemplateFm',
-			'<%= HtmlUtil.escapeJS(journalSelectDDMTemplateDisplayContext.getEventName()) %>'
-		);
-	});
-</aui:script>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_version.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/select_version.jsp
@@ -20,7 +20,6 @@
 long groupId = ParamUtil.getLong(request, "groupId");
 String articleId = ParamUtil.getString(request, "articleId");
 double sourceVersion = ParamUtil.getDouble(request, "sourceVersion");
-String eventName = ParamUtil.getString(request, "eventName", liferayPortletResponse.getNamespace() + "selectVersionFm");
 
 PortletURL portletURL = PortletURLBuilder.createRenderURL(
 	renderResponse
@@ -93,10 +92,3 @@ PortletURL portletURL = PortletURLBuilder.createRenderURL(
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectVersionFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>


### PR DESCRIPTION
This is a part of https://issues.liferay.com/browse/LPS-129599.

The change relies on `openSelectionModal` that is already implemented and removes the now obsolete usage of `Liferay.Util.selectEntityHandler`.

Only a part because removal of `Liferay.Util.getOpener().Liferay.fire` is waiting for https://github.com/pei-jung/liferay-portal/pull/824. So I just sent a PR that fixes half of the task but perfectly functions on it's own.

I've tested the changes manually, and everything works!