### PR TITLE
[TS] LPS-140318 | Changes in the master page won't propagate to the content page

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.service.PortletPreferenceValueLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -198,9 +199,13 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 
 			String defaultPreferences = StringPool.BLANK;
 
+			long plid = ParamUtil.getLong(
+				fragmentEntryProcessorContext.getHttpServletRequest(),
+				"p_l_id");
+
 			if (originalFragmentEntryLink != null) {
 				defaultPreferences = _getPreferences(
-					portletName, originalFragmentEntryLink, id,
+					plid, portletName, originalFragmentEntryLink, id,
 					StringPool.BLANK);
 			}
 			else {
@@ -212,7 +217,8 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 				fragmentEntryProcessorContext.getHttpServletResponse(),
 				portletName, instanceId,
 				_getPreferences(
-					portletName, fragmentEntryLink, id, defaultPreferences));
+					plid, portletName, fragmentEntryLink, id,
+					defaultPreferences));
 
 			Element portletElement = new Element("div");
 
@@ -315,8 +321,8 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 	}
 
 	private String _getPreferences(
-			String portletName, FragmentEntryLink fragmentEntryLink, String id,
-			String defaultPreferences)
+			long plid, String portletName, FragmentEntryLink fragmentEntryLink,
+			String id, String defaultPreferences)
 		throws PortalException {
 
 		String defaultPortletId = _getPortletId(
@@ -350,7 +356,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 					PortletPreferencesFactoryUtil.toXML(jxPortletPreferences));
 
 			_updateLayoutPortletSetup(
-				portletPreferencesList, jxPortletPreferences);
+				plid, portletPreferencesList, jxPortletPreferences);
 		}
 
 		Document preferencesDocument = _getDocument(
@@ -396,6 +402,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 	}
 
 	private void _updateLayoutPortletSetup(
+		long layoutPlid,
 		List<com.liferay.portal.kernel.model.PortletPreferences>
 			portletPreferencesList,
 		PortletPreferences jxPortletPreferences) {
@@ -403,10 +410,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 		long plid = 0;
 
 		if (jxPortletPreferences instanceof PortletPreferencesImpl) {
-			PortletPreferencesImpl portletPreferencesImpl =
-				(PortletPreferencesImpl)jxPortletPreferences;
-
-			plid = portletPreferencesImpl.getPlid();
+			plid = layoutPlid;
 		}
 
 		String portletPreferencesXML = PortletPreferencesFactoryUtil.toXML(


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-140318
Thank you!

----

When using widgets in fragments on master pages the portlet preferences will never get updated on the layouts created from the master page. I think the reason behind it is that the updateLayoutPortletSetup will always use the received portletPreferences to get the plid which will point on the master page over the current page. 

@laszlopap