### PR TITLE
LPS-139952 Only join on ViewCountEntry once

### DIFF
--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetEntryServiceTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetEntryServiceTest.java
@@ -216,6 +216,24 @@ public class AssetEntryServiceTest {
 		validateAssetEntries(expectedAssetEntries, actualAssetEntries);
 	}
 
+	@Test
+	public void testGetTopViewedEntries() throws Exception {
+		AssetEntry assetEntry = AssetTestUtil.addAssetEntry(
+			_group.getGroupId(), new Date(), "testClass");
+
+		ViewCountManagerUtil.incrementViewCount(
+			assetEntry.getCompanyId(),
+			ClassNameLocalServiceUtil.getClassNameId(AssetEntry.class),
+			assetEntry.getEntryId(), 2);
+
+		List<AssetEntry> topViewEntries =
+			AssetEntryLocalServiceUtil.getTopViewedEntries(
+				"testClass", false, -1, -1);
+
+		Assert.assertEquals(
+			topViewEntries.toString(), 1, topViewEntries.size());
+	}
+
 	protected List<AssetEntry> createAssetEntries() throws Exception {
 		Calendar calendar = CalendarFactoryUtil.getCalendar();
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetEntryFinderImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/persistence/impl/AssetEntryFinderImpl.java
@@ -354,8 +354,9 @@ public class AssetEntryFinderImpl
 			sb.append("AssetEntry.classPK)");
 		}
 
-		if (orderByCol1.equals("viewCount") ||
-			orderByCol2.equals("viewCount")) {
+		if (!entryQuery.isExcludeZeroViewCount() &&
+			(orderByCol1.equals("viewCount") ||
+			 orderByCol2.equals("viewCount"))) {
 
 			sb.append(" LEFT JOIN ViewCountEntry ON ");
 			sb.append("(ViewCountEntry.companyId = AssetEntry.companyId) AND ");


### PR DESCRIPTION
Hi Team,

There are 2 possible joins for ViewCountEntry, line 328 and line 357. If both joins are added to the final sql without an alias they produce the error `Not unique table/alias: 'ViewCountEntry'`. Because both of the joins are used to produce a ViewCountEntry.viewCount, it is enough to have one of them used.

Can you please review?
https://issues.liferay.com/browse/LPS-139952

Thanks,
Balázs