### PR TITLE
LPS-130069 It's not possible to scroll a structure when the mouse is on the left side of the builder

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -193,7 +193,6 @@ $productMenuWidth: 320px;
 				max-height: calc(
 					100vh - #{$controlMenuHeight + $portletLayoutMargin} - #{$toolbarHeight}
 				);
-				overflow: auto;
 
 				@include media-breakpoint-up(lg) {
 					max-height: calc(


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-130069