### PR TITLE
LPS-142506 Keep the first single slash in friendly URLs

### DIFF
--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -392,7 +392,9 @@ public class FriendlyURLEntryLocalServiceImpl
 		long groupId, long classNameId, long classPK, String urlTitle,
 		String languageId) {
 
-		urlTitle = urlTitle.replaceAll("^/+", StringPool.BLANK);
+		if (urlTitle.startsWith(StringPool.SLASH)) {
+			urlTitle = urlTitle.replaceAll("^/+", StringPool.SLASH);
+		}
 
 		String normalizedUrlTitle =
 			FriendlyURLNormalizerUtil.normalizeWithEncoding(urlTitle);


### PR DESCRIPTION
This was caused by https://issues.liferay.com/browse/LPS-132908. @dacousalr @ealonso See
comments in the original PR; in general, it is not possible to keep prepending slashes and avoiding too extra slashes in URLs without changing the way URLs are generated. This cannot be fixed in the friendly URL service, URL generation will need to be changed.

I'll let you decide whether to revert the whole change, or merge this and cross fingers.