### PR TITLE
[TS] LPS-137055 Hide this option like how SetAsDefaultAssetPublisher is hidden

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/set_enable.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/set_enable.jsp
@@ -35,9 +35,9 @@ String helpMessage2 = "<em>" + LanguageUtil.format(request, "content-with-tag-x"
 
 <c:if test="<%= assetPublisherDisplayContext.isEnableSetAsDefaultAssetPublisher() %>">
 	<aui:input helpMessage="set-as-the-default-asset-publisher-for-this-page-help" label="set-as-the-default-asset-publisher-for-this-page" name="defaultAssetPublisher" type="checkbox" value="<%= assetPublisherWebHelper.isDefaultAssetPublisher(layout, portletDisplay.getId(), assetPublisherDisplayContext.getPortletResource()) %>" />
-</c:if>
 
-<aui:input label='<%= LanguageUtil.format(request, "show-only-assets-with-x-as-its-display-page-template", HtmlUtil.escape(layout.getName(locale)), false) %>' name="preferences--showOnlyLayoutAssets--" type="checkbox" value="<%= assetPublisherDisplayContext.isShowOnlyLayoutAssets() %>" />
+	<aui:input label='<%= LanguageUtil.format(request, "show-only-assets-with-x-as-its-display-page-template", HtmlUtil.escape(layout.getName(locale)), false) %>' name="preferences--showOnlyLayoutAssets--" type="checkbox" value="<%= assetPublisherDisplayContext.isShowOnlyLayoutAssets() %>" />
+</c:if>
 
 <aui:input label="include-tags-specified-in-the-url" name="preferences--mergeUrlTags--" type="checkbox" value="<%= assetPublisherDisplayContext.isMergeURLTags() %>" />
 


### PR DESCRIPTION
Hi Team,

Given that 'Show only assets with [name] as its display page template' sets a layoutUuid filter to to the Asset Publisher's query, it is not needed if we can't set a page as Display Page Template using a default Asset Publisher (https://issues.liferay.com/browse/LPS-108269).

Another approach would be to improve how asset searching happens, but I wanted to validate the easier solution first.

Can you please review?
https://issues.liferay.com/browse/LPS-137055

Thanks,
Balázs