### PR TITLE
LPS-129701 Migrate open selection modals in site modules

### DIFF
--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/menu/MySitesPersonalMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/menu/MySitesPersonalMenuEntry.java
@@ -86,7 +86,7 @@ public class MySitesPersonalMenuEntry implements PersonalMenuEntry {
 		StringBuilder sb = new StringBuilder(12);
 
 		sb.append("javascript:Liferay.Util.openSelectionModal({");
-		sb.append("customSelectEvent: true, id: '");
+		sb.append("id: '");
 		sb.append(namespace);
 		sb.append("selectSite', onSelect: function(selectedItem) ");
 		sb.append("{Liferay.Util.navigate(selectedItem.url);}");

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_icon_sites.jspf
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_icon_sites.jspf
@@ -47,7 +47,6 @@ PortletURL itemSelectorURL = itemSelector.getItemSelectorURL(RequestBackedPortle
 		if (manageSitesLink) {
 			manageSitesLink.addEventListener('click', (event) => {
 				Liferay.Util.openSelectionModal({
-					customSelectEvent: true,
 					id: '<portlet:namespace />selectSite',
 					onSelect: function (selectedItem) {
 						Liferay.Util.navigate(selectedItem.url);

--- a/modules/apps/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
+++ b/modules/apps/site/site-item-selector-web/src/main/resources/META-INF/resources/view_sites.jsp
@@ -254,10 +254,3 @@ String target = ParamUtil.getString(request, "target", groupItemSelectorCriterio
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="aui-base">
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectGroupFm',
-		'<%= HtmlUtil.escapeJS(siteItemSelectorViewDisplayContext.getItemSelectedEventName()) %>'
-	);
-</aui:script>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/OrganizationsManagementToolbarPropsTransformer.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/OrganizationsManagementToolbarPropsTransformer.js
@@ -33,24 +33,26 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
 			multiple: true,
-			onSelect(selectedItem) {
-				if (selectedItem) {
-					const form = document.getElementById(
+			onSelect(selectedItems) {
+				if (selectedItems.length) {
+					const addGroupOrganizationsFm = document.getElementById(
 						`${portletNamespace}addGroupOrganizationsFm`
 					);
 
-					if (!form) {
+					if (!addGroupOrganizationsFm) {
 						return;
 					}
 
-					selectedItem.forEach((item) => {
-						form.appendChild(item);
-					});
+					const input = document.createElement('input');
 
-					submitForm(form);
+					input.name = `${portletNamespace}rowIds`;
+					input.value = selectedItems.map((item) => item.value);
+
+					addGroupOrganizationsFm.appendChild(input);
+
+					submitForm(addGroupOrganizationsFm);
 				}
 			},
-			selectEventName: `${portletNamespace}selectOrganizations`,
 			title: Liferay.Util.sub(
 				Liferay.Language.get('assign-organizations-to-this-x'),
 				itemData?.groupTypeLabel

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarPropsTransformer.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserGroupsManagementToolbarPropsTransformer.js
@@ -74,21 +74,24 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
 			multiple: true,
-			onSelect(selectedItem) {
-				if (selectedItem) {
-					const form = document.getElementById(
+			onSelect(selectedItems) {
+				if (selectedItems.length) {
+					const addGroupUserGroupsFm = document.getElementById(
 						`${portletNamespace}addGroupUserGroupsFm`
 					);
 
-					if (!form) {
+					if (!addGroupUserGroupsFm) {
 						return;
 					}
 
-					selectedItem.forEach((item) => {
-						form.appendChild(item);
-					});
+					const input = document.createElement('input');
 
-					submitForm(form);
+					input.name = `${portletNamespace}rowIds`;
+					input.value = selectedItems.map((item) => item.value);
+
+					addGroupUserGroupsFm.appendChild(input);
+
+					submitForm(addGroupUserGroupsFm);
 				}
 			},
 			selectEventName: `${portletNamespace}selectUserGroups`,

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserManagementToolbarPropsTransformer.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/UserManagementToolbarPropsTransformer.js
@@ -33,8 +33,8 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
 			multiple: true,
-			onSelect(selectedItem) {
-				if (selectedItem) {
+			onSelect: (selectedItems) => {
+				if (selectedItems.length) {
 					const form = document.getElementById(
 						`${portletNamespace}fm`
 					);
@@ -43,14 +43,16 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 						return;
 					}
 
-					selectedItem.forEach((item) => {
-						form.appendChild(item);
-					});
+					const input = document.createElement('input');
+
+					input.name = `${portletNamespace}rowIds`;
+					input.value = selectedItems.map((item) => item.value);
+
+					form.appendChild(input);
 
 					submitForm(form, itemData?.editUsersRolesURL);
 				}
 			},
-			selectEventName: `${portletNamespace}selectRole`,
 			title: Liferay.Language.get('assign-roles'),
 			url: itemData?.selectRoleURL,
 		});
@@ -74,24 +76,26 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
 			multiple: true,
-			onSelect(selectedItem) {
-				if (selectedItem) {
-					const form = document.getElementById(
+			onSelect: (selectedItems) => {
+				if (selectedItems.length) {
+					const addGroupUsersFm = document.getElementById(
 						`${portletNamespace}addGroupUsersFm`
 					);
 
-					if (!form) {
+					if (!addGroupUsersFm) {
 						return;
 					}
 
-					selectedItem.forEach((item) => {
-						form.appendChild(item);
-					});
+					const input = document.createElement('input');
 
-					submitForm(form);
+					input.name = `${portletNamespace}rowIds`;
+					input.value = selectedItems.map((item) => item.value);
+
+					addGroupUsersFm.appendChild(input);
+
+					submitForm(addGroupUsersFm);
 				}
 			},
-			selectEventName: `${portletNamespace}selectUsers`,
 			title: Liferay.Util.sub(
 				Liferay.Language.get('assign-users-to-this-x'),
 				itemData?.groupTypeLabel

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/actions.js
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/js/actions.js
@@ -19,15 +19,22 @@ export const ACTIONS = {
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
 			multiple: true,
-			onSelect: (selectedItem) => {
-				if (selectedItem) {
+			onSelect: (selectedItems) => {
+				if (selectedItems.length) {
 					const editUserGroupRoleFm = document.getElementById(
 						`${portletNamespace}editUserGroupRoleFm`
 					);
 
-					selectedItem.forEach((item) => {
-						editUserGroupRoleFm.append(item);
-					});
+					if (!editUserGroupRoleFm) {
+						return;
+					}
+
+					const input = document.createElement('input');
+
+					input.name = `${portletNamespace}rowIds`;
+					input.value = selectedItems.map((item) => item.value);
+
+					editUserGroupRoleFm.appendChild(input);
 
 					submitForm(
 						editUserGroupRoleFm,
@@ -35,7 +42,6 @@ export const ACTIONS = {
 					);
 				}
 			},
-			selectEventName: `${portletNamespace}selectUsersRoles`,
 			title: Liferay.Language.get('assign-roles'),
 			url: itemData.assignRolesURL,
 		});

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_organizations.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_organizations.jsp
@@ -51,26 +51,3 @@ SelectOrganizationsDisplayContext selectOrganizationsDisplayContext = new Select
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get(
-		'<portlet:namespace />organizations'
-	);
-
-	searchContainer.on('rowToggled', (event) => {
-		var result = {};
-
-		var data = event.elements.allSelectedElements.getDOMNodes();
-
-		if (data.length) {
-			result = {
-				data: data,
-			};
-		}
-
-		Liferay.Util.getOpener().Liferay.fire(
-			'<%= HtmlUtil.escapeJS(selectOrganizationsDisplayContext.getEventName()) %>',
-			result
-		);
-	});
-</aui:script>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_site_role.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_site_role.jsp
@@ -100,10 +100,3 @@ SelectRolesDisplayContext selectRolesDisplayContext = new SelectRolesDisplayCont
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script>
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />fm',
-		'<%= HtmlUtil.escapeJS(selectRolesDisplayContext.getEventName()) %>'
-	);
-</aui:script>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_user_groups.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_user_groups.jsp
@@ -51,26 +51,3 @@ SelectUserGroupsDisplayContext selectUserGroupsDisplayContext = new SelectUserGr
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get(
-		'<portlet:namespace />userGroups'
-	);
-
-	searchContainer.on('rowToggled', (event) => {
-		var result = {};
-
-		var data = event.elements.allSelectedElements.getDOMNodes();
-
-		if (data.length) {
-			result = {
-				data: data,
-			};
-		}
-
-		Liferay.Util.getOpener().Liferay.fire(
-			'<%= HtmlUtil.escapeJS(selectUserGroupsDisplayContext.getEventName()) %>',
-			result
-		);
-	});
-</aui:script>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_users.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/select_users.jsp
@@ -54,24 +54,3 @@ SelectUsersDisplayContext selectUsersDisplayContext = new SelectUsersDisplayCont
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get('<portlet:namespace />users');
-
-	searchContainer.on('rowToggled', (event) => {
-		var result = {};
-
-		var data = event.elements.allSelectedElements.getDOMNodes();
-
-		if (data.length) {
-			result = {
-				data: data,
-			};
-		}
-
-		Liferay.Util.getOpener().Liferay.fire(
-			'<%= HtmlUtil.escapeJS(selectUsersDisplayContext.getEventName()) %>',
-			result
-		);
-	});
-</aui:script>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_group_action.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_group_action.jsp
@@ -100,6 +100,10 @@ UserGroup userGroup = (UserGroup)row.getObject();
 			var addUserGroupGroupRoleFm =
 				document.<portlet:namespace />addUserGroupGroupRoleFm;
 
+			if (!addUserGroupGroupRoleFm) {
+				return;
+			}
+
 			Liferay.Util.setFormValues(addUserGroupGroupRoleFm, {
 				userGroupId: target.dataset.usergroupid,
 			});
@@ -108,18 +112,23 @@ UserGroup userGroup = (UserGroup)row.getObject();
 				buttonAddLabel: '<liferay-ui:message key="done" />',
 				multiple: true,
 				onSelect: function (selectedItems) {
-					if (selectedItems) {
-						Array.prototype.forEach.call(
+					if (selectedItems.length) {
+						const input = document.createElement('input');
+
+						input.name = '<portlet:namespace />rowIds';
+
+						const selectedUserGroupIds = Array.prototype.map.call(
 							selectedItems,
-							(selectedItem, index) => {
-								addUserGroupGroupRoleFm.append(selectedItem);
-							}
+							(item) => item.value
 						);
+
+						input.value = selectedUserGroupIds.join();
+
+						addUserGroupGroupRoleFm.appendChild(input);
 
 						submitForm(addUserGroupGroupRoleFm);
 					}
 				},
-				selectEventName: '<portlet:namespace />selectUserGroupsRoles',
 				title: '<liferay-ui:message key="assign-roles" />',
 				url: target.dataset.href,
 			});
@@ -139,6 +148,10 @@ UserGroup userGroup = (UserGroup)row.getObject();
 			var unassignUserGroupGroupRoleFm =
 				document.<portlet:namespace />unassignUserGroupGroupRoleFm;
 
+			if (!unassignUserGroupGroupRoleFm) {
+				return;
+			}
+
 			Liferay.Util.setFormValues(unassignUserGroupGroupRoleFm, {
 				userGroupId: target.dataset.usergroupid,
 			});
@@ -147,13 +160,19 @@ UserGroup userGroup = (UserGroup)row.getObject();
 				buttonAddLabel: '<liferay-ui:message key="done" />',
 				multiple: true,
 				onSelect: function (selectedItems) {
-					if (selectedItems) {
-						Array.prototype.forEach.call(
+					if (selectedItems.length) {
+						const input = document.createElement('input');
+
+						input.name = '<portlet:namespace />rowIds';
+
+						const selectedUserGroupIds = Array.prototype.map.call(
 							selectedItems,
-							(selectedItem, index) => {
-								unassignUserGroupGroupRoleFm.append(selectedItem);
-							}
+							(item) => item.value
 						);
+
+						input.value = selectedUserGroupIds.join();
+
+						unassignUserGroupGroupRoleFm.appendChild(input);
 
 						submitForm(unassignUserGroupGroupRoleFm);
 					}

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_groups_roles.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_groups_roles.jsp
@@ -48,18 +48,3 @@ UserGroupRolesDisplayContext userGroupRolesDisplayContext = new UserGroupRolesDi
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get(
-		'<portlet:namespace />userGroupGroupRoleRole'
-	);
-
-	searchContainer.on('rowToggled', (event) => {
-		Liferay.Util.getOpener().Liferay.fire(
-			'<%= HtmlUtil.escapeJS(userGroupRolesDisplayContext.getEventName()) %>',
-			{
-				data: event.elements.allSelectedElements.getDOMNodes(),
-			}
-		);
-	});
-</aui:script>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users_roles.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/users_roles.jsp
@@ -50,18 +50,3 @@ UserRolesDisplayContext userRolesDisplayContext = new UserRolesDisplayContext(re
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get(
-		'<portlet:namespace />userGroupRoleRole'
-	);
-
-	searchContainer.on('rowToggled', (event) => {
-		Liferay.Util.getOpener().Liferay.fire(
-			'<%= HtmlUtil.escapeJS(userRolesDisplayContext.getEventName()) %>',
-			{
-				data: event.elements.allSelectedElements.getDOMNodes(),
-			}
-		);
-	});
-</aui:script>

--- a/modules/apps/site/site-taglib/src/main/resources/META-INF/resources/site_browser/page.jsp
+++ b/modules/apps/site/site-taglib/src/main/resources/META-INF/resources/site_browser/page.jsp
@@ -17,7 +17,6 @@
 <%@ include file="/site_browser/init.jsp" %>
 
 <%
-String eventName = GetterUtil.getString(request.getAttribute("liferay-site:site-browser:eventName"));
 long[] selectedGroupIds = GetterUtil.getLongValues(request.getAttribute("liferay-site:site-browser:selectedGroupIds"));
 %>
 
@@ -123,10 +122,3 @@ long[] selectedGroupIds = GetterUtil.getLongValues(request.getAttribute("liferay
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="aui-base">
-	Liferay.Util.selectEntityHandler(
-		'#<portlet:namespace />selectGroupFm',
-		'<%= HtmlUtil.escapeJS(eventName) %>'
-	);
-</aui:script>

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditSiteTeamAssignmentsUserGroupsManagementToolbarPropsTransformer.js
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditSiteTeamAssignmentsUserGroupsManagementToolbarPropsTransformer.js
@@ -44,24 +44,28 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 			if (action === 'selectUserGroup') {
 				openSelectionModal({
 					multiple: true,
-					onSelect(selectedItem) {
-						if (selectedItem) {
-							const form = document.getElementById(
+					onSelect: (selectedItems) => {
+						if (selectedItems.length) {
+							const addTeamUserGroupsFm = document.getElementById(
 								`${portletNamespace}addTeamUserGroupsFm`
 							);
 
-							if (!form) {
+							if (!addTeamUserGroupsFm) {
 								return;
 							}
 
-							selectedItem.forEach((item) => {
-								form.appendChild(item);
-							});
+							const input = document.createElement('input');
 
-							submitForm(form);
+							input.name = `${portletNamespace}rowIds`;
+							input.value = selectedItems.map(
+								(item) => item.value
+							);
+
+							addTeamUserGroupsFm.appendChild(input);
+
+							submitForm(addTeamUserGroupsFm);
 						}
 					},
-					selectEventName: `${portletNamespace}selectUserGroup`,
 					title: data?.title,
 					url: data?.selectUserGroupURL,
 				});

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUsersManagementToolbarPropsTransformer.js
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/js/EditTeamAssignmentsUsersManagementToolbarPropsTransformer.js
@@ -44,24 +44,28 @@ export default function propsTransformer({portletNamespace, ...otherProps}) {
 			if (action === 'selectUser') {
 				openSelectionModal({
 					multiple: true,
-					onSelect(selectedItem) {
-						if (selectedItem) {
-							const form = document.getElementById(
+					onSelect: (selectedItems) => {
+						if (selectedItems.length) {
+							const addTeamUsersFm = document.getElementById(
 								`${portletNamespace}addTeamUsersFm`
 							);
 
-							if (!form) {
+							if (!addTeamUsersFm) {
 								return;
 							}
 
-							selectedItem.forEach((item) => {
-								form.appendChild(item);
-							});
+							const input = document.createElement('input');
 
-							submitForm(form);
+							input.name = `${portletNamespace}rowIds`;
+							input.value = selectedItems.map(
+								(item) => item.value
+							);
+
+							addTeamUsersFm.appendChild(input);
+
+							submitForm(addTeamUsersFm);
 						}
 					},
-					selectEventName: `${portletNamespace}selectUser`,
 					title: data?.title,
 					url: data?.selectUserURL,
 				});

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/select_user_groups.jsp
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/select_user_groups.jsp
@@ -94,18 +94,3 @@ SelectUserGroupsDisplayContext selectUserGroupsDisplayContext = new SelectUserGr
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get(
-		'<portlet:namespace />userGroups'
-	);
-
-	searchContainer.on('rowToggled', (event) => {
-		Liferay.Util.getOpener().Liferay.fire(
-			'<%= HtmlUtil.escapeJS(selectUserGroupsDisplayContext.getEventName()) %>',
-			{
-				data: event.elements.allSelectedElements.getDOMNodes(),
-			}
-		);
-	});
-</aui:script>

--- a/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/select_users.jsp
+++ b/modules/apps/site/site-teams-web/src/main/resources/META-INF/resources/select_users.jsp
@@ -84,16 +84,3 @@ SelectUsersDisplayContext selectUsersDisplayContext = new SelectUsersDisplayCont
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get('<portlet:namespace />users');
-
-	searchContainer.on('rowToggled', (event) => {
-		Liferay.Util.getOpener().Liferay.fire(
-			'<%= HtmlUtil.escapeJS(selectUsersDisplayContext.getEventName()) %>',
-			{
-				data: event.elements.allSelectedElements.getDOMNodes(),
-			}
-		);
-	});
-</aui:script>


### PR DESCRIPTION
Hi @liferay-echo, here's a new PR migrating open selection modals, the first PR (https://github.com/liferay-echo/liferay-portal/pull/4185) wasn't a great success - it got reverted. So here's a new one, encompassing all of the usages (except 2 - explained later) which should eliminate all of the usages of the old modal implementation and use the new `openSelectionModal`.

# 👀  The missing usages

There are 2 leftover usages, one of them is being migrated as part of the `users-admin` migration, the other one is bugged. 

1. `site-browser-web/view.jsp` - Handled as part of `users-admin` migration in [https://github.com/pei-jung/liferay-portal/pull/830](https://github.com/pei-jung/liferay-portal/pull/830)
2.  `site-memberships-web/site_roles.jsp` - Bugged - [https://issues.liferay.com/browse/LPS-130400](https://issues.liferay.com/browse/LPS-130400)

# 🧪 Testing

I've documented the test scenarios for these modals below:

## `user_groups_roles.jsp`

- People > Memberships > User Groups
- User Group options > Assign Roles/Unassign Roles

## `select_user_groups.jsp`

- People > Memberships > User Groups
- Assign a User Group

## `users_roles.jsp`

- People > Memberships > Users
- User options > Assign Roles

## `select_organizations.jsp`

- People > Memberships > Organizations
- Select an organization

## `select_users.jsp`

- People > Memberships > Users
- Assign a new user to site

## `select_site_role.jsp`

- People > Memberships > Filter by Roles

## `site-item-selector-web/view_sites.jsp`

- User Profile Icon -> My Sites
- `site_administration_header_icon_sites.jspf` same but button on left sidebar

## `site-taglib/site_browser/page.jsp`

- Add a new user -> Memberships section -> Click the Select button of Sites section