### PR TITLE
[TS] LPS-140318 | Changes in the master page won't propagate to the content page

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.service.PortletPreferenceValueLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -199,9 +200,13 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 
 			String defaultPreferences = StringPool.BLANK;
 
+			long plid = ParamUtil.getLong(
+				fragmentEntryProcessorContext.getHttpServletRequest(),
+				"p_l_id");
+
 			if (originalFragmentEntryLink != null) {
 				defaultPreferences = _getPreferences(
-					portletName, originalFragmentEntryLink, id,
+					plid, portletName, originalFragmentEntryLink, id,
 					StringPool.BLANK);
 			}
 			else {
@@ -213,7 +218,8 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 				fragmentEntryProcessorContext.getHttpServletResponse(),
 				portletName, instanceId,
 				_getPreferences(
-					portletName, fragmentEntryLink, id, defaultPreferences));
+					plid, portletName, fragmentEntryLink, id,
+					defaultPreferences));
 
 			Element portletElement = new Element("div");
 
@@ -343,8 +349,8 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 	}
 
 	private String _getPreferences(
-			String portletName, FragmentEntryLink fragmentEntryLink, String id,
-			String defaultPreferences)
+			long plid, String portletName, FragmentEntryLink fragmentEntryLink,
+			String id, String defaultPreferences)
 		throws PortalException {
 
 		String defaultPortletId = _getPortletId(
@@ -378,7 +384,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 					PortletPreferencesFactoryUtil.toXML(jxPortletPreferences));
 
 			_updateLayoutPortletSetup(
-				portletPreferencesList, jxPortletPreferences);
+				plid, portletPreferencesList, jxPortletPreferences);
 		}
 
 		Document preferencesDocument = _getDocument(
@@ -424,6 +430,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 	}
 
 	private void _updateLayoutPortletSetup(
+		long layoutPlid,
 		List<com.liferay.portal.kernel.model.PortletPreferences>
 			portletPreferencesList,
 		PortletPreferences jxPortletPreferences) {
@@ -431,10 +438,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 		long plid = 0;
 
 		if (jxPortletPreferences instanceof PortletPreferencesImpl) {
-			PortletPreferencesImpl portletPreferencesImpl =
-				(PortletPreferencesImpl)jxPortletPreferences;
-
-			plid = portletPreferencesImpl.getPlid();
+			plid = layoutPlid;
 		}
 
 		for (com.liferay.portal.kernel.model.PortletPreferences

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
@@ -49,9 +49,10 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portlet.PortletPreferencesImpl;
 
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Objects;
+import java.util.Map;
 import java.util.ResourceBundle;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -275,6 +276,33 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 		return false;
 	}
 
+	private boolean _comparePreferences(
+		PortletPreferences currentPortletPreferences,
+		PortletPreferences sourcePortletPreferences) {
+
+		Map<String, String[]> currentPreferences =
+			currentPortletPreferences.getMap();
+
+		Map<String, String[]> sourcePreferences =
+			sourcePortletPreferences.getMap();
+
+		if (currentPreferences.size() != sourcePreferences.size()) {
+			return false;
+		}
+
+		for (Map.Entry<String, String[]> entry :
+				currentPreferences.entrySet()) {
+
+			if (!Arrays.equals(
+					sourcePreferences.get(entry.getKey()), entry.getValue())) {
+
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	private Document _getDocument(String html) {
 		Document document = Jsoup.parseBodyFragment(html);
 
@@ -409,9 +437,6 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 			plid = portletPreferencesImpl.getPlid();
 		}
 
-		String portletPreferencesXML = PortletPreferencesFactoryUtil.toXML(
-			jxPortletPreferences);
-
 		for (com.liferay.portal.kernel.model.PortletPreferences
 				portletPreferencesImpl : portletPreferencesList) {
 
@@ -420,10 +445,8 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 					portletPreferencesImpl);
 
 			if ((plid != portletPreferencesImpl.getPlid()) ||
-				Objects.equals(
-					PortletPreferencesFactoryUtil.toXML(
-						currentPortletPreferences),
-					portletPreferencesXML)) {
+				_comparePreferences(
+					currentPortletPreferences, jxPortletPreferences)) {
 
 				continue;
 			}


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-140318
Thank you!

------

We discussed the [regression](https://issues.liferay.com/browse/LPS-140737) issue on [PTR-2713](https://issues.liferay.com/browse/PTR-2713) with @dacousalr. According to my findings, the HSQL database regression was caused by the difference in the preferences map order. The validation was based on the string comparison of two XMLs, because of this, the comparison becomes order sensitive to the order of the preferences. To remove this limitation, I compare the two preferences map directly without creating XMLs from them.