### PR TITLE
[TS] LPS-141980 Get the scoped asset counts for displaying tags with the "Color by Popularity" template

### DIFF
--- a/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/portlet/template/AssetTagsNavigationPortletDisplayTemplateHandler.java
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/portlet/template/AssetTagsNavigationPortletDisplayTemplateHandler.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.portletdisplaytemplate.BasePortletDisplayTemplateHandler;
 import com.liferay.portal.kernel.template.TemplateHandler;
 import com.liferay.portal.kernel.template.TemplateVariableGroup;
+import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portlet.display.template.constants.PortletDisplayTemplateConstants;
@@ -48,6 +49,13 @@ public class AssetTagsNavigationPortletDisplayTemplateHandler
 	@Override
 	public String getClassName() {
 		return AssetTag.class.getName();
+	}
+
+	@Override
+	public Map<String, Object> getCustomContextObjects() {
+		return HashMapBuilder.<String, Object>put(
+			"assetTagService", _assetTagService
+		).build();
 	}
 
 	@Override
@@ -106,7 +114,14 @@ public class AssetTagsNavigationPortletDisplayTemplateHandler
 			"/dependencies/portlet-display-templates.xml";
 	}
 
+	@Reference(unbind = "-")
+	protected void setAssetTagService(AssetTagService assetTagService) {
+		_assetTagService = assetTagService;
+	}
+
 	@Reference
 	protected Portal portal;
+
+	private AssetTagService _assetTagService;
 
 }

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/init.jsp
@@ -34,6 +34,7 @@ page import="com.liferay.portal.kernel.security.permission.ResourceActionsUtil" 
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.ListUtil" %><%@
+page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.PrefsParamUtil" %>
 
 <%@ page import="java.util.ArrayList" %><%@

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/view.jsp
@@ -20,10 +20,10 @@
 List<AssetTag> assetTags = null;
 
 if (showAssetCount && (classNameId > 0)) {
-	assetTags = AssetTagServiceUtil.getTags(scopeGroupId, classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
+	assetTags = AssetTagServiceUtil.getTags(PortalUtil.getSiteGroupId(scopeGroupId), classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
 }
 else {
-	assetTags = AssetTagServiceUtil.getGroupTags(scopeGroupId, 0, maxAssetTags, new AssetTagCountComparator());
+	assetTags = AssetTagServiceUtil.getGroupTags(PortalUtil.getSiteGroupId(scopeGroupId), 0, maxAssetTags, new AssetTagCountComparator());
 }
 
 assetTags = ListUtil.sort(assetTags);

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/resources/com/liferay/asset/tags/navigation/web/portlet/template/dependencies/portlet_display_template_color_by_popularity.ftl
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/resources/com/liferay/asset/tags/navigation/web/portlet/template/dependencies/portlet_display_template_color_by_popularity.ftl
@@ -8,12 +8,6 @@
 			minCount = 1
 		/>
 
-		<#if serviceLocator??>
-			<#assign
-				assetTagService = serviceLocator.findService("com.liferay.asset.kernel.service.AssetTagService")
-			/>
-		</#if>
-
 		<#list entries as entry>
 			<#if assetTagService??>
 				<#if classNameId <= 0>

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/resources/com/liferay/asset/tags/navigation/web/portlet/template/dependencies/portlet_display_template_color_by_popularity.ftl
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/resources/com/liferay/asset/tags/navigation/web/portlet/template/dependencies/portlet_display_template_color_by_popularity.ftl
@@ -8,11 +8,29 @@
 			minCount = 1
 		/>
 
-		<#list entries as entry>
+		<#if serviceLocator??>
 			<#assign
-				maxCount = liferay.max(maxCount, entry.getAssetCount())
-				minCount = liferay.min(minCount, entry.getAssetCount())
+				assetTagService = serviceLocator.findService("com.liferay.asset.kernel.service.AssetTagService")
 			/>
+		</#if>
+
+		<#list entries as entry>
+			<#if assetTagService??>
+				<#if classNameId <= 0>
+					<#assign assetCount = assetTagService.getVisibleAssetsTagsCount(scopeGroupId, entry.getName()) />
+				<#else>
+					<#assign assetCount = assetTagService.getVisibleAssetsTagsCount(scopeGroupId, classNameId, entry.getName()) />
+				</#if>
+			<#else>
+				<#assign assetCount = entry.getAssetCount() />
+			</#if>
+
+			<#if (assetCount > 0) || getterUtil.getBoolean(showZeroAssetCount)>
+				<#assign
+					maxCount = liferay.max(maxCount, assetCount)
+					minCount = liferay.min(minCount, assetCount)
+				/>
+			</#if>
 		</#list>
 
 		<#assign multiplier = 1 />
@@ -22,30 +40,42 @@
 		</#if>
 
 		<#list entries as entry>
-			<li class="taglib-asset-tags-summary">
-				<#assign popularity = (maxCount - (maxCount - (entry.getAssetCount() - minCount))) * multiplier />
-
-				<#if popularity < 1>
-					<#assign displayType = "success" />
-				<#elseif (popularity >= 1) && (popularity < 2)>
-					<#assign displayType = "warning" />
+			<#if assetTagService??>
+				<#if classNameId <= 0>
+					<#assign assetCount = assetTagService.getVisibleAssetsTagsCount(scopeGroupId, entry.getName()) />
 				<#else>
-					<#assign displayType = "danger" />
+					<#assign assetCount = assetTagService.getVisibleAssetsTagsCount(scopeGroupId, classNameId, entry.getName()) />
 				</#if>
+			<#else>
+				<#assign assetCount = entry.getAssetCount() />
+			</#if>
 
-				<#assign tagURL = renderResponse.createRenderURL() />
+			<#if (assetCount > 0) || getterUtil.getBoolean(showZeroAssetCount)>
+				<li class="taglib-asset-tags-summary">
+					<#assign popularity = (maxCount - (maxCount - (assetCount - minCount))) * multiplier />
 
-				${tagURL.setParameter("resetCur", "true")}
-				${tagURL.setParameter("tag", entry.getName())}
-
-				<a class="label label-${displayType} tag" href="${tagURL}">
-					<span class="label-item label-item-expand">${entry.getName()}</span>
-
-					<#if entry.getAssetCount()?? && getterUtil.getBoolean(showAssetCount)>
-						<span class="label-item label-item-after tag-asset-count">(${entry.getAssetCount()})</span>
+					<#if popularity < 1>
+						<#assign displayType = "success" />
+					<#elseif (popularity >= 1) && (popularity < 2)>
+						<#assign displayType = "warning" />
+					<#else>
+						<#assign displayType = "danger" />
 					</#if>
-				</a>
-			</li>
+
+					<#assign tagURL = renderResponse.createRenderURL() />
+
+					${tagURL.setParameter("resetCur", "true")}
+					${tagURL.setParameter("tag", entry.getName())}
+
+					<a class="label label-${displayType} tag" href="${tagURL}">
+						<span class="label-item label-item-expand">${entry.getName()}</span>
+
+						<#if assetCount?? && getterUtil.getBoolean(showAssetCount)>
+							<span class="label-item label-item-after tag-asset-count">(${assetCount})</span>
+						</#if>
+					</a>
+				</li>
+			</#if>
 		</#list>
 	</ul>
 


### PR DESCRIPTION
Hi @liferay-echo team,

I'm resending a previous PR ( https://github.com/liferay-echo/liferay-portal/pull/6341 ), with the modification suggested in the PTR.

I'm not completely sure whether this is the right solution, as I solved it by using `serviceLocator` in the FTL template. As I saw, it's still used in [some places](https://github.com/liferay/liferay-portal/search?l=FreeMarker&q=%22serviceLocator%22). Please let me know whether using a `TemplateContextContributor` would be a better solution in this case.

cc: @lfbesada , @jkappler 

Thanks,
Vendel