### PR TITLE
LPS-139714 Objects from Main Instance are being displayed to be selected on Collection Providers on the Virtual Instance and vice versa

### DIFF
--- a/modules/apps/info/info-collection-provider-item-selector-web/src/main/java/com/liferay/info/collection/provider/item/selector/web/internal/InfoCollectionProviderItemSelectorView.java
+++ b/modules/apps/info/info-collection-provider-item-selector-web/src/main/java/com/liferay/info/collection/provider/item/selector/web/internal/InfoCollectionProviderItemSelectorView.java
@@ -23,6 +23,7 @@ import com.liferay.info.list.provider.item.selector.criterion.InfoListProviderIt
 import com.liferay.item.selector.ItemSelectorReturnType;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 
 import java.io.IOException;
@@ -103,21 +104,26 @@ public class InfoCollectionProviderItemSelectorView
 		InfoCollectionProviderItemSelectorCriterion
 			infoCollectionProviderItemSelectorCriterion) {
 
-		List<InfoCollectionProvider<?>> infoCollectionProviders =
+		List<InfoCollectionProvider<?>> infoCollectionProviders1 =
 			new ArrayList<>();
 
 		List<String> itemTypes =
 			infoCollectionProviderItemSelectorCriterion.getItemTypes();
 
 		for (String itemType : itemTypes) {
-			infoCollectionProviders.addAll(
+			List<InfoCollectionProvider<?>> infoCollectionProviders2 =
 				_infoItemServiceTracker.getAllInfoItemServices(
 					(Class<InfoCollectionProvider<?>>)
 						(Class<?>)InfoCollectionProvider.class,
-					itemType));
+					itemType);
+
+			infoCollectionProviders2 = ListUtil.filter(
+				infoCollectionProviders2, InfoCollectionProvider::isAvailable);
+
+			infoCollectionProviders1.addAll(infoCollectionProviders2);
 		}
 
-		return Collections.unmodifiableList(infoCollectionProviders);
+		return Collections.unmodifiableList(infoCollectionProviders1);
 	}
 
 	private static final List<ItemSelectorReturnType>

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
@@ -53,6 +53,7 @@ import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.search.generic.NestedQuery;
 import com.liferay.portal.kernel.search.generic.TermQueryImpl;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -192,6 +193,17 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 	@Override
 	public List<InfoFilter> getSupportedInfoFilters() {
 		return Arrays.asList(new KeywordsInfoFilter());
+	}
+
+	@Override
+	public boolean isAvailable() {
+		if (_objectDefinition.getCompanyId() !=
+				CompanyThreadLocal.getCompanyId()) {
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private SearchContext _buildSearchContext(CollectionQuery collectionQuery)


### PR DESCRIPTION
Hey guys, I overrode InfoCollectionProvider.isAvailable() method to scope our collection providers by company.
I had to adjust InfoCollectionProviderItemSelectorView#_getInfoCollectionProviders to return just available collections. I saw the same approach in SelectLayoutCollectionDisplayContext#_getInfoCollectionProviders

Please let me know if you have a better solution for this.
cc: @ealonso @jkappler 