### PR TITLE
[TS] LPS-135017 | Asset Publisher configuration: Tags shown twice if they come from different sites

### DIFF
--- a/modules/apps/asset/asset-tags-selector-web/src/main/java/com/liferay/asset/tags/selector/web/internal/display/context/AssetTagsSelectorDisplayContext.java
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/java/com/liferay/asset/tags/selector/web/internal/display/context/AssetTagsSelectorDisplayContext.java
@@ -27,6 +27,8 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.asset.util.comparator.AssetTagNameComparator;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 
 import javax.portlet.PortletURL;
@@ -133,17 +135,16 @@ public class AssetTagsSelectorDisplayContext {
 				new EntriesChecker(_renderRequest, _renderResponse));
 		}
 
-		int tagsCount = AssetTagServiceUtil.getTagsCount(
-			_getGroupIds(), _getKeywords());
-
-		tagsSearchContainer.setTotal(tagsCount);
-
 		List<AssetTag> tags = AssetTagServiceUtil.getTags(
 			_getGroupIds(), _getKeywords(), tagsSearchContainer.getStart(),
 			tagsSearchContainer.getEnd(),
 			tagsSearchContainer.getOrderByComparator());
 
-		tagsSearchContainer.setResults(tags);
+		List<AssetTag> filteredTags = _removeDuplicatedAssetTags(tags);
+
+		tagsSearchContainer.setTotal(filteredTags.size());
+
+		tagsSearchContainer.setResults(filteredTags);
 
 		_tagsSearchContainer = tagsSearchContainer;
 
@@ -199,6 +200,20 @@ public class AssetTagsSelectorDisplayContext {
 			_httpServletRequest, "orderByCol", "name");
 
 		return _orderByCol;
+	}
+
+	private List<AssetTag> _removeDuplicatedAssetTags(List<AssetTag> tags) {
+		HashMap<String, AssetTag> filteredTags = new HashMap<>();
+
+		for (AssetTag tag : tags) {
+			String tagName = tag.getName();
+
+			if (!filteredTags.containsKey(tagName)) {
+				filteredTags.put(tagName, tag);
+			}
+		}
+
+		return new ArrayList<>(filteredTags.values());
 	}
 
 	private String _eventName;


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-135017
Thank you!

-----

I modified the AssetTagSelectorDisplayContext to not return a tag more than once. Currently, if we create the same tag in two sites and on one of the sites create a page with an asset publisher and configure the asset publisher scope to include the other site as well. In this case, if we want to filter by tags in the filter -> tag section the selector window will list both of the tags with the same value. As we do not show any other info about the tags except their name this duplication is confusing. Also in the previous use case selecting any of the tags or both makes no difference in the result of the filtering.