### PR TITLE
[TS] LPS-141980 Use the same tag filtering for Tags Widget Templates as for the default portlet rendering

### DIFF
--- a/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/init.jsp
@@ -34,6 +34,7 @@ page import="com.liferay.portal.kernel.security.permission.ResourceActionsUtil" 
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.ListUtil" %><%@
+page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.PrefsParamUtil" %>
 
 <%@ page import="java.util.ArrayList" %><%@

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/view.jsp
@@ -20,13 +20,36 @@
 List<AssetTag> assetTags = null;
 
 if (showAssetCount && (classNameId > 0)) {
-	assetTags = AssetTagServiceUtil.getTags(scopeGroupId, classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
+	assetTags = AssetTagServiceUtil.getTags(PortalUtil.getSiteGroupId(scopeGroupId), classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
 }
 else {
-	assetTags = AssetTagServiceUtil.getGroupTags(scopeGroupId, 0, maxAssetTags, new AssetTagCountComparator());
+	assetTags = AssetTagServiceUtil.getGroupTags(PortalUtil.getSiteGroupId(scopeGroupId), 0, maxAssetTags, new AssetTagCountComparator());
 }
 
 assetTags = ListUtil.sort(assetTags);
+
+List<AssetTag> filteredAssetTags = new ArrayList<>();
+
+for (AssetTag tag : assetTags) {
+	String tagName = tag.getName();
+
+	int count = 0;
+
+	if (classNameId > 0) {
+		count = AssetTagServiceUtil.getVisibleAssetsTagsCount(scopeGroupId, classNameId, tagName);
+	}
+	else {
+		count = AssetTagServiceUtil.getVisibleAssetsTagsCount(scopeGroupId, tagName);
+	}
+
+	if ((count > 0) || showZeroAssetCount) {
+		AssetTag filteredTag = (AssetTag)tag.clone();
+
+		filteredTag.setAssetCount(count);
+
+		filteredAssetTags.add(filteredTag);
+	}
+}
 %>
 
 <liferay-ddm:template-renderer
@@ -38,7 +61,7 @@ assetTags = ListUtil.sort(assetTags);
 	%>'
 	displayStyle="<%= displayStyle %>"
 	displayStyleGroupId="<%= displayStyleGroupId %>"
-	entries="<%= assetTags %>"
+	entries="<%= filteredAssetTags %>"
 >
 	<liferay-asset:asset-tags-navigation
 		classNameId="<%= classNameId %>"


### PR DESCRIPTION
Hi @liferay-echo Team,

I've implemented a fix of [LPS-141980](https://issues.liferay.com/browse/LPS-141980) to eliminate the differences between the default Tag Cloud/Tags Navigation portlet rendering and when the "Color by Popularity" widget template is used. I tried to replicate the same behavior as `_buildTagsNavigation()` in: https://github.com/liferay/liferay-portal/blob/master/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_navigation/page.jsp .

Please review my changes.

Thanks,
Vendel

