### PR TITLE
[TS] LPS-134704 - check against site template as well when setting workflow for web content folders

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -310,6 +310,14 @@ renderResponse.setTitle(title);
 								<%
 								WorkflowDefinitionLink workflowDefinitionLink = WorkflowDefinitionLinkLocalServiceUtil.fetchWorkflowDefinitionLink(company.getCompanyId(), scopeGroupId, JournalFolder.class.getName(), folderId, JournalArticleConstants.DDM_STRUCTURE_ID_ALL, true);
 
+								if (workflowDefinitionLink == null) {
+									LayoutSet layoutSet = LayoutSetLocalServiceUtil.getLayoutSet(scopeGroupId, false);
+
+									Group layoutSetPrototypeGroup = GroupLocalServiceUtil.getLayoutSetPrototypeGroup(company.getCompanyId(), layoutSet.getLayoutSetPrototypeId());
+
+									workflowDefinitionLink = WorkflowDefinitionLinkLocalServiceUtil.fetchWorkflowDefinitionLink(company.getCompanyId(), layoutSetPrototypeGroup.getGroupId(), JournalFolder.class.getName(), folderId, JournalArticleConstants.DDM_STRUCTURE_ID_ALL, true);
+								}
+
 								for (WorkflowDefinition workflowDefinition : workflowDefinitions) {
 									boolean selected = false;
 


### PR DESCRIPTION
Hi Echo team!

I'm sending this to you since it relates specifically to Journal folders, but if you feel like it's more appropriate elsewhere please just let me know. This adds a check to the layout set prototype group's setting in the case we can't find a setting for our own scope group since otherwise the setting is not carried over at all from the site template.