### PR TITLE
LPS-137335 HTML Fragment Editor Modal unisolate the modal so ace edit…

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/HTMLProcessor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/HTMLProcessor.js
@@ -66,6 +66,9 @@ function createEditor(element, changeCallback, destroyCallback) {
 				},
 			},
 		],
+		containerProps: {
+			className: '',
+		},
 		onClose: () => destroyCallback(),
 		onOpen: () => {
 			Liferay.Util.getTop()


### PR DESCRIPTION
…or styles still apply

https://issues.liferay.com/browse/LPS-137335

@victorg1991 This is a temp solution to fix this bug. I'll send another pr isolating the modal once https://github.com/liferay/clay/pull/4223 and https://github.com/liferay/clay/pull/4225 are released and brought in. Feel free to close this if a fix isn't needed immediately.