### PR TITLE
LPS-142917 Avoiding use infoForm.getName() as className.

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/provider/DisplayPageSiteNavigationMenuItemTypeProviderTrackerImpl.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-display-page/src/main/java/com/liferay/site/navigation/menu/item/display/page/internal/type/provider/DisplayPageSiteNavigationMenuItemTypeProviderTrackerImpl.java
@@ -16,7 +16,6 @@ package com.liferay.site.navigation.menu.item.display.page.internal.type.provide
 
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.frontend.taglib.servlet.taglib.util.JSPRenderer;
-import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.InfoItemClassDetails;
 import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.info.item.capability.InfoItemCapability;
@@ -29,6 +28,7 @@ import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
 import com.liferay.layout.page.template.info.item.capability.DisplayPageInfoItemCapability;
 import com.liferay.osgi.util.ServiceTrackerFactory;
+import com.liferay.petra.reflect.GenericUtil;
 import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
@@ -145,9 +145,8 @@ public class DisplayPageSiteNavigationMenuItemTypeProviderTrackerImpl {
 				return infoItemFormProvider;
 			}
 
-			InfoForm infoForm = infoItemFormProvider.getInfoForm();
-
-			String className = infoForm.getName();
+			String className = GenericUtil.getGenericClassName(
+				infoItemFormProvider);
 
 			if (Validator.isNull(className) ||
 				!_hasDisplayPageInfoItemCapability(className)) {
@@ -219,15 +218,15 @@ public class DisplayPageSiteNavigationMenuItemTypeProviderTrackerImpl {
 			ServiceReference<InfoItemFormProvider<?>> serviceReference,
 			InfoItemFormProvider<?> infoItemFormProvider) {
 
-			InfoForm infoForm = infoItemFormProvider.getInfoForm();
+			String className = GenericUtil.getGenericClassName(
+				infoItemFormProvider);
 
-			if (Validator.isNull(infoForm.getName())) {
+			if (Validator.isNull(className)) {
 				return;
 			}
 
 			ServiceRegistration<SiteNavigationMenuItemType>
-				serviceRegistration = _serviceRegistrations.remove(
-					infoForm.getName());
+				serviceRegistration = _serviceRegistrations.remove(className);
 
 			if (serviceRegistration != null) {
 				serviceRegistration.unregister();


### PR DESCRIPTION
Currently, all InfoForm implementations use the className as their name, but although it is a convention, it is not a rule. Since we don't know if there are any custom implementations that didn't follow this convention, it is more prudent to change it so that we get the className using GenericUtil.getGenericClass.

See: https://github.com/brianchandotcom/liferay-portal/pull/110726#issuecomment-985719323

https://issues.liferay.com/browse/LPS-142917
