### PR TITLE
LPS-139184 Added permission check to path string bundler

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalHelperImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalHelperImpl.java
@@ -38,6 +38,8 @@ import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.Indexer;
 import com.liferay.portal.kernel.search.IndexerRegistryUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.templateparser.TransformerListener;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -113,6 +115,9 @@ public class JournalHelperImpl implements JournalHelper {
 		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
+		PermissionChecker permissionChecker =
+			themeDisplay.getPermissionChecker();
+
 		if (folderId == JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 			return themeDisplay.translate("home");
 		}
@@ -130,14 +135,36 @@ public class JournalHelperImpl implements JournalHelper {
 		sb.append(StringPool.SPACE);
 
 		for (JournalFolder curFolder : folders) {
-			sb.append(StringPool.RAQUO_CHAR);
-			sb.append(StringPool.SPACE);
-			sb.append(curFolder.getName());
+			if (permissionChecker.hasPermission(
+					curFolder.getGroupId(), JournalFolder.class.getName(),
+					curFolder.getFolderId(), ActionKeys.VIEW)) {
+
+				sb.append(StringPool.RAQUO_CHAR);
+				sb.append(StringPool.SPACE);
+				sb.append(curFolder.getName());
+				sb.append(StringPool.SPACE);
+			}
+			else {
+				sb.append(StringPool.RAQUO_CHAR);
+				sb.append(StringPool.SPACE);
+				sb.append(StringPool.TRIPLE_PERIOD);
+				sb.append(StringPool.SPACE);
+			}
 		}
 
-		sb.append(StringPool.RAQUO_CHAR);
-		sb.append(StringPool.SPACE);
-		sb.append(folder.getName());
+		if (permissionChecker.hasPermission(
+				folder.getGroupId(), JournalFolder.class.getName(),
+				folder.getFolderId(), ActionKeys.VIEW)) {
+
+			sb.append(StringPool.RAQUO_CHAR);
+			sb.append(StringPool.SPACE);
+			sb.append(folder.getName());
+		}
+		else {
+			sb.append(StringPool.RAQUO_CHAR);
+			sb.append(StringPool.SPACE);
+			sb.append(StringPool.TRIPLE_PERIOD);
+		}
 
 		return sb.toString();
 	}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -192,7 +192,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 							value="<%= StringUtil.shorten(HtmlUtil.stripHtml(curArticle.getDescription(locale)), 200) %>"
 						/>
 
-						<c:if test="<%= journalDisplayContext.isSearch() && ((curArticle.getFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curArticle.getFolder(), ActionKeys.VIEW)) %>">
+						<c:if test="<%= journalDisplayContext.isSearch() %>">
 							<liferay-ui:search-container-column-text
 								cssClass="table-cell-expand-smallest table-cell-minw-200"
 								name="path"
@@ -384,7 +384,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 							value="<%= HtmlUtil.escape(curFolder.getDescription()) %>"
 						/>
 
-						<c:if test="<%= journalDisplayContext.isSearch() && ((curFolder.getParentFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curFolder.getParentFolder(), ActionKeys.VIEW)) %>">
+						<c:if test="<%= journalDisplayContext.isSearch() %>">
 							<liferay-ui:search-container-column-text
 								cssClass="table-cell-expand-smallest table-cell-minw-200"
 								name="path"


### PR DESCRIPTION
Comments from @javalosjr96:

> @mbowerman
The permission check for adding the path to the table view was removed from view_entries in Journal-Web in order to fix the skewed row that is created by the varying differences in permissions. The permission check was added to JournalHelperImpl in the getAbsoultePath method. If a user does not have permission to view a certain folder, the folder's name is replaced with ". . ." as indicated by the PT member in the [PTR ticket](https://issues.liferay.com/browse/PTR-2643) .

/cc @javalosjr96 

https://issues.liferay.com/browse/LPS-139184