### PR TITLE
[TS] LPS-132376

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1140,6 +1140,7 @@ public class JournalDisplayContext {
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setAndSearch(false);
+		searchContext.setAttribute("head", Boolean.TRUE);
 		searchContext.setAttribute("latest", Boolean.TRUE);
 
 		LinkedHashMap<String, Object> params =
@@ -1171,8 +1172,6 @@ public class JournalDisplayContext {
 				Field.TITLE, getKeywords()
 			).put(
 				"ddmStructureKey", getDDMStructureKey()
-			).put(
-				"head", !showVersions
 			).put(
 				"params", params
 			).build());

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1140,8 +1140,6 @@ public class JournalDisplayContext {
 		SearchContext searchContext = new SearchContext();
 
 		searchContext.setAndSearch(false);
-		searchContext.setAttribute("head", Boolean.TRUE);
-		searchContext.setAttribute("latest", Boolean.TRUE);
 
 		LinkedHashMap<String, Object> params =
 			LinkedHashMapBuilder.<String, Object>put(
@@ -1149,12 +1147,6 @@ public class JournalDisplayContext {
 			).put(
 				"keywords", getKeywords()
 			).build();
-
-		searchContext.setAttribute("params", params);
-
-		if (!showVersions) {
-			searchContext.setAttribute("showNonindexable", Boolean.TRUE);
-		}
 
 		searchContext.setAttributes(
 			HashMapBuilder.<String, Serializable>put(
@@ -1176,12 +1168,23 @@ public class JournalDisplayContext {
 				"params", params
 			).build());
 
+		searchContext.setAttribute("head", !showVersions);
+		searchContext.setAttribute("latest", !showVersions);
+		searchContext.setAttribute("params", params);
 		searchContext.setCompanyId(_themeDisplay.getCompanyId());
 		searchContext.setEnd(end);
 		searchContext.setFolderIds(_getFolderIds());
 		searchContext.setGroupIds(new long[] {_themeDisplay.getScopeGroupId()});
 		searchContext.setIncludeInternalAssetCategories(true);
 		searchContext.setKeywords(getKeywords());
+
+		if (!showVersions) {
+			searchContext.setAttribute("showNonindexable", Boolean.TRUE);
+		}
+
+		searchContext.setEnd(end);
+		searchContext.setFolderIds(folderIds);
+		searchContext.setStart(start);
 
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1182,10 +1182,6 @@ public class JournalDisplayContext {
 			searchContext.setAttribute("showNonindexable", Boolean.TRUE);
 		}
 
-		searchContext.setEnd(end);
-		searchContext.setFolderIds(folderIds);
-		searchContext.setStart(start);
-
 		QueryConfig queryConfig = searchContext.getQueryConfig();
 
 		queryConfig.setHighlightEnabled(false);


### PR DESCRIPTION
Hi team,

Could you please review this PR?

In order to preserve previous behavior in Web Content Admin search is necessary to revert a commit which should not have applied to Journal Web module although it did make sense for Journal Article Item Selector.

The other commit to revert was a partial attempt to restore part of the former behavior, which is no longer needed after reverting the first commit.

More details can be found PTR-2441.

Thanks in advance