### PR TITLE
[TS] LPS-129980 | When configuring a Page it is not highlighted on the Page Tree

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/application/list/GroupPagesPanelApp.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/application/list/GroupPagesPanelApp.java
@@ -20,8 +20,13 @@ import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
+
+import javax.portlet.PortletURL;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -42,6 +47,18 @@ public class GroupPagesPanelApp extends BasePanelApp {
 	@Override
 	public String getPortletId() {
 		return LayoutAdminPortletKeys.GROUP_PAGES;
+	}
+
+	@Override
+	public PortletURL getPortletURL(HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		PortletURL portletURL = super.getPortletURL(httpServletRequest);
+
+		portletURL.setParameter(
+			"selPlid", String.valueOf(LayoutConstants.DEFAULT_PLID));
+
+		return portletURL;
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/GroupPagesPortlet.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/GroupPagesPortlet.java
@@ -107,7 +107,8 @@ import org.osgi.service.component.annotations.Reference;
 		"javax.portlet.init-param.view-template=/view.jsp",
 		"javax.portlet.name=" + LayoutAdminPortletKeys.GROUP_PAGES,
 		"javax.portlet.resource-bundle=content.Language",
-		"javax.portlet.supported-public-render-parameter=layoutSetBranchId"
+		"javax.portlet.supported-public-render-parameter=layoutSetBranchId",
+		"javax.portlet.supported-public-render-parameter=selPlid"
 	},
 	service = Portlet.class
 )

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/filter/GroupPagesRenderParametersPortletFilter.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/filter/GroupPagesRenderParametersPortletFilter.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.admin.web.internal.portlet.filter;
+
+import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portlet.RenderParametersPool;
+import com.liferay.portlet.layoutsadmin.display.context.GroupDisplayContextHelper;
+
+import java.io.IOException;
+
+import javax.portlet.PortletException;
+import javax.portlet.PortletRequest;
+import javax.portlet.PortletURL;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+import javax.portlet.filter.FilterChain;
+import javax.portlet.filter.FilterConfig;
+import javax.portlet.filter.PortletFilter;
+import javax.portlet.filter.RenderFilter;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Attila Bakay
+ */
+@Component(
+	immediate = true,
+	property = "javax.portlet.name=" + LayoutAdminPortletKeys.GROUP_PAGES,
+	service = PortletFilter.class
+)
+public class GroupPagesRenderParametersPortletFilter implements RenderFilter {
+
+	@Override
+	public void destroy() {
+	}
+
+	@Override
+	public void doFilter(
+			RenderRequest renderRequest, RenderResponse renderResponse,
+			FilterChain filterChain)
+		throws IOException, PortletException {
+
+		long selPlid = ParamUtil.getLong(
+			renderRequest, "selPlid", LayoutConstants.DEFAULT_PLID);
+
+		if (selPlid != LayoutConstants.DEFAULT_PLID) {
+			GroupDisplayContextHelper groupDisplayContextHelper =
+				new GroupDisplayContextHelper(
+					_portal.getHttpServletRequest(renderRequest));
+
+			Group selGroup = groupDisplayContextHelper.getSelGroup();
+
+			Layout selLayout = _layoutLocalService.fetchLayout(selPlid);
+
+			try {
+				if ((selLayout == null) ||
+					!_layoutLocalService.hasLayout(
+						selLayout.getUuid(), selGroup.getGroupId(),
+						selLayout.isPrivateLayout())) {
+
+					clearRenderRequestParameters(
+						_portal.getHttpServletRequest(renderRequest),
+						renderRequest);
+
+					PortletURL portletURL = PortletURLBuilder.create(
+						_portal.getControlPanelPortletURL(
+							renderRequest, LayoutAdminPortletKeys.GROUP_PAGES,
+							PortletRequest.RENDER_PHASE)
+					).build();
+
+					portletURL.setParameter(
+						"p_v_l_s_g_id", String.valueOf(selGroup.getGroupId()));
+
+					HttpServletResponse httpServletResponse =
+						_portal.getHttpServletResponse(renderResponse);
+
+					httpServletResponse.sendRedirect(portletURL.toString());
+
+					return;
+				}
+			}
+			catch (PortalException portalException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(portalException, portalException);
+				}
+			}
+		}
+
+		filterChain.doFilter(renderRequest, renderResponse);
+	}
+
+	@Override
+	public void init(FilterConfig filterConfig) {
+	}
+
+	protected void clearRenderRequestParameters(
+		HttpServletRequest httpServletRequest, RenderRequest renderRequest) {
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		RenderParametersPool.clear(
+			httpServletRequest, themeDisplay.getPlid(),
+			"PUBLIC_RENDER_PARAMETERS");
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GroupPagesRenderParametersPortletFilter.class);
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.PortletProvider;
 import com.liferay.portal.kernel.portlet.PortletProviderUtil;
+import com.liferay.portal.kernel.portlet.PortletQName;
 import com.liferay.portal.kernel.portlet.PortletURLFactoryUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -70,15 +71,13 @@ public class LayoutsTreeDisplayContext {
 	public String getAddChildCollectionURLTemplate() throws Exception {
 		return StringBundler.concat(
 			getAddCollectionLayoutURL(), StringPool.AMPERSAND,
-			PortalUtil.getPortletNamespace(LayoutAdminPortletKeys.GROUP_PAGES),
-			"selPlid={plid}");
+			PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE, "selPlid={plid}");
 	}
 
 	public String getAddChildURLTemplate() throws Exception {
 		return StringBundler.concat(
 			getAddLayoutURL(), StringPool.AMPERSAND,
-			PortalUtil.getPortletNamespace(LayoutAdminPortletKeys.GROUP_PAGES),
-			"selPlid={plid}");
+			PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE, "selPlid={plid}");
 	}
 
 	public String getAddCollectionLayoutURL() throws Exception {
@@ -200,8 +199,7 @@ public class LayoutsTreeDisplayContext {
 	public String getConfigureLayoutURLTemplate() throws Exception {
 		return StringBundler.concat(
 			getConfigureLayoutURL(), StringPool.AMPERSAND,
-			PortalUtil.getPortletNamespace(LayoutAdminPortletKeys.GROUP_PAGES),
-			"selPlid={plid}");
+			PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE, "selPlid={plid}");
 	}
 
 	public long getGroupId() {

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
@@ -26,6 +26,7 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletURL;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
@@ -298,6 +299,11 @@ public class LayoutsTreeDisplayContext {
 		).setWindowState(
 			LiferayWindowState.EXCLUSIVE
 		).buildString();
+	}
+
+	public long getSelPlid() {
+		return ParamUtil.get(
+			_liferayPortletRequest, "selPlid", LayoutConstants.DEFAULT_PLID);
 	}
 
 	public String getViewCollectionItemsURL()

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
@@ -18,6 +18,12 @@
 
 <%
 LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayContext(liferayPortletRequest);
+
+Long selPlid = layout.getPlid();
+
+if (layout.isTypeControlPanel()) {
+	selPlid = layoutsTreeDisplayContext.getSelPlid();
+}
 %>
 
 <div id="<%= liferayPortletResponse.getNamespace() + "-layout-finder" %>">
@@ -159,7 +165,7 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = new LayoutsTreeDisplayCont
 		privateLayout="<%= layoutsTreeDisplayContext.isPrivateLayout() %>"
 		rootLinkTemplate='<a tabindex="-1" class="{cssClass}ml-1" href="javascript:void(0);" id="{id}" title="{title}">{label}</a>'
 		rootNodeName="<%= siteGroup.getLayoutRootNodeName(layoutsTreeDisplayContext.isPrivateLayout(), locale) %>"
-		selPlid="<%= plid %>"
+		selPlid="<%= selPlid %>"
 		treeId="pagesTree"
 	/>
 


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
According to [PTR-2364](https://issues.liferay.com/browse/PTR-2364) I made selPlid a public render parameter again and fixed the regression issue under [LPS-88949](https://issues.liferay.com/browse/LPS-88949) with the GroupPagesRenderParametersPortletFilter.
The root cause of the regression was the selPLid being able to call on a layout that is not part of the current group.  The new filter will remove any selPlid param that is pointing to another group plid or a non-existing plid.
The last commit makes sure that when we open the pages from the control panel, we will always start on the default plid. This was required by the failure of the poshi tests from the previous pull.

https://issues.liferay.com/browse/LPS-129980
Thank you!

----
Previous pull request: #4321