### PR TITLE
LPS-132737 product-navigation-control-menu-theme-contributor adds imp…

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -50,6 +50,15 @@ html#{$cadmin-selector} {
 				padding: 2px;
 			}
 
+			#impersonate-user-sticker {
+				bottom: -6.4px;
+				color: $cadmin-gray-900;
+				font-size: 9.6px;
+				height: 19.2px;
+				right: -6.4px;
+				width: 19.2px;
+			}
+
 			a:not(.dropdown-item),
 			button:not(.btn-link):not(.dropdown-item):not(.nav-link) {
 				&:focus,


### PR DESCRIPTION
…ersonate-user-icon styles. They are being overwritten by cadmin.

@victorg1991 This fixes the `impersonate-user-icon` being wrong size and color. The other issues in the Product Menu and Control Menu are due to `product-navigation-product-menu-web` and `product-navigation-control-menu-web` css not being included.

Screenshot:
![impersonate-user1](https://user-images.githubusercontent.com/788266/127193559-062c736d-8525-4c2b-a753-51ab789a7037.jpg)
