### PR TITLE
LPS 130080 Simulation sidebar color change

### DIFF
--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
@@ -22,9 +22,9 @@
 			cssClass="devices"
 		>
 			<clay:row
-				cssClass="default-devices"
+				cssClass="default-devices mb-2"
 			>
-				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item selected text-center" data-device="desktop" type="button">
+				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item mb-3 selected text-center" data-device="desktop" type="button">
 					<div class="c-inner px-0" tabindex="-1">
 						<aui:icon cssClass="icon icon-monospaced" image="desktop" markupView="lexicon" />
 
@@ -32,7 +32,7 @@
 					</div>
 				</button>
 
-				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item text-center" data-device="tablet" type="button">
+				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item mb-3 text-center" data-device="tablet" type="button">
 					<div class="c-inner px-0" tabindex="-1">
 						<aui:icon cssClass="icon icon-monospaced" image="tablet-portrait" markupView="lexicon" />
 
@@ -42,7 +42,7 @@
 					</div>
 				</button>
 
-				<button class="btn btn-unstyled col-4 lfr-device-item text-center" data-device="smartphone" type="button">
+				<button class="btn btn-unstyled col-4 lfr-device-item mb-3 text-center" data-device="smartphone" type="button">
 					<div class="c-inner px-0" tabindex="-1">
 						<aui:icon cssClass="icon icon-monospaced" image="mobile-portrait" markupView="lexicon" />
 
@@ -70,12 +70,12 @@
 			</clay:row>
 
 			<clay:row
-				cssClass="custom-devices d-lg-flex d-none hide"
+				cssClass="custom-devices d-lg-flex d-none hide mt-3"
 				id='<%= liferayPortletResponse.getNamespace() + "customDeviceContainer" %>'
 			>
-				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "height") + " (px):" %>' name="height" size="4" value="600" wrapperCssClass="col-6" />
+				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "height") + " (px):" %>' name="height" size="4" value="600" wrapperCssClass="flex-grow-1 mr-3" />
 
-				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "width") + " (px):" %>' name="width" size="4" value="600" wrapperCssClass="col-6" />
+				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "width") + " (px):" %>' name="width" size="4" value="600" wrapperCssClass="flex-grow-1" />
 			</clay:row>
 		</clay:container-fluid>
 	</div>

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
@@ -25,37 +25,47 @@
 				cssClass="default-devices"
 			>
 				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item selected text-center" data-device="desktop" type="button">
-					<aui:icon cssClass="icon icon-monospaced" image="desktop" markupView="lexicon" />
+					<div class="c-inner px-0" tabindex="-1">
+						<aui:icon cssClass="icon icon-monospaced" image="desktop" markupView="lexicon" />
 
-					<small><%= LanguageUtil.get(resourceBundle, "desktop") %></small>
+						<small><%= LanguageUtil.get(resourceBundle, "desktop") %></small>
+					</div>
 				</button>
 
 				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item text-center" data-device="tablet" type="button">
-					<aui:icon cssClass="icon icon-monospaced" image="tablet-portrait" markupView="lexicon" />
+					<div class="c-inner px-0" tabindex="-1">
+						<aui:icon cssClass="icon icon-monospaced" image="tablet-portrait" markupView="lexicon" />
 
-					<aui:icon cssClass="hide icon icon-monospaced icon-rotate" image="tablet-landscape" markupView="lexicon" />
+						<aui:icon cssClass="hide icon icon-monospaced icon-rotate" image="tablet-landscape" markupView="lexicon" />
 
-					<small><%= LanguageUtil.get(resourceBundle, "tablet") %></small>
+						<small><%= LanguageUtil.get(resourceBundle, "tablet") %></small>
+					</div>
 				</button>
 
 				<button class="btn btn-unstyled col-4 lfr-device-item text-center" data-device="smartphone" type="button">
-					<aui:icon cssClass="icon icon-monospaced" image="mobile-portrait" markupView="lexicon" />
+					<div class="c-inner px-0" tabindex="-1">
+						<aui:icon cssClass="icon icon-monospaced" image="mobile-portrait" markupView="lexicon" />
 
-					<aui:icon cssClass="hide icon icon-monospaced icon-rotate" image="mobile-landscape" markupView="lexicon" />
+						<aui:icon cssClass="hide icon icon-monospaced icon-rotate" image="mobile-landscape" markupView="lexicon" />
 
-					<small><%= LanguageUtil.get(resourceBundle, "mobile") %></small>
+						<small><%= LanguageUtil.get(resourceBundle, "mobile") %></small>
+					</div>
 				</button>
 
 				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item text-center" data-device="autosize" type="button">
-					<aui:icon cssClass="icon icon-monospaced" image="autosize" markupView="lexicon" />
+					<div class="c-inner px-0" tabindex="-1">
+						<aui:icon cssClass="icon icon-monospaced" image="autosize" markupView="lexicon" />
 
-					<small><%= LanguageUtil.get(resourceBundle, "autosize") %></small>
+						<small><%= LanguageUtil.get(resourceBundle, "autosize") %></small>
+					</div>
 				</button>
 
 				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item text-center" data-device="custom" type="button">
-					<aui:icon cssClass="icon icon-monospaced" image="custom-size" markupView="lexicon" />
+					<div class="c-inner px-0" tabindex="-1">
+						<aui:icon cssClass="icon icon-monospaced" image="custom-size" markupView="lexicon" />
 
-					<small><liferay-ui:message key="custom" /></small>
+						<small><liferay-ui:message key="custom" /></small>
+					</div>
 				</button>
 			</clay:row>
 

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
@@ -28,7 +28,7 @@
 					<div class="c-inner px-0" tabindex="-1">
 						<aui:icon cssClass="icon icon-monospaced" image="desktop" markupView="lexicon" />
 
-						<small><%= LanguageUtil.get(resourceBundle, "desktop") %></small>
+						<small><liferay-ui:message key="desktop" /></small>
 					</div>
 				</button>
 
@@ -38,7 +38,7 @@
 
 						<aui:icon cssClass="hide icon icon-monospaced icon-rotate" image="tablet-landscape" markupView="lexicon" />
 
-						<small><%= LanguageUtil.get(resourceBundle, "tablet") %></small>
+						<small><liferay-ui:message key="tablet" /></small>
 					</div>
 				</button>
 
@@ -48,7 +48,7 @@
 
 						<aui:icon cssClass="hide icon icon-monospaced icon-rotate" image="mobile-landscape" markupView="lexicon" />
 
-						<small><%= LanguageUtil.get(resourceBundle, "mobile") %></small>
+						<small><liferay-ui:message key="mobile" /></small>
 					</div>
 				</button>
 
@@ -56,7 +56,7 @@
 					<div class="c-inner px-0" tabindex="-1">
 						<aui:icon cssClass="icon icon-monospaced" image="autosize" markupView="lexicon" />
 
-						<small><%= LanguageUtil.get(resourceBundle, "autosize") %></small>
+						<small><liferay-ui:message key="autosize" /></small>
 					</div>
 				</button>
 

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
@@ -26,7 +26,11 @@
 			>
 				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item mb-3 selected text-center" data-device="desktop" type="button">
 					<div class="c-inner px-0" tabindex="-1">
-						<aui:icon cssClass="icon icon-monospaced" image="desktop" markupView="lexicon" />
+						<span class="icon icon-monospaced">
+							<clay:icon
+								symbol="desktop"
+							/>
+						</span>
 
 						<small><liferay-ui:message key="desktop" /></small>
 					</div>
@@ -34,9 +38,16 @@
 
 				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item mb-3 text-center" data-device="tablet" type="button">
 					<div class="c-inner px-0" tabindex="-1">
-						<aui:icon cssClass="icon icon-monospaced" image="tablet-portrait" markupView="lexicon" />
-
-						<aui:icon cssClass="hide icon icon-monospaced icon-rotate" image="tablet-landscape" markupView="lexicon" />
+						<span class="icon icon-monospaced">
+							<clay:icon
+								symbol="tablet-portrait"
+							/>
+						</span>
+						<span class="hide icon icon-monospaced icon-rotate">
+							<clay:icon
+								symbol="tablet-landscape"
+							/>
+						</span>
 
 						<small><liferay-ui:message key="tablet" /></small>
 					</div>
@@ -44,9 +55,16 @@
 
 				<button class="btn btn-unstyled col-4 lfr-device-item mb-3 text-center" data-device="smartphone" type="button">
 					<div class="c-inner px-0" tabindex="-1">
-						<aui:icon cssClass="icon icon-monospaced" image="mobile-portrait" markupView="lexicon" />
-
-						<aui:icon cssClass="hide icon icon-monospaced icon-rotate" image="mobile-landscape" markupView="lexicon" />
+						<span class="icon icon-monospaced">
+							<clay:icon
+								symbol="mobile-portrait"
+							/>
+						</span>
+						<span class="hide icon icon-monospaced icon-rotate">
+							<clay:icon
+								symbol="mobile-landscape"
+							/>
+						</span>
 
 						<small><liferay-ui:message key="mobile" /></small>
 					</div>
@@ -54,7 +72,11 @@
 
 				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item text-center" data-device="autosize" type="button">
 					<div class="c-inner px-0" tabindex="-1">
-						<aui:icon cssClass="icon icon-monospaced" image="autosize" markupView="lexicon" />
+						<span class="icon icon-monospaced">
+							<clay:icon
+								symbol="autosize"
+							/>
+						</span>
 
 						<small><liferay-ui:message key="autosize" /></small>
 					</div>
@@ -62,7 +84,11 @@
 
 				<button class="btn btn-unstyled col-4 d-lg-block d-none lfr-device-item text-center" data-device="custom" type="button">
 					<div class="c-inner px-0" tabindex="-1">
-						<aui:icon cssClass="icon icon-monospaced" image="custom-size" markupView="lexicon" />
+						<span class="icon icon-monospaced">
+							<clay:icon
+								symbol="custom-size"
+							/>
+						</span>
 
 						<small><liferay-ui:message key="custom" /></small>
 					</div>

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_panel.scss
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_panel.scss
@@ -65,7 +65,6 @@
 		}
 
 		small {
-			color: #a7a9bc;
 			margin: 4px 0 16px;
 		}
 	}
@@ -74,23 +73,17 @@
 		color: $gray-600;
 		max-width: 33.33%;
 
-		.icon {
-			color: $gray-600;
+		&:hover {
+			color: $gray-900;
 		}
 
-		small {
-			color: $gray-600;
-		}
 
 		&.selected {
+			color: $gray-900;
+
 			.icon {
 				background-color: $gray-200;
 				border-radius: 4px;
-				color: $gray-900;
-			}
-
-			small {
-				color: $gray-900;
 			}
 		}
 	}

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_panel.scss
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_panel.scss
@@ -20,7 +20,7 @@
 		padding-bottom: 6px;
 		padding-top: 6px;
 
-		.collapse-icon-closed, 
+		.collapse-icon-closed,
 		.collapse-icon-open {
 			color: $gray-600;
 			right: 0;
@@ -32,14 +32,6 @@
 	}
 
 	.custom-devices {
-		border-radius: 4px;
-		margin: 0 10px 20px;
-		padding: 8px 6px 16px;
-
-		label {
-			font-size: 12px;
-		}
-
 		.form-control {
 			border-radius: 4px;
 			padding: 8px 12px;
@@ -51,8 +43,6 @@
 	}
 
 	.default-devices {
-		margin-bottom: 24px;
-
 		.icon-monospaced {
 			height: 2.5rem;
 			width: 2.5rem;
@@ -71,12 +61,10 @@
 
 	.lfr-device-item {
 		color: $gray-600;
-		max-width: 33.33%;
 
 		&:hover {
 			color: $gray-900;
 		}
-
 
 		&.selected {
 			color: $gray-900;

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_panel.scss
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_panel.scss
@@ -4,14 +4,39 @@
 		width: 320px;
 	}
 
+	.sidebar {
+		border-left: 1px solid $gray-300;
+	}
+
+	.sidebar-header {
+		line-height: 32px;
+	}
+
+	.panel-header {
+		border-bottom: 1px solid $gray-500;
+		color: $gray-900;
+		font-size: 12px;
+		line-height: 18px;
+		padding-bottom: 6px;
+		padding-top: 6px;
+
+		.collapse-icon-closed, 
+		.collapse-icon-open {
+			color: $gray-600;
+			right: 0;
+		}
+	}
+
+	.list-group-item {
+		border: 0 none;
+	}
+
 	.custom-devices {
-		background-color: #393a4a;
 		border-radius: 4px;
 		margin: 0 10px 20px;
 		padding: 8px 6px 16px;
 
 		label {
-			color: #a7a9bc;
 			font-size: 12px;
 		}
 
@@ -26,11 +51,9 @@
 	}
 
 	.default-devices {
-		margin-bottom: 20px;
-		padding: 0 14px;
+		margin-bottom: 24px;
 
 		.icon-monospaced {
-			color: #a7a9bc;
 			height: 2.5rem;
 			width: 2.5rem;
 
@@ -48,28 +71,33 @@
 	}
 
 	.lfr-device-item {
-		&.selected {
-			color: #fff;
+		color: $gray-600;
+		max-width: 33.33%;
 
+		.icon {
+			color: $gray-600;
+		}
+
+		small {
+			color: $gray-600;
+		}
+
+		&.selected {
 			.icon {
-				background-color: #393a4a;
+				background-color: $gray-200;
 				border-radius: 4px;
-				color: #fff;
+				color: $gray-900;
 			}
 
 			small {
-				color: #fff;
+				color: $gray-900;
 			}
-		}
-
-		.icon {
-			margin-top: 8px;
 		}
 	}
 
 	.panel {
 		.simulation-app-panel-body {
-			padding: 12px 0 4px;
+			padding: 16px 0 0;
 		}
 	}
 }

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/META-INF/resources/portlet/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/META-INF/resources/portlet/view.jsp
@@ -24,7 +24,7 @@ PanelCategory panelCategory = panelCategoryRegistry.getPanelCategory(ProductNavi
 PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(panelAppRegistry, panelCategoryRegistry);
 %>
 
-<div class="simulation-menu" data-qa-id="simulationMenuBody" id="<portlet:namespace />simulationPanelContainer">
+<div class="pb-3 px-3 simulation-menu" data-qa-id="simulationMenuBody" id="<portlet:namespace />simulationPanelContainer">
 	<div aria-multiselectable="true" class="panel-group" role="tablist">
 
 		<%
@@ -33,8 +33,8 @@ PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(panelAppRegist
 
 			<div class="panel">
 				<div class="panel-heading" id="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Header" role="tab">
-					<a aria-controls="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" aria-expanded="<%= true %>" class="collapse-icon collapse-icon-middle list-group-heading panel-header" data-toggle="liferay-collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" role="button">
-						<span class="category-name text-truncate"><%= panelApp.getLabel(locale) %></span>
+					<a aria-controls="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" aria-expanded="<%= true %>" class="collapse-icon collapse-icon-middle list-group-heading panel-header pl-0 text-decoration-none" data-toggle="liferay-collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" role="button">
+						<span class="category-name font-weight-semi-bold text-truncate text-uppercase"><%= panelApp.getLabel(locale) %></span>
 
 						<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
 

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/META-INF/resources/portlet/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/META-INF/resources/portlet/view.jsp
@@ -31,7 +31,7 @@ PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(panelAppRegist
 		for (PanelApp panelApp : panelCategoryHelper.getAllPanelApps(panelCategory.getKey())) {
 		%>
 
-			<div class="panel">
+			<div class="mb-3 panel">
 				<div class="panel-heading" id="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Header" role="tab">
 					<a aria-controls="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" aria-expanded="<%= true %>" class="collapse-icon collapse-icon-middle list-group-heading panel-header pl-0 text-decoration-none" data-toggle="liferay-collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" role="button">
 						<span class="category-name font-weight-semi-bold text-truncate text-uppercase"><%= panelApp.getLabel(locale) %></span>

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/body.tmpl
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/body.tmpl
@@ -1,9 +1,9 @@
 <div class="closed lfr-admin-panel lfr-product-menu-panel lfr-simulation-panel sidenav-fixed sidenav-menu-slider sidenav-right" id="${portletNamespace}simulationPanelId">
-	<div class="product-menu sidebar sidebar-inverse sidenav-menu">
-		<div class="sidebar-header">
+	<div class="sidebar sidebar-inverse sidenav-menu sidebar-light sidebar-sm">
+		<div class="d-flex justify-content-between sidebar-header">
 			<h1 class="sr-only">${simulationPanel}</h1>
 
-			<span>${sidebarMessage}</span>
+			<span class="font-weight-bold">${sidebarMessage}</span>
 
 			${sidebarIcon}
 		</div>

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
@@ -38,10 +38,10 @@ SegmentsSimulationDisplayContext segmentsSimulationDisplayContext = new Segments
 					for (SegmentsEntry segmentsEntry : segmentsSimulationDisplayContext.getSegmentsEntries()) {
 					%>
 
-						<li class="bg-transparent list-group-item list-group-item-flex">
+						<li class="bg-transparent list-group-item list-group-item-flex pb-3 pt-0 px-0">
 							<span>
 								<div class="custom-checkbox">
-									<label class="position-relative text-light">
+									<label class="position-relative">
 										<input class="custom-control-input simulated-segment" name="<%= segmentsSimulationDisplayContext.getPortletNamespace() + "segmentsEntryId" %>" type="checkbox" value="<%= String.valueOf(segmentsEntry.getSegmentsEntryId()) %>" />
 
 										<span class="custom-control-label">

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
@@ -21,7 +21,7 @@ SegmentsSimulationDisplayContext segmentsSimulationDisplayContext = new Segments
 %>
 
 <clay:container-fluid
-	cssClass="segments-simulation"
+	cssClass="p-0 segments-simulation"
 	id='<%= liferayPortletResponse.getNamespace() + "segmentsSimulationContainer" %>'
 >
 	<c:choose>


### PR DESCRIPTION
[Jira Link](https://issues.liferay.com/browse/LPS-130080)
[Design](https://www.figma.com/file/BodTnJ55QzOPhltwsdVbuG/LPS-132404-Tango-Side-panels?node-id=88%3A60050)

- LPS-130080 Change simulation sidebar styles from black to white
- LPS-130080 Changed simulation sidebar icons colors and improved focused state styles
- LPS-130080 Changed simulation sidebar segments checkboxes colors and spacing
- LPS-130080 Improvements in simulation sidebar layout removing rows and cols
- LPS-130080 SF
