### PR TITLE
[TS] LPS-137002 | master

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutModelListener.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutModelListener.java
@@ -101,6 +101,22 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 		}
 	}
 
+	private Void _copySiteNavigationMenu(
+		Layout layout, UnicodeProperties unicodeProperties) {
+
+		UnicodeProperties layoutUnicodeProperties =
+			layout.getTypeSettingsProperties();
+
+		if (layoutUnicodeProperties.containsKey("siteNavigationMenuId")) {
+			String siteNavigationMenuId = layoutUnicodeProperties.getProperty(
+				"siteNavigationMenuId");
+
+			unicodeProperties.put("siteNavigationMenuId", siteNavigationMenuId);
+		}
+
+		return null;
+	}
+
 	private Void _copyStructure(
 			LayoutPageTemplateEntry layoutPageTemplateEntry, Layout layout)
 		throws Exception {
@@ -122,6 +138,8 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 
 		UnicodeProperties unicodeProperties =
 			draftLayout.getTypeSettingsProperties();
+
+		_copySiteNavigationMenu(layout, unicodeProperties);
 
 		unicodeProperties.put("published", Boolean.FALSE.toString());
 


### PR DESCRIPTION
### Issue
 "Add This Page to Menu" doesn't add the page to the menu when using a custom template
Reference: https://issues.liferay.com/browse/LPS-137002

### Steps to reproduce

1.  Go to Site Builder --> Navigation Menu
2.  Create a new Navigation Menu with a name "Test Menu"
3.  Go to Home page and click on configuration of the Navigation Menu portlet
4.  Choose your new menu "Test Menu"
5.  Go to Design --> Page Templates --> (Tab) Page Templates
6.  Create new Collections with a name "Test Collection"
7.  Create new Content Page Template with a name "Test Collection Page" and Publish
8.  Go to Site Builder --> Pages
9.  Add a new Public Pages and select your "Test Collection Page" in "Test Collection".
10. Create a new Page with name "Test Page", check the box "Add This Page to Test Menu" and Publish

### Expected Behavior
Navigation menu "Test Menu" is visible in "Test Page".

### Actual Behavior
Navigation menu is not visible. You must add "Test Page" in "Test Menu" configuration to be able to visible it.

### Additional Information
The issue does not happen  when the page is created with a global template.

### Solution proposed:
In https://github.com/liferay-echo/liferay-portal/blob/master/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/model/listener/LayoutModelListener.java#L118-L119 a layout draft is done from original layout. 
But the type setting property '_siteNavigationMenuId_' is not copied into the draft layout so the navigation menu is lost.
The proposed solution checks whether that property is present in original layout. If so, it is copied to the draft layout to keep navigation menu reference.

Regards.
 Sergio.