### PR TITLE
[TS] LPS-142251 Remove portletResource, because it causes not persisting portlet settings when saving a content in addcontent panel and returning to the widget page. Regression caused by LPS-116913.

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-portlet/src/main/resources/META-INF/resources/layout/view/portlet.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-portlet/src/main/resources/META-INF/resources/layout/view/portlet.jsp
@@ -16,14 +16,6 @@
 
 <%@ include file="/init.jsp" %>
 
-<%
-String portletResource = ParamUtil.getString(request, "portletResource");
-%>
-
-<c:if test="<%= Validator.isNotNull(portletResource) %>">
-	<liferay-ui:success key='<%= portletResource + "requestProcessed" %>' message="your-request-completed-successfully" />
-</c:if>
-
 <c:choose>
 	<c:when test="<%= themeDisplay.isStatePopUp() || themeDisplay.isWidget() || layoutTypePortlet.hasStateMax() %>">
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/AddContentPanelDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/AddContentPanelDisplayContext.java
@@ -24,7 +24,6 @@ import com.liferay.asset.kernel.model.ClassTypeReader;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.util.AssetHelper;
 import com.liferay.asset.util.AssetPublisherAddItemHolder;
-import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -56,7 +55,6 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
-import com.liferay.portal.kernel.util.HttpUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -70,7 +68,6 @@ import com.liferay.portal.kernel.util.comparator.PortletCategoryComparator;
 import com.liferay.portal.kernel.util.comparator.PortletTitleComparator;
 import com.liferay.portal.util.PortletCategoryUtil;
 import com.liferay.portal.util.WebAppPool;
-import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuPortletKeys;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -359,13 +356,8 @@ public class AddContentPanelDisplayContext {
 
 					return _assetHelper.getAddURLPopUp(
 						curGroupId, _themeDisplay.getPlid(),
-						PortletURLBuilder.create(
-							assetPublisherAddItemHolder.getPortletURL()
-						).setPortletResource(
-							ProductNavigationControlMenuPortletKeys.
-								PRODUCT_NAVIGATION_CONTROL_MENU
-						).buildPortletURL(),
-						false, _themeDisplay.getLayout());
+						assetPublisherAddItemHolder.getPortletURL(), false,
+						_themeDisplay.getLayout());
 				}
 			).build()
 		).collect(
@@ -620,13 +612,8 @@ public class AddContentPanelDisplayContext {
 	}
 
 	private String _getRedirectURL() throws Exception {
-		String layoutFullURL = PortalUtil.getLayoutFullURL(
+		return PortalUtil.getLayoutFullURL(
 			_themeDisplay.getLayout(), _themeDisplay);
-
-		return HttpUtil.addParameter(
-			layoutFullURL, "portletResource",
-			ProductNavigationControlMenuPortletKeys.
-				PRODUCT_NAVIGATION_CONTROL_MENU);
 	}
 
 	private List<Map<String, Object>> _getWidgetCategories(


### PR DESCRIPTION
Hi Team,

LPS: https://issues.liferay.com/browse/LPS-142251
Regression issue caused by https://issues.liferay.com/browse/LPS-116913 that effects the configured portlets on widget page. After creating a content and returning to the page, the portlets look like non-configured. This seems a critical issue that was reported by one of our customer. 

We had similar issue in the past with portletResource when we removed it after experiencing regressions.

@jkappler @victorg1991 

Could you please review it?
Thank you!