### PR TITLE
[TS] LPS-139624

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/BaseJournalFormNavigatorEntry.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/BaseJournalFormNavigatorEntry.java
@@ -21,8 +21,11 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanParamUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 
 import java.util.Locale;
@@ -66,6 +69,28 @@ public abstract class BaseJournalFormNavigatorEntry
 			article, portletRequest, "classNameId");
 
 		if (classNameId > JournalArticleConstants.CLASS_NAME_ID_DEFAULT) {
+			return true;
+		}
+
+		return false;
+	}
+
+	protected boolean isGlobalSiteOrDepot(JournalArticle article) {
+		Group group = null;
+
+		if ((article != null) && (article.getId() > 0)) {
+			group = GroupLocalServiceUtil.fetchGroup(article.getGroupId());
+		}
+		else {
+			ServiceContext serviceContext =
+				ServiceContextThreadLocal.getServiceContext();
+
+			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+			group = themeDisplay.getScopeGroup();
+		}
+
+		if ((group != null) && (group.isCompany() || group.isDepot())) {
 			return true;
 		}
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/JournalDisplayPageFormNavigatorEntry.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/JournalDisplayPageFormNavigatorEntry.java
@@ -17,12 +17,7 @@ package com.liferay.journal.web.internal.frontend.taglib.form.navigator;
 import com.liferay.frontend.taglib.form.navigator.FormNavigatorEntry;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.journal.model.JournalArticle;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
-import com.liferay.portal.kernel.service.GroupLocalService;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 
 import javax.servlet.ServletContext;
 
@@ -46,21 +41,7 @@ public class JournalDisplayPageFormNavigatorEntry
 
 	@Override
 	public boolean isVisible(User user, JournalArticle article) {
-		Group group = null;
-
-		if ((article != null) && (article.getId() > 0)) {
-			group = _groupLocalService.fetchGroup(article.getGroupId());
-		}
-		else {
-			ServiceContext serviceContext =
-				ServiceContextThreadLocal.getServiceContext();
-
-			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
-
-			group = themeDisplay.getScopeGroup();
-		}
-
-		if ((group != null) && (group.isCompany() || group.isDepot())) {
+		if (isGlobalSiteOrDepot(article)) {
 			return false;
 		}
 
@@ -89,8 +70,5 @@ public class JournalDisplayPageFormNavigatorEntry
 	protected String getJspPath() {
 		return "/article/display_page.jsp";
 	}
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/JournalFriendlyURLFormNavigatorEntry.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/JournalFriendlyURLFormNavigatorEntry.java
@@ -40,7 +40,7 @@ public class JournalFriendlyURLFormNavigatorEntry
 
 	@Override
 	public boolean isVisible(User user, JournalArticle article) {
-		if (isEditDefaultValues(article)) {
+		if (isEditDefaultValues(article) || isGlobalSiteOrDepot(article)) {
 			return false;
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-139624

## Problem overview

We were trying to figure out a good reason for why the friendly URL field is still available for content in the global scope I theorized that it would allow you to create content in the global scope, export the content as a LAR, and then import that LAR into a non-global site, most likely in a different portal instance (or portal server).

However, for that, you could just create a non-global site, so it didn't seem to be a compelling reason. Since we couldn't come up with any other compelling reasons, we felt it best to remove the option to avoid any potential confusion as to the meaning of a "friendly URL" field.

If the friendly URL field is intentionally visible, can we have an explanation for what it would be used for? Thanks in advance.