### PR TITLE
LPS-142147 | master

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
@@ -86,6 +86,7 @@ if (assetPublisherDisplayContext.isEnableTagBasedNavigation() && !assetPublisher
 <c:if test="<%= assetPublisherDisplayContext.isShowMetadataDescriptions() %>">
 	<liferay-asset:categorization-filter
 		assetType="content"
+		groupIds="<%= assetPublisherDisplayContext.getGroupIds() %>"
 		portletURL="<%= assetPublisherDisplayContext.getPortletURL() %>"
 	/>
 </c:if>

--- a/modules/apps/asset/asset-taglib/bnd.bnd
+++ b/modules/apps/asset/asset-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset Taglib
 Bundle-SymbolicName: com.liferay.asset.taglib
-Bundle-Version: 6.1.20
+Bundle-Version: 6.2.0
 Export-Package: com.liferay.asset.taglib.servlet.taglib
 Liferay-JS-Config: /META-INF/resources/config.js
 Provide-Capability:\

--- a/modules/apps/asset/asset-taglib/package.json
+++ b/modules/apps/asset/asset-taglib/package.json
@@ -17,5 +17,5 @@
 		"checkFormat": "liferay-npm-scripts check",
 		"format": "liferay-npm-scripts fix"
 	},
-	"version": "6.1.20"
+	"version": "6.2.0"
 }

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/CategorizationFilterTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/CategorizationFilterTag.java
@@ -31,12 +31,20 @@ public class CategorizationFilterTag extends IncludeTag {
 		return _assetType;
 	}
 
+	public long[] getGroupIds() {
+		return _groupIds;
+	}
+
 	public PortletURL getPortletURL() {
 		return _portletURL;
 	}
 
 	public void setAssetType(String assetType) {
 		_assetType = assetType;
+	}
+
+	public void setGroupIds(long[] groupIds) {
+		_groupIds = groupIds;
 	}
 
 	@Override
@@ -55,6 +63,7 @@ public class CategorizationFilterTag extends IncludeTag {
 		super.cleanUp();
 
 		_assetType = null;
+		_groupIds = null;
 		_portletURL = null;
 	}
 
@@ -68,12 +77,15 @@ public class CategorizationFilterTag extends IncludeTag {
 		httpServletRequest.setAttribute(
 			"liferay-asset:categorization-filter:assetType", _assetType);
 		httpServletRequest.setAttribute(
+			"liferay-asset:categorization-filter:groupIds", _groupIds);
+		httpServletRequest.setAttribute(
 			"liferay-asset:categorization-filter:portletURL", _portletURL);
 	}
 
 	private static final String _PAGE = "/categorization_filter/page.jsp";
 
 	private String _assetType;
+	private long[] _groupIds;
 	private PortletURL _portletURL;
 
 }

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/liferay-asset.tld
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/liferay-asset.tld
@@ -592,6 +592,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>groupIds</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>portletURL</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/categorization_filter/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/categorization_filter/page.jsp
@@ -19,6 +19,8 @@
 <%
 String assetType = GetterUtil.getString((String)request.getAttribute("liferay-asset:categorization-filter:assetType"), "content");
 
+long[] groupIds = GetterUtil.getLongValues(request.getAttribute("liferay-asset:categorization-filter:groupIds"), new long[] {layout.getGroupId()});
+
 PortletURL portletURL = (PortletURL)request.getAttribute("liferay-asset:categorization-filter:portletURL");
 
 if (portletURL == null) {
@@ -29,7 +31,9 @@ long assetCategoryId = ParamUtil.getLong(request, "categoryId");
 
 String assetTagName = ParamUtil.getString(request, "tag");
 
-if (Validator.isNotNull(assetTagName) && !AssetTagLocalServiceUtil.hasTag(layout.getGroupId(), assetTagName)) {
+long[] tagIds = AssetTagLocalServiceUtil.getTagIds(groupIds, assetTagName);
+
+if (Validator.isNotNull(assetTagName) && (tagIds.length == 0)) {
 	assetTagName = null;
 }
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/com/liferay/asset/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/asset/asset-taglib/src/main/resources/com/liferay/asset/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 2.3.0
+version 2.4.0


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-142147

### Steps to reproduce

1. Go to Global site > Categorization > Tags
2. Add a tag named "global"
3. Go to Content & Data > Web Content
4. Add a web content with "global" tag
5. Go to default site and edit the home page
6. Add a Tags Navigation widget
7. Open "Tags Navigation - Configuration > Scope" and change scope to Global
8. Add a Asset Publisher widget
9. Open "Asset Publisher - Configuration > Setup: Asset Selection: SCOPE" and change scope to Global
10. Publish the changes
11. Click "global" tag displayed on the Tags Navigation widget

**Actual result**: "Content with tag XXX" is not displayed above the Asset Publisher widget.
**Expected result**: "Content with tag XXX" is displayed above the Asset Publisher widget.

### Notes about the solution

Given that the issue is that the tag has no idea which sites were configured, it made the most sense to pass that along as a tag attribute from code that did know (in this case, asset publisher). For backwards compatibility, that attribute is optional.