### PR TITLE
LPS-137424

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -1386,9 +1386,9 @@ public class GroupFinderImpl
 			int pos = join.indexOf("WHERE");
 
 			if (pos != -1) {
-				join = join.substring(pos + 5);
+				join = StringPool.OPEN_PARENTHESIS + join.substring(pos + 5);
 
-				join = join.concat(" AND ");
+				join = join.concat(") AND ");
 			}
 			else {
 				join = StringPool.BLANK;


### PR DESCRIPTION
Hey Echo Team,

This is a follow-up pull to https://github.com/liferay-echo/liferay-portal/pull/5686, because an issue was caused by one of my SF commits.

When @javalosjr96 initially sent that pull request, he had included a set of outer parenthesis in the WHERE clause [here](https://github.com/liferay-echo/liferay-portal/pull/5686/commits/bb53e4e2c5284c73f3955fc39ce21255caaa76c6#diff-f9fb12b720960a90a21e7815480ce750203e23f51551a563bd786eb25372a65cR212-R221). The Source Formatter claimed that these parentheses were redundant, so I removed them.

In actuality, these parentheses are necessary. The SF would have been correct if we were just taking that query and directly running it. But that's not what we're doing. We actually strip the WHERE clause from this query and AND it with WHERE clauses from other queries. So these parentheses are necessary to ensure that the order of operations in the query remains correct after this happens.

Since we cannot placate the Source Formatter by adding parentheses there, instead @javalosjr96 has fixed this issue by always appending outer parentheses during the part where we strip the WHERE clauses. This should ensure that the order of operations remains correct, and should continue to be even if we add more queries in the future with WHERE clauses that undergo this operation. 

Please let me know if you have any questions.

https://issues.liferay.com/browse/LPS-137424

/cc @javalosjr96