### PR TITLE
[TS] LPS-123875

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -1048,7 +1048,8 @@ public class JournalArticleStagedModelDataHandler
 			if (article.isExpired() || importedArticle.isExpired()) {
 				_journalArticleLocalService.expireArticle(
 					userId, importedArticle.getGroupId(),
-					importedArticle.getArticleId(), articleURL, serviceContext);
+					importedArticle.getArticleId(),
+					importedArticle.getVersion(), articleURL, serviceContext);
 			}
 
 			serviceContext.setModifiedDate(importedArticle.getModifiedDate());


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-123875

This issue resolves [LPS-123875](https://issues.liferay.com/browse/LPS-123875) while still resolving [LPS-120527](https://issues.liferay.com/browse/LPS-120527).

The first ticket related to this PR is [LPS-120527](https://issues.liferay.com/browse/LPS-120527), which describes an issue where "Never Expire" articles are set to `draft` in live instead of `expired`.

[LPS-121293](https://issues.liferay.com/browse/LPS-121293), which is being partially reverted in this PR, describes a different issue, but nonetheless resolves [LPS-120527](https://issues.liferay.com/browse/LPS-120527), likely unintentionally.  [LPS-121293](https://issues.liferay.com/browse/LPS-121293) consists of three commits:

1. https://github.com/liferay/liferay-portal/commit/60c8426bd04a3fb4d32b8bcfaa0f58e04ccb9e50 - causes the regression described in [LPS-123875](https://issues.liferay.com/browse/LPS-123875) while offering "a solution" to [LPS-121293](https://issues.liferay.com/browse/LPS-121293).
2. https://github.com/liferay/liferay-portal/commit/09603b9ac0f949db7d6ef0de5adc8a44292f31fe - is a small perfornance boost which has no functional impact (safe).
3. https://github.com/liferay/liferay-portal/commit/8fb243ae5da3ec4042b781722c0919cc88087181 - resolves the issue described in [LPS-120527](https://issues.liferay.com/browse/LPS-120527).  It's likely this was fixed in this ticket because of an edge case the engineer found.

The problem with the issue described in [LPS-121293](https://issues.liferay.com/browse/LPS-121293) is it's not a bug, or at least the implementation of the fix is wrong.  [LPS-121293](https://issues.liferay.com/browse/LPS-121293) describes an issue where an article with `Approved` and `Expired` versions shows both status' in `Live`.

- First, this behavior also occurs in `Staging`.  What's happening is the status' appearing are that of all versions, and the latest version (regardless of it's status) is displayed within the control panel.  So, if I have versions `1.0` through `1.2`, and version `1.2` is expired, the entry in the control panel will show `1.2 Approved Expired`, and viewing the version history will provide more context.
- Second, even if this is the incorrect behavior, the solution provided in [LPS-121293](https://issues.liferay.com/browse/LPS-121293) "resolves" it by expiring all versions so there are no `Approved` versions, thus the only status left is `Expired`.  This means instead of versions `1.0` and `1.1` being `Approved` upon publish, all versions are actually set to `Expired`.

Lastly, [LPS-123875](https://issues.liferay.com/browse/LPS-123875) described the regression caused by [LPS-121293](https://issues.liferay.com/browse/LPS-121293).

Please let me know if you have any questions, thanks!