### PR TITLE
[TS] LPS-134264

### DIFF
--- a/modules/apps/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserDisplayContext.java
+++ b/modules/apps/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserDisplayContext.java
@@ -496,6 +496,9 @@ public class SiteBrowserDisplayContext {
 
 			_groupParams.put("usersGroups", user.getUserId());
 		}
+		else {
+			_groupParams.put("actionId", ActionKeys.ASSIGN_MEMBERS);
+		}
 
 		_groupParams.put("site", Boolean.TRUE);
 


### PR DESCRIPTION
Prior to https://issues.liferay.com/browse/LPS-128817 groups were filtered using the following logic:

https://github.com/liferay/liferay-portal-ee/blob/fix-pack-dxp-12-7210/modules/apps/site/site-browser-web/src/main/java/com/liferay/site/browser/web/internal/display/context/SiteBrowserDisplayContext.java#L398-L404

After LPS-128817 filtering only took place if:

1. `filterManageableGroups` is true
2. A value for `usersGroups` is supplied to the group search

This change in behavior allowed all sites to be returned when a user was adding another user to a site (https://issues.liferay.com/browse/LPS-134264).

The changes in this pull attempt to bring back the previous behavior by checking for the "Assign Members" permission.

Please let me know if there are any questions or if there are any flaws in the logic. Thank you.