### PR TITLE
LPS-133325, LP-133326

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-browser-web/src/main/resources/META-INF/resources/view.jsp
@@ -37,6 +37,7 @@
 		<liferay-ui:search-container-row
 			className="com.liferay.asset.kernel.model.AssetEntry"
 			escapedModel="<%= true %>"
+			keyProperty="entryId"
 			modelVar="assetEntry"
 		>
 

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
@@ -239,7 +239,7 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 						Array.prototype.forEach.call(
 							selectedItems,
 							(assetEntry) => {
-								assetEntryIds.push(assetEntry.entityid);
+								assetEntryIds.push(assetEntry.value);
 							}
 						);
 


### PR DESCRIPTION
Hi Team

could you pleae review my fix?

In case of the keyProperty is not set the input value is the whole model object which breaks the HTML markup.
https://github.com/liferay/liferay-portal/blob/master/util-taglib/src/com/liferay/taglib/ui/SearchContainerRowTag.java#L310

In case of pagination the selectedItem value is stored in a hidden input which not has the tr element that stores the data entityid attribute, therefore we need to use the value instead of. 

https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js#L370

https://issues.liferay.com/browse/LPS-133325
https://issues.liferay.com/browse/LPS-133326

Thanks, Roland