### PR TITLE
[TS] LPS-135330 Content display fragment points to staging web content in live site

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -1011,7 +1011,7 @@ public class JournalArticleStagedModelDataHandler
 			StagedModelDataHandlerUtil.importReferenceStagedModels(
 				portletDataContext, article, Layout.class);
 
-			content =
+			String replacedContent =
 				_journalArticleExportImportContentProcessor.
 					replaceImportContentReferences(
 						portletDataContext, article, content);
@@ -1022,15 +1022,15 @@ public class JournalArticleStagedModelDataHandler
 			if (newContent !=
 					JournalCreationStrategy.ARTICLE_CONTENT_UNCHANGED) {
 
-				content = newContent;
+				replacedContent = newContent;
 			}
 
-			if (!StringUtil.equals(importedArticle.getContent(), content)) {
+			if (!StringUtil.equals(replacedContent, content)) {
 				importedArticle = _journalArticleLocalService.updateArticle(
 					userId, importedArticle.getGroupId(), folderId,
 					importedArticle.getArticleId(), article.getVersion(),
 					article.getTitleMap(), article.getDescriptionMap(),
-					friendlyURLMap, content, parentDDMStructureKey,
+					friendlyURLMap, replacedContent, parentDDMStructureKey,
 					parentDDMTemplateKey, article.getLayoutUuid(),
 					displayDateMonth, displayDateDay, displayDateYear,
 					displayDateHour, displayDateMinute, expirationDateMonth,

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -1003,6 +1003,11 @@ public class JournalArticleStagedModelDataHandler
 				article.getResourcePrimKey(),
 				importedArticle.getResourcePrimKey());
 
+			if (Validator.isNull(newArticleId)) {
+				articleIds.put(
+					article.getArticleId(), importedArticle.getArticleId());
+			}
+
 			StagedModelDataHandlerUtil.importReferenceStagedModels(
 				portletDataContext, article, Layout.class);
 


### PR DESCRIPTION
Hi @liferay-echo ,

I've implemented a fix for this staging related issue ([LPS-135330](https://issues.liferay.com/browse/LPS-135330), but also fixes the use-case of [LPS-125882](https://issues.liferay.com/browse/LPS-125882)). The problem is caused by a circular dependency between staged entities, which changes the order of import. Thus, the ID mapping of the JournalArticle will not be available in PortletDataContext, when the references in FragmentEntryLink are replaced.
My fix basically adds Layouts to the list of entity types that should be skipped prior to JournalArticle import: https://github.com/liferay-echo/liferay-portal/commit/cce01c9e3676958d030ff2bc03fb2cce83386185#diff-89c6f3ff2379bd22f157f28fa71fbc6fd2d985d8b0f5a64fb6663d03e54e566aR1283
And it starts importing them, once the JournalArticle record is created (or found for update) and its ID mapping is put in PortletDataContext.
As a final solution, we are investigating whether a 2-phase import for all entries would be possible ([LPS-136646](https://issues.liferay.com/browse/LPS-136646)).
However, that would require changes in the staging framework as well, so I'm changing only `JournalArticleStagedModelDataHandler` now.

Please review my changes.

Thanks,
Vendel