### PR TITLE
LPS-131534 As a Content Publisher, I want to change to a specific site pages variation by using the Site Pages Variation selector

### DIFF
--- a/modules/apps/export-import/export-import-service/build.gradle
+++ b/modules/apps/export-import/export-import-service/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	compileOnly group: "biz.aQute.bnd", name: "biz.aQute.bnd.annotation", version: "4.2.0"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.java", version: "default"

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/FFSystemLayoutVersioningConfiguration.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/configuration/FFSystemLayoutVersioningConfiguration.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.exportimport.internal.configuration;
+
+import aQute.bnd.annotation.metatype.Meta;
+
+import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
+
+/**
+ * @author Tamas Molnar
+ */
+@ExtendedObjectClassDefinition(generateUI = false)
+@Meta.OCD(
+	id = "com.liferay.exportimport.internal.configuration.FFSystemLayoutVersioningConfiguration"
+)
+public interface FFSystemLayoutVersioningConfiguration {
+
+	@Meta.AD(deflt = "false", required = false)
+	public boolean enabled();
+
+}

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/LayoutStagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/LayoutStagingImpl.java
@@ -107,7 +107,7 @@ public class LayoutStagingImpl implements LayoutStaging {
 
 	@Override
 	public boolean isBranchingLayout(Layout layout) {
-		if ((layout == null) || layout.isSystem()) {
+		if (layout == null) {
 			return false;
 		}
 

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/LayoutStagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/LayoutStagingImpl.java
@@ -14,10 +14,12 @@
 
 package com.liferay.exportimport.internal.staging;
 
+import com.liferay.exportimport.internal.configuration.FFSystemLayoutVersioningConfiguration;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.staging.LayoutStaging;
 import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
 import com.liferay.layout.util.LayoutCopyHelper;
+import com.liferay.portal.configuration.metatype.bnd.util.ConfigurableUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -46,14 +48,20 @@ import com.liferay.portlet.exportimport.staging.StagingAdvicesThreadLocal;
 import java.lang.reflect.InvocationHandler;
 
 import java.util.List;
+import java.util.Map;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Modified;
 import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Raymond Augé
  */
-@Component(immediate = true, service = LayoutStaging.class)
+@Component(
+	configurationPid = "com.liferay.exportimport.internal.configuration.FFSystemLayoutVersioningConfiguration",
+	immediate = true, service = LayoutStaging.class
+)
 public class LayoutStagingImpl implements LayoutStaging {
 
 	@Override
@@ -106,6 +114,10 @@ public class LayoutStagingImpl implements LayoutStaging {
 	public void copyLayoutBranch(
 			LayoutBranch layoutBranch, long layoutRevisionId)
 		throws Exception {
+
+		if (!_isSystemLayoutVersioningEnabled()) {
+			return;
+		}
 
 		LayoutRevision newLayoutRevision =
 			_layoutRevisionLocalService.fetchLatestLayoutRevision(
@@ -188,7 +200,7 @@ public class LayoutStagingImpl implements LayoutStaging {
 
 	@Override
 	public boolean isBranchingLayout(Layout layout) {
-		if (layout == null) {
+		if ((layout == null) || !_isLayoutVersioningEnabled(layout)) {
 			return false;
 		}
 
@@ -372,6 +384,10 @@ public class LayoutStagingImpl implements LayoutStaging {
 	public Layout publishLayout(Layout draftLayout, Layout layout, long userId)
 		throws Exception {
 
+		if (!_isSystemLayoutVersioningEnabled()) {
+			return _layoutCopyHelper.copyLayout(draftLayout, layout);
+		}
+
 		LayoutRevision layoutRevision = LayoutStagingUtil.getLayoutRevision(
 			layout);
 
@@ -412,7 +428,9 @@ public class LayoutStagingImpl implements LayoutStaging {
 
 	@Override
 	public long swapPlidForRevisionId(long plid) {
-		if (!StagingAdvicesThreadLocal.isEnabled()) {
+		if (!_isSystemLayoutVersioningEnabled() ||
+			!StagingAdvicesThreadLocal.isEnabled()) {
+
 			return plid;
 		}
 
@@ -423,6 +441,14 @@ public class LayoutStagingImpl implements LayoutStaging {
 		}
 
 		return layoutRevision.getLayoutRevisionId();
+	}
+
+	@Activate
+	@Modified
+	protected void activate(Map<String, Object> properties) {
+		_ffSystemLayoutVersioningConfiguration =
+			ConfigurableUtil.createConfigurable(
+				FFSystemLayoutVersioningConfiguration.class, properties);
 	}
 
 	@Reference(unbind = "-")
@@ -460,8 +486,23 @@ public class LayoutStagingImpl implements LayoutStaging {
 		return null;
 	}
 
+	private boolean _isLayoutVersioningEnabled(Layout layout) {
+		if (!layout.isSystem()) {
+			return true;
+		}
+
+		return _isSystemLayoutVersioningEnabled();
+	}
+
+	private boolean _isSystemLayoutVersioningEnabled() {
+		return _ffSystemLayoutVersioningConfiguration.enabled();
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		LayoutStagingImpl.class);
+
+	private volatile FFSystemLayoutVersioningConfiguration
+		_ffSystemLayoutVersioningConfiguration;
 
 	@Reference
 	private LayoutCopyHelper _layoutCopyHelper;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.fragment.service.impl;
 
 import com.liferay.document.library.util.DLURLHelper;
+import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
 import com.liferay.fragment.constants.FragmentEntryLinkConstants;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
@@ -33,12 +34,14 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
@@ -129,8 +132,10 @@ public class FragmentEntryLinkLocalServiceImpl
 		fragmentEntryLink.setFragmentEntryId(fragmentEntryId);
 		fragmentEntryLink.setSegmentsExperienceId(segmentsExperienceId);
 		fragmentEntryLink.setClassNameId(_portal.getClassNameId(Layout.class));
-		fragmentEntryLink.setClassPK(plid);
-		fragmentEntryLink.setPlid(plid);
+		fragmentEntryLink.setClassPK(
+			LayoutStagingUtil.swapPlidForRevisionId(plid));
+		fragmentEntryLink.setPlid(
+			LayoutStagingUtil.swapPlidForRevisionId(plid));
 		fragmentEntryLink.setCss(css);
 
 		html = _replaceResources(fragmentEntryId, html);
@@ -295,7 +300,8 @@ public class FragmentEntryLinkLocalServiceImpl
 		long groupId, long classNameId, long classPK) {
 
 		return fragmentEntryLinkPersistence.countByG_C_C(
-			groupId, classNameId, classPK);
+			groupId, classNameId,
+			LayoutStagingUtil.swapPlidForRevisionId(classPK));
 	}
 
 	@Override
@@ -332,7 +338,8 @@ public class FragmentEntryLinkLocalServiceImpl
 		long groupId, long classNameId, long classPK) {
 
 		return fragmentEntryLinkPersistence.findByG_C_C(
-			groupId, classNameId, classPK);
+			groupId, classNameId,
+			LayoutStagingUtil.swapPlidForRevisionId(classPK));
 	}
 
 	/**
@@ -385,7 +392,8 @@ public class FragmentEntryLinkLocalServiceImpl
 	public List<FragmentEntryLink> getFragmentEntryLinksByPlid(
 		long groupId, long plid) {
 
-		return fragmentEntryLinkPersistence.findByG_P(groupId, plid);
+		return fragmentEntryLinkPersistence.findByG_P(
+			groupId, LayoutStagingUtil.swapPlidForRevisionId(plid));
 	}
 
 	@Override
@@ -393,7 +401,8 @@ public class FragmentEntryLinkLocalServiceImpl
 		long groupId, long segmentsExperienceId, long plid) {
 
 		return fragmentEntryLinkPersistence.findByG_S_P(
-			groupId, segmentsExperienceId, plid);
+			groupId, segmentsExperienceId,
+			LayoutStagingUtil.swapPlidForRevisionId(plid));
 	}
 
 	/**
@@ -408,7 +417,8 @@ public class FragmentEntryLinkLocalServiceImpl
 		long classPK) {
 
 		return fragmentEntryLinkPersistence.findByG_S_C_C(
-			groupId, segmentsExperienceId, classNameId, classPK);
+			groupId, segmentsExperienceId, classNameId,
+			LayoutStagingUtil.swapPlidForRevisionId(classPK));
 	}
 
 	@Override
@@ -468,7 +478,8 @@ public class FragmentEntryLinkLocalServiceImpl
 
 	@Override
 	public int getFragmentEntryLinksCountByPlid(long groupId, long plid) {
-		return fragmentEntryLinkPersistence.countByG_P(groupId, plid);
+		return fragmentEntryLinkPersistence.countByG_P(
+			groupId, LayoutStagingUtil.swapPlidForRevisionId(plid));
 	}
 
 	@Override
@@ -510,6 +521,13 @@ public class FragmentEntryLinkLocalServiceImpl
 
 	@Override
 	public void updateClassedModel(long plid) {
+		LayoutRevision layoutRevision =
+			_layoutRevisionLocalService.fetchLayoutRevision(plid);
+
+		if (layoutRevision != null) {
+			plid = layoutRevision.getPlid();
+		}
+
 		Layout layout = _layoutLocalService.fetchLayout(plid);
 
 		if (layout == null) {
@@ -590,8 +608,10 @@ public class FragmentEntryLinkLocalServiceImpl
 			originalFragmentEntryLinkId);
 		fragmentEntryLink.setFragmentEntryId(fragmentEntryId);
 		fragmentEntryLink.setClassNameId(_portal.getClassNameId(Layout.class));
-		fragmentEntryLink.setClassPK(plid);
-		fragmentEntryLink.setPlid(plid);
+		fragmentEntryLink.setClassPK(
+			LayoutStagingUtil.swapPlidForRevisionId(plid));
+		fragmentEntryLink.setPlid(
+			LayoutStagingUtil.swapPlidForRevisionId(plid));
 		fragmentEntryLink.setCss(css);
 		fragmentEntryLink.setHtml(html);
 		fragmentEntryLink.setJs(js);
@@ -886,6 +906,9 @@ public class FragmentEntryLinkLocalServiceImpl
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutRevisionLocalService _layoutRevisionLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkServiceImpl.java
@@ -21,10 +21,12 @@ import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServ
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.BaseModelPermissionCheckerUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 
@@ -179,6 +181,13 @@ public class FragmentEntryLinkServiceImpl
 			long groupId, long plid, boolean checkUpdateLayoutContentPermission)
 		throws PortalException {
 
+		LayoutRevision layoutRevision =
+			_layoutRevisionLocalService.fetchLayoutRevision(plid);
+
+		if (layoutRevision != null) {
+			plid = layoutRevision.getPlid();
+		}
+
 		String className = Layout.class.getName();
 		long classPK = plid;
 
@@ -226,5 +235,8 @@ public class FragmentEntryLinkServiceImpl
 	@Reference
 	private LayoutPageTemplateEntryLocalService
 		_layoutPageTemplateEntryLocalService;
+
+	@Reference
+	private LayoutRevisionLocalService _layoutRevisionLocalService;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutMVCActionCommand.java
@@ -14,6 +14,7 @@
 
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
+import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
 import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.listener.ContentPageEditorListenerTracker;
@@ -149,7 +150,13 @@ public class PublishLayoutMVCActionCommand
 				serviceContext, Collections.emptyMap());
 		}
 		else {
-			layout = _layoutCopyHelper.copyLayout(draftLayout, layout);
+			if (LayoutStagingUtil.isBranchingLayout(layout)) {
+				layout = LayoutStagingUtil.publishLayout(
+					draftLayout, layout, userId);
+			}
+			else {
+				layout = _layoutCopyHelper.copyLayout(draftLayout, layout);
+			}
 
 			layout.setType(draftLayout.getType());
 			layout.setStatus(WorkflowConstants.STATUS_APPROVED);

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
@@ -17,6 +17,7 @@ package com.liferay.layout.internal.util;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.counter.kernel.service.CounterLocalService;
+import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
@@ -633,8 +634,12 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 				targetSegmentsExperienceId);
 			newFragmentEntryLink.setClassNameId(
 				_portal.getClassNameId(Layout.class));
-			newFragmentEntryLink.setClassPK(targetLayout.getPlid());
-			newFragmentEntryLink.setPlid(targetLayout.getPlid());
+			newFragmentEntryLink.setClassPK(
+				LayoutStagingUtil.swapPlidForRevisionId(
+					targetLayout.getPlid()));
+			newFragmentEntryLink.setPlid(
+				LayoutStagingUtil.swapPlidForRevisionId(
+					targetLayout.getPlid()));
 			newFragmentEntryLink.setLastPropagationDate(
 				serviceContext.getCreateDate(new Date()));
 

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureLocalServiceImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.layout.page.template.service.impl;
 
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
@@ -33,6 +34,7 @@ import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
@@ -69,7 +71,8 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 		throws PortalException {
 
 		return addLayoutPageTemplateStructure(
-			userId, groupId, classPK, data, serviceContext);
+			userId, groupId, LayoutStagingUtil.swapPlidForRevisionId(classPK),
+			data, serviceContext);
 	}
 
 	@Override
@@ -99,7 +102,8 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 			serviceContext.getModifiedDate(new Date()));
 		layoutPageTemplateStructure.setClassNameId(
 			_portal.getClassNameId(Layout.class));
-		layoutPageTemplateStructure.setClassPK(plid);
+		layoutPageTemplateStructure.setClassPK(
+			LayoutStagingUtil.swapPlidForRevisionId(plid));
 
 		layoutPageTemplateStructure =
 			layoutPageTemplateStructurePersistence.update(
@@ -107,7 +111,7 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 
 		int count =
 			_fragmentEntryLinkLocalService.getFragmentEntryLinksCountByPlid(
-				groupId, plid);
+				groupId, LayoutStagingUtil.swapPlidForRevisionId(plid));
 
 		if (count > 0) {
 			_fragmentEntryLinkLocalService.updateClassedModel(plid);
@@ -162,7 +166,8 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 
 		LayoutPageTemplateStructure layoutPageTemplateStructure =
 			layoutPageTemplateStructurePersistence.findByG_C_C(
-				groupId, _portal.getClassNameId(Layout.class), plid);
+				groupId, _portal.getClassNameId(Layout.class),
+				LayoutStagingUtil.swapPlidForRevisionId(plid));
 
 		layoutPageTemplateStructureLocalService.
 			deleteLayoutPageTemplateStructure(layoutPageTemplateStructure);
@@ -188,7 +193,8 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 		long groupId, long plid) {
 
 		return layoutPageTemplateStructurePersistence.fetchByG_C_C(
-			groupId, _portal.getClassNameId(Layout.class), plid);
+			groupId, _portal.getClassNameId(Layout.class),
+			LayoutStagingUtil.swapPlidForRevisionId(plid));
 	}
 
 	@Override
@@ -315,7 +321,8 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 
 		LayoutPageTemplateStructure layoutPageTemplateStructure =
 			layoutPageTemplateStructurePersistence.findByG_C_C(
-				groupId, _portal.getClassNameId(Layout.class), plid);
+				groupId, _portal.getClassNameId(Layout.class),
+				LayoutStagingUtil.swapPlidForRevisionId(plid));
 
 		layoutPageTemplateStructure.setModifiedDate(new Date());
 
@@ -410,6 +417,9 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 	@Reference
 	private LayoutPageTemplateStructureRelLocalService
 		_layoutPageTemplateStructureRelLocalService;
+
+	@Reference
+	private LayoutRevisionLocalService _layoutRevisionLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureServiceImpl.java
@@ -19,9 +19,11 @@ import com.liferay.layout.page.template.service.base.LayoutPageTemplateStructure
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.BaseModelPermissionCheckerUtil;
+import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.util.Portal;
 
 import org.osgi.service.component.annotations.Component;
@@ -61,6 +63,13 @@ public class LayoutPageTemplateStructureServiceImpl
 			long groupId, long plid, long segmentsExperienceId, String data)
 		throws PortalException {
 
+		LayoutRevision layoutRevision =
+			_layoutRevisionLocalService.fetchLayoutRevision(plid);
+
+		if (layoutRevision != null) {
+			plid = layoutRevision.getPlid();
+		}
+
 		Boolean containsPermission =
 			BaseModelPermissionCheckerUtil.containsBaseModelPermission(
 				getPermissionChecker(), groupId, Layout.class.getName(), plid,
@@ -75,6 +84,9 @@ public class LayoutPageTemplateStructureServiceImpl
 			updateLayoutPageTemplateStructureData(
 				groupId, plid, segmentsExperienceId, data);
 	}
+
+	@Reference
+	private LayoutRevisionLocalService _layoutRevisionLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
@@ -106,6 +106,20 @@ LayoutSetBranchDisplayContext layoutSetBranchDisplayContext = new LayoutSetBranc
 %>
 
 <%!
+private boolean _isShowLayoutVersioningOption(Layout layout) {
+	if (layout == null) {
+		return false;
+	}
+
+	if (!layout.isTypeContent()) {
+		return true;
+	}
+
+	Layout draftLayout = LayoutLocalServiceUtil.fetchDraftLayout(layout.getPlid());
+
+	return LayoutStagingUtil.isBranchingLayout(draftLayout);
+}
+
 private long _getLastImportLayoutRevisionId(Group group, Layout layout, User user) {
 	long lastImportLayoutRevisionId = 0;
 

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -157,7 +157,7 @@ if (liveLayout != null) {
 											</clay:col>
 
 											<clay:col>
-												<c:if test="<%= !layoutRevision.isIncomplete() && !layout.isTypeContent() %>">
+												<c:if test="<%= !layoutRevision.isIncomplete() %>">
 													<liferay-util:include page="/view_layout_branch_details.jsp" servletContext="<%= application %>" />
 												</c:if>
 											</clay:col>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -157,7 +157,7 @@ if (liveLayout != null) {
 											</clay:col>
 
 											<clay:col>
-												<c:if test="<%= !layoutRevision.isIncomplete() %>">
+												<c:if test="<%= !layoutRevision.isIncomplete() && _isShowLayoutVersioningOption(layout) %>">
 													<liferay-util:include page="/view_layout_branch_details.jsp" servletContext="<%= application %>" />
 												</c:if>
 											</clay:col>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_details.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_details.jsp
@@ -173,7 +173,7 @@ else {
 					</a>
 				</li>
 
-				<c:if test="<%= !layoutRevision.isIncomplete() && !layout.isTypeContent() %>">
+				<c:if test="<%= !layoutRevision.isIncomplete() %>">
 					<li>
 						<a class="dropdown-item" href="javascript:;" id="manageLayoutRevisions" onclick="<%= liferayPortletResponse.getNamespace() + "openPageVariationsDialog();" %>">
 							<liferay-ui:message key="page-variations" />
@@ -186,7 +186,7 @@ else {
 					</li>
 				</c:if>
 
-				<c:if test="<%= !hasWorkflowTask && !layout.isTypeContent() %>">
+				<c:if test="<%= !hasWorkflowTask %>">
 					<c:if test="<%= !layoutRevision.isMajor() && (layoutRevision.getParentLayoutRevisionId() != LayoutRevisionConstants.DEFAULT_PARENT_LAYOUT_REVISION_ID) %>">
 						<li>
 							<a class="dropdown-item" href="javascript:Liferay.fire('<%= liferayPortletResponse.getNamespace() %>undo', {layoutRevisionId: '<%= layoutRevision.getLayoutRevisionId() %>', layoutSetBranchId: '<%= layoutRevision.getLayoutSetBranchId() %>'}); void(0);" id="undoLink">

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_details.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view_layout_revision_details.jsp
@@ -173,7 +173,7 @@ else {
 					</a>
 				</li>
 
-				<c:if test="<%= !layoutRevision.isIncomplete() %>">
+				<c:if test="<%= !layoutRevision.isIncomplete() && _isShowLayoutVersioningOption(layout) %>">
 					<li>
 						<a class="dropdown-item" href="javascript:;" id="manageLayoutRevisions" onclick="<%= liferayPortletResponse.getNamespace() + "openPageVariationsDialog();" %>">
 							<liferay-ui:message key="page-variations" />
@@ -186,7 +186,7 @@ else {
 					</li>
 				</c:if>
 
-				<c:if test="<%= !hasWorkflowTask %>">
+				<c:if test="<%= !hasWorkflowTask && _isShowLayoutVersioningOption(layout) %>">
 					<c:if test="<%= !layoutRevision.isMajor() && (layoutRevision.getParentLayoutRevisionId() != LayoutRevisionConstants.DEFAULT_PARENT_LAYOUT_REVISION_ID) %>">
 						<li>
 							<a class="dropdown-item" href="javascript:Liferay.fire('<%= liferayPortletResponse.getNamespace() %>undo', {layoutRevisionId: '<%= layoutRevision.getLayoutRevisionId() %>', layoutSetBranchId: '<%= layoutRevision.getLayoutSetBranchId() %>'}); void(0);" id="undoLink">

--- a/portal-impl/src/com/liferay/portal/service.xml
+++ b/portal-impl/src/com/liferay/portal/service.xml
@@ -1091,6 +1091,7 @@
 		<!-- References -->
 
 		<reference entity="Layout" package-path="com.liferay.portal" />
+		<reference entity="LayoutBranch" package-path="com.liferay.portal" />
 		<reference entity="LayoutSetBranch" package-path="com.liferay.portal" />
 		<reference entity="PortletPreferences" package-path="com.liferay.portal" />
 		<reference entity="PortletPreferenceValue" package-path="com.liferay.portal" />

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutRevisionLocalServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutRevisionLocalServiceBaseImpl.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.LayoutRevisionLocalServiceUtil;
 import com.liferay.portal.kernel.service.PersistedModelLocalServiceRegistry;
 import com.liferay.portal.kernel.service.persistence.BasePersistence;
+import com.liferay.portal.kernel.service.persistence.LayoutBranchPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutFinder;
 import com.liferay.portal.kernel.service.persistence.LayoutPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutRevisionPersistence;
@@ -512,6 +513,49 @@ public abstract class LayoutRevisionLocalServiceBaseImpl
 	}
 
 	/**
+	 * Returns the layout branch local service.
+	 *
+	 * @return the layout branch local service
+	 */
+	public com.liferay.portal.kernel.service.LayoutBranchLocalService
+		getLayoutBranchLocalService() {
+
+		return layoutBranchLocalService;
+	}
+
+	/**
+	 * Sets the layout branch local service.
+	 *
+	 * @param layoutBranchLocalService the layout branch local service
+	 */
+	public void setLayoutBranchLocalService(
+		com.liferay.portal.kernel.service.LayoutBranchLocalService
+			layoutBranchLocalService) {
+
+		this.layoutBranchLocalService = layoutBranchLocalService;
+	}
+
+	/**
+	 * Returns the layout branch persistence.
+	 *
+	 * @return the layout branch persistence
+	 */
+	public LayoutBranchPersistence getLayoutBranchPersistence() {
+		return layoutBranchPersistence;
+	}
+
+	/**
+	 * Sets the layout branch persistence.
+	 *
+	 * @param layoutBranchPersistence the layout branch persistence
+	 */
+	public void setLayoutBranchPersistence(
+		LayoutBranchPersistence layoutBranchPersistence) {
+
+		this.layoutBranchPersistence = layoutBranchPersistence;
+	}
+
+	/**
 	 * Returns the layout set branch local service.
 	 *
 	 * @return the layout set branch local service
@@ -910,6 +954,15 @@ public abstract class LayoutRevisionLocalServiceBaseImpl
 
 	@BeanReference(type = LayoutFinder.class)
 	protected LayoutFinder layoutFinder;
+
+	@BeanReference(
+		type = com.liferay.portal.kernel.service.LayoutBranchLocalService.class
+	)
+	protected com.liferay.portal.kernel.service.LayoutBranchLocalService
+		layoutBranchLocalService;
+
+	@BeanReference(type = LayoutBranchPersistence.class)
+	protected LayoutBranchPersistence layoutBranchPersistence;
 
 	@BeanReference(
 		type = com.liferay.portal.kernel.service.LayoutSetBranchLocalService.class

--- a/portal-impl/src/com/liferay/portal/service/base/LayoutRevisionServiceBaseImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/base/LayoutRevisionServiceBaseImpl.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiServic
 import com.liferay.portal.kernel.service.BaseServiceImpl;
 import com.liferay.portal.kernel.service.LayoutRevisionService;
 import com.liferay.portal.kernel.service.LayoutRevisionServiceUtil;
+import com.liferay.portal.kernel.service.persistence.LayoutBranchPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutFinder;
 import com.liferay.portal.kernel.service.persistence.LayoutPersistence;
 import com.liferay.portal.kernel.service.persistence.LayoutRevisionPersistence;
@@ -226,6 +227,72 @@ public abstract class LayoutRevisionServiceBaseImpl
 	 */
 	public void setLayoutFinder(LayoutFinder layoutFinder) {
 		this.layoutFinder = layoutFinder;
+	}
+
+	/**
+	 * Returns the layout branch local service.
+	 *
+	 * @return the layout branch local service
+	 */
+	public com.liferay.portal.kernel.service.LayoutBranchLocalService
+		getLayoutBranchLocalService() {
+
+		return layoutBranchLocalService;
+	}
+
+	/**
+	 * Sets the layout branch local service.
+	 *
+	 * @param layoutBranchLocalService the layout branch local service
+	 */
+	public void setLayoutBranchLocalService(
+		com.liferay.portal.kernel.service.LayoutBranchLocalService
+			layoutBranchLocalService) {
+
+		this.layoutBranchLocalService = layoutBranchLocalService;
+	}
+
+	/**
+	 * Returns the layout branch remote service.
+	 *
+	 * @return the layout branch remote service
+	 */
+	public com.liferay.portal.kernel.service.LayoutBranchService
+		getLayoutBranchService() {
+
+		return layoutBranchService;
+	}
+
+	/**
+	 * Sets the layout branch remote service.
+	 *
+	 * @param layoutBranchService the layout branch remote service
+	 */
+	public void setLayoutBranchService(
+		com.liferay.portal.kernel.service.LayoutBranchService
+			layoutBranchService) {
+
+		this.layoutBranchService = layoutBranchService;
+	}
+
+	/**
+	 * Returns the layout branch persistence.
+	 *
+	 * @return the layout branch persistence
+	 */
+	public LayoutBranchPersistence getLayoutBranchPersistence() {
+		return layoutBranchPersistence;
+	}
+
+	/**
+	 * Sets the layout branch persistence.
+	 *
+	 * @param layoutBranchPersistence the layout branch persistence
+	 */
+	public void setLayoutBranchPersistence(
+		LayoutBranchPersistence layoutBranchPersistence) {
+
+		this.layoutBranchPersistence = layoutBranchPersistence;
 	}
 
 	/**
@@ -695,6 +762,21 @@ public abstract class LayoutRevisionServiceBaseImpl
 
 	@BeanReference(type = LayoutFinder.class)
 	protected LayoutFinder layoutFinder;
+
+	@BeanReference(
+		type = com.liferay.portal.kernel.service.LayoutBranchLocalService.class
+	)
+	protected com.liferay.portal.kernel.service.LayoutBranchLocalService
+		layoutBranchLocalService;
+
+	@BeanReference(
+		type = com.liferay.portal.kernel.service.LayoutBranchService.class
+	)
+	protected com.liferay.portal.kernel.service.LayoutBranchService
+		layoutBranchService;
+
+	@BeanReference(type = LayoutBranchPersistence.class)
+	protected LayoutBranchPersistence layoutBranchPersistence;
 
 	@BeanReference(
 		type = com.liferay.portal.kernel.service.LayoutSetBranchLocalService.class

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
@@ -297,6 +297,15 @@ public class LayoutRevisionLocalServiceImpl
 	}
 
 	@Override
+	public LayoutRevision fetchLayoutRevision(
+		long layoutSetBranchId, long parentLayoutRevisionId, long plid) {
+
+		return layoutRevisionPersistence.fetchByL_P_P_First(
+			layoutSetBranchId, parentLayoutRevisionId, plid,
+			new LayoutRevisionCreateDateComparator(false));
+	}
+
+	@Override
 	public List<LayoutRevision> getChildLayoutRevisions(
 		long layoutSetBranchId, long parentLayoutRevisionId, long plid) {
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutBranch;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.model.LayoutRevisionConstants;
@@ -34,6 +35,7 @@ import com.liferay.portal.kernel.model.PortletPreferences;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -143,6 +145,12 @@ public class LayoutRevisionLocalServiceImpl
 		StagingUtil.setRecentLayoutRevisionId(
 			user, layoutSetBranchId, plid,
 			layoutRevision.getLayoutRevisionId());
+
+		Layout layout = layoutLocalService.getLayout(plid);
+
+		if (layout.isTypeContent() && !layout.isSystem()) {
+			_addDraftLayoutRevision(layoutRevision, serviceContext);
+		}
 
 		return layoutRevision;
 	}
@@ -449,7 +457,10 @@ public class LayoutRevisionLocalServiceImpl
 
 		LayoutRevision layoutRevision = null;
 
-		if (_layoutRevisionId.get() > 0) {
+		Layout layout = layoutLocalService.getLayout(
+			oldLayoutRevision.getPlid());
+
+		if ((_layoutRevisionId.get() > 0) && !layout.isTypeContent()) {
 			if (_layoutRevisionId.get() == layoutRevisionId) {
 				layoutRevision = oldLayoutRevision;
 			}
@@ -473,7 +484,8 @@ public class LayoutRevisionLocalServiceImpl
 
 		if (!MergeLayoutPrototypesThreadLocal.isInProgress() &&
 			(workflowAction != WorkflowConstants.ACTION_PUBLISH) &&
-			(layoutRevision == null) && !revisionInProgress) {
+			(layoutRevision == null) && !revisionInProgress &&
+			!layout.isTypeContent()) {
 
 			User user = userPersistence.findByPrimaryKey(userId);
 
@@ -769,6 +781,65 @@ public class LayoutRevisionLocalServiceImpl
 		}
 
 		return layoutRevision;
+	}
+
+	private void _addDraftLayoutRevision(
+			LayoutRevision layoutRevision, ServiceContext serviceContext)
+		throws PortalException {
+
+		Layout draftLayout = layoutLocalService.fetchDraftLayout(
+			layoutRevision.getPlid());
+
+		if (draftLayout == null) {
+			return;
+		}
+
+		User user = userPersistence.findByPrimaryKey(
+			layoutRevision.getUserId());
+
+		LayoutSetBranch draftMasterLayoutSetBranch =
+			layoutSetBranchLocalService.getMasterLayoutSetBranch(
+				draftLayout.getGroupId(), draftLayout.isPrivateLayout());
+
+		LayoutBranch draftMasterLayoutBranch =
+			layoutBranchLocalService.getMasterLayoutBranch(
+				draftMasterLayoutSetBranch.getLayoutSetBranchId(),
+				draftLayout.getPlid(),
+				ServiceContextThreadLocal.getServiceContext());
+
+		long layoutRevisionId = counterLocalService.increment();
+
+		LayoutRevision draftLayoutRevision = layoutRevisionPersistence.create(
+			layoutRevisionId);
+
+		draftLayoutRevision.setGroupId(layoutRevision.getGroupId());
+		draftLayoutRevision.setCompanyId(layoutRevision.getCompanyId());
+		draftLayoutRevision.setUserId(user.getUserId());
+		draftLayoutRevision.setUserName(user.getFullName());
+		draftLayoutRevision.setLayoutSetBranchId(
+			draftMasterLayoutSetBranch.getLayoutSetBranchId());
+		draftLayoutRevision.setLayoutBranchId(
+			draftMasterLayoutBranch.getLayoutBranchId());
+		draftLayoutRevision.setParentLayoutRevisionId(
+			layoutRevision.getLayoutRevisionId());
+		draftLayoutRevision.setHead(false);
+		draftLayoutRevision.setPlid(draftLayout.getPlid());
+		draftLayoutRevision.setPrivateLayout(draftLayout.isPrivateLayout());
+		draftLayoutRevision.setName(layoutRevision.getName());
+		draftLayoutRevision.setTitle(layoutRevision.getTitle());
+		draftLayoutRevision.setDescription(layoutRevision.getDescription());
+		draftLayoutRevision.setKeywords(layoutRevision.getKeywords());
+		draftLayoutRevision.setRobots(layoutRevision.getRobots());
+		draftLayoutRevision.setTypeSettings(layoutRevision.getTypeSettings());
+		draftLayoutRevision.setIconImageId(draftLayout.getIconImageId());
+		draftLayoutRevision.setThemeId(layoutRevision.getThemeId());
+		draftLayoutRevision.setColorSchemeId(layoutRevision.getColorSchemeId());
+		draftLayoutRevision.setCss(layoutRevision.getCss());
+		draftLayoutRevision.setStatus(WorkflowConstants.STATUS_APPROVED);
+		draftLayoutRevision.setStatusDate(
+			serviceContext.getModifiedDate(new Date()));
+
+		layoutRevisionPersistence.update(draftLayoutRevision);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/LayoutStaging.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/LayoutStaging.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetBranch;
 import com.liferay.portal.kernel.model.LayoutSetStagingHandler;
 import com.liferay.portal.kernel.model.LayoutStagingHandler;
-import com.liferay.portal.kernel.service.ServiceContext;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -61,8 +60,7 @@ public interface LayoutStaging {
 	public boolean prepareLayoutStagingHandler(
 		PortletDataContext portletDataContext, Layout layout);
 
-	public Layout publishLayout(
-			Layout draftLayout, Layout layout, long userId)
+	public Layout publishLayout(Layout draftLayout, Layout layout, long userId)
 		throws Exception;
 
 	public long swapPlidForRevisionId(long plid);

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/LayoutStaging.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/LayoutStaging.java
@@ -17,11 +17,13 @@ package com.liferay.exportimport.kernel.staging;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutBranch;
 import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetBranch;
 import com.liferay.portal.kernel.model.LayoutSetStagingHandler;
 import com.liferay.portal.kernel.model.LayoutStagingHandler;
+import com.liferay.portal.kernel.service.ServiceContext;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -30,6 +32,14 @@ import org.osgi.annotation.versioning.ProviderType;
  */
 @ProviderType
 public interface LayoutStaging {
+
+	public Layout copyLayout(
+			long sourceLayoutRevisionId, long targetLayoutRevisionId)
+		throws Exception;
+
+	public void copyLayoutBranch(
+			LayoutBranch layoutBranch, long layoutRevisionId)
+		throws Exception;
 
 	public LayoutRevision getLayoutRevision(Layout layout);
 
@@ -50,6 +60,10 @@ public interface LayoutStaging {
 
 	public boolean prepareLayoutStagingHandler(
 		PortletDataContext portletDataContext, Layout layout);
+
+	public Layout publishLayout(
+			Layout draftLayout, Layout layout, long userId)
+		throws Exception;
 
 	public long swapPlidForRevisionId(long plid);
 

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/LayoutStaging.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/LayoutStaging.java
@@ -51,4 +51,6 @@ public interface LayoutStaging {
 	public boolean prepareLayoutStagingHandler(
 		PortletDataContext portletDataContext, Layout layout);
 
+	public long swapPlidForRevisionId(long plid);
+
 }

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/LayoutStagingUtil.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/LayoutStagingUtil.java
@@ -17,17 +17,34 @@ package com.liferay.exportimport.kernel.staging;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutBranch;
 import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetBranch;
 import com.liferay.portal.kernel.model.LayoutSetStagingHandler;
 import com.liferay.portal.kernel.model.LayoutStagingHandler;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ServiceProxyFactory;
 
 /**
  * @author Raymond Augé
  */
 public class LayoutStagingUtil {
+
+	public static Layout copyLayout(
+			long sourceLayoutRevisionId, long targetLayoutRevisionId)
+		throws Exception {
+
+		return _layoutStaging.copyLayout(
+			sourceLayoutRevisionId, targetLayoutRevisionId);
+	}
+
+	public static void copyLayoutBranch(
+			LayoutBranch layoutBranch, long layoutRevisionId)
+		throws Exception {
+
+		_layoutStaging.copyLayoutBranch(layoutBranch, layoutRevisionId);
+	}
 
 	public static LayoutRevision getLayoutRevision(Layout layout) {
 		return _layoutStaging.getLayoutRevision(layout);
@@ -72,6 +89,19 @@ public class LayoutStagingUtil {
 
 		return _layoutStaging.prepareLayoutStagingHandler(
 			portletDataContext, layout);
+	}
+
+	public static long swapPlidForRevisionId(long plid) {
+		return _layoutStaging.swapPlidForRevisionId(plid);
+	}
+
+	public Layout publishLayout(
+			Layout dratLayout, Layout layout, ServiceContext serviceContext,
+			long userId)
+		throws Exception {
+
+		return _layoutStaging.publishLayout(
+			dratLayout, layout, serviceContext, userId);
 	}
 
 	private static volatile LayoutStaging _layoutStaging =

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/LayoutStagingUtil.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/LayoutStagingUtil.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutSetBranch;
 import com.liferay.portal.kernel.model.LayoutSetStagingHandler;
 import com.liferay.portal.kernel.model.LayoutStagingHandler;
-import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.ServiceProxyFactory;
 
 /**
@@ -95,8 +94,7 @@ public class LayoutStagingUtil {
 			Layout dratLayout, Layout layout, long userId)
 		throws Exception {
 
-		return _layoutStaging.publishLayout(
-			dratLayout, layout, userId);
+		return _layoutStaging.publishLayout(dratLayout, layout, userId);
 	}
 
 	public static long swapPlidForRevisionId(long plid) {

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/LayoutStagingUtil.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/LayoutStagingUtil.java
@@ -91,17 +91,16 @@ public class LayoutStagingUtil {
 			portletDataContext, layout);
 	}
 
-	public static long swapPlidForRevisionId(long plid) {
-		return _layoutStaging.swapPlidForRevisionId(plid);
-	}
-
-	public Layout publishLayout(
-			Layout dratLayout, Layout layout, ServiceContext serviceContext,
-			long userId)
+	public static Layout publishLayout(
+			Layout dratLayout, Layout layout, long userId)
 		throws Exception {
 
 		return _layoutStaging.publishLayout(
-			dratLayout, layout, serviceContext, userId);
+			dratLayout, layout, userId);
+	}
+
+	public static long swapPlidForRevisionId(long plid) {
+		return _layoutStaging.swapPlidForRevisionId(plid);
 	}
 
 	private static volatile LayoutStaging _layoutStaging =

--- a/portal-kernel/src/com/liferay/exportimport/kernel/staging/packageinfo
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/staging/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.LayoutBranchLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutRevisionLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetBranchLocalServiceUtil;
+import com.liferay.portal.kernel.service.RecentLayoutRevisionLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
@@ -155,6 +156,21 @@ public class LayoutStagingHandler implements InvocationHandler, Serializable {
 
 		if (layoutRevision != null) {
 			return layoutRevision;
+		}
+
+		User defaultUser = UserLocalServiceUtil.getDefaultUser(
+			layout.getCompanyId());
+
+		RecentLayoutRevision recentLayoutRevision =
+			RecentLayoutRevisionLocalServiceUtil.fetchRecentLayoutRevision(
+				defaultUser.getUserId(),
+				RecentLayoutRevisionConstants.
+					DEFAULT_RECENT_LAYOUT_SET_BRANCH_ID,
+				layout.getPlid());
+
+		if (recentLayoutRevision != null) {
+			return LayoutRevisionLocalServiceUtil.getLayoutRevision(
+				recentLayoutRevision.getLayoutRevisionId());
 		}
 
 		ServiceContext serviceContext =

--- a/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/LayoutStagingHandler.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.kernel.model;
 
+import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
 import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -174,7 +175,7 @@ public class LayoutStagingHandler implements InvocationHandler, Serializable {
 				recentLayoutRevision.getLayoutRevisionId());
 		}
 
-		if (layout.isSystem()) {
+		if (layout.isSystem() && LayoutStagingUtil.isBranchingLayout(layout)) {
 			layoutRevision = _getSystemLayoutRevision(layout);
 
 			if (layoutRevision != null) {

--- a/portal-kernel/src/com/liferay/portal/kernel/model/RecentLayoutRevisionConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/model/RecentLayoutRevisionConstants.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.model;
+
+/**
+ * @author Tamas Molnar
+ */
+public class RecentLayoutRevisionConstants {
+
+	public static final long DEFAULT_RECENT_LAYOUT_SET_BRANCH_ID = 0;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutRevisionLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutRevisionLocalService.java
@@ -238,6 +238,10 @@ public interface LayoutRevisionLocalService
 		long layoutSetBranchId, long layoutBranchId, boolean head, long plid);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public LayoutRevision fetchLayoutRevision(
+		long layoutSetBranchId, long parentLayoutRevisionId, long plid);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public ActionableDynamicQuery getActionableDynamicQuery();
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutRevisionLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutRevisionLocalServiceUtil.java
@@ -285,6 +285,13 @@ public class LayoutRevisionLocalServiceUtil {
 			layoutSetBranchId, layoutBranchId, head, plid);
 	}
 
+	public static LayoutRevision fetchLayoutRevision(
+		long layoutSetBranchId, long parentLayoutRevisionId, long plid) {
+
+		return getService().fetchLayoutRevision(
+			layoutSetBranchId, parentLayoutRevisionId, plid);
+	}
+
 	public static com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutRevisionLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutRevisionLocalServiceWrapper.java
@@ -319,6 +319,14 @@ public class LayoutRevisionLocalServiceWrapper
 	}
 
 	@Override
+	public com.liferay.portal.kernel.model.LayoutRevision fetchLayoutRevision(
+		long layoutSetBranchId, long parentLayoutRevisionId, long plid) {
+
+		return _layoutRevisionLocalService.fetchLayoutRevision(
+			layoutSetBranchId, parentLayoutRevisionId, plid);
+	}
+
+	@Override
 	public com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery
 		getActionableDynamicQuery() {
 


### PR DESCRIPTION
Hi guys,

This is the continuation of the previous [pull request](https://github.com/liferay-echo/liferay-portal/pull/5363) with the feature flag. I'm copying the description:

**This isn't the final code**, I'd just like to open a discussion about how Page Versioning could be implemented for Content Pages.

Right now in master when Page Versioning is enabled, only the Site Pages Variation option is available for Content Pages (without History and Page Variations) and changes made on different Variations affect each other.

With the current solution we should be able to create different versions of the pages and preserve the History, add new Page Variations, select a version for "Ready for Publish Process" and publish them to Live.
Please turn on Page Versioning before creating any content pages, during the initial publication there is an inverse publication from the Live to the Stage site, which is not implemented yet.

###  Highlights of the changes:

1. **History and Page Variation options are reenabled**

2. **Plid is swapped for layout revisionId in LayoutPageTemplateStructure and FragmentEntryLink services** (later Segments have to be considered)
In order to differentiate between the revisions, we need to connect the LayoutPageTemplateStructure and FragmentEntryLink entities to a revision. This is how it works for PortletPreferences, in PortletPreferencesLocalServiceImpl the plids are swapped to the revisionId.

3. **Draft pages are versioned too**
In the current solution for each published layout revision, there is a connected draft layout revision. (Publish meaining: Publishing a Content Page after editing, not Publishing to Live).
It seems necessary to me, as users can start editing previous versions via the History.  E.g. if there are 1.0-1.5 versions of a layout, someone can go back to 1.3 and start editing it. We need a draft revision for 1.3 where the changes are stored. 
It's a bit unambiguous what should happen when we are editing an older version, how we should preserve the history. When we publish version 1.3, a new version is created with the latest changes, and the 1.3 version of the published layout is copied back to the draft 1.3, so next time we go back to 1.3 in the History, we'll see that version.

4) **Changes for handling LayoutRevisions**
These changes are mostly needed because Widget Pages and Content Pages are different.

### Problems to consider:
1. There are quite a lot of problems with Page Versioning in general, even for Widget Pages which will also affect Content Pages once versioning is enabled for them.
Most of the entities are not prepared to handle a revisionId instead of a plid.
For example when we are adding a tag to a page, the plid is stored in the database. This way we cannot add separate tags for different layout revisions. The same applies for Portlet Permissions, Categories, Custom fields, SEO, Open graph, Custom Meta Tags, Layout Classed Model Usages and so on (probably all the places where we store the plid instead of the revisionId).

2. Developers have to remember that getPlid() calls can result in a revisionId. This is a problem for PortletPreferences as well, portletPreferences.getPlid() calls should be prepared for receiving revisionId. As far as i can see, there are only a few corner cases where this can cause a problem, but once LayoutPageTemplateStructures, FragmentEntryLinks and Segments will work the same way, it can cause quite a lot of problem.

Sorry for the long post, feel free to ping me with any questions.

Best,
Tamas
