### PR TITLE
LPS-129830 Uses configurationRenderURL as redirect instead of currentURL, like we are doing for scopes

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_selection_action.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_selection_action.jsp
@@ -24,9 +24,11 @@ ResultRow row = (ResultRow)request.getAttribute(WebKeys.SEARCH_CONTAINER_RESULT_
 int assetEntryOrder = searchContainer.getStart() + row.getPos();
 %>
 
+<liferay-portlet:renderURL portletConfiguration="<%= true %>" varImpl="configurationRenderURL" />
+
 <liferay-portlet:actionURL portletConfiguration="<%= true %>" var="deleteURL">
 	<portlet:param name="<%= Constants.CMD %>" value="remove-selection" />
-	<portlet:param name="redirect" value="<%= currentURL %>" />
+	<portlet:param name="redirect" value="<%= configurationRenderURL.toString() %>" />
 	<portlet:param name="assetEntryOrder" value="<%= String.valueOf(assetEntryOrder) %>" />
 </liferay-portlet:actionURL>
 


### PR DESCRIPTION
Hey @holatuwol,

I fixed https://issues.liferay.com/browse/LPS-129830 with another solution, since the the problem seems to be related with the redirect. I copied the solution from scope.jsp, since we had a similar problem in https://issues.liferay.com/browse/LPS-114182.

Please let me know if you have any question.

Regards,
Eudaldo.