### PR TITLE
LPS-138591 Isolate Page Editor Edit Image and Edit HTML modals

### DIFF
--- a/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
+++ b/modules/apps/frontend-css/frontend-css-cadmin-web/src/main/resources/META-INF/resources/clay_admin.scss
@@ -280,6 +280,15 @@ html#{$cadmin-selector} {
 			padding: 12px;
 		}
 
+		// Lfr Source Editor
+
+		&.lfr-fullscreen-source-editor-header {
+			height: 40px;
+			margin-right: 4px;
+			margin-top: 4px;
+			min-height: 40px;
+		}
+
 		// Lfr Upload Container
 
 		.upload-drop-intent .lfr-upload-container .upload-target {

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/fullscreen_source_editor.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/fullscreen_source_editor.js
@@ -18,7 +18,7 @@ AUI.add(
 		var Lang = A.Lang;
 
 		var CONTENT_TEMPLATE =
-			'<div class="lfr-fullscreen-source-editor-header row">' +
+			'<div class="cadmin lfr-fullscreen-source-editor-header row">' +
 			'<div class="col-6">' +
 			'<button class="btn btn-secondary btn-sm float-right lfr-portal-tooltip" data-title="{iconMoonTooltip}" id="switchTheme" type="button">' +
 			'<svg class="lexicon-icon lexicon-icon-moon" focusable="false" role="img">' +

--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/Modal.js
@@ -31,6 +31,8 @@ const Modal = ({
 		className: 'cadmin',
 	},
 	customEvents,
+	footerCssClass,
+	headerCssClass,
 	headerHTML,
 	height,
 	id,
@@ -181,7 +183,7 @@ const Modal = ({
 					status={status}
 					zIndex={zIndex}
 				>
-					<ClayModal.Header>
+					<ClayModal.Header className={headerCssClass}>
 						{headerHTML ? (
 							<div
 								dangerouslySetInnerHTML={{
@@ -224,6 +226,7 @@ const Modal = ({
 					</div>
 					{buttons && (
 						<ClayModal.Footer
+							className={footerCssClass}
 							last={
 								<ClayButton.Group spaced>
 									{buttons.map((button, index) => (
@@ -273,6 +276,8 @@ const openModal = (props) => {
 
 const openPortletModal = ({
 	containerProps,
+	footerCssClass,
+	headerCssClass,
 	iframeBodyCssClass,
 	onClose,
 	portletSelector,
@@ -310,6 +315,8 @@ const openPortletModal = ({
 
 		openModal({
 			containerProps,
+			footerCssClass,
+			headerCssClass,
 			headerHTML,
 			iframeBodyCssClass,
 			onClose,

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/css/image_editor.scss
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/css/image_editor.scss
@@ -1,110 +1,201 @@
-@import 'atlas-variables';
+@import 'cadmin-variables';
 
-.image-editor {
-	background-color: #4d4f65;
-	height: calc(100% - 56px);
-	position: relative;
+html#{$cadmin-selector}:not(._) {
+	.image-editor {
+		background-color: #4d4f65;
+		height: calc(100% - 56px);
+		position: relative;
 
-	.cropper-line {
-		background-color: $primary;
-		opacity: 1;
+		.cropper-container {
+			font-size: 0;
+			line-height: 0;
 
-		&.line-e,
-		&.line-w {
-			width: 2px;
+			img {
+				height: 100%;
+				width: 100%;
+			}
 		}
 
-		&.line-n,
-		&.line-s {
-			height: 2px;
+		.cropper-drag-box {
+			background-color: #fff;
+			cursor: grab;
+			opacity: 0;
+
+			&:active {
+				cursor: grabbing;
+			}
 		}
 
-		&.line-e {
-			right: 0;
+		.cropper-modal {
+			background-color: #000;
+			opacity: 0.5;
 		}
 
-		&.line-n {
-			top: 0;
+		.cropper-view-box {
+			height: 100%;
+			outline-color: $cadmin-primary;
+			width: 100%;
 		}
 
-		&.line-s {
-			bottom: 0;
+		.cropper-dashed {
+			&.dashed-h {
+				border-bottom-width: 1px;
+				border-top-width: 1px;
+				height: calc(100% / 3);
+				width: 100%;
+			}
+
+			&.dashed-v {
+				border-left-width: 1px;
+				border-right-width: 1px;
+				height: 100%;
+				width: calc(100% / 3);
+			}
 		}
 
-		&.line-w {
-			left: 0;
-		}
-	}
-
-	.cropper-point {
-		background-color: $white;
-		border: 3px solid $primary;
-		border-radius: 5px;
-		height: 10px !important;
-		width: 10px !important;
-
-		&.point-e {
-			margin-top: -5px;
-			right: -5px;
+		.cropper-center {
+			height: 0;
+			width: 0;
 		}
 
-		&.point-n {
-			margin-left: -5px;
-			top: -5px;
+		.cropper-face,
+		.cropper-line,
+		.cropper-point {
+			height: 100%;
+			width: 100%;
 		}
 
-		&.point-ne {
-			right: -5px;
-			top: -5px;
+		.cropper-face {
+			background-color: #fff;
 		}
 
-		&.point-nw {
-			left: -5px;
-			top: -5px;
+		.cropper-line {
+			background-color: $cadmin-primary;
+			opacity: 1;
+
+			&.line-e,
+			&.line-w {
+				width: 2px;
+			}
+
+			&.line-n,
+			&.line-s {
+				height: 2px;
+			}
+
+			&.line-e {
+				right: 0;
+			}
+
+			&.line-n {
+				top: 0;
+			}
+
+			&.line-s {
+				bottom: 0;
+			}
+
+			&.line-w {
+				left: 0;
+			}
 		}
 
-		&.point-s {
-			bottom: -5px;
-			margin-left: -5px;
+		.cropper-point {
+			background-color: $cadmin-white;
+			border: 3px solid $cadmin-primary;
+			border-radius: 5px;
+			height: 10px !important;
+			width: 10px !important;
+
+			&.point-e {
+				margin-top: -5px;
+				right: -5px;
+			}
+
+			&.point-n {
+				margin-left: -5px;
+				top: -5px;
+			}
+
+			&.point-ne {
+				right: -5px;
+				top: -5px;
+			}
+
+			&.point-nw {
+				left: -5px;
+				top: -5px;
+			}
+
+			&.point-s {
+				bottom: -5px;
+				margin-left: -5px;
+			}
+
+			&.point-se {
+				bottom: -5px;
+				height: 20px;
+				right: -5px;
+				width: 20px;
+
+				@include media-breakpoint-up(md, $cadmin-grid-breakpoints) {
+					height: 15px;
+					width: 15px;
+				}
+
+				@include media-breakpoint-up(lg, $cadmin-grid-breakpoints) {
+					height: 10px;
+					width: 10px;
+				}
+
+				@include media-breakpoint-up(xl, $cadmin-grid-breakpoints) {
+					height: 5px;
+					width: 5px;
+				}
+			}
+
+			&.point-sw {
+				bottom: -5px;
+				left: -5px;
+			}
+
+			&.point-w {
+				left: -5px;
+				margin-top: -5px;
+			}
 		}
 
-		&.point-se {
-			bottom: -5px;
-			right: -5px;
+		.cropper-bg {
+			background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQAQMAAAAlPW0iAAAAA3NCSVQICAjb4U/gAAAABlBMVEXMzMz////TjRV2AAAACXBIWXMAAArrAAAK6wGCiw1aAAAAHHRFWHRTb2Z0d2FyZQBBZG9iZSBGaXJld29ya3MgQ1M26LyyjAAAABFJREFUCJlj+M/AgBVhF/0PAH6/D/HkDxOGAAAAAElFTkSuQmCC);
 		}
 
-		&.point-sw {
-			bottom: -5px;
-			left: -5px;
+		.cropper-hide {
+			height: 0;
+			width: 0;
 		}
 
-		&.point-w {
-			left: -5px;
-			margin-top: -5px;
-		}
-	}
-
-	.cropper-view-box {
-		outline-color: $primary;
-	}
-
-	.tbar {
-		background-color: $dark-d2;
-		border: none;
-		padding: 8px;
-		text-align: center;
-
-		&.component-tbar,
-		.btn:not(.btn-primary),
-		.form-control,
-		.input-group-text {
-			color: $secondary-l1;
-		}
-
-		.form-control,
-		.input-group-text {
-			background-color: transparent;
+		.tbar {
+			background-color: $cadmin-dark-d2;
 			border: none;
+			padding: 8px;
+			text-align: center;
+
+			&.component-tbar,
+			.btn:not(.btn-primary),
+			.form-control,
+			.input-group-text {
+				color: $cadmin-secondary-l1;
+			}
+
+			.form-control,
+			.input-group-text {
+				background-color: transparent;
+				border: none;
+			}
 		}
+	}
+
+	.image-editor-modal .modal-body {
+		padding: 0;
 	}
 }

--- a/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/css/item_selector_preview.scss
+++ b/modules/apps/item-selector/item-selector-taglib/src/main/resources/META-INF/resources/css/item_selector_preview.scss
@@ -1,114 +1,116 @@
-@import 'atlas-variables';
+@import 'cadmin-variables';
 
-.item-selector-preview {
-	&.fullscreen {
-		background-color: $dark;
-		height: 100%;
-		left: 0;
-		position: fixed;
-		top: 0;
-		width: 100%;
-		z-index: 1;
-	}
-
-	.header > nav {
-		padding: 0.5rem 0;
-
-		strong {
-			font-size: 1rem;
-		}
-	}
-
-	.carousel {
-		height: calc(100% - 6.5rem);
-		padding: 3.5rem;
-		text-align: center;
-
-		@media (max-width: 768px) {
-			padding: 1rem;
-		}
-
-		.sidenav-content {
+html#{$cadmin-selector}:not(._) {
+	.item-selector-preview {
+		&.fullscreen {
+			background-color: $cadmin-dark;
 			height: 100%;
-			position: relative;
+			left: 0;
+			position: fixed;
+			top: 0;
+			width: 100%;
+			z-index: 1;
+		}
 
-			.pull-left,
-			.pull-right {
-				position: absolute;
-				top: calc(50% - 2rem);
-			}
+		.header > nav {
+			padding: 8px 0;
 
-			.pull-left {
-				left: 0;
-			}
-
-			.pull-right {
-				right: 0;
+			strong {
+				font-size: 16px;
 			}
 		}
 
-		img {
-			max-height: 100%;
-			max-width: 100%;
-		}
+		.carousel {
+			height: calc(100% - 104px);
+			padding: 56px;
+			text-align: center;
 
-		.icon-arrow {
-			font-size: 2rem;
-			position: relative;
-			z-index: 20;
+			@include media-breakpoint-down(sm, $cadmin-grid-breakpoints) {
+				padding: 16px;
+			}
 
-			&:active,
-			&:hover,
-			&:focus {
-				color: $white;
+			.sidenav-content {
+				height: 100%;
+				position: relative;
+
+				.pull-left,
+				.pull-right {
+					position: absolute;
+					top: calc(50% - 32px);
+				}
+
+				.pull-left {
+					left: 0;
+				}
+
+				.pull-right {
+					right: 0;
+				}
+			}
+
+			img {
+				max-height: 100%;
+				max-width: 100%;
+			}
+
+			.icon-arrow {
+				font-size: 32px;
+				position: relative;
+				z-index: 20;
+
+				&:active,
+				&:hover,
+				&:focus {
+					color: $cadmin-white;
+				}
+			}
+
+			.info-panel {
+				color: $cadmin-white;
+				height: calc(100% - 112px);
+				text-align: left;
+
+				.sidebar-header,
+				.sidebar-body {
+					min-width: $cadmin-sidenav-width;
+				}
+
+				.nav-link.active {
+					color: $cadmin-white;
+				}
+
+				.sidebar-dd {
+					color: $cadmin-secondary-l1;
+				}
+			}
+
+			&:not(.open) {
+				img,
+				.video-preview {
+					left: 50%;
+					position: absolute;
+					top: 50%;
+					transform: translate(-50%, -50%);
+				}
 			}
 		}
 
-		.info-panel {
-			color: $white;
-			height: calc(100% - 7rem);
-			text-align: left;
+		.footer {
+			background-color: $cadmin-secondary-d2;
+			bottom: 0;
+			color: $cadmin-white;
+			padding: 12px 24px;
+			position: fixed;
+			text-align: center;
+			width: 100%;
 
-			.sidebar-header,
-			.sidebar-body {
-				min-width: $sidenav-width;
-			}
-
-			.nav-link.active {
-				color: $white;
-			}
-
-			.sidebar-dd {
-				color: $secondary-l1;
+			> div {
+				float: right;
 			}
 		}
 
-		&:not(.open) {
-			img,
-			.video-preview {
-				left: 50%;
-				position: absolute;
-				top: 50%;
-				transform: translate(-50%, -50%);
-			}
+		.image-editor {
+			height: calc(100% - 115px);
 		}
-	}
-
-	.footer {
-		background-color: $secondary-d2;
-		bottom: 0;
-		color: $white;
-		padding: 0.75rem 1.5rem;
-		position: fixed;
-		text-align: center;
-		width: 100%;
-
-		> div {
-			float: right;
-		}
-	}
-
-	.image-editor {
-		height: calc(100% - 115px);
 	}
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/HTMLProcessor.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/processors/HTMLProcessor.js
@@ -69,6 +69,8 @@ function createEditor(element, changeCallback, destroyCallback) {
 		containerProps: {
 			className: '',
 		},
+		footerCssClass: 'cadmin',
+		headerCssClass: 'cadmin',
 		onClose: () => destroyCallback(),
 		onOpen: () => {
 			Liferay.Util.getTop()

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/contents/components/ImageEditorModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/contents/components/ImageEditorModal.js
@@ -110,6 +110,7 @@ export default function ImageEditorModal({
 	return (
 		<ClayModal
 			className="image-editor-modal"
+			containerProps={{className: 'cadmin'}}
 			observer={observer}
 			size="full-screen"
 		>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-138591

This pr isolates the Page Editor Image Edit and HTML Content Edit modals. Image Edit modal is fully isolated. HTML Content Edit modal is only partially isolated, only `modal-header`, `modal-footer`, and source editor toolbar contents have the cadmin class. 

/cc @victorg1991 

Screenshots:
![html-edit-content](https://user-images.githubusercontent.com/788266/131895311-f47d1eda-95a4-405e-b2e6-9d1c0ff34ded.jpg)
![page-editor-edit-image](https://user-images.githubusercontent.com/788266/131895447-c331bdf4-ef1b-4bef-9e66-37cfd5ab0e86.jpg)
