### PR TITLE
LPS-140916 Add missing info to make this view consistent with sites admin

### DIFF
--- a/modules/apps/site/site-my-sites-web/src/main/java/com/liferay/site/my/sites/web/internal/display/context/SiteMySitesDisplayContext.java
+++ b/modules/apps/site/site-my-sites-web/src/main/java/com/liferay/site/my/sites/web/internal/display/context/SiteMySitesDisplayContext.java
@@ -23,6 +23,8 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.SearchDisplayStyleUtil;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
+import com.liferay.portal.kernel.service.UserGroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -41,6 +43,7 @@ import com.liferay.site.my.sites.web.internal.servlet.taglib.util.SiteActionDrop
 import com.liferay.users.admin.kernel.util.UsersAdminUtil;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -85,6 +88,29 @@ public class SiteMySitesDisplayContext {
 				group, _renderRequest, _renderResponse, getTabs1());
 
 		return siteActionDropdownItemsProvider.getActionDropdownItems();
+	}
+
+	public int getGroupOrganizationsCount(long groupId) {
+		if (_groupOrganizationsCounts != null) {
+			return GetterUtil.getInteger(
+				_groupOrganizationsCounts.get(groupId));
+		}
+
+		_groupOrganizationsCounts = new HashMap<>();
+
+		GroupSearch groupSearch = getGroupSearchContainer();
+
+		long[] groupIds = ListUtil.toLongArray(
+			groupSearch.getResults(), Group.GROUP_ID_ACCESSOR);
+
+		for (long curGroupId : groupIds) {
+			_groupOrganizationsCounts.put(
+				curGroupId,
+				OrganizationLocalServiceUtil.getGroupOrganizationsCount(
+					curGroupId));
+		}
+
+		return GetterUtil.getInteger(_groupOrganizationsCounts.get(groupId));
 	}
 
 	public GroupSearch getGroupSearchContainer() {
@@ -145,6 +171,27 @@ public class SiteMySitesDisplayContext {
 		_groupSearch = groupSearch;
 
 		return _groupSearch;
+	}
+
+	public int getGroupUserGroupsCount(long groupId) {
+		if (_groupUserGroupsCounts != null) {
+			return GetterUtil.getInteger(_groupUserGroupsCounts.get(groupId));
+		}
+
+		_groupUserGroupsCounts = new HashMap<>();
+
+		GroupSearch groupSearch = getGroupSearchContainer();
+
+		long[] groupIds = ListUtil.toLongArray(
+			groupSearch.getResults(), Group.GROUP_ID_ACCESSOR);
+
+		for (long curGroupId : groupIds) {
+			_groupUserGroupsCounts.put(
+				curGroupId,
+				UserGroupLocalServiceUtil.getGroupUserGroupsCount(curGroupId));
+		}
+
+		return GetterUtil.getInteger(_groupUserGroupsCounts.get(groupId));
 	}
 
 	public int getGroupUsersCounts(long groupId) {
@@ -241,7 +288,9 @@ public class SiteMySitesDisplayContext {
 	}
 
 	private String _displayStyle;
+	private Map<Long, Integer> _groupOrganizationsCounts;
 	private GroupSearch _groupSearch;
+	private Map<Long, Integer> _groupUserGroupsCounts;
 	private Map<Long, Integer> _groupUsersCounts;
 	private final HttpServletRequest _httpServletRequest;
 	private String _orderByCol;

--- a/modules/apps/site/site-my-sites-web/src/main/java/com/liferay/site/my/sites/web/internal/servlet/taglib/clay/SiteVerticalCard.java
+++ b/modules/apps/site/site-my-sites-web/src/main/java/com/liferay/site/my/sites/web/internal/servlet/taglib/clay/SiteVerticalCard.java
@@ -16,6 +16,8 @@ package com.liferay.site.my.sites.web.internal.servlet.taglib.clay;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.soy.VerticalCard;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -44,12 +46,15 @@ public class SiteVerticalCard implements VerticalCard {
 
 	public SiteVerticalCard(
 		BaseModel<?> baseModel, RenderRequest renderRequest,
-		RenderResponse renderResponse, String tabs1, int groupUsersCount) {
+		RenderResponse renderResponse, String tabs1, int groupUsersCount,
+		int groupOrganizationsCount, int groupUserGroupsCount) {
 
 		_renderRequest = renderRequest;
 		_renderResponse = renderResponse;
 		_tabs1 = tabs1;
 		_groupUsersCount = groupUsersCount;
+		_groupOrganizationsCount = groupOrganizationsCount;
+		_groupUserGroupsCount = groupUserGroupsCount;
 
 		_group = (Group)baseModel;
 		_httpServletRequest = PortalUtil.getHttpServletRequest(renderRequest);
@@ -107,8 +112,54 @@ public class SiteVerticalCard implements VerticalCard {
 
 	@Override
 	public String getSubtitle() {
-		return LanguageUtil.get(_httpServletRequest, "members") + ": " +
-			_groupUsersCount;
+		StringBundler sb = new StringBundler(5);
+
+		if (_groupUsersCount == 1) {
+			sb.append(
+				LanguageUtil.format(
+					_httpServletRequest, "x-user", _groupUsersCount, false));
+		}
+		else {
+			sb.append(
+				LanguageUtil.format(
+					_httpServletRequest, "x-users", _groupUsersCount, false));
+		}
+
+		if (_groupOrganizationsCount > 0) {
+			sb.append(StringPool.COMMA + StringPool.SPACE);
+
+			if (_groupOrganizationsCount == 1) {
+				sb.append(
+					LanguageUtil.format(
+						_httpServletRequest, "x-organization",
+						_groupOrganizationsCount, false));
+			}
+			else {
+				sb.append(
+					LanguageUtil.format(
+						_httpServletRequest, "x-organizations",
+						_groupOrganizationsCount, false));
+			}
+		}
+
+		if (_groupUserGroupsCount > 0) {
+			sb.append(StringPool.COMMA + StringPool.SPACE);
+
+			if (_groupUserGroupsCount == 1) {
+				sb.append(
+					LanguageUtil.format(
+						_httpServletRequest, "x-user-group",
+						_groupUserGroupsCount, false));
+			}
+			else {
+				sb.append(
+					LanguageUtil.format(
+						_httpServletRequest, "x-user-groups",
+						_groupUserGroupsCount, false));
+			}
+		}
+
+		return sb.toString();
 	}
 
 	@Override
@@ -135,6 +186,8 @@ public class SiteVerticalCard implements VerticalCard {
 		SiteVerticalCard.class);
 
 	private final Group _group;
+	private final int _groupOrganizationsCount;
+	private final int _groupUserGroupsCount;
 	private final int _groupUsersCount;
 	private final HttpServletRequest _httpServletRequest;
 	private final RenderRequest _renderRequest;

--- a/modules/apps/site/site-my-sites-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-my-sites-web/src/main/resources/META-INF/resources/view.jsp
@@ -98,9 +98,35 @@
 							/>
 						</h6>
 
-						<h6 class="text-default">
-							<strong><liferay-ui:message key="members" /></strong>: <%= siteMySitesDisplayContext.getGroupUsersCounts(group.getGroupId()) %>
-						</h6>
+						<%
+						int usersCount = siteMySitesDisplayContext.getGroupUsersCounts(group.getGroupId());
+						%>
+
+						<c:if test="<%= usersCount > 0 %>">
+							<h6 class="text-default">
+								<strong><liferay-ui:message arguments="<%= usersCount %>" key='<%= (usersCount > 1) ? "x-users" : "x-user" %>' /></strong>
+							</h6>
+						</c:if>
+
+						<%
+						int organizationsCount = siteMySitesDisplayContext.getGroupOrganizationsCount(group.getGroupId());
+						%>
+
+						<c:if test="<%= organizationsCount > 0 %>">
+							<h6 class="text-default">
+								<strong><liferay-ui:message arguments="<%= organizationsCount %>" key='<%= (organizationsCount > 1) ? "x-organizations" : "x-organization" %>' /></strong>
+							</h6>
+						</c:if>
+
+						<%
+						int userGroupsCount = siteMySitesDisplayContext.getGroupUserGroupsCount(group.getGroupId());
+						%>
+
+						<c:if test="<%= userGroupsCount > 0 %>">
+							<h6 class="text-default">
+								<strong><liferay-ui:message arguments="<%= userGroupsCount %>" key='<%= (userGroupsCount > 1) ? "x-user-groups" : "x-user-group" %>' /></strong>
+							</h6>
+						</c:if>
 
 						<c:if test='<%= Objects.equals(siteMySitesDisplayContext.getTabs1(), "my-sites") && PropsValues.LIVE_USERS_ENABLED %>'>
 							<h6 class="text-default">
@@ -121,7 +147,7 @@
 				<c:when test='<%= Objects.equals(siteMySitesDisplayContext.getDisplayStyle(), "icon") %>'>
 					<liferay-ui:search-container-column-text>
 						<clay:vertical-card
-							verticalCard="<%= new SiteVerticalCard(group, renderRequest, renderResponse, siteMySitesDisplayContext.getTabs1(), siteMySitesDisplayContext.getGroupUsersCounts(group.getGroupId())) %>"
+							verticalCard="<%= new SiteVerticalCard(group, renderRequest, renderResponse, siteMySitesDisplayContext.getTabs1(), siteMySitesDisplayContext.getGroupUsersCounts(group.getGroupId()), siteMySitesDisplayContext.getGroupOrganizationsCount(group.getGroupId()), siteMySitesDisplayContext.getGroupUserGroupsCount(group.getGroupId())) %>"
 						/>
 					</liferay-ui:search-container-column-text>
 				</c:when>
@@ -151,8 +177,44 @@
 
 					<liferay-ui:search-container-column-text
 						name="members"
-						value="<%= String.valueOf(siteMySitesDisplayContext.getGroupUsersCounts(group.getGroupId())) %>"
-					/>
+					>
+						<span onmouseover="Liferay.Portal.ToolTip.show(this, '<liferay-ui:message key="inherited-memberships-are-not-included-in-members-count" unicode="<%= true %>" />');">
+
+							<%
+							int usersCount = siteMySitesDisplayContext.getGroupUsersCounts(group.getGroupId());
+							%>
+
+							<c:if test="<%= usersCount > 0 %>">
+								<div class="user-count">
+									<%= LanguageUtil.format(request, usersCount > 1 ? "x-users" : "x-user", usersCount, false) %>
+								</div>
+							</c:if>
+
+							<%
+							int organizationsCount = siteMySitesDisplayContext.getGroupOrganizationsCount(group.getGroupId());
+							%>
+
+							<c:if test="<%= organizationsCount > 0 %>">
+								<div class="organization-count">
+									<%= LanguageUtil.format(request, organizationsCount > 1 ? "x-organizations" : "x-organization", organizationsCount, false) %>
+								</div>
+							</c:if>
+
+							<%
+							int userGroupsCount = siteMySitesDisplayContext.getGroupUserGroupsCount(group.getGroupId());
+							%>
+
+							<c:if test="<%= userGroupsCount > 0 %>">
+								<div class="user-group-count">
+									<%= LanguageUtil.format(request, userGroupsCount > 1 ? "x-user-groups" : "x-user-group", userGroupsCount, false) %>
+								</div>
+							</c:if>
+
+							<c:if test="<%= (usersCount + organizationsCount + userGroupsCount) <= 0 %>">
+								0
+							</c:if>
+						</span>
+					</liferay-ui:search-container-column-text>
 
 					<c:if test='<%= Objects.equals(siteMySitesDisplayContext.getTabs1(), "my-sites") && PropsValues.LIVE_USERS_ENABLED %>'>
 						<liferay-ui:search-container-column-text


### PR DESCRIPTION
What I've done here is show the same information in my sites portlet as seen in sites admin (users, user groups and organizations).

I've changed the 3 views to be consistent and show the same info in all the cases