### PR TITLE
LPS-130033 This cannot be cached since some fields like geolocation cannot be cached, since they are adding scripts and css to the top of the page that 

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalDefaultTemplateProviderImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalDefaultTemplateProviderImpl.java
@@ -95,7 +95,7 @@ public class JournalDefaultTemplateProviderImpl
 
 	@Override
 	public boolean isCacheable() {
-		return true;
+		return false;
 	}
 
 }


### PR DESCRIPTION
Hey brian,

The change to make default templates for web content cacheable wasn't added for performance reasons but to solve a bug (LPS-105196). This bug is no longer reproducible. 

We are disabling this option because the geolocation default template cannot be cached. These default templates are only used as a fallback when the user didn't select a template, so usages should be limited, so I don't think it could cause severe performance problems
