### PR TITLE
 LPS-132737 product-navigation-simulation-device width and height inputs should only show on the custom tab

### DIFF
--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/_sidebar.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/_sidebar.scss
@@ -3,6 +3,12 @@ html#{$cadmin-selector} {
 		.sidebar-sm {
 			font-size: 14px;
 
+			.sidebar-header {
+				.close {
+					font-size: 14px;
+				}
+			}
+
 			.sheet-subtitle {
 				font-size: 12px;
 				margin-bottom: 16px;

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
@@ -91,7 +91,8 @@
 			</clay:row>
 
 			<clay:row
-				cssClass="custom-devices d-lg-flex d-none hide mt-3"
+				cssClass="custom-devices hide mt-3"
+				hidden="hidden"
 				id='<%= liferayPortletResponse.getNamespace() + "customDeviceContainer" %>'
 			>
 				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "height") + " (px):" %>' name="height" size="4" value="600" wrapperCssClass="flex-grow-1 mr-3" />

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_panel.scss
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_panel.scss
@@ -34,6 +34,10 @@ html#{$cadmin-selector} {
 			}
 
 			.custom-devices {
+				@include media-breakpoint-down(md, $cadmin-grid-breakpoints) {
+					display: none !important;
+				}
+
 				.form-control {
 					border-radius: 4px;
 					padding: 8px 12px;

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/java/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/SimulationProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/java/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/SimulationProductNavigationControlMenuEntry.java
@@ -233,7 +233,7 @@ public class SimulationProductNavigationControlMenuEntry
 
 			IconTag iconTag = new IconTag();
 
-			iconTag.setCssClass("icon-monospaced sidenav-close");
+			iconTag.setCssClass("close sidenav-close");
 			iconTag.setImage("times");
 			iconTag.setMarkupView("lexicon");
 			iconTag.setUrl("javascript:;");


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-132737

- product-navigation-simulation-web sidebar close button should be styled and line up vertically with panel collapse icons

![custom-device-hidden](https://user-images.githubusercontent.com/788266/127036681-5c0c9724-fc7b-42af-ab8c-1e5296bcccd7.jpg)
![custom-device-show](https://user-images.githubusercontent.com/788266/127036745-3a9f575f-0801-4c9c-941d-2954b31cc8ed.jpg)
