### PR TITLE
Lps 130057 v6 20210506

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -19,8 +19,10 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Html;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -59,7 +61,18 @@ public class LayoutModelDocumentContributor
 		document.addLocalizedText(Field.NAME, layout.getNameMap());
 		document.addText(
 			"privateLayout", String.valueOf(layout.isPrivateLayout()));
-		document.addText(Field.TYPE, layout.getType());
+
+		String type = layout.getType();
+
+		if (type.equals(LayoutConstants.TYPE_CONTENT)) {
+			document.addText(
+				"contentLayoutPublished",
+				String.valueOf(
+					GetterUtil.getBoolean(
+						layout.getTypeSettingsProperty("published"))));
+		}
+
+		document.addText(Field.TYPE, type);
 
 		LayoutPageTemplateStructure layoutPageTemplateStructure =
 			_layoutPageTemplateStructureLocalService.

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/query/contributor/LayoutModelPreFilterContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/query/contributor/LayoutModelPreFilterContributor.java
@@ -19,6 +19,7 @@ import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
+import com.liferay.portal.kernel.search.filter.ExistsFilter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.util.ArrayUtil;
@@ -67,6 +68,34 @@ public class LayoutModelPreFilterContributor
 				"privateLayout", privateLayout);
 
 			booleanFilter.add(privateLayoutTermFilter, BooleanClauseOccur.MUST);
+		}
+
+		String contentLayoutPublished = (String)searchContext.getAttribute(
+			"contentLayoutPublished");
+
+		if (Validator.isNotNull(contentLayoutPublished)) {
+			BooleanFilter publishedFilter = new BooleanFilter();
+
+			BooleanFilter publishedNotExistsBooleanFilter = new BooleanFilter();
+
+			publishedNotExistsBooleanFilter.add(
+				new ExistsFilter("contentLayoutPublished"),
+				BooleanClauseOccur.MUST_NOT);
+
+			publishedFilter.add(
+				publishedNotExistsBooleanFilter, BooleanClauseOccur.SHOULD);
+
+			BooleanFilter publishedValueBooleanFilter = new BooleanFilter();
+
+			publishedValueBooleanFilter.add(
+				new TermFilter(
+					"contentLayoutPublished", contentLayoutPublished),
+				BooleanClauseOccur.MUST);
+
+			publishedFilter.add(
+				publishedValueBooleanFilter, BooleanClauseOccur.SHOULD);
+
+			booleanFilter.add(publishedFilter, BooleanClauseOccur.MUST);
 		}
 	}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerIndexedFieldsTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerIndexedFieldsTest.java
@@ -17,6 +17,7 @@ package com.liferay.layout.search.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
@@ -24,6 +25,7 @@ import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -191,6 +193,7 @@ public class LayoutIndexerIndexedFieldsTest {
 
 		_populateName(layout, map);
 		_populateDates(layout, map);
+		_populatePublished(layout, map);
 		_populateRoles(layout, map);
 
 		return map;
@@ -212,6 +215,18 @@ public class LayoutIndexerIndexedFieldsTest {
 			map.put(
 				LocalizationUtil.getLocalizedName(Field.NAME, languageId),
 				layout.getName(locale));
+		}
+	}
+
+	private void _populatePublished(Layout layout, Map<String, String> map) {
+		String type = layout.getType();
+
+		if (type.equals(LayoutConstants.TYPE_CONTENT)) {
+			map.put(
+				"contentLayoutPublished",
+				String.valueOf(
+					GetterUtil.getBoolean(
+						layout.getTypeSettingsProperty("published"))));
 		}
 	}
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutPublishedSearchTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutPublishedSearchTest.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.search.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.search.IndexerRegistry;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DataGuard;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.search.test.util.IndexerFixture;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.io.Serializable;
+
+import java.util.Map;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Ricardo Couso
+ */
+@DataGuard(scope = DataGuard.Scope.METHOD)
+@RunWith(Arquillian.class)
+public class LayoutPublishedSearchTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		setUpLayoutFixture();
+
+		setUpLayoutIndexerFixture();
+	}
+
+	@Test
+	public void testPublishedPageSearch() throws PortalException {
+		Layout layout = layoutFixture.createLayout("foo foo foo bar");
+
+		Map<String, Serializable> attributes =
+			HashMapBuilder.<String, Serializable>put(
+				"contentLayoutPublished", String.valueOf(Boolean.TRUE)
+			).build();
+
+		layoutIndexerFixture.searchNoOne("foo", null, attributes);
+
+		_publishLayout(layout);
+
+		layoutIndexerFixture.searchOnlyOne("foo", null, attributes);
+	}
+
+	protected void setUpLayoutFixture() {
+		layoutFixture = new LayoutFixture(_group);
+	}
+
+	protected void setUpLayoutIndexerFixture() {
+		layoutIndexerFixture = new IndexerFixture<>(Layout.class);
+	}
+
+	@Inject
+	protected IndexerRegistry indexerRegistry;
+
+	protected LayoutFixture layoutFixture;
+	protected IndexerFixture<Layout> layoutIndexerFixture;
+
+	private Layout _publishLayout(Layout layout) throws PortalException {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId());
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		ReflectionTestUtil.invoke(
+			_mvcActionCommand, "_publishLayout",
+			new Class<?>[] {
+				Layout.class, Layout.class, ServiceContext.class, long.class
+			},
+			layout.fetchDraftLayout(), layout, serviceContext,
+			TestPropsValues.getUserId());
+
+		return LayoutLocalServiceUtil.fetchLayout(layout.getPlid());
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "mvc.command.name=/layout_content_page_editor/publish_layout"
+	)
+	private MVCActionCommand _mvcActionCommand;
+
+}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/request/SearchRequestImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/search/request/SearchRequestImpl.java
@@ -115,6 +115,8 @@ public class SearchRequestImpl {
 	protected SearchContext buildSearchContext() {
 		SearchContext searchContext = _searchContextBuilder.getSearchContext();
 
+		searchContext.setAttribute(
+			"contentLayoutPublished", String.valueOf(Boolean.TRUE));
 		searchContext.setAttribute("filterExpired", Boolean.TRUE);
 		searchContext.setAttribute("paginationType", "more");
 


### PR DESCRIPTION
Hi @liferay-echo,

This pr is a solution for the issue [LPS-130057 (Unpublished content pages can be found in search)](https://issues.liferay.com/browse/LPS-130057). The issue is that content pages that are not published can still be searched, even by guest users, using the Search Portlet. 

The approach to the solution is:
- to index an attribute `"contentLayoutPublished"` for layouts of type content (but not for others since those can't be "not published"),
- to take this attribute into account when building the search query.

For this last point it's important to notice that layouts can also be searched from:
- The page builder in the site administration: this search filters by private or public layout and should also return unpublished layouts
- The Page Tree functionality: this search doesn't filter by private or public layout but should also return unpublished layouts.

To respect these conditions I had to include the attribute `"contentLayoutPublished"` in the `searchContext` of  `SearchRequestImpl.java` and check for it in `LayoutModelPreFilterContributor.java`. For searches done via the Search Portlet this attribute is informed whereas for the page builder search and the Page Tree search it won't be. (These latter searches make use of a method `getLayouts` which creates its own `searchContext` and takes into account the boolean `privateLayout`; passing another argument with information about published status would requiere changing many associated methods. So this seems to be the simplest solution.)

Finally, the search query in `LayoutModelPreFilterContributor.java` it's an OR-clause for the case of a layout without the attribute `"contentLayoutPublished"` indexed, or the case of a layout with it. 

Note: For this solution to be effective it's necessary to reindex the layouts. 

Please let me know if you have any questions. 

Thanks!