### PR TITLE
[TS] LPS-137532 Have search container return only the orphan portlets to be displayed

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/OrphanPortletsDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/OrphanPortletsDisplayContext.java
@@ -184,9 +184,13 @@ public class OrphanPortletsDisplayContext {
 
 		List<Portlet> portlets = getOrphanPortlets();
 
-		orphanPortletsSearchContainer.setResults(portlets);
-
 		orphanPortletsSearchContainer.setTotal(portlets.size());
+
+		portlets = ListUtil.subList(
+			portlets, orphanPortletsSearchContainer.getStart(),
+			orphanPortletsSearchContainer.getEnd());
+
+		orphanPortletsSearchContainer.setResults(portlets);
 
 		_orphanPortletsSearchContainer = orphanPortletsSearchContainer;
 


### PR DESCRIPTION
Hi team,

Can you help review this PR?

**Notes from @noornajj:**

> https://issues.liferay.com/browse/LPS-137532
> 
> The issue here was that the orphan widgets page would not update with the correct number of entries when the number of entries per paged was less than the total number of entries.
>
> To fix this, I made sure the results in the orphanPortletsSearchContainer only holds the portlets to be displayed instead of all the portlets.

Feel free to let us know if you have any questions.
Thanks!