### PR TITLE
[TS] LPS-132134

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/details.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/details.jsp
@@ -146,11 +146,11 @@ String friendlyURLBase = StringPool.BLANK;
 
 			<%
 			LayoutSetPrototype layoutSetPrototype = LayoutSetPrototypeLocalServiceUtil.getLayoutSetPrototype(group.getClassPK());
-
-			boolean layoutSetPrototypeUpdateable = GetterUtil.getBoolean(layoutSetPrototype.getSettingsProperty("layoutsUpdateable"), true);
 			%>
 
-			<aui:input disabled="<%= !layoutSetPrototypeUpdateable %>" helpMessage="allow-site-administrators-to-modify-this-page-for-their-site-help" label="allow-site-administrators-to-modify-this-page-for-their-site" name="TypeSettingsProperties--layoutUpdateable--" type="checkbox" value='<%= GetterUtil.getBoolean(selLayoutType.getTypeSettingsProperty("layoutUpdateable"), true) %>' />
+			<c:if test='<%= GetterUtil.getBoolean(layoutSetPrototype.getSettingsProperty("layoutsUpdateable"), true) %>'>
+				<aui:input helpMessage="allow-site-administrators-to-modify-this-page-for-their-site-help" label="allow-site-administrators-to-modify-this-page-for-their-site" name="TypeSettingsProperties--layoutUpdateable--" type="checkbox" value='<%= GetterUtil.getBoolean(selLayoutType.getTypeSettingsProperty("layoutUpdateable"), true) %>' />
+			</c:if>
 		</c:if>
 	</c:when>
 	<c:otherwise>


### PR DESCRIPTION
Currently, sites created from a site template can be incorrectly given the "layoutUpdateable" setting due to unexpected behavior from the checkbox that controls this property. Previously, when a site template had the option for site admins to be able to alter layouts ("layoutsUpdateable" in the settings) was set to 'false', this checkbox on the individual layout's customization menu would be disabled. However, a quirk in aui:input means that the disabled property still submits a value despite a vanilla input tag not working in the same manner. An aui:input checkbox-type tag will always submit false if disabled regardless of value. Discussion with the FEI team can be seen [here](https://liferay.slack.com/archives/CNBG06JS3/p1630666813056400?thread_ts=1630610583.055500&cid=CNBG06JS3) regarding this behavior.

Since changing this behavior in the aui:input tag, despite it arguably being a bug, would cause huge ramifications across the portal, I've opted to implement this workaround as suggested by the FEI team. The checkbox will no longer be disabled based on the site template's setting. Instead, the input will be hidden based on this setting.

Please let me know if there's any questions or changes you want made to this. Thanks!