### PR TITLE
LPS-139221 Web Content History - Geolocation was changed but the comparison does not display the change

### DIFF
--- a/modules/apps/map/map-taglib/src/main/resources/META-INF/resources/map_display/init.jsp
+++ b/modules/apps/map/map-taglib/src/main/resources/META-INF/resources/map_display/init.jsp
@@ -17,6 +17,8 @@
 <%@ include file="/init.jsp" %>
 
 <%
+double latitude = GetterUtil.getDouble(request.getAttribute("liferay-map:map:latitude"));
+double longitude = GetterUtil.getDouble(request.getAttribute("liferay-map:map:longitude"));
 String name = (String)request.getAttribute("liferay-map:map:name");
 MapProvider mapProvider = (MapProvider)request.getAttribute("liferay-map:map:mapProvider");
 

--- a/modules/apps/map/map-taglib/src/main/resources/META-INF/resources/map_display/page.jsp
+++ b/modules/apps/map/map-taglib/src/main/resources/META-INF/resources/map_display/page.jsp
@@ -18,7 +18,7 @@
 
 <c:choose>
 	<c:when test="<%= mapProvider != null %>">
-		<div class="lfr-map" id="<%= name %>Map">
+		<div class="lfr-map" data-latitude="<%= latitude %>" data-longitude="<%= longitude %>" id="<%= name %>Map">
 
 			<%
 			mapProvider.include(request, PipingServletResponseFactory.createPipingServletResponse(pageContext));


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

We use the third-party tool [DaisyDiff](https://github.com/DaisyDiff/DaisyDiff) to generate diff information during version comparisons. It can render text and image field differences but cannot handle custom fields like Geolocation. In the diff results, only a `div` element with the `lfr-map` class is present. When a new location is set on the map, the id of the `div` element changes, everything else stays the same. Even if the location stays the same, the id changes as it is generated randomly each time the map is rendered.

The changes I made are twofold:

- as `map-display` taglib receives the latitude and longitude values, I'm including this information to be rendered https://github.com/liferay-echo/liferay-portal/commit/91b6a15e3b3cd837fb05f161bd668a35a541c017
- now that the latitude and longitude are included in the `div` element, they are included in the diff results generated by DaisyDiff in the `changes` attribute of a span element nested in the `div`. I'm extracting the coordinates and the ids using a regex and comparing them. If at least one component of the coordinates changed (latitude or longitude), I'm creating a new `div` with the data before the changes and placing it above the div already rendered. Finally, I'm applying styling on the div fields to indicate which one of them is the "old" and the "new" https://github.com/liferay-echo/liferay-portal/pull/5929/commits/9866fba5b87f864346f6ffe3a4ffe4ad3ad90c73

A similar approach is already using for Knowledge Base Article diffs in [KBArticleDiffUtil](https://github.com/liferay-echo/liferay-portal/blob/master/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/util/KBArticleDiffUtil.java).

Thank you and best regards,
István