### PR TITLE
LPS-138306 Use data-tooltip-align="bottom-left" to fix tooltip position

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/resources/META-INF/resources/js/ApplicationsMenu.js
@@ -483,7 +483,7 @@ const ApplicationsMenu = ({
 				className="dropdown-toggle lfr-portal-tooltip"
 				data-qa-id="applicationsMenu"
 				data-title-set-as-html
-				data-tooltip-align="bottom"
+				data-tooltip-align="bottom-left"
 				displayType="unstyled"
 				onClick={handleTriggerButtonClick}
 				onFocus={fetchCategories}


### PR DESCRIPTION
This is a follow up pull request on #5674, which fixes the tooltip's
position. For more information, please check [this](https://github.com/liferay/clay/issues/4249) issue.

**Before**

![](https://user-images.githubusercontent.com/5572/131984451-55ded617-18fd-4063-8b25-c25b54ab69c9.png)

**After**

![](https://user-images.githubusercontent.com/5572/131984487-889d0ff3-2931-43b2-9153-09752514f7d3.png)


**Test plan**
- Fetch this branch
- Deploy the `product-navigation-applications-menu-web` module
- Assert the tooltip is displayed correctly