### PR TITLE
[TS] LPS-141980 Get the scoped asset counts for displaying tags with the "Color by Popularity" template

### DIFF
--- a/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/display/context/AssetTagsNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/display/context/AssetTagsNavigationDisplayContext.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.tags.navigation.web.internal.display.context;
+
+import com.liferay.asset.kernel.model.AssetTag;
+import com.liferay.asset.kernel.service.AssetTagServiceUtil;
+import com.liferay.asset.util.comparator.AssetTagCountComparator;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PrefsParamUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.portlet.RenderRequest;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Vendel Toreki
+ */
+public class AssetTagsNavigationDisplayContext {
+
+	public AssetTagsNavigationDisplayContext(
+		HttpServletRequest httpServletRequest, RenderRequest renderRequest) {
+
+		_httpServletRequest = httpServletRequest;
+
+		_renderRequest = renderRequest;
+
+		_classNameId = PrefsParamUtil.getLong(
+			_renderRequest.getPreferences(), _renderRequest, "classNameId");
+
+		_themeDisplay = (ThemeDisplay)_httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
+		_scopeGroupId = _themeDisplay.getScopeGroupId();
+	}
+
+	public List<AssetTag> getAssetTags() {
+		if (_assetTags != null) {
+			return _assetTags;
+		}
+
+		int maxAssetTags = PrefsParamUtil.getInteger(
+			_renderRequest.getPreferences(), _renderRequest, "maxAssetTags",
+			10);
+		boolean showAssetCount = PrefsParamUtil.getBoolean(
+			_renderRequest.getPreferences(), _renderRequest, "showAssetCount");
+
+		if (showAssetCount && (_classNameId > 0)) {
+			_assetTags = AssetTagServiceUtil.getTags(
+				PortalUtil.getSiteGroupId(_scopeGroupId), _classNameId, null, 0,
+				maxAssetTags, new AssetTagCountComparator());
+		}
+		else {
+			_assetTags = AssetTagServiceUtil.getGroupTags(
+				PortalUtil.getSiteGroupId(_scopeGroupId), 0, maxAssetTags,
+				new AssetTagCountComparator());
+		}
+
+		_assetTags = ListUtil.sort(_assetTags);
+
+		return _assetTags;
+	}
+
+	public Map<String, Integer> getScopedAssetCounts() {
+		if (_scopedAssetCounts != null) {
+			return _scopedAssetCounts;
+		}
+
+		_scopedAssetCounts = new HashMap<>();
+
+		for (AssetTag assetTag : getAssetTags()) {
+			int count = 0;
+
+			if (_classNameId > 0) {
+				count = AssetTagServiceUtil.getVisibleAssetsTagsCount(
+					_scopeGroupId, _classNameId, assetTag.getName());
+			}
+			else {
+				count = AssetTagServiceUtil.getVisibleAssetsTagsCount(
+					_scopeGroupId, assetTag.getName());
+			}
+
+			_scopedAssetCounts.put(assetTag.getName(), count);
+		}
+
+		return _scopedAssetCounts;
+	}
+
+	private List<AssetTag> _assetTags;
+	private final long _classNameId;
+	private final HttpServletRequest _httpServletRequest;
+	private final RenderRequest _renderRequest;
+	private Map<String, Integer> _scopedAssetCounts;
+	private final long _scopeGroupId;
+	private final ThemeDisplay _themeDisplay;
+
+}

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/portlet/AssetTagsCloudPortlet.java
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/portlet/AssetTagsCloudPortlet.java
@@ -15,10 +15,18 @@
 package com.liferay.asset.tags.navigation.web.internal.portlet;
 
 import com.liferay.asset.tags.navigation.constants.AssetTagsNavigationPortletKeys;
+import com.liferay.asset.tags.navigation.web.internal.display.context.AssetTagsNavigationDisplayContext;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.io.IOException;
 
 import javax.portlet.Portlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -53,6 +61,22 @@ import org.osgi.service.component.annotations.Reference;
 	service = Portlet.class
 )
 public class AssetTagsCloudPortlet extends MVCPortlet {
+
+	@Override
+	public void render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		renderRequest.setAttribute(
+			WebKeys.PORTLET_DISPLAY_CONTEXT,
+			new AssetTagsNavigationDisplayContext(
+				_portal.getHttpServletRequest(renderRequest), renderRequest));
+
+		super.render(renderRequest, renderResponse);
+	}
+
+	@Reference
+	private Portal _portal;
 
 	@Reference(
 		target = "(&(release.bundle.symbolic.name=com.liferay.asset.tags.navigation.web)(&(release.schema.version>=1.0.0)(!(release.schema.version>=2.0.0))))"

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/portlet/AssetTagsNavigationPortlet.java
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/portlet/AssetTagsNavigationPortlet.java
@@ -15,10 +15,18 @@
 package com.liferay.asset.tags.navigation.web.internal.portlet;
 
 import com.liferay.asset.tags.navigation.constants.AssetTagsNavigationPortletKeys;
+import com.liferay.asset.tags.navigation.web.internal.display.context.AssetTagsNavigationDisplayContext;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+
+import java.io.IOException;
 
 import javax.portlet.Portlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -53,6 +61,22 @@ import org.osgi.service.component.annotations.Reference;
 	service = Portlet.class
 )
 public class AssetTagsNavigationPortlet extends MVCPortlet {
+
+	@Override
+	public void render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		renderRequest.setAttribute(
+			WebKeys.PORTLET_DISPLAY_CONTEXT,
+			new AssetTagsNavigationDisplayContext(
+				_portal.getHttpServletRequest(renderRequest), renderRequest));
+
+		super.render(renderRequest, renderResponse);
+	}
+
+	@Reference
+	private Portal _portal;
 
 	@Reference(
 		target = "(&(release.bundle.symbolic.name=com.liferay.asset.tags.navigation.web)(&(release.schema.version>=1.0.0)(!(release.schema.version>=2.0.0))))"

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/init.jsp
@@ -34,6 +34,7 @@ page import="com.liferay.portal.kernel.security.permission.ResourceActionsUtil" 
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.ListUtil" %><%@
+page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.PrefsParamUtil" %>
 
 <%@ page import="java.util.ArrayList" %><%@

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/init.jsp
@@ -27,15 +27,14 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 <%@ page import="com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil" %><%@
 page import="com.liferay.asset.kernel.model.AssetRendererFactory" %><%@
 page import="com.liferay.asset.kernel.model.AssetTag" %><%@
-page import="com.liferay.asset.kernel.service.AssetTagServiceUtil" %><%@
+page import="com.liferay.asset.tags.navigation.web.internal.display.context.AssetTagsNavigationDisplayContext" %><%@
 page import="com.liferay.asset.util.comparator.AssetRendererFactoryTypeNameComparator" %><%@
-page import="com.liferay.asset.util.comparator.AssetTagCountComparator" %><%@
 page import="com.liferay.portal.kernel.security.permission.ResourceActionsUtil" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.ListUtil" %><%@
-page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
-page import="com.liferay.portal.kernel.util.PrefsParamUtil" %>
+page import="com.liferay.portal.kernel.util.PrefsParamUtil" %><%@
+page import="com.liferay.portal.kernel.util.WebKeys" %>
 
 <%@ page import="java.util.ArrayList" %><%@
 page import="java.util.List" %>

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/view.jsp
@@ -20,10 +20,10 @@
 List<AssetTag> assetTags = null;
 
 if (showAssetCount && (classNameId > 0)) {
-	assetTags = AssetTagServiceUtil.getTags(scopeGroupId, classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
+	assetTags = AssetTagServiceUtil.getTags(PortalUtil.getSiteGroupId(scopeGroupId), classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
 }
 else {
-	assetTags = AssetTagServiceUtil.getGroupTags(scopeGroupId, 0, maxAssetTags, new AssetTagCountComparator());
+	assetTags = AssetTagServiceUtil.getGroupTags(PortalUtil.getSiteGroupId(scopeGroupId), 0, maxAssetTags, new AssetTagCountComparator());
 }
 
 assetTags = ListUtil.sort(assetTags);

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/resources/META-INF/resources/view.jsp
@@ -17,28 +17,21 @@
 <%@ include file="/init.jsp" %>
 
 <%
-List<AssetTag> assetTags = null;
-
-if (showAssetCount && (classNameId > 0)) {
-	assetTags = AssetTagServiceUtil.getTags(PortalUtil.getSiteGroupId(scopeGroupId), classNameId, null, 0, maxAssetTags, new AssetTagCountComparator());
-}
-else {
-	assetTags = AssetTagServiceUtil.getGroupTags(PortalUtil.getSiteGroupId(scopeGroupId), 0, maxAssetTags, new AssetTagCountComparator());
-}
-
-assetTags = ListUtil.sort(assetTags);
+AssetTagsNavigationDisplayContext assetTagsNavigationDisplayContext = (AssetTagsNavigationDisplayContext)request.getAttribute(WebKeys.PORTLET_DISPLAY_CONTEXT);
 %>
 
 <liferay-ddm:template-renderer
 	className="<%= AssetTag.class.getName() %>"
 	contextObjects='<%=
 		HashMapBuilder.<String, Object>put(
+			"assetTagsNavigationDisplayContext", assetTagsNavigationDisplayContext
+		).put(
 			"scopeGroupId", Long.valueOf(scopeGroupId)
 		).build()
 	%>'
 	displayStyle="<%= displayStyle %>"
 	displayStyleGroupId="<%= displayStyleGroupId %>"
-	entries="<%= assetTags %>"
+	entries="<%= assetTagsNavigationDisplayContext.getAssetTags() %>"
 >
 	<liferay-asset:asset-tags-navigation
 		classNameId="<%= classNameId %>"

--- a/modules/apps/asset/asset-tags-navigation-web/src/main/resources/com/liferay/asset/tags/navigation/web/portlet/template/dependencies/portlet_display_template_color_by_popularity.ftl
+++ b/modules/apps/asset/asset-tags-navigation-web/src/main/resources/com/liferay/asset/tags/navigation/web/portlet/template/dependencies/portlet_display_template_color_by_popularity.ftl
@@ -3,16 +3,25 @@
 		<#assign
 			scopeGroupId = getterUtil.getLong(scopeGroupId, themeDisplay.getScopeGroupId())
 			classNameId = getterUtil.getLong(classNameId, 0)
+			scopedAssetCounts = assetTagsNavigationDisplayContext.getScopedAssetCounts()
 
 			maxCount = 1
 			minCount = 1
 		/>
 
 		<#list entries as entry>
-			<#assign
-				maxCount = liferay.max(maxCount, entry.getAssetCount())
-				minCount = liferay.min(minCount, entry.getAssetCount())
-			/>
+			<#if scopedAssetCounts??>
+				<#assign assetCount = scopedAssetCounts[entry.getName()] />
+			<#else>
+				<#assign assetCount = entry.getAssetCount() />
+			</#if>
+
+			<#if (assetCount > 0) || getterUtil.getBoolean(showZeroAssetCount)>
+				<#assign
+					maxCount = liferay.max(maxCount, assetCount)
+					minCount = liferay.min(minCount, assetCount)
+				/>
+			</#if>
 		</#list>
 
 		<#assign multiplier = 1 />
@@ -22,30 +31,38 @@
 		</#if>
 
 		<#list entries as entry>
-			<li class="taglib-asset-tags-summary">
-				<#assign popularity = (maxCount - (maxCount - (entry.getAssetCount() - minCount))) * multiplier />
+			<#if scopedAssetCounts??>
+				<#assign assetCount = scopedAssetCounts[entry.getName()] />
+			<#else>
+				<#assign assetCount = entry.getAssetCount() />
+			</#if>
 
-				<#if popularity < 1>
-					<#assign displayType = "success" />
-				<#elseif (popularity >= 1) && (popularity < 2)>
-					<#assign displayType = "warning" />
-				<#else>
-					<#assign displayType = "danger" />
-				</#if>
+			<#if (assetCount > 0) || getterUtil.getBoolean(showZeroAssetCount)>
+				<li class="taglib-asset-tags-summary">
+					<#assign popularity = (maxCount - (maxCount - (assetCount - minCount))) * multiplier />
 
-				<#assign tagURL = renderResponse.createRenderURL() />
-
-				${tagURL.setParameter("resetCur", "true")}
-				${tagURL.setParameter("tag", entry.getName())}
-
-				<a class="label label-${displayType} tag" href="${tagURL}">
-					<span class="label-item label-item-expand">${entry.getName()}</span>
-
-					<#if entry.getAssetCount()?? && getterUtil.getBoolean(showAssetCount)>
-						<span class="label-item label-item-after tag-asset-count">(${entry.getAssetCount()})</span>
+					<#if popularity < 1>
+						<#assign displayType = "success" />
+					<#elseif (popularity >= 1) && (popularity < 2)>
+						<#assign displayType = "warning" />
+					<#else>
+						<#assign displayType = "danger" />
 					</#if>
-				</a>
-			</li>
+
+					<#assign tagURL = renderResponse.createRenderURL() />
+
+					${tagURL.setParameter("resetCur", "true")}
+					${tagURL.setParameter("tag", entry.getName())}
+
+					<a class="label label-${displayType} tag" href="${tagURL}">
+						<span class="label-item label-item-expand">${entry.getName()}</span>
+
+						<#if assetCount?? && getterUtil.getBoolean(showAssetCount)>
+							<span class="label-item label-item-after tag-asset-count">(${assetCount})</span>
+						</#if>
+					</a>
+				</li>
+			</#if>
 		</#list>
 	</ul>
 


### PR DESCRIPTION
Hi @liferay-echo ,

Since the last PR has been rejected (https://github.com/brianchandotcom/liferay-portal/pull/110140#issuecomment-974148060), I came up with a new solution: created `DisplayContext` class for `AssetTagsNavigation` portlet as well. We have one already for the `AssetCategoriesNavigation` portlet: [AssetCategoriesNavigationDisplayContext](https://github.com/liferay/liferay-portal/blob/master/modules/apps/asset/asset-categories-navigation-web/src/main/java/com/liferay/asset/categories/navigation/web/internal/display/context/AssetCategoriesNavigationDisplayContext.java)

Unfortunately, I could not inject the count values through [AssetTagsNavigationPortletDisplayTemplateHandler](https://github.com/liferay/liferay-portal/blob/master/modules/apps/asset/asset-tags-navigation-web/src/main/java/com/liferay/asset/tags/navigation/web/internal/portlet/template/AssetTagsNavigationPortletDisplayTemplateHandler.java). The first problem is that I can't really access the parameters needed for executing the queries there, and the second is that it would contradict the 1st requirement: https://github.com/liferay-echo/liferay-portal/pull/6341#issuecomment-962981393 . As it would execute the count queries even if we don't use them in the template.

Hopefully this will satisfy both requirements:
* Don't query the asset counts of tags when we don't need them
* Keep only the necessary logic in the FTL (we can't really remove more logic, since the template should still be able to control how it filters the tags, see [PTR comment](https://issues.liferay.com/browse/PTR-2689?focusedCommentId=2555552&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2555552))

cc: @lfbesada , @jkappler 

Please review my changes.

Thanks,
Vendel