### PR TITLE
[TS] LPS-141548

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
@@ -233,7 +233,11 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 						Array.prototype.forEach.call(
 							selectedItems,
 							(assetEntry) => {
-								assetEntryIds.push(assetEntry.value);
+								if (assetEntry.entityid === undefined) {
+									assetEntryIds.push(assetEntry.value);
+								} else {
+									assetEntryIds.push(assetEntry.entityid);
+								}
 							}
 						);
 

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
@@ -235,7 +235,8 @@ AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 							(assetEntry) => {
 								if (assetEntry.entityid === undefined) {
 									assetEntryIds.push(assetEntry.value);
-								} else {
+								}
+								else {
 									assetEntryIds.push(assetEntry.entityid);
 								}
 							}

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
@@ -242,7 +242,8 @@ for (long groupId : groupIds) {
 		Array.prototype.forEach.call(assetEntryList, (assetEntry) => {
 			if (assetEntry.entityid === undefined) {
 				assetEntryIds.push(assetEntry.value);
-			} else {
+			}
+			else {
 				assetEntryIds.push(assetEntry.entityid);
 			}
 

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
@@ -240,7 +240,11 @@ for (long groupId : groupIds) {
 		var assetEntryIds = [];
 
 		Array.prototype.forEach.call(assetEntryList, (assetEntry) => {
-			assetEntryIds.push(assetEntry.entityid);
+			if (assetEntry.entityid === undefined) {
+				assetEntryIds.push(assetEntry.value);
+			} else {
+				assetEntryIds.push(assetEntry.entityid);
+			}
 
 			assetClassName = assetEntry.assetclassname;
 		});
@@ -267,6 +271,7 @@ for (long groupId : groupIds) {
 			var delegateTarget = event.delegateTarget;
 
 			Liferay.Util.openSelectionModal({
+				customSelectEvent: true,
 				multiple: true,
 				onSelect: function (selectedItems) {
 					if (selectedItems) {


### PR DESCRIPTION
Hello team,

I'm trying to fix issues with card views logic when manually selecting assets in AP. 

This fixes the following:

- Use case described in LPS-141548. (Cards view in asset publisher).
- Regression I just found while testing, caused by LPS-133326, where **not** paginated asset selection in cards view wasn't working in Collections.
- List and table view logic when selecting assets from different pages in **AP**.

It does **not** fix:

- Cards view logic when items from different pages are selected in **AP**. Only last one is added to the list. Both entityid and value of previous pages are undefined, but I haven't been able to figure out the root cause.
- Cards view logic when items from different pages are selected in **Collections**. Same behaviour as the previous use case.

Could you please take a look at the changes?

cc/ @victorg1991 