### PR TITLE
LPS-136518

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/DefaultAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/DefaultAssetDisplayPageFriendlyURLResolver.java
@@ -112,6 +112,7 @@ public class DefaultAssetDisplayPageFriendlyURLResolver
 
 			themeDisplay.setScopeGroupId(groupId);
 			themeDisplay.setSiteGroupId(groupId);
+			themeDisplay.setRequest(httpServletRequest);
 
 			String assetFriendlyURL =
 				_assetDisplayPageFriendlyURLProvider.getFriendlyURL(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -57,6 +58,8 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
  * @author Alejandro Tardín
@@ -95,18 +98,12 @@ public class FileEntryInfoDisplayContributorTest {
 						StringUtil.lowerCase(_group.getGroupKey()), "/d/",
 						fileEntry.getFileEntryId());
 
-					ThemeDisplay themeDisplay = new ThemeDisplay();
-
-					themeDisplay.setLocale(locale);
-					themeDisplay.setScopeGroupId(_group.getGroupId());
-					themeDisplay.setServerName("localhost");
-					themeDisplay.setSiteGroupId(_group.getGroupId());
-
 					Assert.assertEquals(
 						expectedURL,
 						_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 							FileEntry.class.getName(),
-							fileEntry.getFileEntryId(), themeDisplay));
+							fileEntry.getFileEntryId(),
+							_getThemeDisplay(locale)));
 				});
 		}
 		finally {
@@ -133,18 +130,12 @@ public class FileEntryInfoDisplayContributorTest {
 						"/web/", StringUtil.lowerCase(_group.getGroupKey()),
 						"/d/", fileEntry.getFileEntryId());
 
-					ThemeDisplay themeDisplay = new ThemeDisplay();
-
-					themeDisplay.setLocale(locale);
-					themeDisplay.setScopeGroupId(_group.getGroupId());
-					themeDisplay.setServerName("localhost");
-					themeDisplay.setSiteGroupId(_group.getGroupId());
-
 					Assert.assertEquals(
 						expectedURL,
 						_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 							FileEntry.class.getName(),
-							fileEntry.getFileEntryId(), themeDisplay));
+							fileEntry.getFileEntryId(),
+							_getThemeDisplay(locale)));
 				});
 		}
 		finally {
@@ -172,18 +163,12 @@ public class FileEntryInfoDisplayContributorTest {
 						StringUtil.lowerCase(_group.getGroupKey()), "/d/",
 						fileEntry.getFileEntryId());
 
-					ThemeDisplay themeDisplay = new ThemeDisplay();
-
-					themeDisplay.setLocale(locale);
-					themeDisplay.setScopeGroupId(_group.getGroupId());
-					themeDisplay.setServerName("localhost");
-					themeDisplay.setSiteGroupId(_group.getGroupId());
-
 					Assert.assertEquals(
 						expectedURL,
 						_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 							FileEntry.class.getName(),
-							fileEntry.getFileEntryId(), themeDisplay));
+							fileEntry.getFileEntryId(),
+							_getThemeDisplay(locale)));
 				});
 		}
 		finally {
@@ -210,18 +195,12 @@ public class FileEntryInfoDisplayContributorTest {
 						"/web/", StringUtil.lowerCase(_group.getGroupKey()),
 						"/d/", fileEntry.getFileEntryId());
 
-					ThemeDisplay themeDisplay = new ThemeDisplay();
-
-					themeDisplay.setLocale(locale);
-					themeDisplay.setScopeGroupId(_group.getGroupId());
-					themeDisplay.setServerName("localhost");
-					themeDisplay.setSiteGroupId(_group.getGroupId());
-
 					Assert.assertEquals(
 						expectedURL,
 						_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 							FileEntry.class.getName(),
-							fileEntry.getFileEntryId(), themeDisplay));
+							fileEntry.getFileEntryId(),
+							_getThemeDisplay(locale)));
 				});
 		}
 		finally {
@@ -257,6 +236,25 @@ public class FileEntryInfoDisplayContributorTest {
 			dlFileEntry.getFileEntryId(),
 			layoutPageTemplateEntry.getLayoutPageTemplateEntryId(),
 			AssetDisplayPageConstants.TYPE_SPECIFIC, serviceContext);
+	}
+
+	private ThemeDisplay _getThemeDisplay(Locale locale) {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setLocale(locale);
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setServerName("localhost");
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		themeDisplay.setRequest(mockHttpServletRequest);
+
+		return themeDisplay;
 	}
 
 	private void _withAndWithoutAssetEntry(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
@@ -251,6 +251,8 @@ public class FileEntryInfoDisplayContributorTest {
 
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
+		mockHttpServletRequest.setRequestURI(
+			"/web/" + StringUtil.lowerCase(_group.getGroupKey()));
 
 		themeDisplay.setRequest(mockHttpServletRequest);
 

--- a/modules/apps/layout/layout-seo-web-test/src/testIntegration/java/com/liferay/layout/seo/web/internal/servlet/taglib/test/OpenGraphTopHeadDynamicIncludeTest.java
+++ b/modules/apps/layout/layout-seo-web-test/src/testIntegration/java/com/liferay/layout/seo/web/internal/servlet/taglib/test/OpenGraphTopHeadDynamicIncludeTest.java
@@ -611,14 +611,19 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 		Document document = Jsoup.parse(
 			mockHttpServletResponse.getContentAsString());
 
+		HttpServletRequest mockHttpServletRequest = _getHttpServletRequest();
+
 		_assertAlternateLinkTagAssetDisplayPage(
 			document, fileEntry,
-			_language.getAvailableLocales(_group.getGroupId()));
+			_language.getAvailableLocales(_group.getGroupId()),
+			(ThemeDisplay)mockHttpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY));
 		_assertCanonicalLinkTag(
 			document,
 			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 				FileEntry.class.getName(), fileEntry.getFileEntryId(),
-				_getThemeDisplay()));
+				(ThemeDisplay)mockHttpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY)));
 	}
 
 	@Test
@@ -641,14 +646,19 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 		Document document = Jsoup.parse(
 			mockHttpServletResponse.getContentAsString());
 
+		HttpServletRequest mockHttpServletRequest = _getHttpServletRequest();
+
 		_assertAlternateLinkTagAssetDisplayPage(
 			document, fileEntry,
-			_getAvailableLocalesLayoutTranslatedLanguages());
+			_getAvailableLocalesLayoutTranslatedLanguages(),
+			(ThemeDisplay)mockHttpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY));
 		_assertCanonicalLinkTag(
 			document,
 			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 				FileEntry.class.getName(), fileEntry.getFileEntryId(),
-				_getThemeDisplay()));
+				(ThemeDisplay)mockHttpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY)));
 	}
 
 	@Test
@@ -673,14 +683,19 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 		Document document = Jsoup.parse(
 			mockHttpServletResponse.getContentAsString());
 
+		HttpServletRequest mockHttpServletRequest = _getHttpServletRequest();
+
 		_assertAlternateLinkTagAssetDisplayPage(
 			document, fileEntry,
-			_getAvailableLocalesLayoutTranslatedLanguages());
+			_getAvailableLocalesLayoutTranslatedLanguages(),
+			(ThemeDisplay)mockHttpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY));
 		_assertCanonicalLinkTag(
 			document,
 			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 				FileEntry.class.getName(), fileEntry.getFileEntryId(),
-				_getThemeDisplay()));
+				(ThemeDisplay)mockHttpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY)));
 	}
 
 	@Test
@@ -703,14 +718,19 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 		Document document = Jsoup.parse(
 			mockHttpServletResponse.getContentAsString());
 
+		HttpServletRequest mockHttpServletRequest = _getHttpServletRequest();
+
 		_assertAlternateLinkTagAssetDisplayPage(
 			document, fileEntry,
-			_language.getAvailableLocales(_group.getGroupId()));
+			_language.getAvailableLocales(_group.getGroupId()),
+			(ThemeDisplay)mockHttpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY));
 		_assertCanonicalLinkTag(
 			document,
 			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 				FileEntry.class.getName(), fileEntry.getFileEntryId(),
-				_getThemeDisplay()));
+				(ThemeDisplay)mockHttpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY)));
 	}
 
 	@Test
@@ -733,14 +753,19 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 		Document document = Jsoup.parse(
 			mockHttpServletResponse.getContentAsString());
 
+		HttpServletRequest mockHttpServletRequest = _getHttpServletRequest();
+
 		_assertCanonicalLinkTag(
 			document,
 			_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 				FileEntry.class.getName(), fileEntry.getFileEntryId(),
-				_getThemeDisplay()));
+				(ThemeDisplay)mockHttpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY)));
 		_assertAlternateLinkTagAssetDisplayPage(
 			document, fileEntry,
-			_getAvailableLocalesLayoutTranslatedLanguages());
+			_getAvailableLocalesLayoutTranslatedLanguages(),
+			(ThemeDisplay)mockHttpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY));
 	}
 
 	@Test
@@ -1395,7 +1420,8 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 	}
 
 	private void _assertAlternateLinkTagAssetDisplayPage(
-			Document document, FileEntry fileEntry, Set<Locale> locales)
+			Document document, FileEntry fileEntry, Set<Locale> locales,
+			ThemeDisplay themeDisplay)
 		throws Exception {
 
 		Elements alternateLinkElements = document.select(
@@ -1413,7 +1439,7 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 			Assert.assertEquals(
 				_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 					FileEntry.class.getName(), fileEntry.getFileEntryId(),
-					locale, _getThemeDisplay()),
+					locale, themeDisplay),
 				localeAlternateLinkElement.attr("href"));
 		}
 	}

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLProviderImpl.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLProviderImpl.java
@@ -169,7 +169,7 @@ public class AssetDisplayPageFriendlyURLProviderImpl
 
 		String requestURI = httpServletRequest.getRequestURI();
 
-		if (!requestURI.contains("/web/")) {
+		if (!requestURI.contains("/group/") && !requestURI.contains("/web/")) {
 			friendlyURL = friendlyURL.split("/web/")[0];
 		}
 

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLProviderImpl.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLProviderImpl.java
@@ -35,6 +35,8 @@ import com.liferay.portal.util.PropsValues;
 import java.util.Locale;
 import java.util.Set;
 
+import javax.servlet.http.HttpServletRequest;
+
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -115,7 +117,9 @@ public class AssetDisplayPageFriendlyURLProviderImpl
 		}
 
 		return StringBundler.concat(
-			_getGroupFriendlyURL(groupId, locale, themeDisplay),
+			_removeGroupNameIfNotNeeded(
+				_getGroupFriendlyURL(groupId, locale, themeDisplay),
+				themeDisplay),
 			layoutDisplayPageProvider.getURLSeparator(),
 			layoutDisplayPageObjectProvider.getURLTitle(locale));
 	}
@@ -153,6 +157,23 @@ public class AssetDisplayPageFriendlyURLProviderImpl
 		}
 
 		return StringPool.SLASH + locale.toLanguageTag();
+	}
+
+	private String _removeGroupNameIfNotNeeded(
+		String friendlyURL, ThemeDisplay themeDisplay) {
+
+		HttpServletRequest httpServletRequest = themeDisplay.getRequest();
+
+		httpServletRequest = _portal.getOriginalServletRequest(
+			httpServletRequest);
+
+		String requestURI = httpServletRequest.getRequestURI();
+
+		if (!requestURI.contains("/web/")) {
+			friendlyURL = friendlyURL.split("/web/")[0];
+		}
+
+		return friendlyURL;
 	}
 
 	private void _setThemeDisplayI18n(

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLProviderImpl.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-asset-display/src/main/java/com/liferay/layout/type/controller/asset/display/internal/portlet/AssetDisplayPageFriendlyURLProviderImpl.java
@@ -16,7 +16,6 @@ package com.liferay.layout.type.controller.asset.display.internal.portlet;
 
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.display.page.util.AssetDisplayPageUtil;
-import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
@@ -176,9 +175,6 @@ public class AssetDisplayPageFriendlyURLProviderImpl
 		themeDisplay.setLanguageId(LocaleUtil.toLanguageId(locale));
 		themeDisplay.setLocale(locale);
 	}
-
-	@Reference
-	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
 	private GroupLocalService _groupLocalService;


### PR DESCRIPTION
Hi Team,

Found that the source of the poshi test failures. Non-guest site's control panel should not remove the `web/group-name/` from the URL.

Can you please review?
https://issues.liferay.com/browse/LPS-136518

Thanks,
Balázs