### PR TITLE
LPS-130642 We should be casting tag names to lower case

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -85,6 +85,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TimeZone;
+import java.util.stream.Stream;
 
 import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
@@ -518,7 +519,13 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 			}
 		}
 
-		return allAssetTagNames.toArray(new String[0]);
+		Stream<String> stream = allAssetTagNames.stream();
+
+		return stream.map(
+			String::toLowerCase
+		).toArray(
+			String[]::new
+		);
 	}
 
 	@Override

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetTagPersistenceImpl.java
@@ -3117,6 +3117,8 @@ public class AssetTagPersistenceImpl
 	public AssetTag findByG_N(long groupId, String name)
 		throws NoSuchTagException {
 
+		name = StringUtil.toLowerCase(name.trim());
+
 		AssetTag assetTag = fetchByG_N(groupId, name);
 
 		if (assetTag == null) {
@@ -3167,6 +3169,8 @@ public class AssetTagPersistenceImpl
 		long groupId, String name, boolean useFinderCache) {
 
 		name = Objects.toString(name, "");
+
+		name = StringUtil.toLowerCase(name.trim());
 
 		boolean productionMode = CTPersistenceHelperUtil.isProductionMode(
 			AssetTag.class);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-130642

In Liferay 6.2, when fetching and finding AssetTags by name and groupId we cast the name passed in from PortletPreferences to lower case. The method was changed from 6.2 in [LPS-52588](https://issues.liferay.com/browse/LPS-52588) to simplify some of the calls for asset tags. However the method AssetTagFinderImpl.doFindByG_N used prior to LPS-52588 [cast the name passed in to lower case](https://github.com/brianchandotcom/liferay-portal/pull/23223/commits/b02d2ac41e6345c66ab3bd96cbfe96aad5808d97#diff-0cca6d98caade78feb402775c9a8267db01974d99bd490cd563d83728ff081d8L350), the methods now used do not however.