### PR TITLE
LPS-131180 Use site group ID when resolving display pages

### DIFF
--- a/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-display-page-api/src/main/java/com/liferay/asset/display/page/portlet/BaseAssetDisplayPageFriendlyURLResolver.java
@@ -144,7 +144,8 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 
 		Locale locale = portal.getLocale(httpServletRequest);
 		Layout layout = _getLayoutDisplayPageObjectProviderLayout(
-			layoutDisplayPageObjectProvider, layoutDisplayPageProvider);
+			groupId, layoutDisplayPageObjectProvider,
+			layoutDisplayPageProvider);
 
 		InfoItemFieldValuesProvider<Object> infoItemFieldValuesProvider =
 			infoItemServiceTracker.getFirstInfoItemService(
@@ -204,7 +205,8 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 		}
 
 		Layout layout = _getLayoutDisplayPageObjectProviderLayout(
-			layoutDisplayPageObjectProvider, layoutDisplayPageProvider);
+			groupId, layoutDisplayPageObjectProvider,
+			layoutDisplayPageProvider);
 
 		HttpServletRequest httpServletRequest =
 			(HttpServletRequest)requestContext.get("request");
@@ -331,13 +333,13 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 	}
 
 	private Layout _getLayoutDisplayPageObjectProviderLayout(
+		long groupId,
 		LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider,
 		LayoutDisplayPageProvider<?> layoutDisplayPageProvider) {
 
 		AssetDisplayPageEntry assetDisplayPageEntry =
 			assetDisplayPageEntryLocalService.fetchAssetDisplayPageEntry(
-				layoutDisplayPageObjectProvider.getGroupId(),
-				layoutDisplayPageObjectProvider.getClassNameId(),
+				groupId, layoutDisplayPageObjectProvider.getClassNameId(),
 				layoutDisplayPageObjectProvider.getClassPK());
 
 		if (assetDisplayPageEntry != null) {
@@ -371,7 +373,7 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 
 				if (parentLayoutDisplayPageObjectProvider != null) {
 					return _getLayoutDisplayPageObjectProviderLayout(
-						parentLayoutDisplayPageObjectProvider,
+						groupId, parentLayoutDisplayPageObjectProvider,
 						layoutDisplayPageProvider);
 				}
 			}
@@ -379,8 +381,7 @@ public abstract class BaseAssetDisplayPageFriendlyURLResolver
 
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			layoutPageTemplateEntryService.fetchDefaultLayoutPageTemplateEntry(
-				layoutDisplayPageObjectProvider.getGroupId(),
-				layoutDisplayPageObjectProvider.getClassNameId(),
+				groupId, layoutDisplayPageObjectProvider.getClassNameId(),
 				layoutDisplayPageObjectProvider.getClassTypeId());
 
 		if (layoutPageTemplateEntry != null) {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java
@@ -403,7 +403,7 @@ public class JournalArticleAssetRenderer
 			layout = themeDisplay.getLayout();
 		}
 
-		if (!_isShowDisplayPage(_article.getGroupId(), _article)) {
+		if (!_isShowDisplayPage(themeDisplay.getScopeGroupId(), _article)) {
 			String hitLayoutURL = getHitLayoutURL(
 				layout.isPrivateLayout(), noSuchEntryRedirect, themeDisplay);
 
@@ -657,20 +657,21 @@ public class JournalArticleAssetRenderer
 	private boolean _isShowDisplayPage(long groupId, JournalArticle article)
 		throws Exception {
 
+		if (Validator.isNotNull(article.getLayoutUuid())) {
+			return false;
+		}
+
 		AssetRendererFactory<JournalArticle> assetRendererFactory =
 			getAssetRendererFactory();
 
 		AssetEntry assetEntry = assetRendererFactory.getAssetEntry(
 			JournalArticle.class.getName(), article.getResourcePrimKey());
 
-		boolean hasDisplayPage = AssetDisplayPageUtil.hasAssetDisplayPage(
-			groupId, assetEntry);
-
-		if (Validator.isNull(article.getLayoutUuid()) && !hasDisplayPage) {
-			return false;
+		if (AssetDisplayPageUtil.hasAssetDisplayPage(groupId, assetEntry)) {
+			return true;
 		}
 
-		return true;
+		return false;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
@@ -14,6 +14,7 @@
 
 package com.liferay.journal.web.internal.layout.display.page;
 
+import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
@@ -63,15 +64,13 @@ public class JournalArticleLayoutDisplayPageProvider
 	public LayoutDisplayPageObjectProvider<JournalArticle>
 		getLayoutDisplayPageObjectProvider(long groupId, String urlTitle) {
 
-		JournalArticle article =
-			journalArticleLocalService.fetchArticleByUrlTitle(
-				groupId, urlTitle);
-
-		if ((article == null) || article.isInTrash()) {
-			return null;
-		}
-
 		try {
+			JournalArticle article = _getArticle(groupId, urlTitle);
+
+			if ((article == null) || article.isInTrash()) {
+				return null;
+			}
+
 			return new JournalArticleLayoutDisplayPageObjectProvider(article);
 		}
 		catch (PortalException portalException) {
@@ -86,5 +85,27 @@ public class JournalArticleLayoutDisplayPageProvider
 
 	@Reference
 	protected JournalArticleLocalService journalArticleLocalService;
+
+	private JournalArticle _getArticle(long groupId, String urlTitle)
+		throws PortalException {
+
+		for (long connectedGroupId :
+				_siteConnectedGroupGroupProvider.
+					getCurrentAndAncestorSiteAndDepotGroupIds(groupId)) {
+
+			JournalArticle article =
+				journalArticleLocalService.fetchArticleByUrlTitle(
+					connectedGroupId, urlTitle);
+
+			if (article != null) {
+				return article;
+			}
+		}
+
+		return null;
+	}
+
+	@Reference
+	private SiteConnectedGroupGroupProvider _siteConnectedGroupGroupProvider;
 
 }

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLProviderImpl.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLProviderImpl.java
@@ -68,26 +68,21 @@ public class AssetDisplayPageFriendlyURLProviderImpl
 			return null;
 		}
 
-		if (!AssetDisplayPageUtil.hasAssetDisplayPage(
-				layoutDisplayPageObjectProvider.getGroupId(),
-				layoutDisplayPageObjectProvider.getClassNameId(),
-				layoutDisplayPageObjectProvider.getClassPK(),
-				layoutDisplayPageObjectProvider.getClassTypeId())) {
+		String friendlyURL = _getFriendlyURL(
+			themeDisplay.getScopeGroupId(), layoutDisplayPageProvider,
+			layoutDisplayPageObjectProvider, locale, themeDisplay);
 
-			return null;
+		if ((friendlyURL != null) ||
+			(themeDisplay.getScopeGroupId() ==
+				layoutDisplayPageObjectProvider.getGroupId())) {
+
+			return friendlyURL;
 		}
 
-		StringBundler sb = new StringBundler(3);
-
-		sb.append(
-			_getGroupFriendlyURL(
-				layoutDisplayPageObjectProvider.getGroupId(), locale,
-				themeDisplay));
-
-		sb.append(layoutDisplayPageProvider.getURLSeparator());
-		sb.append(layoutDisplayPageObjectProvider.getURLTitle(locale));
-
-		return sb.toString();
+		return _getFriendlyURL(
+			layoutDisplayPageObjectProvider.getGroupId(),
+			layoutDisplayPageProvider, layoutDisplayPageObjectProvider, locale,
+			themeDisplay);
 	}
 
 	@Override
@@ -97,6 +92,30 @@ public class AssetDisplayPageFriendlyURLProviderImpl
 
 		return getFriendlyURL(
 			className, classPK, themeDisplay.getLocale(), themeDisplay);
+	}
+
+	private String _getFriendlyURL(
+			long groupId,
+			LayoutDisplayPageProvider<?> layoutDisplayPageProvider,
+			LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider,
+			Locale locale, ThemeDisplay themeDisplay)
+		throws PortalException {
+
+		if (!AssetDisplayPageUtil.hasAssetDisplayPage(
+				groupId, layoutDisplayPageObjectProvider.getClassNameId(),
+				layoutDisplayPageObjectProvider.getClassPK(),
+				layoutDisplayPageObjectProvider.getClassTypeId())) {
+
+			return null;
+		}
+
+		StringBundler sb = new StringBundler(3);
+
+		sb.append(_getGroupFriendlyURL(groupId, locale, themeDisplay));
+		sb.append(layoutDisplayPageProvider.getURLSeparator());
+		sb.append(layoutDisplayPageObjectProvider.getURLTitle(locale));
+
+		return sb.toString();
 	}
 
 	private String _getGroupFriendlyURL(


### PR DESCRIPTION
Currently, when looking for a display page, the element group ID is used. This makes it not possible to use the site default display page with content from Global or any Asset Library.

See video attached to the Jira ticket to see this behaviour.

Thanks!