### PR TITLE
[TS] LPS-132154 Set the configuration field of fragmentEntryLink before rendering FTL

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -707,6 +707,7 @@ public class FragmentEntryLinkLocalServiceImpl
 			fragmentEntryLink.getFragmentEntryId());
 
 		fragmentEntryLink.setHtml(fragmentEntry.getHtml());
+		fragmentEntryLink.setConfiguration(fragmentEntry.getConfiguration());
 
 		String processedHTML = _getProcessedHTML(
 			fragmentEntryLink, ServiceContextThreadLocal.getServiceContext());
@@ -717,7 +718,6 @@ public class FragmentEntryLinkLocalServiceImpl
 
 		fragmentEntryLink.setCss(fragmentEntry.getCss());
 		fragmentEntryLink.setJs(fragmentEntry.getJs());
-		fragmentEntryLink.setConfiguration(fragmentEntry.getConfiguration());
 
 		String newEditableValues = _mergeEditableValues(
 			defaultEditableValues, fragmentEntryLink.getEditableValues());


### PR DESCRIPTION
Dear @liferay-echo team,

I've changed the order to call `setConfiguration(..)` earlier, so `_getProcessedHTML(..)` can already see the new configuration attributes. This fixes the case for [LPS-132154](https://issues.liferay.com/browse/LPS-132154).

Please review my changes.

Thanks,
Vendel