### PR TITLE
LPS-139117 Make sure that plids and revisionIds will not conflict

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -687,9 +687,8 @@ public class LayoutStagedModelDataHandler
 		Layout importedLayout = null;
 
 		if (existingLayout == null) {
-			long plid = _counterLocalService.increment(Layout.class.getName());
-
-			importedLayout = _layoutLocalService.createLayout(plid);
+			importedLayout = _layoutLocalService.createLayout(
+				_layoutLocalServiceHelper.getUniquePlid());
 
 			if (layoutsImportMode.equals(
 					PortletDataHandlerKeys.

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -14,6 +14,7 @@
 
 package com.liferay.portal.service.impl;
 
+import com.liferay.counter.kernel.service.CounterLocalService;
 import com.liferay.petra.string.CharPool;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanReference;
@@ -43,6 +44,7 @@ import com.liferay.portal.kernel.module.framework.service.IdentifiableOSGiServic
 import com.liferay.portal.kernel.portlet.FriendlyURLMapper;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
 import com.liferay.portal.kernel.service.PortletLocalServiceUtil;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
@@ -225,6 +227,16 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 		}
 
 		return parentLayoutId;
+	}
+
+	public long getUniquePlid() {
+		long plid = counterLocalService.increment(Layout.class.getName());
+
+		while (layoutRevisionLocalService.fetchLayoutRevision(plid) != null) {
+			plid = counterLocalService.increment(Layout.class.getName());
+		}
+
+		return plid;
 	}
 
 	public boolean hasLayoutSetPrototypeLayout(
@@ -674,11 +686,17 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 			ActionKeys.VIEW);
 	}
 
+	@BeanReference(type = CounterLocalService.class)
+	protected CounterLocalService counterLocalService;
+
 	@BeanReference(type = LayoutFriendlyURLPersistence.class)
 	protected LayoutFriendlyURLPersistence layoutFriendlyURLPersistence;
 
 	@BeanReference(type = LayoutPersistence.class)
 	protected LayoutPersistence layoutPersistence;
+
+	@BeanReference(type = LayoutRevisionLocalService.class)
+	protected LayoutRevisionLocalService layoutRevisionLocalService;
 
 	@BeanReference(type = LayoutSetPersistence.class)
 	protected LayoutSetPersistence layoutSetPersistence;

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -268,9 +268,8 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 
 		Date date = new Date();
 
-		long plid = counterLocalService.increment(Layout.class.getName());
-
-		Layout layout = layoutPersistence.create(plid);
+		Layout layout = layoutPersistence.create(
+			layoutLocalServiceHelper.getUniquePlid());
 
 		String uuid = serviceContext.getUuid();
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java
@@ -88,7 +88,7 @@ public class LayoutRevisionLocalServiceImpl
 		parentLayoutRevisionId = getParentLayoutRevisionId(
 			layoutSetBranchId, parentLayoutRevisionId, plid);
 
-		long layoutRevisionId = counterLocalService.increment();
+		long layoutRevisionId = getUniqueLayoutRevisionId();
 
 		LayoutRevision layoutRevision = layoutRevisionPersistence.create(
 			layoutRevisionId);
@@ -479,10 +479,8 @@ public class LayoutRevisionLocalServiceImpl
 
 			User user = _userPersistence.findByPrimaryKey(userId);
 
-			long newLayoutRevisionId = counterLocalService.increment();
-
 			layoutRevision = layoutRevisionPersistence.create(
-				newLayoutRevisionId);
+				getUniqueLayoutRevisionId());
 
 			layoutRevision.setGroupId(oldLayoutRevision.getGroupId());
 			layoutRevision.setCompanyId(oldLayoutRevision.getCompanyId());
@@ -712,6 +710,16 @@ public class LayoutRevisionLocalServiceImpl
 		}
 
 		return LayoutRevisionConstants.DEFAULT_PARENT_LAYOUT_REVISION_ID;
+	}
+
+	protected long getUniqueLayoutRevisionId() {
+		long layoutRevisionId = counterLocalService.increment();
+
+		while (_layoutLocalService.fetchLayout(layoutRevisionId) != null) {
+			layoutRevisionId = counterLocalService.increment();
+		}
+
+		return layoutRevisionId;
 	}
 
 	protected boolean isWorkflowEnabled(long plid) throws PortalException {


### PR DESCRIPTION
Hey guys,

For plid generation, a specific Layout counter is used, which can result in conflicting plids and revisionIds.
This ticket is about an upgrade issue, but I can imagine other use case as well.

This can be problematic, because in the PortletPreferences table the revisionIds are used as plids. In case if conflicting ids, irrelevant Preferences can be returned.

This fix is a bit of a hack, but I couldn't come up with a better solution, if we want to keep the unique counter for layouts.
An alternative solution could be to use the general counter. I tried to track down the reason why we have a layout counter, but the [commit message ](https://github.com/brianchandotcom/liferay-portal/pull/75860/commits/a7b6d1c5c4f72be5c60ed24f951295e8d5d16698) doesn't really explains it.

Best,
Tamas