### PR TITLE
LPS-134122 Favorite structures not being displayed unless there is a page reload

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/ManagementToolbarPropsTransformer.js
@@ -123,9 +123,18 @@ export default function propsTransformer({
 			}
 		},
 		onShowMoreButtonClick() {
+			let refreshOnClose = true;
+
 			openSelectionModal({
+				onClose: () => {
+					if (refreshOnClose) {
+						navigate(location.href);
+					}
+				},
 				onSelect: (selectedItem) => {
 					if (selectedItem) {
+						refreshOnClose = false;
+
 						navigate(
 							addParams(
 								`${portletNamespace}ddmStructureKey=${selectedItem.ddmstructurekey}`,


### PR DESCRIPTION
Fixes: https://issues.liferay.com/browse/LPS-134122

See description and steps to reproduce in the JIRA ticket.

This is a regression from a pretty old commit, https://github.com/liferay/liferay-portal/commit/e199b578974c1ee669eab71599d1705e2353e68a#diff-4152ae545dcac35e48b5d463b517d83006b86a4e9a5b005242b0213d1a2ef7b9L69-L84. In it, we failed to migrate the refresh on close. In this PR, we are restoring that behavior. 

Notes:
- This would be a standard single selection modal if we only had a click on menu item, that navigates to 'New Web Content' page. The favorites feature is rare, if not unique, and introduces some complications. A solution is to refresh page after modal close.
- `onSelect` will always be before `onClose`, so you may be wondering why we need the `refreshOnClose` flag. We need it because `navigate` with start async navigation. Without `refreshOnClose`, we would have a needless and glitchy-looking refresh before navigation resolves.
- In this PR, we are restoring the original behavior, where we refresh page on every modal close. I believe this could be improved: we could refresh page _only_ if favorites were changed. To achieve this, we would need to somehow mark the add/remove favorites event, similar to [here](https://github.com/liferay/liferay-portal/blob/master/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/fields.jsp#L195-L231). It may be something like
```js
onOpen: ({iframeWindow}) => {
	delegate(
		iframeWindow.document, 'click', STAR_ICON_CSS_SELECTOR, () => {
			refreshOnClose = true;
		}
	);
},
```
I tried this, but there are complications: star icon links don't have a clear marker, and invoke `event.preventDefault` on click. This started to require too many changes, so I left it out of this PR. It is up to you if even wish to make this improvement.

/cc @victorvalle

After PR:
![after](https://user-images.githubusercontent.com/5435511/121908139-fd7cc600-cd2c-11eb-8287-aad66a6f3f2a.gif)