### PR TITLE
[TS] LPS-134318

### DIFF
--- a/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashManagementToolbarDisplayContext.java
+++ b/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashManagementToolbarDisplayContext.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -218,7 +219,13 @@ public class TrashManagementToolbarDisplayContext
 
 	@Override
 	protected String[] getOrderByKeys() {
-		return new String[] {"removed-date"};
+		String[] orderColumns = {"removed-date"};
+
+		if (_trashDisplayContext.isSearch()) {
+			orderColumns = ArrayUtil.append(orderColumns, "relevance");
+		}
+
+		return orderColumns;
 	}
 
 	private boolean _isDeletable(TrashEntry trashEntry) throws PortalException {


### PR DESCRIPTION
[LPS-134318](https://issues.liferay.com/browse/LPS-134318)

From @jesseyeh-liferay:

> When searching in the Recycle Bin, the Removed Date option in the Filter and Order dropdown sorts the returned results by Relevance instead. In the original implementation, the sort is of type `Sort.STRING_TYPE` and is not a sortable field. As a result, [instead of using `removedDate` as the `fieldName`, `_score` is used instead](https://github.com/liferay/liferay-portal/blob/85814ef7676c26e27ce56e76978bcdb55ff29e1f/portal-kernel/src/com/liferay/portal/kernel/search/Field.java#L232-L236), i.e., sorting by Relevance. By using a numeric type such as `Sort.LONG_TYPE`, sorting the search results by Removed Date returns the results in the correct order (see [documentation on sortable fields](https://learn.liferay.com/dxp/latest/en/using-search/search-pages-and-widgets/search-results/sorting-search-results.html#finding-sortable-fields)).