### PR TITLE
LPS-131584 Use selected locale to format separator decimals for number field

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
@@ -37,6 +37,8 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.text.DecimalFormat;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -143,6 +145,20 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 		}
 		else if (type.equals("geolocation")) {
 			return _getGeolocationData();
+		}
+		else if (type.equals("numeric")) {
+			String numberValue = (String)get("data");
+
+			Locale locale = LocaleUtil.getMostRelevantLocale();
+
+			DecimalFormat decimalFormat =
+				(DecimalFormat)DecimalFormat.getInstance(locale);
+
+			decimalFormat.setGroupingUsed(false);
+			decimalFormat.setMaximumFractionDigits(Integer.MAX_VALUE);
+			decimalFormat.setParseBigDecimal(true);
+
+			return decimalFormat.format(Double.valueOf(numberValue));
 		}
 
 		return (String)get("data");


### PR DESCRIPTION
Use selected locale to format separator decimals for fields type ddm-number and ddm-decimal, always displays the decimal separator as point
For more details please check https://issues.liferay.com/browse/LPS-131584

Resend this PR https://github.com/liferay-forms/liferay-portal/pull/203 to Echo Team 