### PR TITLE
LPS-136434 Gracefully handle invalid FragmentCollection

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryStagedModelDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryStagedModelDataHandler.java
@@ -26,6 +26,8 @@ import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -199,6 +201,9 @@ public class FragmentEntryStagedModelDataHandler
 		return _stagedModelRepository;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		FragmentEntryStagedModelDataHandler.class);
+
 	@Reference(target = "(content.processor.type=DLReferences)")
 	private ExportImportContentProcessor<String>
 		_dlReferencesExportImportContentProcessor;
@@ -214,5 +219,6 @@ public class FragmentEntryStagedModelDataHandler
 		unbind = "-"
 	)
 	private StagedModelRepository<FragmentEntry> _stagedModelRepository;
+
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryStagedModelDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryStagedModelDataHandler.java
@@ -25,6 +25,7 @@ import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.service.FragmentCollectionLocalService;
 import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -81,6 +82,22 @@ public class FragmentEntryStagedModelDataHandler
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.fetchFragmentCollection(
 				fragmentEntry.getFragmentCollectionId());
+
+		if (fragmentCollection == null) {
+			if (_log.isWarnEnabled()) {
+				StringBundler sb = new StringBundler(5);
+
+				sb.append("FragmentEntry ");
+				sb.append(fragmentEntry.getFragmentEntryId());
+				sb.append(" - ");
+				sb.append(fragmentEntry.getFragmentEntryKey());
+				sb.append(" has invalid fragment collection, unable to export");
+
+				_log.warn(sb.toString());
+			}
+
+			return;
+		}
 
 		StagedModelDataHandlerUtil.exportReferenceStagedModel(
 			portletDataContext, fragmentEntry, fragmentCollection,
@@ -219,6 +236,5 @@ public class FragmentEntryStagedModelDataHandler
 		unbind = "-"
 	)
 	private StagedModelRepository<FragmentEntry> _stagedModelRepository;
-
 
 }


### PR DESCRIPTION
This is for https://issues.liferay.com/browse/LPS-136434. A client keeps getting into situations where the FragmentCollection is invalid leading the an NPE which totally stops publishing from staging until the data is cleaned up. This change will report the fragment with the invalid FragmentCollection and return, and will not stop publishing from completing.