### PR TITLE
LPS-141922 | master

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6684,7 +6684,9 @@ public class JournalArticleLocalServiceImpl
 						extraDataJSONObject.toString(), 0);
 				}
 			}
-			else if (oldStatus == WorkflowConstants.STATUS_APPROVED) {
+			else if ((oldStatus == WorkflowConstants.STATUS_APPROVED) &&
+					 (status != WorkflowConstants.STATUS_IN_TRASH)) {
+
 				updatePreviousApprovedArticle(article);
 			}
 		}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -4407,9 +4407,12 @@ public class JournalArticleLocalServiceImpl
 			JournalArticle.class.getName(), article.getResourcePrimKey());
 
 		if (visible) {
-			_assetEntryLocalService.updateVisible(
-				JournalArticle.class.getName(), article.getResourcePrimKey(),
-				true);
+			AssetEntry entry = _assetEntryLocalService.getEntry(
+				JournalArticle.class.getName(), article.getResourcePrimKey());
+
+			entry.setTitle(article.getTitleMapAsXML());
+
+			_assetEntryLocalService.updateVisible(entry, true);
 		}
 
 		// Comment


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-141922

### Steps to reproduce

1. Add an asset publisher to a page, and update its display settings to show Titles Only
2. Navigate to Default site > Content & Data > Web Content
3. Add a web content with the title "version 1.0" and publish
4. Edit the content created in Step 2
5. Change the title to "version 1.1" and publish
6. Check the page with the asset publisher to confirm it shows the title "version 1.1"
7. Move the web content to Recycle bin
8. Restore the web content from Recycle bin
9. Check the page with the asset publisher

**Actual result**: Title shows version 1.0
**Expected result**: Title shows version 1.1

### Notes about the solution

Issue happens due to a call to `updatePreviousApprovedArticle` when moving items to the trash.

In theory, a complete solution has two parts: one which makes sure that it doesn't happen again, and another which tries to fix the issue when restoring the web content in the case of legacy content that is still in the recycle bin. This has been provided as two separate commits.

If it doesn't make sense to include the changes which fix the issue on restore, we can fix the existing entries that are in the recycle bin with a Groovy script instead and remove the second commit from the fix.

Please let me know how you'd like to proceed.