### PR TITLE
LPS-142109 Use - instead of _ in the language labels

### DIFF
--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -631,7 +631,7 @@ AUI.add(
 					if (languageStatusNode) {
 						languageStatusNode.setHTML(
 							A.Lang.sub(instance.TRANSLATION_STATUS_TEMPLATE, {
-								languageId,
+								languageId: languageId.replace(/_/, '-'),
 								translationStatus,
 								translationStatusCssClass,
 							})


### PR DESCRIPTION
In the UI we show the language code with a `-` instead of a `_`. (e. g. en-US instead of en_US) This PR fixes that behaviour in the input localized

How to try this:

- go to web content
- create a new structure
- open the language selector

Before the PR
The label of the language is displayed with a `_`
![Screenshot 2021-11-15 at 10 24 26](https://user-images.githubusercontent.com/11654230/141755981-d6a83240-1e66-4a8c-92ca-3319672d27f9.png)

After the PR
The label of the language is displayed with a `-`
![Screenshot 2021-11-15 at 10 24 03](https://user-images.githubusercontent.com/11654230/141755930-1cf5ba74-ddc7-46a8-87c5-cd6a365e698b.png)


