### PR TITLE
LPS-131457 Check null value

### DIFF
--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/list/provider/RelatedAssetsInfoItemRelatedListProvider.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/list/provider/RelatedAssetsInfoItemRelatedListProvider.java
@@ -57,8 +57,8 @@ public class RelatedAssetsInfoItemRelatedListProvider
 
 		try {
 			AssetEntryQuery assetEntryQuery = _getAssetEntryQuery(
-				assetEntry.getCompanyId(), assetEntry.getGroupId(),
-				sort.getFieldName(), _getOrderByType(sort), pagination);
+				assetEntry.getCompanyId(), assetEntry.getGroupId(), pagination,
+				sort);
 
 			assetEntryQuery.setLinkedAssetEntryId(assetEntry.getEntryId());
 
@@ -72,8 +72,7 @@ public class RelatedAssetsInfoItemRelatedListProvider
 	}
 
 	private AssetEntryQuery _getAssetEntryQuery(
-			long companyId, long groupId, String orderByCol, String orderByType,
-			Pagination pagination)
+			long companyId, long groupId, Pagination pagination, Sort sort)
 		throws PortalException {
 
 		AssetEntryQuery assetEntryQuery = new AssetEntryQuery();
@@ -96,6 +95,14 @@ public class RelatedAssetsInfoItemRelatedListProvider
 
 		if (pagination != null) {
 			assetEntryQuery.setEnd(pagination.getEnd());
+		}
+
+		String orderByCol = Field.MODIFIED_DATE;
+		String orderByType = "DESC";
+
+		if (sort != null) {
+			orderByCol = sort.getFieldName();
+			orderByType = _getOrderByType(sort);
 		}
 
 		assetEntryQuery.setGroupIds(new long[] {groupId});
@@ -122,8 +129,7 @@ public class RelatedAssetsInfoItemRelatedListProvider
 	private int _getTotalCount(AssetEntry assetEntry, Sort sort) {
 		try {
 			AssetEntryQuery assetEntryQuery = _getAssetEntryQuery(
-				assetEntry.getCompanyId(), assetEntry.getGroupId(),
-				sort.getFieldName(), _getOrderByType(sort), null);
+				assetEntry.getCompanyId(), assetEntry.getGroupId(), null, sort);
 
 			assetEntryQuery.setLinkedAssetEntryId(assetEntry.getEntryId());
 

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/pagination/InfoPage.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/pagination/InfoPage.java
@@ -44,7 +44,7 @@ public class InfoPage<T> {
 		return _pageItems;
 	}
 
-	public long getTotalCount() {
+	public int getTotalCount() {
 		return _totalCountSupplier.get();
 	}
 

--- a/modules/apps/info/info-list-provider-item-selector-web/src/main/java/com/liferay/info/list/provider/item/selector/web/internal/InfoItemRelatedListProviderItemSelectorView.java
+++ b/modules/apps/info/info-list-provider-item-selector-web/src/main/java/com/liferay/info/list/provider/item/selector/web/internal/InfoItemRelatedListProviderItemSelectorView.java
@@ -166,9 +166,9 @@ public class InfoItemRelatedListProviderItemSelectorView
 							WebKeys.THEME_DISPLAY);
 
 					return JSONUtil.put(
-						"key", infoItemRelatedItemsProvider.getKey()
+						"itemType", relatedItemClass.getName()
 					).put(
-						"relatedItemType", relatedItemClass.getName()
+						"key", infoItemRelatedItemsProvider.getKey()
 					).put(
 						"sourceItemType", sourceItemClass.getName()
 					).put(

--- a/modules/apps/info/info-list-provider-item-selector-web/src/main/java/com/liferay/info/list/provider/item/selector/web/internal/layout/list/retriever/InfoItemRelatedListProviderLayoutListRetriever.java
+++ b/modules/apps/info/info-list-provider-item-selector-web/src/main/java/com/liferay/info/list/provider/item/selector/web/internal/layout/list/retriever/InfoItemRelatedListProviderLayoutListRetriever.java
@@ -1,0 +1,179 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.info.list.provider.item.selector.web.internal.layout.list.retriever;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.info.item.InfoItemFieldValues;
+import com.liferay.info.item.InfoItemReference;
+import com.liferay.info.item.InfoItemServiceTracker;
+import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
+import com.liferay.info.list.provider.DefaultInfoListProviderContext;
+import com.liferay.info.list.provider.InfoItemRelatedListProvider;
+import com.liferay.info.list.provider.InfoListProviderContext;
+import com.liferay.info.list.provider.item.selector.criterion.InfoItemRelatedListProviderItemSelectorReturnType;
+import com.liferay.info.pagination.InfoPage;
+import com.liferay.info.pagination.Pagination;
+import com.liferay.layout.list.retriever.KeyListObjectReference;
+import com.liferay.layout.list.retriever.LayoutListRetriever;
+import com.liferay.layout.list.retriever.LayoutListRetrieverContext;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.ClassedModel;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Víctor Galán
+ */
+@Component(immediate = true, service = LayoutListRetriever.class)
+public class InfoItemRelatedListProviderLayoutListRetriever
+	implements LayoutListRetriever
+		<InfoItemRelatedListProviderItemSelectorReturnType,
+		 KeyListObjectReference> {
+
+	@Override
+	public List<Object> getList(
+		KeyListObjectReference keyListObjectReference,
+		LayoutListRetrieverContext layoutListRetrieverContext) {
+
+		InfoPage<Object> infoPage = _getRelatedItemInfoPage(
+			keyListObjectReference, layoutListRetrieverContext);
+
+		return (List<Object>)infoPage.getPageItems();
+	}
+
+	@Override
+	public int getListCount(
+		KeyListObjectReference keyListObjectReference,
+		LayoutListRetrieverContext layoutListRetrieverContext) {
+
+		InfoPage<Object> infoPage = _getRelatedItemInfoPage(
+			keyListObjectReference, layoutListRetrieverContext);
+
+		return infoPage.getTotalCount();
+	}
+
+	private Optional<AssetEntry> _getAssetEntryOptional(Object contextObject) {
+		if (!(contextObject instanceof ClassedModel)) {
+			return Optional.empty();
+		}
+
+		ClassedModel classedModel = (ClassedModel)contextObject;
+
+		InfoItemFieldValuesProvider<Object> infoItemFieldValuesProvider =
+			_infoItemServiceTracker.getFirstInfoItemService(
+				InfoItemFieldValuesProvider.class,
+				classedModel.getModelClassName());
+
+		InfoItemFieldValues infoItemFieldValues =
+			infoItemFieldValuesProvider.getInfoItemFieldValues(contextObject);
+
+		InfoItemReference infoItemReference =
+			infoItemFieldValues.getInfoItemReference();
+
+		AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+			infoItemReference.getClassName(), infoItemReference.getClassPK());
+
+		return Optional.ofNullable(assetEntry);
+	}
+
+	private InfoListProviderContext _getInfoListProviderContext() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		Group group = _groupLocalService.fetchGroup(
+			serviceContext.getScopeGroupId());
+
+		User user = _userLocalService.fetchUser(
+			PrincipalThreadLocal.getUserId());
+
+		return new DefaultInfoListProviderContext(group, user);
+	}
+
+	private InfoPage<Object> _getRelatedItemInfoPage(
+		KeyListObjectReference keyListObjectReference,
+		LayoutListRetrieverContext layoutListRetrieverContext) {
+
+		InfoItemRelatedListProvider<Object, Object>
+			infoItemRelatedListProvider =
+				_infoItemServiceTracker.getInfoItemService(
+					InfoItemRelatedListProvider.class,
+					keyListObjectReference.getKey());
+
+		Optional<Object> contextObjectOptional =
+			layoutListRetrieverContext.getContextObjectOptional();
+
+		if ((infoItemRelatedListProvider == null) ||
+			!contextObjectOptional.isPresent()) {
+
+			return InfoPage.of(Collections.emptyList());
+		}
+
+		Object contextObject = contextObjectOptional.get();
+
+		Optional<Pagination> paginationOptional =
+			layoutListRetrieverContext.getPaginationOptional();
+
+		Pagination pagination = paginationOptional.orElse(
+			Pagination.of(QueryUtil.ALL_POS, QueryUtil.ALL_POS));
+
+		if (Objects.equals(
+				infoItemRelatedListProvider.getSourceItemClass(),
+				AssetEntry.class)) {
+
+			Optional<AssetEntry> assetEntryOptional = _getAssetEntryOptional(
+				contextObject);
+
+			return (InfoPage<Object>)assetEntryOptional.map(
+				assetEntry ->
+					infoItemRelatedListProvider.getRelatedItemsInfoPage(
+						assetEntry, _getInfoListProviderContext(), pagination,
+						null)
+			).orElse(
+				InfoPage.of(Collections.emptyList())
+			);
+		}
+
+		return (InfoPage<Object>)
+			infoItemRelatedListProvider.getRelatedItemsInfoPage(
+				contextObject, _getInfoListProviderContext(), pagination, null);
+	}
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private InfoItemServiceTracker _infoItemServiceTracker;
+
+	@Reference
+	private UserLocalService _userLocalService;
+
+}

--- a/modules/apps/info/info-list-provider-item-selector-web/src/main/java/com/liferay/info/list/provider/item/selector/web/internal/layout/list/retriever/InfoItemRelatedListProviderListObjectReferenceFactory.java
+++ b/modules/apps/info/info-list-provider-item-selector-web/src/main/java/com/liferay/info/list/provider/item/selector/web/internal/layout/list/retriever/InfoItemRelatedListProviderListObjectReferenceFactory.java
@@ -1,0 +1,38 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.info.list.provider.item.selector.web.internal.layout.list.retriever;
+
+import com.liferay.info.list.provider.item.selector.criterion.InfoItemRelatedListProviderItemSelectorReturnType;
+import com.liferay.layout.list.retriever.KeyListObjectReference;
+import com.liferay.layout.list.retriever.ListObjectReference;
+import com.liferay.layout.list.retriever.ListObjectReferenceFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Víctor Galán
+ */
+@Component(immediate = true, service = ListObjectReferenceFactory.class)
+public class InfoItemRelatedListProviderListObjectReferenceFactory
+	implements ListObjectReferenceFactory
+		<InfoItemRelatedListProviderItemSelectorReturnType> {
+
+	@Override
+	public ListObjectReference getListObjectReference(JSONObject jsonObject) {
+		return new KeyListObjectReference(jsonObject);
+	}
+
+}

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/list/retriever/DefaultLayoutListRetrieverContext.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/list/retriever/DefaultLayoutListRetrieverContext.java
@@ -30,6 +30,11 @@ public class DefaultLayoutListRetrieverContext
 	}
 
 	@Override
+	public Optional<Object> getContextObjectOptional() {
+		return Optional.ofNullable(_contextObject);
+	}
+
+	@Override
 	public Optional<Pagination> getPaginationOptional() {
 		return Optional.ofNullable(_pagination);
 	}
@@ -50,6 +55,10 @@ public class DefaultLayoutListRetrieverContext
 
 	public void setAssetCategoryIds(long[][] assetCategoryIds) {
 		_assetCategoryIds = assetCategoryIds;
+	}
+
+	public void setContextObject(Object contextObject) {
+		_contextObject = contextObject;
 	}
 
 	public void setPagination(Pagination pagination) {
@@ -78,6 +87,7 @@ public class DefaultLayoutListRetrieverContext
 	}
 
 	private long[][] _assetCategoryIds;
+	private Object _contextObject;
 	private Pagination _pagination;
 	private long[] _segmentsEntryIds;
 	private long[] _segmentsExperienceIds;

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/list/retriever/LayoutListRetrieverContext.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/list/retriever/LayoutListRetrieverContext.java
@@ -28,6 +28,8 @@ public interface LayoutListRetrieverContext {
 
 	public Optional<long[][]> getAssetCategoryIdsOptional();
 
+	public Optional<Object> getContextObjectOptional();
+
 	public Optional<Pagination> getPaginationOptional();
 
 	public Optional<long[]> getSegmentsEntryIdsOptional();

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -163,6 +163,7 @@ import com.liferay.style.book.util.DefaultStyleBookEntryUtil;
 import com.liferay.style.book.util.comparator.StyleBookEntryNameComparator;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -686,6 +687,33 @@ public class ContentPageEditorDisplayContext {
 			Layout.class.getName());
 	}
 
+	protected List<ItemSelectorCriterion>
+		getCollectionItemSelectorCriterionList() {
+
+		InfoListItemSelectorCriterion infoListItemSelectorCriterion =
+			new InfoListItemSelectorCriterion();
+
+		infoListItemSelectorCriterion.setItemTypes(
+			_getInfoItemFormProviderClassNames());
+
+		infoListItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
+			new InfoListItemSelectorReturnType());
+
+		InfoListProviderItemSelectorCriterion
+			infoListProviderItemSelectorCriterion =
+				new InfoListProviderItemSelectorCriterion();
+
+		infoListProviderItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
+			new InfoListProviderItemSelectorReturnType());
+		infoListProviderItemSelectorCriterion.setItemTypes(
+			_getInfoItemFormProviderClassNames());
+		infoListProviderItemSelectorCriterion.setPlid(themeDisplay.getPlid());
+
+		return Arrays.asList(
+			infoListItemSelectorCriterion,
+			infoListProviderItemSelectorCriterion);
+	}
+
 	protected String getFragmentEntryActionURL(String action) {
 		return getFragmentEntryActionURL(action, null);
 	}
@@ -906,30 +934,14 @@ public class ContentPageEditorDisplayContext {
 	}
 
 	private String _getCollectionSelectorURL() {
-		InfoListItemSelectorCriterion infoListItemSelectorCriterion =
-			new InfoListItemSelectorCriterion();
-
-		infoListItemSelectorCriterion.setItemTypes(
-			_getInfoItemFormProviderClassNames());
-
-		infoListItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
-			new InfoListItemSelectorReturnType());
-
-		InfoListProviderItemSelectorCriterion
-			infoListProviderItemSelectorCriterion =
-				new InfoListProviderItemSelectorCriterion();
-
-		infoListProviderItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
-			new InfoListProviderItemSelectorReturnType());
-		infoListProviderItemSelectorCriterion.setItemTypes(
-			_getInfoItemFormProviderClassNames());
-		infoListProviderItemSelectorCriterion.setPlid(themeDisplay.getPlid());
+		List<ItemSelectorCriterion> collectionItemSelectorCriterionList =
+			getCollectionItemSelectorCriterionList();
 
 		PortletURL infoListSelectorURL = _itemSelector.getItemSelectorURL(
 			RequestBackedPortletURLFactoryUtil.create(httpServletRequest),
 			_renderResponse.getNamespace() + "selectInfoList",
-			infoListItemSelectorCriterion,
-			infoListProviderItemSelectorCriterion);
+			collectionItemSelectorCriterionList.toArray(
+				new ItemSelectorCriterion[0]));
 
 		if (infoListSelectorURL == null) {
 			return StringPool.BLANK;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/item-selector-value/itemSelectorValueToCollection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/item-selector-value/itemSelectorValueToCollection.js
@@ -12,6 +12,15 @@
  * details.
  */
 
+const RETURN_TYPES = {
+	assetList:
+		'com.liferay.item.selector.criteria.InfoListItemSelectorReturnType',
+	infoItemRelatedList:
+		'com.liferay.info.list.provider.item.selector.criterion.InfoItemRelatedListProviderItemSelectorReturnType',
+	infoList:
+		'com.liferay.info.list.provider.item.selector.criterion.InfoListProviderItemSelectorReturnType',
+};
+
 export default function itemSelectorValueToCollection(collection) {
 	const {
 		classNameId,
@@ -19,17 +28,40 @@ export default function itemSelectorValueToCollection(collection) {
 		itemSubtype,
 		itemType,
 		key,
-		returnType,
+		returnType: type,
+		sourceItemType,
 		title,
 	} = collection;
 
-	return {
-		classNameId,
-		classPK,
-		itemSubtype,
-		itemType,
-		key,
-		title,
-		type: returnType,
-	};
+	switch (type) {
+		case RETURN_TYPES.assetList:
+			return {
+				classNameId,
+				classPK,
+				itemSubtype,
+				itemType,
+				title,
+				type,
+			};
+
+		case RETURN_TYPES.infoItemRelatedList:
+			return {
+				itemType,
+				key,
+				sourceItemType,
+				title,
+				type,
+			};
+		case RETURN_TYPES.infoList:
+			return {
+				itemSubtype,
+				itemType,
+				key,
+				title,
+				type,
+			};
+
+		default:
+			return {...collection};
+	}
 }

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -174,6 +174,8 @@ public class RenderLayoutStructureDisplayContext {
 
 		defaultLayoutListRetrieverContext.setAssetCategoryIds(
 			_getAssetCategoryIds());
+		defaultLayoutListRetrieverContext.setContextObject(
+			_httpServletRequest.getAttribute(InfoDisplayWebKeys.INFO_ITEM));
 		defaultLayoutListRetrieverContext.setSegmentsEntryIds(
 			_getSegmentsEntryIds());
 		defaultLayoutListRetrieverContext.setPagination(


### PR DESCRIPTION
## Included in this PR

Added the ability to select related item collections in display pages

## how to test this

For now only the related assets collection is available, so:

1. Create a web content for example with a couple of related asset
2. Create a display page, add a collection display
3. Select the related asset collection provider under the "related item collection providers" tab
4. add a heading editable and map it to title
5. Publish
6. Mark the display page as default
7. Go to the web content and preview it

