### PR TITLE
LPS-138557 Reserve locale variable for the current portal locale and add articleLocale variable to store the current journal article's locale analogously to articleGroupId variable

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
@@ -54,6 +54,7 @@ import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.PropertiesUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -269,10 +270,12 @@ public class JournalTransformer {
 				}
 
 				template.put("articleGroupId", articleGroupId);
+				template.put("articleLocale", locale);
 				template.put("company", getCompany(themeDisplay, companyId));
 				template.put("companyId", companyId);
 				template.put("device", getDevice(themeDisplay));
-				template.put("locale", locale);
+				template.put(
+					"locale", PortalUtil.getLocale(httpServletRequest));
 				template.put(
 					"permissionChecker",
 					PermissionThreadLocal.getPermissionChecker());


### PR DESCRIPTION
Hi team,

The original fix for LPS-108651 caused some regression bugs like LPS-125409, whose fix, which was absolutely correct, made LPS-108651 reproducible again, so I created LPS-138557 to propose another fix approach.

Looking into the place where this code was introduced in [LEP-5809](https://issues.liferay.com/browse/LEP-5809), the original intention was to provide some localized error messages so the variable locale was put in place. However, the value of locale variable was tied to the JournalArticle's locale instead of storing the current portal locale. Those values are usually the same expect for when the JournalArticle is rendered in a classic Display Page. I would like to friendly remember that the use of classic Display Pages was introduced much later in [LPS-15961](https://issues.liferay.com/browse/LPS-15951).

Following the naming of articleGroupId, I decided to add a new variable, articleLocale, to store the specific JournalArticle's locale so that value can still be available.

Could you please review this change?

Please, let me know if you need more information about this.

Thanks in advance