### PR TITLE
LPS-133735 Prevent the Page Tree and the Site Builder's Pages menu from being open at the same time

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -69,6 +69,7 @@ page import="com.liferay.layout.page.template.service.LayoutPageTemplateCollecti
 page import="com.liferay.layout.page.template.service.LayoutPageTemplateCollectionServiceUtil" %><%@
 page import="com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil" %><%@
 page import="com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil" %><%@
+page import="com.liferay.petra.portlet.url.builder.PortletURLBuilder" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.bean.BeanParamUtil" %><%@
 page import="com.liferay.portal.kernel.dao.search.ResultRow" %><%@
@@ -109,6 +110,7 @@ page import="com.liferay.portal.kernel.model.User" %><%@
 page import="com.liferay.portal.kernel.model.UserGroup" %><%@
 page import="com.liferay.portal.kernel.plugin.PluginPackage" %><%@
 page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
+page import="com.liferay.portal.kernel.portlet.PortletURLFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.security.permission.ActionKeys" %><%@
 page import="com.liferay.portal.kernel.security.permission.ResourceActionsUtil" %><%@
 page import="com.liferay.portal.kernel.service.GroupLocalServiceUtil" %><%@
@@ -146,6 +148,7 @@ page import="com.liferay.portal.kernel.webserver.WebServerServletTokenUtil" %><%
 page import="com.liferay.portal.kernel.workflow.WorkflowConstants" %><%@
 page import="com.liferay.portal.util.LayoutTypeControllerTracker" %><%@
 page import="com.liferay.portal.util.PropsValues" %><%@
+page import="com.liferay.product.navigation.product.menu.constants.ProductNavigationProductMenuPortletKeys" %><%@
 page import="com.liferay.segments.exception.RequiredSegmentsExperienceException" %><%@
 page import="com.liferay.site.navigation.model.SiteNavigationMenu" %><%@
 page import="com.liferay.sites.kernel.util.SitesUtil" %><%@
@@ -161,7 +164,8 @@ page import="java.util.ResourceBundle" %><%@
 page import="java.util.TreeMap" %>
 
 <%@ page import="javax.portlet.PortletRequest" %><%@
-page import="javax.portlet.PortletURL" %>
+page import="javax.portlet.PortletURL" %><%@
+page import="javax.portlet.RenderRequest" %>
 
 <liferay-frontend:defineObjects />
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -82,3 +82,51 @@ portletDisplay.setShowStagingIcon(false);
 		</c:otherwise>
 	</c:choose>
 </aui:form>
+
+<%
+PortletURL portletURL = PortletURLBuilder.create(
+	PortletURLFactoryUtil.create(request, ProductNavigationProductMenuPortletKeys.PRODUCT_NAVIGATION_PRODUCT_MENU, RenderRequest.RENDER_PHASE)
+).setMVCPath(
+	"/portlet/product_menu.jsp"
+).setWindowState(
+	LiferayWindowState.EXCLUSIVE
+).build();
+%>
+
+<aui:script sandbox="<%= true %>">
+	Liferay.Util.Session.get(
+		'com.liferay.product.navigation.product.menu.web_pagesTreeState'
+	).then((result) => {
+		if (result === 'open') {
+			Liferay.Util.Session.set(
+				'com.liferay.product.navigation.product.menu.web_pagesTreeState',
+				'closed'
+			).then(() => {
+				Liferay.Util.fetch('<%= portletURL.toString() %>')
+					.then((response) => {
+						if (!response.ok) {
+							throw new Error(
+								'<liferay-ui:message key="an-unexpected-error-occurred" />'
+							);
+						}
+
+						return response.text();
+					})
+					.then((response) => {
+						var sidebar = document.querySelector(
+							'.lfr-product-menu-sidebar .sidebar-body'
+						);
+
+						sidebar.innerHTML = '';
+
+						var range = document.createRange();
+						range.selectNode(sidebar);
+
+						var fragment = range.createContextualFragment(response);
+
+						sidebar.appendChild(fragment);
+					});
+			});
+		}
+	});
+</aui:script>

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
@@ -179,6 +179,18 @@ public class LayoutsTreeDisplayContext {
 		).build();
 	}
 
+	public Map<String, Object> getAdministrationLinkData()
+		throws WindowStateException {
+
+		return HashMapBuilder.<String, Object>put(
+			"href", getAdministrationPortletURL()
+		).put(
+			"namespace", getNamespace()
+		).put(
+			"productMenuPortletURL", getProductMenuPortletURL()
+		).build();
+	}
+
 	public String getAdministrationPortletURL() {
 		return PortletURLBuilder.create(
 			PortalUtil.getControlPanelPortletURL(

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesAdministrationLink.es.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesAdministrationLink.es.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {fetch, openToast} from 'frontend-js-web';
+import React from 'react';
+
+const PagesAdministrationLink = (props) => {
+	const handleOnClick = () => {
+		Liferay.Portlet.destroy(`#p_p_id${props.namespace}`, true);
+
+		Liferay.Util.Session.set(
+			'com.liferay.product.navigation.product.menu.web_pagesTreeState',
+			'closed'
+		).then(() => {
+			fetch(props.productMenuPortletURL)
+				.then((response) => {
+					if (!response.ok) {
+						throw new Error();
+					}
+
+					return response.text();
+				})
+				.then((productMenuContent) => {
+					const sidebar = document.querySelector(
+						'.lfr-product-menu-sidebar .sidebar-body'
+					);
+
+					sidebar.innerHTML = '';
+
+					const range = document.createRange();
+					range.selectNode(sidebar);
+
+					sidebar.appendChild(
+						range.createContextualFragment(productMenuContent)
+					);
+				})
+				.catch(() => {
+					openToast({
+						message: Liferay.Language.get(
+							'an-unexpected-error-occurred'
+						),
+						title: Liferay.Language.get('error'),
+						type: 'danger',
+					});
+				});
+		});
+	};
+
+	return (
+		<div className="pages-administration-link">
+			<a className="ml-2" href={props.href} onClick={handleOnClick}>
+				{Liferay.Language.get('go-to-pages-administration')}
+			</a>
+		</div>
+	);
+};
+
+export default PagesAdministrationLink;

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
@@ -31,7 +31,6 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
 <%@ page import="com.liferay.application.list.PanelCategory" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
@@ -180,8 +180,11 @@ LayoutsTreeDisplayContext layoutsTreeDisplayContext = (LayoutsTreeDisplayContext
 			/>
 
 			<c:if test="<%= layoutsTreeDisplayContext.hasAdministrationPortletPermission() %>">
-				<div class="pages-administration-link">
-					<aui:a cssClass="ml-2" href="<%= layoutsTreeDisplayContext.getAdministrationPortletURL() %>"><%= LanguageUtil.get(request, "go-to-pages-administration") %></aui:a>
+				<div>
+					<react:component
+						module="js/PagesAdministrationLink.es"
+						props="<%= layoutsTreeDisplayContext.getAdministrationLinkData() %>"
+					/>
 				</div>
 			</c:if>
 		</c:otherwise>

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -134,6 +134,15 @@ Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 			'<portlet:namespace />pagesTreeSidenavToggleId'
 		);
 
+		if (
+			Liferay.currentURL.includes(
+				'com_liferay_layout_admin_web_portlet_GroupPagesPortlet'
+			) &&
+			!Liferay.currentURL.includes('p_l_back_url')
+		) {
+			pagesTreeToggle.classList.add('disabled');
+		}
+
 		pagesTreeToggle.addEventListener('click', (event) => {
 			Liferay.Portlet.destroy('#p_p_id<portlet:namespace />', true);
 


### PR DESCRIPTION
Hey,
[LPS-133735](https://issues.liferay.com/browse/LPS-133735),

My changes:
- The Page-Tree button is disabled while we are viewing the GroupPagesPortlet
- I kept the Page Administration link and I close the Page-tree with an onClick on the link
- I also check in layout-admin wether the Page-tree is open when it's loaded, if yes I close it from there.
This was needed to handle scenarios where the user is navigating back

Last PR: https://github.com/liferay-echo/liferay-portal/pull/5071

Please review my changes,

/cc @victorg1991 