### PR TITLE
[TS] LPS-131694 Use groupId, className, classPK to look up existing entry as uuid might not match

### DIFF
--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/exportimport/data/handler/AssetDisplayPageStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/exportimport/data/handler/AssetDisplayPageStagedModelDataHandler.java
@@ -15,6 +15,7 @@
 package com.liferay.asset.display.page.internal.exportimport.data.handler;
 
 import com.liferay.asset.display.page.model.AssetDisplayPageEntry;
+import com.liferay.asset.display.page.service.AssetDisplayPageEntryLocalService;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
@@ -114,23 +115,24 @@ public class AssetDisplayPageStagedModelDataHandler
 			layoutPageTemplateEntryId);
 		importedAssetDisplayPageEntry.setPlid(plid);
 
+		Map<Long, Long> newClassPKsMap =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				importedAssetDisplayPageEntry.getClassName());
+
+		long existingClassPK = MapUtil.getLong(
+			newClassPKsMap, importedAssetDisplayPageEntry.getClassPK(),
+			importedAssetDisplayPageEntry.getClassPK());
+
 		AssetDisplayPageEntry existingAssetDisplayPageEntry =
-			_stagedModelRepository.fetchStagedModelByUuidAndGroupId(
-				assetDisplayPageEntry.getUuid(),
-				portletDataContext.getScopeGroupId());
+			_assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
+				portletDataContext.getScopeGroupId(),
+				importedAssetDisplayPageEntry.getClassNameId(),
+				existingClassPK);
 
 		if ((existingAssetDisplayPageEntry == null) ||
 			!portletDataContext.isDataStrategyMirror()) {
 
-			Map<Long, Long> newPrimaryKeysMap =
-				(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
-					importedAssetDisplayPageEntry.getClassName());
-
-			importedAssetDisplayPageEntry.setClassPK(
-				MapUtil.getLong(
-					newPrimaryKeysMap,
-					importedAssetDisplayPageEntry.getClassPK(),
-					importedAssetDisplayPageEntry.getClassPK()));
+			importedAssetDisplayPageEntry.setClassPK(existingClassPK);
 
 			try {
 				importedAssetDisplayPageEntry =
@@ -174,6 +176,10 @@ public class AssetDisplayPageStagedModelDataHandler
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		AssetDisplayPageStagedModelDataHandler.class);
+
+	@Reference
+	private AssetDisplayPageEntryLocalService
+		_assetDisplayPageEntryLocalService;
 
 	@Reference
 	private LayoutPageTemplateEntryLocalService


### PR DESCRIPTION
Hi @liferay-echo ,

AssetDisplayPageEntries that were created in an UpgradeProcess for Assets that were Export+Imported might not have a matching uuid. 

Can you please review?
https://issues.liferay.com/browse/LPS-131694

Thanks,
Balázs