### PR TITLE
master_LPS-138778

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
@@ -747,6 +747,18 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 			draftLayout.getMasterLayoutPlid(),
 			draftLayout.getStyleBookEntryId(), serviceContext);
 
+		Layout layout = layoutLocalService.getLayout(
+			layoutPageTemplateEntry.getPlid());
+
+		layoutLocalService.updateLayout(
+			layout.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),
+			layout.getParentLayoutId(), titleMap, titleMap,
+			layout.getDescriptionMap(), layout.getKeywordsMap(),
+			layout.getRobotsMap(), layout.getType(), layout.isHidden(),
+			layout.getFriendlyURLMap(), layout.getIconImage(), null,
+			layout.getMasterLayoutPlid(), layout.getStyleBookEntryId(),
+			serviceContext);
+
 		return layoutPageTemplateEntry;
 	}
 


### PR DESCRIPTION
Hi team,

This PR is a fix of the regression bug produced by LPS-94001 (commit 3967db8) in the rename Display Page Template action.

With the change made in LPS-94001, when a Display Page Template is renamed, only the draft Layout is changed but not the main Layout. Thereby producing that when the Display Page Template name must be shown, the old value is used.

To fix the error, I added the necessary code to save the main layout.

Please, let me know if you have any doubt.