### PR TITLE
LPS-143395 Check group permissions tests

### DIFF
--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/util/test/GroupSearchProviderTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/util/test/GroupSearchProviderTest.java
@@ -66,13 +66,13 @@ public class GroupSearchProviderTest {
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@BeforeClass
-	public static void setUpClass() {
+	public void setUpClass() {
 		_originalGroupsComplexSQLClassNames =
 			PropsValues.GROUPS_COMPLEX_SQL_CLASS_NAMES;
 	}
 
 	@AfterClass
-	public static void tearDownClass() {
+	public void tearDownClass() {
 		ReflectionTestUtil.setFieldValue(
 			PropsValues.class, "GROUPS_COMPLEX_SQL_CLASS_NAMES",
 			_originalGroupsComplexSQLClassNames);
@@ -173,8 +173,6 @@ public class GroupSearchProviderTest {
 		return themeDisplay;
 	}
 
-	private static String[] _originalGroupsComplexSQLClassNames;
-
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
@@ -183,5 +181,7 @@ public class GroupSearchProviderTest {
 
 	@Inject
 	private GroupSearchProvider _groupSearchProvider;
+
+	private String[] _originalGroupsComplexSQLClassNames;
 
 }

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/util/test/GroupSearchProviderTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/util/test/GroupSearchProviderTest.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
@@ -69,6 +70,9 @@ public class GroupSearchProviderTest {
 	public void setUpClass() {
 		_originalGroupsComplexSQLClassNames =
 			PropsValues.GROUPS_COMPLEX_SQL_CLASS_NAMES;
+
+		_originalPermissionChecker =
+			PermissionThreadLocal.getPermissionChecker();
 	}
 
 	@AfterClass
@@ -76,6 +80,8 @@ public class GroupSearchProviderTest {
 		ReflectionTestUtil.setFieldValue(
 			PropsValues.class, "GROUPS_COMPLEX_SQL_CLASS_NAMES",
 			_originalGroupsComplexSQLClassNames);
+
+		PermissionThreadLocal.setPermissionChecker(_originalPermissionChecker);
 	}
 
 	@Test
@@ -183,5 +189,6 @@ public class GroupSearchProviderTest {
 	private GroupSearchProvider _groupSearchProvider;
 
 	private String[] _originalGroupsComplexSQLClassNames;
+	private PermissionChecker _originalPermissionChecker;
 
 }

--- a/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/util/test/GroupSearchProviderTest.java
+++ b/modules/apps/site/site-test/src/testIntegration/java/com/liferay/site/util/test/GroupSearchProviderTest.java
@@ -67,7 +67,7 @@ public class GroupSearchProviderTest {
 			PermissionCheckerMethodTestRule.INSTANCE);
 
 	@BeforeClass
-	public void setUpClass() {
+	public static void setUpClass() {
 		_originalGroupsComplexSQLClassNames =
 			PropsValues.GROUPS_COMPLEX_SQL_CLASS_NAMES;
 
@@ -76,7 +76,7 @@ public class GroupSearchProviderTest {
 	}
 
 	@AfterClass
-	public void tearDownClass() {
+	public static void tearDownClass() {
 		ReflectionTestUtil.setFieldValue(
 			PropsValues.class, "GROUPS_COMPLEX_SQL_CLASS_NAMES",
 			_originalGroupsComplexSQLClassNames);
@@ -179,6 +179,9 @@ public class GroupSearchProviderTest {
 		return themeDisplay;
 	}
 
+	private static String[] _originalGroupsComplexSQLClassNames;
+	private static PermissionChecker _originalPermissionChecker;
+
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
@@ -187,8 +190,5 @@ public class GroupSearchProviderTest {
 
 	@Inject
 	private GroupSearchProvider _groupSearchProvider;
-
-	private String[] _originalGroupsComplexSQLClassNames;
-	private PermissionChecker _originalPermissionChecker;
 
 }


### PR DESCRIPTION
I have tried to do what is asked in this comment: https://github.com/brianchandotcom/liferay-portal/pull/110995#issuecomment-991384885

But the source formater fails if the setUpClass and tearDownClass methods are not static, even though the method's names are the correct ones: https://github.com/liferay/liferay-portal/blob/master/modules/util/source-formatter/src/main/resources/documentation/checks/java_test_method_annotations_check.markdown

Therefore I have been forced to add the last commit restoring the static modifier.