### PR TITLE
[TS] LPS-131773 | The page is created as a child page when page item is highlighted in pages tree

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
@@ -259,11 +259,13 @@ public class LayoutsTreeDisplayContext {
 
 	public Map<String, Object> getPageTypeSelectorData() throws Exception {
 		return HashMapBuilder.<String, Object>put(
-			"addCollectionLayoutURL", getAddCollectionLayoutURL()
+			"addCollectionLayoutURL",
+			_addDefaultselPlidParam(getAddCollectionLayoutURL())
 		).put(
-			"addLayoutURL", getAddLayoutURL()
+			"addLayoutURL", _addDefaultselPlidParam(getAddLayoutURL())
 		).put(
-			"configureLayoutSetURL", getConfigureLayoutSetURL()
+			"configureLayoutSetURL",
+			_addDefaultselPlidParam(getConfigureLayoutSetURL())
 		).put(
 			"namespace", getNamespace()
 		).put(
@@ -355,6 +357,13 @@ public class LayoutsTreeDisplayContext {
 					ProductNavigationProductMenuWebKeys.PRIVATE_LAYOUT,
 				"false"),
 			layout.isPrivateLayout());
+	}
+
+	private String _addDefaultselPlidParam(String portletUrl) {
+		return StringBundler.concat(
+			portletUrl, StringPool.AMPERSAND,
+			PortletQName.PUBLIC_RENDER_PARAMETER_NAMESPACE, "selPlid=",
+			LayoutConstants.DEFAULT_PLID);
 	}
 
 	private Long _groupId;


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?

The root cause of the regression is that when the first page is created the page is redirected to the page configuration menu and the selPlid will be set for the current page plid. When we click the add button on the Page Tree this selPlid could create a situation where the page will be created as a child for the previous page. To avoid this behavior I added the defaultPlid to the portletURL-s.

https://issues.liferay.com/browse/LPS-131773
Thank you!