### PR TITLE
LPS-135908 Search for portlets in content pages when generating notification link

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 9.3.1
+Bundle-Version: 9.4.0
 Export-Package:\
 	com.liferay.fragment.configuration,\
 	com.liferay.fragment.constants,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalService.java
@@ -309,6 +309,10 @@ public interface FragmentEntryLinkLocalService
 			String uuid, long groupId)
 		throws PortalException;
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public long[] getFragmentEntryLinkClassPKsByPortletId(
+		long groupId, long classNameId, String portletId);
+
 	/**
 	 * Returns a range of all the fragment entry links.
 	 *

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceUtil.java
@@ -365,6 +365,13 @@ public class FragmentEntryLinkLocalServiceUtil {
 		return getService().getFragmentEntryLinkByUuidAndGroupId(uuid, groupId);
 	}
 
+	public static long[] getFragmentEntryLinkClassPKsByPortletId(
+		long groupId, long classNameId, String portletId) {
+
+		return getService().getFragmentEntryLinkClassPKsByPortletId(
+			groupId, classNameId, portletId);
+	}
+
 	/**
 	 * Returns a range of all the fragment entry links.
 	 *

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentEntryLinkLocalServiceWrapper.java
@@ -410,6 +410,15 @@ public class FragmentEntryLinkLocalServiceWrapper
 			getFragmentEntryLinkByUuidAndGroupId(uuid, groupId);
 	}
 
+	@Override
+	public long[] getFragmentEntryLinkClassPKsByPortletId(
+		long groupId, long classNameId, String portletId) {
+
+		return _fragmentEntryLinkLocalService.
+			getFragmentEntryLinkClassPKsByPortletId(
+				groupId, classNameId, portletId);
+	}
+
 	/**
 	 * Returns a range of all the fragment entry links.
 	 *

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
@@ -1,1 +1,1 @@
-version 3.3.0
+version 3.4.0

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -19,12 +19,14 @@ import com.liferay.fragment.constants.FragmentEntryLinkConstants;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.model.FragmentEntryLinkTable;
 import com.liferay.fragment.processor.DefaultFragmentEntryProcessorContext;
 import com.liferay.fragment.processor.FragmentEntryProcessorContext;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
 import com.liferay.fragment.service.base.FragmentEntryLinkLocalServiceBaseImpl;
 import com.liferay.fragment.service.persistence.FragmentCollectionPersistence;
 import com.liferay.fragment.service.persistence.FragmentEntryPersistence;
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -56,6 +58,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
@@ -314,6 +317,32 @@ public class FragmentEntryLinkLocalServiceImpl
 
 		return fragmentEntryLinkPersistence.fetchByG_OFELI_P_First(
 			groupId, originalFragmentEntryLinkId, plid, null);
+	}
+
+	@Override
+	public long[] getFragmentEntryLinkClassPKsByPortletId(
+		long groupId, long classNameId, String portletId) {
+
+		return ArrayUtil.toLongArray(
+			fragmentEntryLinkLocalService.<Collection<Long>>dslQuery(
+				DSLQueryFactoryUtil.select(
+					FragmentEntryLinkTable.INSTANCE.classPK
+				).from(
+					FragmentEntryLinkTable.INSTANCE
+				).where(
+					FragmentEntryLinkTable.INSTANCE.groupId.eq(
+						groupId
+					).and(
+						FragmentEntryLinkTable.INSTANCE.classNameId.eq(
+							classNameId)
+					).and(
+						FragmentEntryLinkTable.INSTANCE.rendererKey.isNull()
+					).and(
+						FragmentEntryLinkTable.INSTANCE.editableValues.like(
+							String.format(
+								"%%\"portletId\":\"%s\"%%", portletId))
+					)
+				)));
 	}
 
 	@Override

--- a/modules/apps/message-boards/message-boards-service/build.gradle
+++ b/modules/apps/message-boards/message-boards-service/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
 	compileOnly project(":apps:comment:comment-api")
 	compileOnly project(":apps:export-import:export-import-api")
+	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:petra:petra-mail")
 	compileOnly project(":apps:petra:petra-model-adapter")

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -25,6 +25,7 @@ import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.expando.kernel.service.ExpandoRowLocalService;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.message.boards.constants.MBCategoryConstants;
 import com.liferay.message.boards.constants.MBConstants;
 import com.liferay.message.boards.constants.MBMessageConstants;
@@ -73,6 +74,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
@@ -97,6 +99,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -1942,8 +1945,8 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 		String portletId = PortletProviderUtil.getPortletId(
 			MBMessage.class.getName(), PortletProvider.Action.VIEW);
 
-		String layoutURL = _portal.getLayoutFullURL(
-			message.getGroupId(), portletId);
+		String layoutURL = _getLayoutFullURL(
+			message, portletId, serviceContext);
 
 		if (Validator.isNotNull(layoutURL)) {
 			return StringBundler.concat(
@@ -2601,6 +2604,36 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 		return StringPool.BLANK;
 	}
 
+	private String _getLayoutFullURL(
+			MBMessage message, String portletId, ServiceContext serviceContext)
+		throws PortalException {
+
+		String layoutFullURL = _portal.getLayoutFullURL(
+			message.getGroupId(), portletId);
+
+		if (Validator.isNotNull(layoutFullURL)) {
+			return layoutFullURL;
+		}
+
+		long[] plids =
+			_fragmentEntryLinkLocalService.
+				getFragmentEntryLinkClassPKsByPortletId(
+					message.getGroupId(),
+					_classNameLocalService.getClassNameId(Layout.class),
+					portletId);
+
+		for (long plid : plids) {
+			Layout layout = _layoutLocalService.fetchLayout(plid);
+
+			if ((layout != null) && !layout.isDraftLayout()) {
+				return _portal.getLayoutFullURL(
+					layout, serviceContext.getThemeDisplay(), false);
+			}
+		}
+
+		return null;
+	}
+
 	private String _getLocalizedRootCategoryName(Group group, Locale locale) {
 		try {
 			return LanguageUtil.get(locale, "home") + " - " +
@@ -2865,10 +2898,16 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 	private ExpandoRowLocalService _expandoRowLocalService;
 
 	@Reference
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@Reference
 	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private Http _http;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private LiferayJSONDeserializationWhitelist


### PR DESCRIPTION
Hey team,

When generating notification links, to see the element in the context
of the current site, we need to use the first layout available that
contains the relevant portlet.

This is the only way I'm aware of that makes it possible. Please take
a look and let me know if there's any other mechanism in place to get
content pages with a particular widget embedded.

Thanks!