### PR TITLE
    LPS-142904 separate resources for each collection

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -153,7 +153,8 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 				_importResources(
 					userId, groupId,
 					fragmentCollection.getFragmentCollectionId(),
-					fragmentCollection.getResourcesFolderId(), zipFile);
+					fragmentCollection.getResourcesFolderId(), entry.getKey(),
+					zipFile);
 
 				_importFragmentCompositions(
 					userId, groupId, zipFile,
@@ -766,7 +767,7 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 
 	private void _importResources(
 			long userId, long groupId, long fragmentCollectionId, long folderId,
-			ZipFile zipFile)
+			String fragmentCollectionKey, ZipFile zipFile)
 		throws Exception {
 
 		Enumeration<? extends ZipEntry> enumeration = zipFile.entries();
@@ -832,8 +833,11 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 			String[] paths = StringUtil.split(
 				zipEntry.getName(), StringPool.FORWARD_SLASH);
 
+			String fileName = zipEntry.getName();
+
 			if (!ArrayUtil.contains(paths, "resources") ||
-				excludePaths.contains(zipEntry.getName())) {
+				excludePaths.contains(zipEntry.getName()) ||
+				!fileName.contains(fragmentCollectionKey)) {
 
 				continue;
 			}


### PR DESCRIPTION
- LPS-141461 LPS-141324 Fix TM dropdown position in mobile
- Revert "7.4.13 Update 1 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, click-to-chat, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, digital-signature, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-data-set, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, google-places, headless, iframe, image-uploader, image, imageio-plugins, info, invitation, item-selector, journal, json-storage, knowledge-base, layout, learn, license-manager, list-type, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, object, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, release-feature-flag, remote-app, roles, rss, segments, server, sharing, site-initializer, site-navigation, site, social, staging, style-book, subscription, template, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream, antivirus, enterprise-product-notification, multi-factor-authentication, portal-search-elasticsearch-cross-cluster-replication, portal-search-elasticsearch-monitoring, portal-search-learning-to-rank, portal-search-similar-results, portal-search-tuning, saml"
- Revert "7.4.3.5 GA5 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, click-to-chat, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, digital-signature, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-data-set, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, google-places, headless, iframe, image-uploader, image, imageio-plugins, info, invitation, item-selector, journal, json-storage, knowledge-base, layout, learn, license-manager, list-type, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, object, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, release-feature-flag, remote-app, roles, rss, segments, server, sharing, site-initializer, site-navigation, site, social, staging, style-book, subscription, template, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream"
- LPS-142746 rest-openapi.yaml: Accept a blueprint with empty query configuration and combine the configurations directly provided by its element instances
- LPS-142746 gw buildREST
- LPS-142746 search-experiences-rest-api: string is properly requoted now, so we can simplify again with plain maps of keys and values (more to come)
- LPS-142746 search-experiences-service: Accept a blueprint with empty query configuration and combine the configurations directly provided by its element instances
- LPS-142746 search-experiences-service: Test: Accept a blueprint with empty query configuration and combine the configurations directly provided by its element instances
- LPS-142746 rename
- LPS-142746 same logic here
- LPS-142746 SF
- LPS-142746 Only used once
- LPS-142746 Inline
- LRQA-71796 Remove pagination not present assertion
- artifact:ignore portal-impl 11.0.4 prep next
- artifact:ignore portal-impl 11.0.4 releng
- artifact:ignore portal-kernel 20.0.1 prep next
- artifact:ignore portal-kernel 20.0.1 releng
- artifact:ignore portal-test 10.1.0 prep next
- artifact:ignore portal-test 10.1.0 releng
- artifact:ignore portal-web 5.0.70 prep next
- artifact:ignore portal-web 5.0.70 releng
- build.gradle auto SF
- LPS-142858 To add Masterclass to liferay-online routine
- LPS-142858 SF
- LPS-142858 add missing space
- artifact:ignore batch-planner-api 5.2.0 change log
- artifact:ignore batch-planner-api 5.2.0 prep next
- artifact:ignore batch-planner-api 5.2.0 artifact properties
- artifact:ignore commerce-report-api 1.0.2 change log
- artifact:ignore commerce-report-api 1.0.2 prep next
- artifact:ignore commerce-report-api 1.0.2 artifact properties
- artifact:ignore data-engine-js-components-web 1.0.34 change log
- artifact:ignore data-engine-js-components-web 1.0.34 prep next
- artifact:ignore data-engine-js-components-web 1.0.34 artifact properties
- artifact:ignore document-library-preview-css 1.0.7 change log
- artifact:ignore document-library-preview-css 1.0.7 prep next
- artifact:ignore document-library-preview-css 1.0.7 artifact properties
- artifact:ignore dynamic-data-mapping-form-field-type 6.0.57 change log
- artifact:ignore dynamic-data-mapping-form-field-type 6.0.57 prep next
- artifact:ignore dynamic-data-mapping-form-field-type 6.0.57 artifact properties
- artifact:ignore dynamic-data-mapping-service 6.0.40 change log
- artifact:ignore dynamic-data-mapping-service 6.0.40 prep next
- artifact:ignore dynamic-data-mapping-service 6.0.40 artifact properties
- artifact:ignore dynamic-data-mapping-test-util 8.1.0 change log
- artifact:ignore dynamic-data-mapping-test-util 8.1.0 prep next
- artifact:ignore dynamic-data-mapping-test-util 8.1.0 artifact properties
- artifact:ignore friendly-url-service 4.0.16 change log
- artifact:ignore friendly-url-service 4.0.16 prep next
- artifact:ignore friendly-url-service 4.0.16 artifact properties
- artifact:ignore frontend-data-set-web 1.0.3 change log
- artifact:ignore frontend-data-set-web 1.0.3 prep next
- artifact:ignore frontend-data-set-web 1.0.3 artifact properties
- artifact:ignore frontend-js-a11y-sample-web 1.0.5 change log
- artifact:ignore frontend-js-a11y-sample-web 1.0.5 prep next
- artifact:ignore frontend-js-a11y-sample-web 1.0.5 artifact properties
- artifact:ignore frontend-js-alert-support-web 2.0.7 change log
- artifact:ignore frontend-js-alert-support-web 2.0.7 prep next
- artifact:ignore frontend-js-alert-support-web 2.0.7 artifact properties
- artifact:ignore frontend-js-aui-web 5.0.19 change log
- artifact:ignore frontend-js-aui-web 5.0.19 prep next
- artifact:ignore frontend-js-aui-web 5.0.19 artifact properties
- artifact:ignore frontend-js-clay-sample-web 2.0.11 change log
- artifact:ignore frontend-js-clay-sample-web 2.0.11 prep next
- artifact:ignore frontend-js-clay-sample-web 2.0.11 artifact properties
- artifact:ignore frontend-js-collapse-support-web 2.0.7 change log
- artifact:ignore frontend-js-collapse-support-web 2.0.7 prep next
- artifact:ignore frontend-js-collapse-support-web 2.0.7 artifact properties
- artifact:ignore frontend-js-components-web 2.0.15 change log
- artifact:ignore frontend-js-components-web 2.0.15 prep next
- artifact:ignore frontend-js-components-web 2.0.15 artifact properties
- artifact:ignore frontend-js-dropdown-support-web 2.0.7 change log
- artifact:ignore frontend-js-dropdown-support-web 2.0.7 prep next
- artifact:ignore frontend-js-dropdown-support-web 2.0.7 artifact properties
- artifact:ignore frontend-js-jquery-web 3.0.15 change log
- artifact:ignore frontend-js-jquery-web 3.0.15 prep next
- artifact:ignore frontend-js-jquery-web 3.0.15 artifact properties
- artifact:ignore frontend-js-module-launcher 1.0.9 change log
- artifact:ignore frontend-js-module-launcher 1.0.9 prep next
- artifact:ignore frontend-js-module-launcher 1.0.9 artifact properties
- artifact:ignore frontend-js-react-web 5.0.14 change log
- artifact:ignore frontend-js-react-web 5.0.14 prep next
- artifact:ignore frontend-js-react-web 5.0.14 artifact properties
- artifact:ignore frontend-js-spa-web 5.0.18 change log
- artifact:ignore frontend-js-spa-web 5.0.18 prep next
- artifact:ignore frontend-js-spa-web 5.0.18 artifact properties
- artifact:ignore frontend-js-tabs-support-web 2.0.8 change log
- artifact:ignore frontend-js-tabs-support-web 2.0.8 prep next
- artifact:ignore frontend-js-tabs-support-web 2.0.8 artifact properties
- artifact:ignore frontend-js-tooltip-support-web 4.0.13 change log
- artifact:ignore frontend-js-tooltip-support-web 4.0.13 prep next
- artifact:ignore frontend-js-tooltip-support-web 4.0.13 artifact properties
- artifact:ignore frontend-js-web 5.0.18 change log
- artifact:ignore frontend-js-web 5.0.18 prep next
- artifact:ignore frontend-js-web 5.0.18 artifact properties
- artifact:ignore frontend-taglib-clay 8.1.1 change log
- artifact:ignore frontend-taglib-clay 8.1.1 prep next
- artifact:ignore frontend-taglib-clay 8.1.1 artifact properties
- artifact:ignore frontend-theme-admin 5.0.11 prep next
- artifact:ignore frontend-theme-admin 5.0.11 artifact properties
- artifact:ignore frontend-theme-browser-support 2.0.8 prep next
- artifact:ignore frontend-theme-browser-support 2.0.8 artifact properties
- artifact:ignore frontend-theme-classic 5.0.18 prep next
- artifact:ignore frontend-theme-classic 5.0.18 artifact properties
- artifact:ignore frontend-theme-classic-style-guide-sample-web 2.0.13 change log
- artifact:ignore frontend-theme-classic-style-guide-sample-web 2.0.13 prep next
- artifact:ignore frontend-theme-classic-style-guide-sample-web 2.0.13 artifact properties
- artifact:ignore frontend-theme-contributor-extender 6.0.6 prep next
- artifact:ignore frontend-theme-contributor-extender 6.0.6 artifact properties
- artifact:ignore frontend-theme-dialect 5.0.6 prep next
- artifact:ignore frontend-theme-dialect 5.0.6 artifact properties
- artifact:ignore frontend-theme-favicon-servlet 5.0.6 prep next
- artifact:ignore frontend-theme-favicon-servlet 5.0.6 artifact properties
- artifact:ignore frontend-theme-font-awesome-web 3.0.14 prep next
- artifact:ignore frontend-theme-font-awesome-web 3.0.14 artifact properties
- artifact:ignore frontend-theme-styled 6.0.14 prep next
- artifact:ignore frontend-theme-styled 6.0.14 artifact properties
- artifact:ignore frontend-theme-unstyled 6.0.15 change log
- artifact:ignore frontend-theme-unstyled 6.0.15 prep next
- artifact:ignore frontend-theme-unstyled 6.0.15 artifact properties
- artifact:ignore journal-article-dynamic-data-mapping-form-field-type 2.0.12 change log
- artifact:ignore journal-article-dynamic-data-mapping-form-field-type 2.0.12 prep next
- artifact:ignore journal-article-dynamic-data-mapping-form-field-type 2.0.12 artifact properties
- artifact:ignore journal-service 7.0.36 change log
- artifact:ignore journal-service 7.0.36 prep next
- artifact:ignore journal-service 7.0.36 artifact properties
- artifact:ignore layout-dynamic-data-mapping-form-field-type 2.0.15 change log
- artifact:ignore layout-dynamic-data-mapping-form-field-type 2.0.15 prep next
- artifact:ignore layout-dynamic-data-mapping-form-field-type 2.0.15 artifact properties
- artifact:ignore layout-impl 6.0.23 change log
- artifact:ignore layout-impl 6.0.23 prep next
- artifact:ignore layout-impl 6.0.23 artifact properties
- artifact:ignore map-common 6.0.7 change log
- artifact:ignore map-common 6.0.7 prep next
- artifact:ignore map-common 6.0.7 artifact properties
- artifact:ignore marketplace-store-web 7.0.13 change log
- artifact:ignore marketplace-store-web 7.0.13 prep next
- artifact:ignore marketplace-store-web 7.0.13 artifact properties
- artifact:ignore portal-language-lang 1.0.40 change log
- artifact:ignore portal-language-lang 1.0.40 prep next
- artifact:ignore portal-language-lang 1.0.40 artifact properties
- artifact:ignore portal-remote-soap-extender-impl 5.0.12 change log
- artifact:ignore portal-remote-soap-extender-impl 5.0.12 prep next
- artifact:ignore portal-remote-soap-extender-impl 5.0.12 artifact properties
- artifact:ignore portal-search-elasticsearch7-impl 6.0.22 change log
- artifact:ignore portal-search-elasticsearch7-impl 6.0.22 prep next
- artifact:ignore portal-search-elasticsearch7-impl 6.0.22 artifact properties
- artifact:ignore portal-workflow-instance-tracker-web 1.0.11 change log
- artifact:ignore portal-workflow-instance-tracker-web 1.0.11 prep next
- artifact:ignore portal-workflow-instance-tracker-web 1.0.11 artifact properties
- artifact:ignore remote-app-client-js 1.0.6 change log
- artifact:ignore remote-app-client-js 1.0.6 prep next
- artifact:ignore remote-app-client-js 1.0.6 artifact properties
- artifact:ignore site-welcome-site-initializer 1.0.11 change log
- artifact:ignore site-welcome-site-initializer 1.0.11 prep next
- artifact:ignore site-welcome-site-initializer 1.0.11 artifact properties
- artifact:ignore site-initializer-masterclass 1.0.6 change log
- artifact:ignore site-initializer-masterclass 1.0.6 prep next
- artifact:ignore site-initializer-masterclass 1.0.6 artifact properties
- artifact:ignore site-initializer-raylife 1.0.11 change log
- artifact:ignore commerce-theme-minium 5.0.17 change log
- artifact:ignore commerce-theme-minium 5.0.17 prep next
- artifact:ignore commerce-theme-minium 5.0.17 artifact properties
- commerce-theme-minium 5.0.17 apply
- artifact:ignore commerce-theme-speedwell 4.0.19 change log
- artifact:ignore commerce-theme-speedwell 4.0.19 prep next
- artifact:ignore commerce-theme-speedwell 4.0.19 artifact properties
- artifact:ignore fragment-collection-contributor-cookie-banner 1.0.10 change log
- artifact:ignore fragment-collection-contributor-cookie-banner 1.0.10 prep next
- artifact:ignore fragment-collection-contributor-cookie-banner 1.0.10 artifact properties
- artifact:ignore headless-discovery-web 4.0.15 change log
- artifact:ignore headless-discovery-web 4.0.15 prep next
- artifact:ignore headless-discovery-web 4.0.15 artifact properties
- artifact:ignore portal-configuration-persistence-impl 4.0.9 change log
- artifact:ignore portal-configuration-persistence-impl 4.0.9 prep next
- artifact:ignore portal-configuration-persistence-impl 4.0.9 artifact properties
- artifact:ignore headless-commerce-admin-order-api 12.0.0 change log
- artifact:ignore headless-commerce-admin-order-api 12.0.0 prep next
- artifact:ignore headless-commerce-admin-order-api 12.0.0 artifact properties
- artifact:ignore headless-commerce-admin-order-client 4.0.11 change log
- artifact:ignore headless-commerce-admin-order-client 4.0.11 prep next
- artifact:ignore headless-commerce-admin-order-client 4.0.11 artifact properties
- artifact:ignore headless-commerce-delivery-catalog-client 4.0.12 change log
- artifact:ignore headless-commerce-delivery-catalog-client 4.0.12 prep next
- artifact:ignore headless-commerce-delivery-catalog-client 4.0.12 artifact properties
- build.gradle auto SF
- artifact:ignore batch-planner-service 1.0.11 change log
- artifact:ignore batch-planner-service 1.0.11 prep next
- artifact:ignore batch-planner-service 1.0.11 artifact properties
- artifact:ignore commerce-report-impl 1.0.2 change log
- artifact:ignore commerce-report-impl 1.0.2 prep next
- artifact:ignore commerce-report-impl 1.0.2 artifact properties
- artifact:ignore fragment-collection-filter-category 1.0.13 change log
- artifact:ignore fragment-collection-filter-category 1.0.13 prep next
- artifact:ignore fragment-collection-filter-category 1.0.13 artifact properties
- artifact:ignore frontend-data-set-api 1.0.0 prep next
- artifact:ignore frontend-data-set-api 1.0.0 artifact properties
- artifact:ignore frontend-data-set-api 1.0.0 change log
- artifact:ignore frontend-data-set-api 1.0.0 prep next
- artifact:ignore frontend-data-set-api 1.0.0 artifact properties
- artifact:ignore frontend-taglib 6.2.8 change log
- artifact:ignore frontend-taglib 6.2.8 prep next
- artifact:ignore frontend-taglib 6.2.8 artifact properties
- artifact:ignore product-navigation-taglib 6.0.17 change log
- artifact:ignore product-navigation-taglib 6.0.17 prep next
- artifact:ignore product-navigation-taglib 6.0.17 artifact properties
- artifact:ignore sharing-taglib 3.0.15 change log
- artifact:ignore sharing-taglib 3.0.15 prep next
- artifact:ignore sharing-taglib 3.0.15 artifact properties
- LPS-140634 add uploadArchives
- artifact:ignore site-initializer-raylife 1.0.12 change log
- Revert "LPS-140634 add uploadArchives"
- Revert "LPS-140634 Skip building artifact for assemble task"
- artifact:ignore site-initializer-raylife 1.0.13 change log
- site-initializer-raylife 1.0.13 packageinfo
- artifact:ignore site-initializer-raylife 1.0.13 prep next
- artifact:ignore site-initializer-raylife 1.0.13 artifact properties
- build.gradle auto SF
- LPS-140835 headless-admin-user-test: includes externalReferenceCode in fields to be compared
- LPS-140835 headless-admin-user-test: adds assertion that externalReferenceCode is tested for uniqueness in the POST method
- LPS-140835 headless-admin-user-impl: schema: allows sending the externalReferenceCode in the request body
- LPS-140835 headless-admin-user: autogenerated: buildRest
- LPS-140835 headless-admin-user-impl: adds exception mapper for DuplicateAccountEntryExternalReferenceCodeException
- LPS-140835 headless-admin-user-impl: writes the externalReferenceCode in the POST method
- LPS-140835 headless-admin-user-impl: updates externalReferenceCode in patch and put methods as well (fixes test failure)
- LPS-140835 SF
- artifact:ignore adaptive-media-web 5.0.22 change log
- artifact:ignore adaptive-media-web 5.0.22 prep next
- artifact:ignore adaptive-media-web 5.0.22 artifact properties
- artifact:ignore asset-categories-selector-web 4.0.14 change log
- artifact:ignore asset-categories-selector-web 4.0.14 prep next
- artifact:ignore asset-categories-selector-web 4.0.14 artifact properties
- artifact:ignore asset-taglib 6.2.1 change log
- artifact:ignore asset-taglib 6.2.1 prep next
- artifact:ignore asset-taglib 6.2.1 artifact properties
- artifact:ignore batch-planner-web 1.0.14 change log
- artifact:ignore batch-planner-web 1.0.14 prep next
- artifact:ignore batch-planner-web 1.0.14 artifact properties
- artifact:ignore change-tracking-web 2.0.31 change log
- artifact:ignore change-tracking-web 2.0.31 prep next
- artifact:ignore change-tracking-web 2.0.31 artifact properties
- artifact:ignore commerce-frontend-js 4.0.27 change log
- artifact:ignore commerce-frontend-js 4.0.27 prep next
- artifact:ignore commerce-frontend-js 4.0.27 artifact properties
- artifact:ignore commerce-product-api 39.0.0 change log
- artifact:ignore commerce-product-api 39.0.0 prep next
- artifact:ignore commerce-product-api 39.0.0 artifact properties
- artifact:ignore content-dashboard-web 2.0.29 change log
- artifact:ignore content-dashboard-web 2.0.29 prep next
- artifact:ignore content-dashboard-web 2.0.29 artifact properties
- artifact:ignore data-engine-taglib 3.3.13 change log
- artifact:ignore data-engine-taglib 3.3.13 prep next
- artifact:ignore data-engine-taglib 3.3.13 artifact properties
- artifact:ignore depot-web 2.0.24 change log
- artifact:ignore depot-web 2.0.24 prep next
- artifact:ignore depot-web 2.0.24 artifact properties
- artifact:ignore digital-signature-web 1.0.13 change log
- artifact:ignore digital-signature-web 1.0.13 prep next
- artifact:ignore digital-signature-web 1.0.13 artifact properties
- artifact:ignore document-library-preview-document 3.0.10 change log
- artifact:ignore document-library-preview-document 3.0.10 prep next
- artifact:ignore document-library-preview-document 3.0.10 artifact properties
- artifact:ignore document-library-preview-image 3.0.11 change log
- artifact:ignore document-library-preview-image 3.0.11 prep next
- artifact:ignore document-library-preview-image 3.0.11 artifact properties
- artifact:ignore document-library-video 1.0.26 change log
- artifact:ignore document-library-video 1.0.26 prep next
- artifact:ignore document-library-video 1.0.26 artifact properties
- artifact:ignore dynamic-data-mapping-form-report-web 2.0.17 change log
- artifact:ignore dynamic-data-mapping-form-report-web 2.0.17 prep next
- artifact:ignore dynamic-data-mapping-form-report-web 2.0.17 artifact properties
- artifact:ignore dynamic-data-mapping-web 5.0.26 change log
- artifact:ignore dynamic-data-mapping-web 5.0.26 prep next
- artifact:ignore dynamic-data-mapping-web 5.0.26 artifact properties
- artifact:ignore flags-taglib 6.0.19 change log
- artifact:ignore flags-taglib 6.0.19 prep next
- artifact:ignore flags-taglib 6.0.19 artifact properties
- artifact:ignore fragment-collection-filter-date 1.0.11 change log
- artifact:ignore fragment-collection-filter-date 1.0.11 prep next
- artifact:ignore fragment-collection-filter-date 1.0.11 artifact properties
- artifact:ignore fragment-renderer-collection-filter-impl 1.0.12 change log
- artifact:ignore fragment-renderer-collection-filter-impl 1.0.12 prep next
- artifact:ignore fragment-renderer-collection-filter-impl 1.0.12 artifact properties
- artifact:ignore fragment-web 4.0.22 change log
- artifact:ignore fragment-web 4.0.22 prep next
- artifact:ignore fragment-web 4.0.22 artifact properties
- artifact:ignore friendly-url-taglib 1.1.1 change log
- artifact:ignore friendly-url-taglib 1.1.1 prep next
- artifact:ignore friendly-url-taglib 1.1.1 artifact properties
- artifact:ignore frontend-data-set-impl 1.0.0 prep next
- artifact:ignore frontend-data-set-impl 1.0.0 artifact properties
- artifact:ignore frontend-data-set-impl 1.0.0 change log
- artifact:ignore frontend-data-set-impl 1.0.0 prep next
- artifact:ignore frontend-data-set-impl 1.0.0 artifact properties
- artifact:ignore frontend-data-set-taglib 1.0.0 prep next
- artifact:ignore frontend-data-set-taglib 1.0.0 artifact properties
- artifact:ignore frontend-data-set-taglib 1.0.0 change log
- artifact:ignore frontend-data-set-taglib 1.0.0 prep next
- artifact:ignore frontend-data-set-taglib 1.0.0 artifact properties
- artifact:ignore frontend-editor-alloyeditor-web 5.0.16 change log
- artifact:ignore frontend-editor-alloyeditor-web 5.0.16 prep next
- artifact:ignore frontend-editor-alloyeditor-web 5.0.16 artifact properties
- artifact:ignore frontend-editor-ckeditor-web 5.0.32 change log
- artifact:ignore frontend-editor-ckeditor-web 5.0.32 prep next
- artifact:ignore frontend-editor-ckeditor-web 5.0.32 artifact properties
- artifact:ignore invitation-invite-members-web 5.0.13 change log
- artifact:ignore invitation-invite-members-web 5.0.13 prep next
- artifact:ignore invitation-invite-members-web 5.0.13 artifact properties
- artifact:ignore item-selector-taglib 5.1.22 change log
- artifact:ignore item-selector-taglib 5.1.22 prep next
- artifact:ignore item-selector-taglib 5.1.22 artifact properties
- artifact:ignore item-selector-url-web 6.0.13 change log
- artifact:ignore item-selector-url-web 6.0.13 prep next
- artifact:ignore item-selector-url-web 6.0.13 artifact properties
- artifact:ignore layout-page-template-admin-web 2.0.28 change log
- artifact:ignore layout-page-template-admin-web 2.0.28 prep next
- artifact:ignore layout-page-template-admin-web 2.0.28 artifact properties
- artifact:ignore layout-reports-web 1.0.18 change log
- artifact:ignore layout-reports-web 1.0.18 prep next
- artifact:ignore layout-reports-web 1.0.18 artifact properties
- artifact:ignore layout-seo-web 2.0.25 change log
- artifact:ignore layout-seo-web 2.0.25 prep next
- artifact:ignore layout-seo-web 2.0.25 artifact properties
- artifact:ignore layout-taglib 7.1.6 change log
- artifact:ignore layout-taglib 7.1.6 prep next
- artifact:ignore layout-taglib 7.1.6 artifact properties
- artifact:ignore object-web 1.0.22 change log
- artifact:ignore object-web 1.0.22 prep next
- artifact:ignore object-web 1.0.22 artifact properties
- artifact:ignore portal-search-admin-web 4.0.13 change log
- artifact:ignore portal-search-admin-web 4.0.13 prep next
- artifact:ignore portal-search-admin-web 4.0.13 artifact properties
- artifact:ignore portal-workflow-taglib 2.0.1 change log
- artifact:ignore portal-workflow-taglib 2.0.1 prep next
- artifact:ignore portal-workflow-taglib 2.0.1 artifact properties
- artifact:ignore portlet-configuration-css-web 6.0.18 change log
- artifact:ignore portlet-configuration-css-web 6.0.18 prep next
- artifact:ignore portlet-configuration-css-web 6.0.18 artifact properties
- artifact:ignore product-navigation-applications-menu-web 2.0.17 change log
- artifact:ignore product-navigation-applications-menu-web 2.0.17 prep next
- artifact:ignore product-navigation-applications-menu-web 2.0.17 artifact properties
- artifact:ignore ratings-taglib 3.0.13 change log
- artifact:ignore ratings-taglib 3.0.13 prep next
- artifact:ignore ratings-taglib 3.0.13 artifact properties
- artifact:ignore redirect-web 2.0.18 change log
- artifact:ignore redirect-web 2.0.18 prep next
- artifact:ignore redirect-web 2.0.18 artifact properties
- artifact:ignore remote-app-web 2.0.15 change log
- artifact:ignore remote-app-web 2.0.15 prep next
- artifact:ignore remote-app-web 2.0.15 artifact properties
- artifact:ignore roles-admin-web 5.0.24 change log
- artifact:ignore roles-admin-web 5.0.24 prep next
- artifact:ignore roles-admin-web 5.0.24 artifact properties
- artifact:ignore segments-web 3.0.26 change log
- artifact:ignore segments-web 3.0.26 prep next
- artifact:ignore segments-web 3.0.26 artifact properties
- artifact:ignore site-navigation-admin-web 4.0.19 change log
- artifact:ignore site-navigation-admin-web 4.0.19 prep next
- artifact:ignore site-navigation-admin-web 4.0.19 artifact properties
- artifact:ignore template-web 1.0.12 change log
- artifact:ignore template-web 1.0.12 prep next
- artifact:ignore template-web 1.0.12 artifact properties
- artifact:ignore translation-web 2.0.25 change log
- artifact:ignore translation-web 2.0.25 prep next
- artifact:ignore translation-web 2.0.25 artifact properties
- artifact:ignore user-associated-data-web 6.0.18 change log
- artifact:ignore user-associated-data-web 6.0.18 prep next
- artifact:ignore user-associated-data-web 6.0.18 artifact properties
- artifact:ignore headless-admin-user-api 15.1.4 change log
- artifact:ignore headless-admin-user-api 15.1.4 prep next
- artifact:ignore headless-admin-user-api 15.1.4 artifact properties
- build.gradle auto SF
- artifact:ignore account-admin-web 2.0.17 change log
- artifact:ignore account-admin-web 2.0.17 prep next
- artifact:ignore account-admin-web 2.0.17 artifact properties
- artifact:ignore asset-categories-item-selector-web 1.0.16 change log
- artifact:ignore asset-categories-item-selector-web 1.0.16 prep next
- artifact:ignore asset-categories-item-selector-web 1.0.16 artifact properties
- artifact:ignore asset-list-web 3.0.20 change log
- artifact:ignore asset-list-web 3.0.20 prep next
- artifact:ignore asset-list-web 3.0.20 artifact properties
- artifact:ignore comment-taglib 4.0.18 change log
- artifact:ignore comment-taglib 4.0.18 prep next
- artifact:ignore comment-taglib 4.0.18 artifact properties
- artifact:ignore commerce-api 29.2.0 change log
- artifact:ignore commerce-api 29.2.0 prep next
- artifact:ignore commerce-api 29.2.0 artifact properties
- artifact:ignore commerce-product-measurement-unit-web 4.0.12 change log
- artifact:ignore commerce-product-measurement-unit-web 4.0.12 prep next
- artifact:ignore commerce-product-measurement-unit-web 4.0.12 artifact properties
- artifact:ignore contacts-web 5.0.18 change log
- artifact:ignore contacts-web 5.0.18 prep next
- artifact:ignore contacts-web 5.0.18 artifact properties
- artifact:ignore document-library-item-selector-web 5.0.17 change log
- artifact:ignore document-library-item-selector-web 5.0.17 prep next
- artifact:ignore document-library-item-selector-web 5.0.17 artifact properties
- artifact:ignore dynamic-data-mapping-form-web 4.0.49 change log
- artifact:ignore dynamic-data-mapping-form-web 4.0.49 prep next
- artifact:ignore dynamic-data-mapping-form-web 4.0.49 artifact properties
- artifact:ignore fragment-impl 4.0.21 change log
- artifact:ignore fragment-impl 4.0.21 prep next
- artifact:ignore fragment-impl 4.0.21 artifact properties
- artifact:ignore journal-web 5.0.43 change log
- artifact:ignore journal-web 5.0.43 prep next
- artifact:ignore journal-web 5.0.43 artifact properties
- artifact:ignore layout-admin-web 5.0.41 change log
- artifact:ignore layout-admin-web 5.0.41 prep next
- artifact:ignore layout-admin-web 5.0.41 artifact properties
- artifact:ignore layout-content-page-editor-web 3.0.59 change log
- artifact:ignore layout-content-page-editor-web 3.0.59 prep next
- artifact:ignore layout-content-page-editor-web 3.0.59 artifact properties
- artifact:ignore message-boards-web 5.0.26 change log
- artifact:ignore message-boards-web 5.0.26 prep next
- artifact:ignore message-boards-web 5.0.26 artifact properties
- artifact:ignore portal-search-web 6.0.26 change log
- artifact:ignore portal-search-web 6.0.26 prep next
- artifact:ignore portal-search-web 6.0.26 artifact properties
- artifact:ignore product-navigation-control-menu-web 6.0.24 change log
- artifact:ignore product-navigation-control-menu-web 6.0.24 prep next
- artifact:ignore product-navigation-control-menu-web 6.0.24 artifact properties
- artifact:ignore product-navigation-product-menu-web 6.0.26 change log
- artifact:ignore product-navigation-product-menu-web 6.0.26 prep next
- artifact:ignore product-navigation-product-menu-web 6.0.26 artifact properties
- artifact:ignore questions-web 2.0.33 change log
- artifact:ignore questions-web 2.0.33 prep next
- artifact:ignore questions-web 2.0.33 artifact properties
- artifact:ignore site-admin-web 5.0.29 change log
- artifact:ignore site-admin-web 5.0.29 prep next
- artifact:ignore site-admin-web 5.0.29 artifact properties
- artifact:ignore site-navigation-item-selector-web 4.0.14 change log
- artifact:ignore site-navigation-item-selector-web 4.0.14 prep next
- artifact:ignore site-navigation-item-selector-web 4.0.14 artifact properties
- artifact:ignore style-book-web 2.0.21 change log
- artifact:ignore style-book-web 2.0.21 prep next
- artifact:ignore style-book-web 2.0.21 artifact properties
- artifact:ignore users-admin-web 6.0.26 change log
- artifact:ignore users-admin-web 6.0.26 prep next
- artifact:ignore users-admin-web 6.0.26 artifact properties
- artifact:ignore headless-admin-user-impl 5.0.22 change log
- artifact:ignore headless-admin-user-impl 5.0.22 prep next
- artifact:ignore headless-admin-user-impl 5.0.22 artifact properties
- artifact:ignore site-initializer-extender 1.0.8 change log
- artifact:ignore site-initializer-extender 1.0.8 prep next
- artifact:ignore site-initializer-extender 1.0.8 artifact properties
- artifact:ignore headless-commerce-delivery-catalog-api 10.6.0 change log
- artifact:ignore headless-commerce-delivery-catalog-api 10.6.0 prep next
- artifact:ignore headless-commerce-delivery-catalog-api 10.6.0 artifact properties
- build.gradle auto SF
- artifact:ignore asset-publisher-web 5.0.35 change log
- artifact:ignore asset-publisher-web 5.0.35 prep next
- artifact:ignore asset-publisher-web 5.0.35 artifact properties
- artifact:ignore blogs-web 6.0.27 change log
- artifact:ignore blogs-web 6.0.27 prep next
- artifact:ignore blogs-web 6.0.27 artifact properties
- artifact:ignore calendar-web 5.0.19 change log
- artifact:ignore calendar-web 5.0.19 prep next
- artifact:ignore calendar-web 5.0.19 artifact properties
- artifact:ignore commerce-frontend-impl 4.0.14 change log
- artifact:ignore commerce-frontend-impl 4.0.14 prep next
- artifact:ignore commerce-frontend-impl 4.0.14 artifact properties
- artifact:ignore commerce-frontend-taglib 14.0.2 change log
- artifact:ignore commerce-frontend-taglib 14.0.2 prep next
- artifact:ignore commerce-frontend-taglib 14.0.2 artifact properties
- artifact:ignore commerce-product-service 6.0.27 change log
- artifact:ignore commerce-product-service 6.0.27 prep next
- artifact:ignore commerce-product-service 6.0.27 artifact properties
- artifact:ignore commerce-service 11.0.37 change log
- artifact:ignore commerce-service 11.0.37 prep next
- artifact:ignore commerce-service 11.0.37 artifact properties
- artifact:ignore document-library-web 6.0.49 change log
- artifact:ignore document-library-web 6.0.49 prep next
- artifact:ignore document-library-web 6.0.49 artifact properties
- artifact:ignore portal-workflow-web 4.0.21 change log
- artifact:ignore portal-workflow-web 4.0.21 prep next
- artifact:ignore portal-workflow-web 4.0.21 artifact properties
- artifact:ignore sharing-web 3.0.18 change log
- artifact:ignore sharing-web 3.0.18 prep next
- artifact:ignore sharing-web 3.0.18 artifact properties
- artifact:ignore wiki-web 7.0.24 change log
- artifact:ignore wiki-web 7.0.24 prep next
- artifact:ignore wiki-web 7.0.24 artifact properties
- artifact:ignore headless-commerce-admin-order-impl 4.0.23 change log
- artifact:ignore headless-commerce-admin-order-impl 4.0.23 prep next
- artifact:ignore headless-commerce-admin-order-impl 4.0.23 artifact properties
- artifact:ignore headless-commerce-delivery-catalog-impl 4.0.20 change log
- artifact:ignore headless-commerce-delivery-catalog-impl 4.0.20 prep next
- artifact:ignore headless-commerce-delivery-catalog-impl 4.0.20 artifact properties
- build.gradle auto SF
- artifact:ignore commerce-order-content-web 4.0.20 change log
- artifact:ignore commerce-order-content-web 4.0.20 prep next
- artifact:ignore commerce-order-content-web 4.0.20 artifact properties
- artifact:ignore commerce-order-web 5.0.19 change log
- artifact:ignore commerce-order-web 5.0.19 prep next
- artifact:ignore commerce-order-web 5.0.19 artifact properties
- artifact:ignore commerce-product-content-web 4.0.18 change log
- artifact:ignore commerce-product-content-web 4.0.18 prep next
- artifact:ignore commerce-product-content-web 4.0.18 artifact properties
- artifact:ignore commerce-product-definitions-web 7.0.24 change log
- artifact:ignore commerce-product-definitions-web 7.0.24 prep next
- artifact:ignore commerce-product-definitions-web 7.0.24 artifact properties
- artifact:ignore commerce-shipping-web 6.0.11 change log
- artifact:ignore commerce-shipping-web 6.0.11 prep next
- artifact:ignore commerce-shipping-web 6.0.11 artifact properties
- build.gradle auto SF
- artifact:ignore commerce-shipping-engine-fedex 5.0.11 change log
- artifact:ignore commerce-shipping-engine-fedex 5.0.11 prep next
- artifact:ignore commerce-shipping-engine-fedex 5.0.11 artifact properties
- artifact:ignore commerce-warehouse-web 4.0.16 change log
- artifact:ignore commerce-warehouse-web 4.0.16 prep next
- artifact:ignore commerce-warehouse-web 4.0.16 artifact properties
- build.gradle auto SF
- artifact:ignore analytics-reports-web 2.0.27 change log
- artifact:ignore analytics-reports-web 2.0.27 prep next
- artifact:ignore analytics-reports-web 2.0.27 artifact properties
- artifact:ignore commerce-dashboard-web 4.0.16 change log
- artifact:ignore commerce-dashboard-web 4.0.16 prep next
- artifact:ignore commerce-dashboard-web 4.0.16 artifact properties
- artifact:ignore commerce-machine-learning-impl 5.0.18 change log
- artifact:ignore commerce-machine-learning-impl 5.0.18 prep next
- artifact:ignore commerce-machine-learning-impl 5.0.18 artifact properties
- artifact:ignore commerce-organization-web 5.0.19 change log
- artifact:ignore commerce-organization-web 5.0.19 prep next
- artifact:ignore commerce-organization-web 5.0.19 artifact properties
- artifact:ignore commerce-shop-by-diagram-web 1.0.24 change log
- artifact:ignore commerce-shop-by-diagram-web 1.0.24 prep next
- artifact:ignore commerce-shop-by-diagram-web 1.0.24 artifact properties
- artifact:ignore frontend-theme-dxp-override 4.0.7 prep next
- artifact:ignore frontend-theme-dxp-override 4.0.7 artifact properties
- artifact:ignore portal-dao-db 5.0.8 change log
- artifact:ignore portal-dao-db 5.0.8 prep next
- artifact:ignore portal-dao-db 5.0.8 artifact properties
- artifact:ignore portal-reports-engine-console-jasper 4.0.11 change log
- artifact:ignore portal-reports-engine-console-jasper 4.0.11 prep next
- artifact:ignore portal-reports-engine-console-jasper 4.0.11 artifact properties
- artifact:ignore portal-reports-engine-console-web 5.0.15 change log
- artifact:ignore portal-reports-engine-console-web 5.0.15 prep next
- artifact:ignore portal-reports-engine-console-web 5.0.15 artifact properties
- artifact:ignore portal-search-tuning-rankings-web 3.0.18 change log
- artifact:ignore portal-search-tuning-rankings-web 3.0.18 prep next
- artifact:ignore portal-search-tuning-rankings-web 3.0.18 artifact properties
- artifact:ignore portal-search-tuning-synonyms-web 3.0.19 change log
- artifact:ignore portal-search-tuning-synonyms-web 3.0.19 prep next
- artifact:ignore portal-search-tuning-synonyms-web 3.0.19 artifact properties
- artifact:ignore portal-workflow-kaleo-designer-web 5.0.26 change log
- artifact:ignore portal-workflow-kaleo-designer-web 5.0.26 prep next
- artifact:ignore portal-workflow-kaleo-designer-web 5.0.26 artifact properties
- artifact:ignore portal-workflow-metrics-web 3.0.27 change log
- artifact:ignore portal-workflow-metrics-web 3.0.27 prep next
- artifact:ignore portal-workflow-metrics-web 3.0.27 artifact properties
- artifact:ignore segments-experiment-web 3.0.18 change log
- artifact:ignore segments-experiment-web 3.0.18 prep next
- artifact:ignore segments-experiment-web 3.0.18 artifact properties
- build.gradle auto SF
- 7.4.3.5 GA5 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, click-to-chat, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, digital-signature, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-data-set, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, google-places, headless, iframe, image-uploader, image, imageio-plugins, info, invitation, item-selector, journal, json-storage, knowledge-base, layout, learn, license-manager, list-type, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, object, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, release-feature-flag, remote-app, roles, rss, segments, server, sharing, site-initializer, site-navigation, site, social, staging, style-book, subscription, template, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream
- 7.4.13 Update 1 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, click-to-chat, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, digital-signature, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-data-set, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, google-places, headless, iframe, image-uploader, image, imageio-plugins, info, invitation, item-selector, journal, json-storage, knowledge-base, layout, learn, license-manager, list-type, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, object, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, release-feature-flag, remote-app, roles, rss, segments, server, sharing, site-initializer, site-navigation, site, social, staging, style-book, subscription, template, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream, antivirus, enterprise-product-notification, multi-factor-authentication, portal-search-elasticsearch-cross-cluster-replication, portal-search-elasticsearch-monitoring, portal-search-learning-to-rank, portal-search-similar-results, portal-search-tuning, saml
- LRQA-67023 Remove blacklisted component through UI
- LRQA-71641 Only close Commerce terms in DXP builds
- LPS-140872 Add RelationshipTabDisappearsWhenInactivatedOneToMany Test
- LPS-140872 SF
- LPS-140872 Fix last assert
- LPS-112856 search-experiences-service: Test: testNotContains was missing _getNotJSONObject in recent asserts
- LPS-142874 rest-openapi.yaml: Element Definition: Simplify schema by using a single value property where multiple typed variants were previously required
- LPS-142874 gw buildREST
- LPS-142874 search-experiences-rest-api: Element Definition: Simplify schema by using a single value property where multiple typed variants were previously required
- LPS-142874 search-experiences-rest-api: Test: Element Definition: Simplify schema by using a single value property where multiple typed variants were previously required
- LPS-142874 search-experiences-service: OOTB Elements: Simplify schema by using a single value property where multiple typed variants were previously required
- LPS-142874 search-experiences-service: Test: Simplify schema by using a single value property where multiple typed variants were previously required
- Revert "LPS-137635 Sort"
- Revert "LPS-137635 Check if users are actually trying to access their own pages"
- Revert "7.4.13 Update 1 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, click-to-chat, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, digital-signature, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-data-set, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, google-places, headless, iframe, image-uploader, image, imageio-plugins, info, invitation, item-selector, journal, json-storage, knowledge-base, layout, learn, license-manager, list-type, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, object, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, release-feature-flag, remote-app, roles, rss, segments, server, sharing, site-initializer, site-navigation, site, social, staging, style-book, subscription, template, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream, antivirus, enterprise-product-notification, multi-factor-authentication, portal-search-elasticsearch-cross-cluster-replication, portal-search-elasticsearch-monitoring, portal-search-learning-to-rank, portal-search-similar-results, portal-search-tuning, saml"
- Revert "7.4.3.5 GA5 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, click-to-chat, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, digital-signature, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-data-set, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, google-places, headless, iframe, image-uploader, image, imageio-plugins, info, invitation, item-selector, journal, json-storage, knowledge-base, layout, learn, license-manager, list-type, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, object, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, release-feature-flag, remote-app, roles, rss, segments, server, sharing, site-initializer, site-navigation, site, social, staging, style-book, subscription, template, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream"
- artifact:ignore portal-impl 11.0.5 prep next
- artifact:ignore portal-impl 11.0.5 releng
- 7.4.3.5 GA5 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, click-to-chat, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, digital-signature, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-data-set, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, google-places, headless, iframe, image-uploader, image, imageio-plugins, info, invitation, item-selector, journal, json-storage, knowledge-base, layout, learn, license-manager, list-type, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, object, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, release-feature-flag, remote-app, roles, rss, segments, server, sharing, site-initializer, site-navigation, site, social, staging, style-book, subscription, template, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream
- 7.4.13 Update 1 Release Apps: account, adaptive-media, address, alloy, analytics, announcements, application-list, asset, batch-engine, bean-portlet, blogs, bulk, calendar, captcha, change-tracking, changeset, click-to-chat, comment, commerce, configuration-admin, connected-app, contacts, content-dashboard, data-cleanup, data-engine, depot, digital-signature, dispatch, document-library-opener, document-library, dynamic-data-lists, dynamic-data-mapping, expando, export-import, external-reference, flags, fragment, friendly-url, frontend-css, frontend-data-set, frontend-editor, frontend-js, frontend-taglib, frontend-theme, frontend-token, gogo-shell, google-places, headless, iframe, image-uploader, image, imageio-plugins, info, invitation, item-selector, journal, json-storage, knowledge-base, layout, learn, license-manager, list-type, login, map, mentions, message-boards, microsoft-translator, mobile-device-rules, monitoring, nested-portlets, notifications, oauth2-provider, object, organizations, password-policies-admin, petra, plugins-admin, portal-background-task, portal-cache, portal-configuration, portal-instances, portal-language, portal-lock, portal-mobile-device-recognition, portal-odata, portal-osgi-debug, portal-portlet-bridge, portal-relationship, portal-remote, portal-reports-engine, portal-rules-engine, portal-scheduler, portal-scripting, portal-search-elasticsearch7, portal-search, portal-security-audit, portal-security-sso, portal-security, portal-settings, portal-store, portal-template, portal-url-builder, portal-validation, portal-vulcan, portal-workflow, portal, portlet-configuration, portlet-dependency-factory, portlet-display-template, product-navigation, questions, ratings, reading-time, redirect, release-feature-flag, remote-app, roles, rss, segments, server, sharing, site-initializer, site-navigation, site, social, staging, style-book, subscription, template, text-localizer, translation, trash, upload, user-associated-data, user-groups-admin, users-admin, view-count, websocket, wiki, xstream, antivirus, enterprise-product-notification, multi-factor-authentication, portal-search-elasticsearch-cross-cluster-replication, portal-search-elasticsearch-monitoring, portal-search-learning-to-rank, portal-search-similar-results, portal-search-tuning, saml
- LPS-141790 Fix test. Test should check that tables are created as a result of the InitialUpgradeExtender on the module's datasource and not manually by the test. So basically, test should check a couple of things:
- LPS-141790 Modify test to check against a different database each time, to avoid Hypersonic caching issues and ensure new external database is completely cleaned.
- LPS-141790 Save module liferayDataSource if extended.
- LPS-141790 Use the module own datasource.
- LPS-141790 Datasource can be extended either using a provider, or by spring. Offer a way to differenciate so that we can then wait for Spring context to get load.
- LPS-141790 Apply renamed method.
- LPS-141790 Create new class to be able to preload just the datasource related application beans.
- LPS-141790 For spring modules wait until the datasource is loaded, which is temporary done instantiating only ext-spring.xml
- LPS-141790 Revert all
- LPS-141790 Construct ModuleApplicationContext ahead of time without refreshing in order to sneak peeking its DataSource. And publish the DataSource as an OSGi service with same property as those from LiferayServiceExtender to provide an unified OSGi access to service module's DataSource before the module's other services are fully ready. This is to open a window of time to create module's tables to proper DataSource.
- LPS-141790 Make InitialUpgrade wait for its service module's DataSource.
- LPS-141790 Select db based on DataSource
- LPS-141790 Don't require portal to run on HSQL
- LPS-141790 No longer needs to prepare the external db's tables ahead of time.
- LPS-141790 Stop checking record in portal db, since the table does not exist.
- LPS-141790 Remove DataSourceDestroyer, com.liferay.portal.dao.jdbc.spring.DataSourceFactoryBean is already doing self cleanup
- LPS-141790 The test now exposes this bug, external datasource created via SPI is not destroyed, causing JDBC connection pool leaking.
- LPS-141790 Add test to expose upgrade process is still using portal datasource.
- LPS-141790 Fix UpgradeProcess to use proper DataSource
- LPS-141790 Fix ReleasePublisher bug. When a release is deleted from db, its osgi servvice remains dangling until portal restart.
- LPS-141790 Unregister old Release after the new one is published, to avoid unnecessary spring context close and reopen.
- LPS-141790 Semantic versioning
- LPS-141790 SF
- LPS-142362 Render DisabledArea only if not dragging
- LPS-113497 Apply the the rename according to 36f3f145cd524ccbd7778e89b092070203d7b266
- LRAC-9857 Allow developers to flag no tracking attribute in the journal Taglib so AC will not track this taglib OOTB
- LPS-137635 Check if users are actually trying to access their own pages
- LPS-137635 Sort
- LPS-77699 Update Translations
- LPS-142904 separate resources for each collection
