### PR TITLE
LPS-132502 Passing collection itemType as request attribute

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentObjectFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentObjectFragmentRenderer.java
@@ -288,6 +288,13 @@ public class ContentObjectFragmentRenderer implements FragmentRenderer {
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		String itemType = (String)httpServletRequest.getAttribute(
+			InfoDisplayWebKeys.INFO_LIST_DISPLAY_OBJECT_ITEM_TYPE);
+
+		if (Validator.isNull(className) && Validator.isNotNull(itemType)) {
+			className = itemType;
+		}
+
 		LayoutDisplayPageProvider<?> layoutDisplayPageProvider =
 			(LayoutDisplayPageProvider<?>)httpServletRequest.getAttribute(
 				LayoutDisplayPageWebKeys.LAYOUT_DISPLAY_PAGE_PROVIDER);

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/constants/InfoDisplayWebKeys.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/constants/InfoDisplayWebKeys.java
@@ -44,6 +44,9 @@ public class InfoDisplayWebKeys {
 	public static final String INFO_LIST_DISPLAY_OBJECT =
 		"INFO_LIST_DISPLAY_OBJECT";
 
+	public static final String INFO_LIST_DISPLAY_OBJECT_ITEM_TYPE =
+		"INFO_LIST_DISPLAY_OBJECT_ITEM_TYPE";
+
 	public static final String VERSION_CLASS_PK = "VERSION_CLASS_PK";
 
 }

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/constants/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.3.0
+version 1.4.0

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderCollectionLayoutStructureItemDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderCollectionLayoutStructureItemDisplayContext.java
@@ -29,6 +29,7 @@ import com.liferay.layout.list.retriever.ListObjectReferenceFactory;
 import com.liferay.layout.list.retriever.ListObjectReferenceFactoryTracker;
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -173,6 +174,27 @@ public class RenderCollectionLayoutStructureItemDisplayContext {
 			listObjectReference, _getDefaultLayoutListRetrieverContext());
 
 		return _collectionCount;
+	}
+
+	public String getCollectionItemType() {
+		if (_collectionItemType != null) {
+			return _collectionItemType;
+		}
+
+		JSONObject collectionJSONObject =
+			_collectionStyledLayoutStructureItem.getCollectionJSONObject();
+
+		String collectionItemType = StringPool.BLANK;
+
+		if ((collectionJSONObject != null) &&
+			collectionJSONObject.has("itemType")) {
+
+			collectionItemType = collectionJSONObject.getString("itemType");
+		}
+
+		_collectionItemType = collectionItemType;
+
+		return _collectionItemType;
 	}
 
 	public LayoutDisplayPageProvider<?>
@@ -467,6 +489,7 @@ public class RenderCollectionLayoutStructureItemDisplayContext {
 
 	private Integer _activePage;
 	private Integer _collectionCount;
+	private String _collectionItemType;
 	private final CollectionStyledLayoutStructureItem
 		_collectionStyledLayoutStructureItem;
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -263,6 +263,11 @@ public class RenderLayoutStructureTag extends IncludeTag {
 						httpServletRequest.setAttribute(
 							InfoDisplayWebKeys.INFO_LIST_DISPLAY_OBJECT,
 							collection.get(index));
+						httpServletRequest.setAttribute(
+							InfoDisplayWebKeys.
+								INFO_LIST_DISPLAY_OBJECT_ITEM_TYPE,
+							renderCollectionLayoutStructureItemDisplayContext.
+								getCollectionItemType());
 
 						ColTag colTag = new ColTag();
 
@@ -288,6 +293,8 @@ public class RenderLayoutStructureTag extends IncludeTag {
 			finally {
 				httpServletRequest.removeAttribute(
 					InfoDisplayWebKeys.INFO_LIST_DISPLAY_OBJECT);
+				httpServletRequest.removeAttribute(
+					InfoDisplayWebKeys.INFO_LIST_DISPLAY_OBJECT_ITEM_TYPE);
 
 				httpServletRequest.setAttribute(
 					LayoutDisplayPageWebKeys.LAYOUT_DISPLAY_PAGE_PROVIDER,


### PR DESCRIPTION
Passing collection itemType as request attribute to check permissions against the proper InfoItemPermissionProvider implementation.

https://issues.liferay.com/browse/LPS-132502