### PR TITLE
LPS-135364 Missing colorpicker in table cell properties dialog

### DIFF
--- a/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
+++ b/modules/apps/frontend-editor/frontend-editor-ckeditor-web/src/main/java/com/liferay/frontend/editor/ckeditor/web/internal/editor/configuration/CKEditorConfigContributor.java
@@ -60,8 +60,8 @@ public class CKEditorConfigContributor extends BaseCKEditorConfigContributor {
 		);
 
 		String extraPlugins =
-			"addimages,autogrow,autolink,filebrowser,itemselector,lfrpopup," +
-				"media,stylescombo,videoembed";
+			"addimages,autogrow,autolink,colordialog,filebrowser,itemselector," +
+				"lfrpopup,media,stylescombo,videoembed";
 
 		boolean inlineEdit = GetterUtil.getBoolean(
 			(String)inputEditorTaglibAttributes.get(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-135364

If you think I should instead forward the request to liferay-frontend, please let me know.

### Steps to reproduce

1. Navigate to Content & Data > Web Content
2. Use the + button to begin drafting a new web content article
3. Add a table (number of rows/columns does not matter)
4. Right click in a cell and choose to update the cell properties

Expected behavior is that the cell properties dialog offers a "choose" button next to the color selection to load a color picker.
Actual behavior is that the cell properties dialog lacks such "choose" buttons.

### Solution notes

The colordialog plugin was removed by default with liferay-ckeditor 4.14.x, in https://github.com/liferay/liferay-ckeditor/commit/cc4b314b87885823eee05a4021f6d17a5c43c158

In maintenance branches, we re-added the colordialog plugin with [LPS-125798](https://issues.liferay.com/browse/LPS-125798):

* 7.2.x: https://github.com/liferay/liferay-portal-ee/commit/ba4b0cebad5251865723a455faad3b92e07bcc75
* 7.1.x: https://github.com/liferay/liferay-portal-ee/commit/5218313220d31c6a484a34c85b405f2ad1fee7e3
* 7.0.x: https://github.com/liferay/liferay-portal-ee/commit/65a8435c6dcb32490c50f779f5b367fa5b91275e

However, these changes were not applied to master, so I thought that it would make sense to add only what we need to resolve this specific issue found by QA.

With that being said, if we intentionally removed color picker and do not need this functionality for master in the table cell properties dialog, I can let QA know that this is expected behavior in master so we can proceed with backporting the original fix where the table cell properties dialog was incomplete in the ways described in the linked ticket.