### PR TITLE
[TS] LPS-134061 The available locales for a site must be retrieved using LanguageUtil.getAvailableLocales

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SiteResourceImpl.java
@@ -17,6 +17,7 @@ package com.liferay.headless.admin.user.internal.resource.v1_0;
 import com.liferay.headless.admin.user.dto.v1_0.Site;
 import com.liferay.headless.admin.user.internal.dto.v1_0.util.CreatorUtil;
 import com.liferay.headless.admin.user.resource.v1_0.SiteResource;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -29,6 +30,9 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
+
+import java.util.Locale;
+import java.util.Set;
 
 import javax.validation.ValidationException;
 
@@ -83,8 +87,12 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 	private Site _toSite(Group group) throws Exception {
 		return new Site() {
 			{
+				Set<Locale> availableLocales = LanguageUtil.getAvailableLocales(
+					group.getGroupId());
+
 				availableLanguages = LocaleUtil.toW3cLanguageIds(
-					group.getAvailableLanguageIds());
+					availableLocales.toArray(new Locale[0]));
+
 				creator = CreatorUtil.toCreator(
 					_portal,
 					_userLocalService.fetchUser(group.getCreatorUserId()));

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/general.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/general.jsp
@@ -131,10 +131,10 @@ renderResponse.setTitle(selLayout.getName(locale));
 			<c:if test="<%= layoutsAdminDisplayContext.isLayoutPageTemplateEntry() || ((selLayout.isTypeAssetDisplay() || selLayout.isTypeContent()) && layoutsAdminDisplayContext.isDraft()) %>">
 
 				<%
-				for (String languageId : group.getAvailableLanguageIds()) {
+				for (Locale availableLocale : LanguageUtil.getAvailableLocales(group.getGroupId())) {
 				%>
 
-					<aui:input name='<%= "name_" + languageId %>' type="hidden" value="<%= selLayout.getName(LocaleUtil.fromLanguageId(languageId)) %>" />
+					<aui:input name='<%= "name_" + LocaleUtil.toLanguageId(availableLocale) %>' type="hidden" value="<%= selLayout.getName(availableLocale) %>" />
 
 				<%
 				}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-134061

When we retrieve the available locales for a site, we must use **LanguageUtil.getAvailableLocales** instead of group.getAvailableLanguageIds().
The group.getAvailableLanguageIds()  method it seems it is intended for retrieving the locales used in the name and description of the group object for Staging purposes.

I have also applied the same change to the headless API in the SiteResourceImpl class as it is getting the wrong locales, after double checking it in slack: https://liferay.slack.com/archives/C5E1CRLJY/p1623393578079400 

/cc @liferay-usm @drewbrokke @pei-jung



