### PR TITLE
LPS-135698 Use host header to pass the virtual host to the server

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/util/LayoutCrawler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/util/LayoutCrawler.java
@@ -79,6 +79,10 @@ public class LayoutCrawler {
 			HttpGet httpGet = new HttpGet(
 				_portal.getLayoutFullURL(layout, themeDisplay));
 
+			String companyVirtualHost = company.getVirtualHostname();
+
+			httpGet.setHeader("Host", companyVirtualHost);
+
 			HttpClientContext httpClientContext = new HttpClientContext();
 
 			CookieStore cookieStore = new BasicCookieStore();


### PR DESCRIPTION
This pull fixes https://issues.liferay.com/browse/LPS-135698

Hi team, could you please review this pull?

**Reproduction steps:**

-   Start a clean bundle
-   Set log levels for class "com.liferay.layout.internal.search.util.LayoutCrawler" to WARNING level
-   Create a new virtual instance
-   Access this virtual instance
-   Create a new page called pag1
-   Add some fragment to the page and click "publish"

**Expected behavior:**

- The page is correctly indexed without warnings in log. This can be verified by entering any text shown in any traduction of the layout in a Search Bar.

**Actual behavior:**

- Page is not indexed and in the logs there are warnings like:
`[LayoutCrawler:105] Unable to get layout content`

**Info:**
Right now when a layout is indexed, in LayoutCrawler class the method _portal.getPortalServerInetAddress is called to obtain server's IP address and from it, the hostname and the port are obtained in order to send the request. The problem is that the InetAddresses are calculated in the first request and they are not recalculated for each layout modification, see [PortalImpl.java#L6881-L6887](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/PortalImpl.java#L6881-L6887). This causes problems when there are multiple virtual instances in the same server because all the requests sent by LayoutCrawler are sent to the same domain.

