### PR TITLE
[TS] LPS-132165 Asset Publisher exports its data even when it's on a content page

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/exportimport/portlet/preferences/processor/AssetPublisherExportImportPortletPreferencesProcessor.java
@@ -224,7 +224,9 @@ public class AssetPublisherExportImportPortletPreferencesProcessor
 		if (selectionStyle.equals(
 				AssetPublisherSelectionStyleConstants.TYPE_DYNAMIC)) {
 
-			if (!_assetPublisherWebConfiguration.dynamicExportEnabled()) {
+			if (!_assetPublisherWebConfiguration.dynamicExportEnabled() ||
+				layout.isTypeAssetDisplay()) {
+
 				return;
 			}
 


### PR DESCRIPTION
Dear @liferay-echo team,

Currently, Asset Publisher portlets export their data even when they are only used is a Display Page Template. This includes many unexpected assets in the export. See details on [LPS-132165](https://issues.liferay.com/browse/LPS-132165).

Please review my changes.

Thanks,
Vendel