### PR TITLE
LPS-141460 Remove autogeneration of URLs in Web Content translations deleting previous friendly URLs when not introduced or left in blank

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/upgrade/FriendlyURLServiceUpgrade.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/upgrade/FriendlyURLServiceUpgrade.java
@@ -16,9 +16,9 @@ package com.liferay.friendly.url.internal.upgrade;
 
 import com.liferay.friendly.url.internal.upgrade.v2_0_0.util.FriendlyURLEntryTable;
 import com.liferay.friendly.url.internal.upgrade.v3_0_0.UpgradeCompanyId;
-import com.liferay.friendly.url.internal.upgrade.v3_1_1.FriendlyURLEntryLocalizationUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.BaseSQLServerDatetimeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
+import com.liferay.portal.kernel.upgrade.DummyUpgradeStep;
 import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
 
 import org.osgi.service.component.annotations.Component;
@@ -44,8 +44,7 @@ public class FriendlyURLServiceUpgrade implements UpgradeStepRegistrator {
 				"FriendlyURLEntry", "FriendlyURLEntryLocalization",
 				"FriendlyURLEntryMapping"));
 
-		registry.register(
-			"3.1.0", "3.1.1", new FriendlyURLEntryLocalizationUpgradeProcess());
+		registry.register("3.1.0", "3.1.1", new DummyUpgradeStep());
 	}
 
 }

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/upgrade/v3_1_1/FriendlyURLEntryLocalizationUpgradeProcess.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/internal/upgrade/v3_1_1/FriendlyURLEntryLocalizationUpgradeProcess.java
@@ -36,8 +36,10 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
+ * @deprecated As of Athanasius (7.3.x)
  * @author Ricardo Couso
  */
+@Deprecated
 public class FriendlyURLEntryLocalizationUpgradeProcess extends UpgradeProcess {
 
 	@Override


### PR DESCRIPTION
Hi team,

This PR tries to accomplish the conclusions reached in [PTR-2609](https://issues.liferay.com/browse/PTR-2609?focusedCommentId=2548745&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2548745):

1. Friendly URL fields are not auto-generated automatically
2. Friendly URL fields can be left blank. Those translations will take the URL from the default language. No warning will be shown.
3. In the cases where a repeated URL is detected, the system will complete the URL to ensure its uniqueness. The current alert after publishing will be shown.
4. It will also fix the problem that re-publication generates a new URL again.
5. The upgrade step that auto-generates all existing translations without friendlyURL when installing Fix Pack 2 will be removed.

Please, let me know if further information or clarification is needed for your review.

Thanks in advance