### PR TITLE
[TS] LPS-131795 Add #banner and #footer to the DEFAULT_WHITELIST to allow configure a portlet if added to the theme's  header or footer section

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisabledArea.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/DisabledArea.js
@@ -38,6 +38,8 @@ const DEFAULT_WHITELIST = [
 	'.control-menu',
 	'.lfr-add-panel',
 	'.lfr-product-menu-panel',
+	'#banner',
+	'#footer',
 ];
 
 const POPOVER_POSITIONS = {


### PR DESCRIPTION
Hi Team,

could you please review my fix?

**Reproduction steps:**
0) Create a theme which includes an embedded WCD within the footer 
(https://issues.liferay.com/secure/attachment/404607/testtheme-theme-master.war)
1) Start the server and log in as admin
2) Deploy the testtheme-theme,
3) Create a Content Page in Liferay
4) On the Content page, at the right-side toolbar, go to "Look and Feel" > Define a specific look and feel for this page > Change Current Theme > testtheme > Save
5) You will see a Web Content Display on the footer of the page. Hover the mouse over it to attempt editing it (e.g. selecting a web content to be displayed) - see the attached screenshot

**Expected:**
The portlet to be editable.

**Actual behavior:**
A message on the interface will pop-up and the portlet is not editable

![image](https://user-images.githubusercontent.com/35058963/117281035-81f14480-ae63-11eb-9b1a-5365292fae64.png)


https://issues.liferay.com/browse/LPS-131795

Thanks, Roland