### PR TITLE
[TS] LPS-135349

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMStructuresDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMStructuresDisplayContext.java
@@ -146,7 +146,7 @@ public class JournalDDMStructuresDisplayContext {
 		}
 
 		_orderByType = ParamUtil.getString(
-			_renderRequest, "orderByType", "asc");
+			_renderRequest, "orderByType", "desc");
 
 		return _orderByType;
 	}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMTemplateDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDDMTemplateDisplayContext.java
@@ -235,7 +235,7 @@ public class JournalDDMTemplateDisplayContext {
 		}
 
 		_orderByType = ParamUtil.getString(
-			_renderRequest, "orderByType", "asc");
+			_renderRequest, "orderByType", "desc");
 
 		return _orderByType;
 	}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalSelectDDMStructureDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalSelectDDMStructureDisplayContext.java
@@ -172,7 +172,7 @@ public class JournalSelectDDMStructureDisplayContext {
 		}
 
 		_orderByType = ParamUtil.getString(
-			_renderRequest, "orderByType", "asc");
+			_renderRequest, "orderByType", "desc");
 
 		return _orderByType;
 	}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalSelectDDMTemplateDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalSelectDDMTemplateDisplayContext.java
@@ -117,7 +117,7 @@ public class JournalSelectDDMTemplateDisplayContext {
 		}
 
 		_orderByType = ParamUtil.getString(
-			_renderRequest, "orderByType", "asc");
+			_renderRequest, "orderByType", "desc");
 
 		return _orderByType;
 	}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalViewMoreMenuItemsDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalViewMoreMenuItemsDisplayContext.java
@@ -181,7 +181,7 @@ public class JournalViewMoreMenuItemsDisplayContext {
 		}
 
 		_orderByType = ParamUtil.getString(
-			_renderRequest, "orderByType", "asc");
+			_renderRequest, "orderByType", "desc");
 
 		return _orderByType;
 	}


### PR DESCRIPTION
Similar to https://issues.liferay.com/browse/LPS-107358 this changes the default ordering for Structures and Templates so that the newly modified entries appear at the top of the list.

If there is a reason the ordering was meant to be ascending please let me know so that I can inform the client.

Thank you.