### PR TITLE
LPS-134846 Make RSS URL behavior consistent

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/AssetPublisherPortlet.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/AssetPublisherPortlet.java
@@ -51,6 +51,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -75,8 +76,10 @@ import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 import javax.portlet.ResourceRequest;
 import javax.portlet.ResourceResponse;
+import javax.portlet.ResourceURL;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
 
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
@@ -220,6 +223,23 @@ public class AssetPublisherPortlet extends MVCPortlet {
 					_log.debug(servletException, servletException);
 				}
 			}
+
+			return;
+		}
+
+		String currentURL = portal.getCurrentURL(resourceRequest);
+
+		String cacheability = httpUtil.getParameter(
+			currentURL, "p_p_cacheability");
+
+		if (cacheability.equals(ResourceURL.FULL)) {
+			HttpServletResponse httpServletResponse =
+				portal.getHttpServletResponse(resourceResponse);
+
+			String redirectURL = httpUtil.removeParameter(
+				currentURL, "p_p_cacheability");
+
+			httpServletResponse.sendRedirect(redirectURL);
 
 			return;
 		}
@@ -404,6 +424,9 @@ public class AssetPublisherPortlet extends MVCPortlet {
 
 	@Reference
 	protected AssetRSSHelper assetRSSHelper;
+
+	@Reference
+	protected HttpUtil httpUtil;
 
 	@Reference
 	protected InfoItemServiceTracker infoItemServiceTracker;


### PR DESCRIPTION
Hi guys,

As I explained in [LPS-134846](https://issues.liferay.com/browse/LPS-134846) this is a common case in environments upgraded from 6.2 or before since we used to add `p_p_cacheability=cacheLevelFull` to the RSS URL. All those end users who stored that URL in their RSS managers (like feedly) are now getting an error when trying to reach the URL... unless the Asset Publisher is set to "show full context" in display settings what should not affect this case at all.

I've followed [Dani's advice in PTR-2520](https://issues.liferay.com/browse/PTR-2520?focusedCommentId=2476327&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2476327) and send a redirect without the parameter in case it is part of the URL, so the behavior is consistent and users are not getting an error in any case.

Thanks.

Regards.