### PR TITLE
LPS-137268 Enable Template App

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/application/list/PortletDisplayTemplatePanelApp.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/application/list/PortletDisplayTemplatePanelApp.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Eudaldo Alonso
  */
 @Component(
-	immediate = true,
+	enabled = false, immediate = true,
 	property = {
 		"panel.app.order:Integer=500",
 		"panel.category.key=" + PanelCategoryKeys.SITE_ADMINISTRATION_DESIGN

--- a/modules/apps/portlet-display-template/portlet-display-template-web-test/bnd.bnd
+++ b/modules/apps/portlet-display-template/portlet-display-template-web-test/bnd.bnd
@@ -1,3 +1,0 @@
-Bundle-Name: Liferay Portlet Display Template Web Test
-Bundle-SymbolicName: com.liferay.portlet.display.template.web.test
-Bundle-Version: 1.0.0

--- a/modules/apps/portlet-display-template/portlet-display-template-web/src/main/java/com/liferay/portlet/display/template/web/internal/exportimport/data/handler/PortletDisplayTemplatePortletDataHandler.java
+++ b/modules/apps/portlet-display-template/portlet-display-template-web/src/main/java/com/liferay/portlet/display/template/web/internal/exportimport/data/handler/PortletDisplayTemplatePortletDataHandler.java
@@ -54,6 +54,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Juan Fernández
  */
 @Component(
+	enabled = false,
 	property = "javax.portlet.name=" + PortletKeys.PORTLET_DISPLAY_TEMPLATE,
 	service = PortletDataHandler.class
 )

--- a/modules/apps/roles/roles-admin-web/build.gradle
+++ b/modules/apps/roles/roles-admin-web/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	compileOnly project(":apps:segments:segments-api")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
+	compileOnly project(":apps:template:template-api")
 	compileOnly project(":core:osgi-service-tracker-collections")
 	compileOnly project(":core:petra:petra-function")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_form.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_form.jsp
@@ -161,7 +161,7 @@ if (Validator.isNotNull(portletResource)) {
 
 						Portlet curPortlet = PortletLocalServiceUtil.getPortletById(company.getCompanyId(), resource);
 
-						if (portlet.isSystem()) {
+						if (curPortlet.isSystem()) {
 							continue;
 						}
 

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_form.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/edit_role_permissions_form.jsp
@@ -121,7 +121,7 @@ if (Validator.isNotNull(portletResource)) {
 			</clay:sheet-section>
 		</c:if>
 
-		<c:if test="<%= portletResource.equals(PortletKeys.PORTLET_DISPLAY_TEMPLATE) %>">
+		<c:if test="<%= portletResource.equals(PortletKeys.PORTLET_DISPLAY_TEMPLATE) || portletResource.equals(TemplatePortletKeys.TEMPLATE) %>">
 			<clay:sheet-section>
 				<h4 class="sheet-subtitle"><liferay-ui:message key="related-application-permissions" /></h4>
 

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -138,6 +138,7 @@ page import="com.liferay.roles.admin.web.internal.role.type.contributor.util.Rol
 page import="com.liferay.roles.admin.web.internal.util.PortletDisplayTemplateUtil" %><%@
 page import="com.liferay.segments.service.SegmentsEntryRoleLocalServiceUtil" %><%@
 page import="com.liferay.taglib.search.ResultRow" %><%@
+page import="com.liferay.template.constants.TemplatePortletKeys" %><%@
 page import="com.liferay.users.admin.kernel.util.UsersAdmin" %><%@
 page import="com.liferay.users.admin.kernel.util.UsersAdminUtil" %>
 

--- a/modules/apps/template/template-web-test/bnd.bnd
+++ b/modules/apps/template/template-web-test/bnd.bnd
@@ -1,0 +1,3 @@
+Bundle-Name: Liferay Template Web Test
+Bundle-SymbolicName: com.liferay.template.web.test
+Bundle-Version: 1.0.0

--- a/modules/apps/template/template-web-test/build.gradle
+++ b/modules/apps/template/template-web-test/build.gradle
@@ -4,5 +4,6 @@ dependencies {
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
 	testIntegrationCompile project(":apps:export-import:export-import-test-util")
 	testIntegrationCompile project(":apps:portlet-display-template:portlet-display-template-api")
+	testIntegrationCompile project(":apps:template:template-api")
 	testIntegrationCompile project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/template/template-web-test/src/testIntegration/java/com/liferay/template/web/internal/exportimport/data/handler/test/TemplatePortletDataHandlerTest.java
+++ b/modules/apps/template/template-web-test/src/testIntegration/java/com/liferay/template/web/internal/exportimport/data/handler/test/TemplatePortletDataHandlerTest.java
@@ -12,7 +12,7 @@
  * details.
  */
 
-package com.liferay.portlet.display.template.web.internal.exportimport.data.handler.test;
+package com.liferay.template.web.internal.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
@@ -20,9 +20,9 @@ import com.liferay.exportimport.kernel.lar.DataLevel;
 import com.liferay.exportimport.test.util.lar.BasePortletDataHandlerTestCase;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portlet.display.template.PortletDisplayTemplate;
+import com.liferay.template.constants.TemplatePortletKeys;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -30,9 +30,10 @@ import org.junit.runner.RunWith;
 
 /**
  * @author Daniel Kocsis
+ * @author Lourdes Fernández Besada
  */
 @RunWith(Arquillian.class)
-public class PortletDisplayTemplatePortletDataHandlerTest
+public class TemplatePortletDataHandlerTest
 	extends BasePortletDataHandlerTestCase {
 
 	@ClassRule
@@ -54,7 +55,7 @@ public class PortletDisplayTemplatePortletDataHandlerTest
 
 	@Override
 	protected String getPortletId() {
-		return PortletKeys.PORTLET_DISPLAY_TEMPLATE;
+		return TemplatePortletKeys.TEMPLATE;
 	}
 
 	@Override

--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/application/list/TemplatePortletPanelApp.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/application/list/TemplatePortletPanelApp.java
@@ -27,7 +27,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Lourdes Fernández Besada
  */
 @Component(
-	enabled = false, immediate = true,
+	immediate = true,
 	property = {
 		"panel.app.order:Integer=350",
 		"panel.category.key=" + PanelCategoryKeys.SITE_ADMINISTRATION_DESIGN

--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/display/context/WidgetTemplatesEditDDMTemplateDisplayContext.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/display/context/WidgetTemplatesEditDDMTemplateDisplayContext.java
@@ -19,6 +19,8 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateHandlerRegistryUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.WebKeys;
 
 /**
  * @author Eudaldo Alonso
@@ -36,11 +38,21 @@ public class WidgetTemplatesEditDDMTemplateDisplayContext
 		_ddmWebConfiguration =
 			(DDMWebConfiguration)liferayPortletRequest.getAttribute(
 				DDMWebConfiguration.class.getName());
+		_themeDisplay = (ThemeDisplay)liferayPortletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 	}
 
 	@Override
 	public boolean autogenerateTemplateKey() {
 		return _ddmWebConfiguration.autogenerateTemplateKey();
+	}
+
+	@Override
+	public String getTemplateTypeLabel() {
+		TemplateHandler templateHandler =
+			TemplateHandlerRegistryUtil.getTemplateHandler(getClassNameId());
+
+		return templateHandler.getName(_themeDisplay.getLocale());
 	}
 
 	@Override
@@ -56,5 +68,6 @@ public class WidgetTemplatesEditDDMTemplateDisplayContext
 	}
 
 	private final DDMWebConfiguration _ddmWebConfiguration;
+	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/portlet/configuration/icon/TemplateExportScriptConfigurationIcon.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/portlet/configuration/icon/TemplateExportScriptConfigurationIcon.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true,
 	property = {
 		"javax.portlet.name=" + TemplatePortletKeys.TEMPLATE,
-		"path=/edit_ddm_template.jsp"
+		"path=/template/edit_ddm_template"
 	},
 	service = PortletConfigurationIcon.class
 )

--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/portlet/configuration/icon/TemplateImportScriptConfigurationIcon.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/portlet/configuration/icon/TemplateImportScriptConfigurationIcon.java
@@ -32,7 +32,7 @@ import org.osgi.service.component.annotations.Reference;
 	immediate = true,
 	property = {
 		"javax.portlet.name=" + TemplatePortletKeys.TEMPLATE,
-		"path=/edit_ddm_template.jsp"
+		"path=/template/edit_ddm_template"
 	},
 	service = PortletConfigurationIcon.class
 )

--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/upgrade/TemplateUpgrade.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/upgrade/TemplateUpgrade.java
@@ -25,9 +25,7 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author Lourdes Fernández Besada
  */
-@Component(
-	enabled = false, immediate = true, service = UpgradeStepRegistrator.class
-)
+@Component(immediate = true, service = UpgradeStepRegistrator.class)
 public class TemplateUpgrade implements UpgradeStepRegistrator {
 
 	@Override

--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/upgrade/TemplateUpgrade.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/upgrade/TemplateUpgrade.java
@@ -35,7 +35,7 @@ public class TemplateUpgrade implements UpgradeStepRegistrator {
 		registry.register("0.0.0", "1.0.0", new DummyUpgradeStep());
 
 		registry.register(
-			"0.0.1", "1.0.1",
+			"1.0.0", "1.0.1",
 			new BasePortletIdUpgradeProcess() {
 
 				@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-137268

This PR enables templates panel app and disables the widget pages panel app. 
Also, it enable TemplatePortlet export/import/staging and disable  export/import/staging of Widget pages portlet.
This change causes, at least, the failure of a lars Import POSHI test because it uses an old lar file, which should be updated to not contain references to widget templates. 
This is an example of a failed execution:

https://testray.liferay.com/reports/production/logs/2021-08/test-1-32/test-portal-acceptance-pullrequest(master)/182/functional-tomcat90-mysql57-jdk8/0/9/LocalFile.StagingUsecase_ImportLARsOnStagedSite/summary.html.gz

It could also be useful to launch more exhaustive tests on this PR