### PR TITLE
LPS-140136 Preview draft action needs update permission

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -1502,8 +1502,12 @@ public class LayoutsAdminDisplayContext {
 		return true;
 	}
 
-	public boolean isShowDraftActions(Layout layout) {
-		if (!layout.isTypeContent()) {
+	public boolean isShowDraftActions(Layout layout) throws PortalException {
+		if (!layout.isTypeContent() ||
+			!LayoutPermissionUtil.contains(
+				themeDisplay.getPermissionChecker(), layout,
+				ActionKeys.UPDATE)) {
+
 			return false;
 		}
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java
@@ -515,7 +515,11 @@ public class LayoutsTreeImpl implements LayoutsTree {
 
 			Layout draftLayout = _getDraftLayout(layout);
 
-			if (draftLayout != null) {
+			if ((draftLayout != null) &&
+				LayoutPermissionUtil.contains(
+					themeDisplay.getPermissionChecker(), layout,
+					ActionKeys.UPDATE)) {
+
 				jsonObject.put("draftStatus", "draft");
 
 				String draftLayoutURL = _portal.getLayoutFriendlyURL(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java
@@ -71,10 +71,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Zsolt Szabó
  * @author Tibor Lipusz
  */
-@Component(
-	configurationPid = "com.liferay.layout.internal.configuration.FFLayoutPreviewDraftConfiguration",
-	immediate = true, service = LayoutsTree.class
-)
+@Component(immediate = true, service = LayoutsTree.class)
 public class LayoutsTreeImpl implements LayoutsTree {
 
 	@Override

--- a/portal-web/test/functional/com/liferay/portalweb/macros/layout/pageeditor/PageEditor.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/layout/pageeditor/PageEditor.macro
@@ -4051,6 +4051,8 @@ definition {
 	}
 
 	macro waitForAutoSave {
+		Pause(locator1 = "1000");
+
 		WaitForVisible(locator1 = "PageEditor#AUTOSAVE_MESSAGE");
 	}
 


### PR DESCRIPTION
- LPS-140136 Don't show preview and discard draft actions when the user doesn't have update permissions for the page
- LPS-140136 Remove unused configurationPid
