### PR TITLE
LPS-144447 | ModifiedDate of fragments are not getting updated

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 11.0.1
+Bundle-Version: 11.1.0
 Export-Package:\
 	com.liferay.fragment.configuration,\
 	com.liferay.fragment.constants,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/util/comparator/FragmentCompositionFragmentEntryModifiedDateComparator.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/util/comparator/FragmentCompositionFragmentEntryModifiedDateComparator.java
@@ -1,0 +1,92 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.fragment.util.comparator;
+
+import com.liferay.fragment.model.FragmentComposition;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.OrderByComparator;
+
+import java.util.Date;
+
+/**
+ * @author Attila Bakay
+ */
+public class FragmentCompositionFragmentEntryModifiedDateComparator
+	extends OrderByComparator<Object> {
+
+	public static final String ORDER_BY_ASC = "modifiedDate ASC";
+
+	public static final String ORDER_BY_DESC = "modifiedDate DESC";
+
+	public static final String[] ORDER_BY_FIELDS = {"modifiedDate"};
+
+	public FragmentCompositionFragmentEntryModifiedDateComparator() {
+		this(true);
+	}
+
+	public FragmentCompositionFragmentEntryModifiedDateComparator(
+		boolean ascending) {
+
+		_ascending = ascending;
+	}
+
+	@Override
+	public int compare(Object object1, Object object2) {
+		int value = DateUtil.compareTo(
+			getModifiedDate(object1), getModifiedDate(object2));
+
+		if (_ascending) {
+			return value;
+		}
+
+		return -value;
+	}
+
+	@Override
+	public String getOrderBy() {
+		if (_ascending) {
+			return ORDER_BY_ASC;
+		}
+
+		return ORDER_BY_DESC;
+	}
+
+	@Override
+	public String[] getOrderByFields() {
+		return ORDER_BY_FIELDS;
+	}
+
+	@Override
+	public boolean isAscending() {
+		return _ascending;
+	}
+
+	protected Date getModifiedDate(Object object) {
+		if (object instanceof FragmentComposition) {
+			FragmentComposition fragmentComposition =
+				(FragmentComposition)object;
+
+			return fragmentComposition.getModifiedDate();
+		}
+
+		FragmentEntry fragmentEntry = (FragmentEntry)object;
+
+		return fragmentEntry.getModifiedDate();
+	}
+
+	private final boolean _ascending;
+
+}

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/util/comparator/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/util/comparator/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/fragment/fragment-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/fragment/fragment-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -63,7 +63,7 @@
 		<![CDATA[
 			SELECT
 				DISTINCT FragmentComposition.fragmentCompositionId AS fragmentCompositionId, 0 AS fragmentEntryId,
-				FragmentComposition.createDate AS createDate, FragmentComposition.name AS name
+				FragmentComposition.createDate AS createDate, FragmentComposition.name AS name, FragmentComposition.modifiedDate AS modifiedDate
 			FROM
 				FragmentComposition
 			WHERE
@@ -76,7 +76,7 @@
 		<![CDATA[
 			SELECT
 				DISTINCT FragmentComposition.fragmentCompositionId AS fragmentCompositionId, 0 AS fragmentEntryId,
-				FragmentComposition.createDate AS createDate, FragmentComposition.name AS name
+				FragmentComposition.createDate AS createDate, FragmentComposition.name AS name, FragmentComposition.modifiedDate AS modifiedDate
 			FROM
 				FragmentComposition
 			WHERE
@@ -90,7 +90,7 @@
 		<![CDATA[
 			SELECT
 				DISTINCT 0 AS fragmentCompositionId, FragmentEntry.fragmentEntryId AS fragmentEntryId,
-				FragmentEntry.createDate AS createDate, FragmentEntry.name AS name
+				FragmentEntry.createDate AS createDate, FragmentEntry.name AS name, FragmentEntry.modifiedDate AS modifiedDate
 			FROM
 				FragmentEntry
 			WHERE
@@ -107,7 +107,7 @@
 		<![CDATA[
 			SELECT
 				DISTINCT 0 AS fragmentCompositionId, FragmentEntry.fragmentEntryId AS fragmentEntryId,
-				FragmentEntry.createDate AS createDate, FragmentEntry.name AS name
+				FragmentEntry.createDate AS createDate, FragmentEntry.name AS name, FragmentEntry.modifiedDate AS modifiedDate
 			FROM
 				FragmentEntry
 			WHERE

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentDisplayContext.java
@@ -706,7 +706,7 @@ public class FragmentDisplayContext {
 
 		_orderByCol = SearchOrderByUtil.getOrderByCol(
 			_httpServletRequest, FragmentPortletKeys.FRAGMENT,
-			"fragment-order-by-col", "create-date");
+			"fragment-order-by-col", "modified-date");
 
 		return _orderByCol;
 	}

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentManagementToolbarDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/FragmentManagementToolbarDisplayContext.java
@@ -74,7 +74,7 @@ public abstract class FragmentManagementToolbarDisplayContext
 
 	@Override
 	protected String[] getOrderByKeys() {
-		return new String[] {"name", "create-date"};
+		return new String[] {"name", "create-date", "modified-date"};
 	}
 
 	protected final FragmentDisplayContext fragmentDisplayContext;

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/clay/BasicFragmentCompositionVerticalCard.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/clay/BasicFragmentCompositionVerticalCard.java
@@ -119,14 +119,14 @@ public class BasicFragmentCompositionVerticalCard
 
 	@Override
 	public String getSubtitle() {
-		Date statusDate = _fragmentComposition.getStatusDate();
+		Date modifiedDate = _fragmentComposition.getModifiedDate();
 
-		String statusDateDescription = LanguageUtil.getTimeDescription(
+		String modifiedDateDescription = LanguageUtil.getTimeDescription(
 			_httpServletRequest,
-			System.currentTimeMillis() - statusDate.getTime(), true);
+			System.currentTimeMillis() - modifiedDate.getTime(), true);
 
 		return LanguageUtil.format(
-			_httpServletRequest, "x-ago", statusDateDescription);
+			_httpServletRequest, "modified-x-ago", modifiedDateDescription);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/clay/BasicFragmentEntryVerticalCard.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/clay/BasicFragmentEntryVerticalCard.java
@@ -127,7 +127,7 @@ public class BasicFragmentEntryVerticalCard
 			System.currentTimeMillis() - modifiedDate.getTime(), true);
 
 		return LanguageUtil.format(
-			_httpServletRequest, "x-ago", modifiedDateDescription);
+			_httpServletRequest, "modified-x-ago", modifiedDateDescription);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/clay/BasicFragmentEntryVerticalCard.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/clay/BasicFragmentEntryVerticalCard.java
@@ -120,14 +120,14 @@ public class BasicFragmentEntryVerticalCard
 
 	@Override
 	public String getSubtitle() {
-		Date statusDate = fragmentEntry.getStatusDate();
+		Date modifiedDate = fragmentEntry.getModifiedDate();
 
-		String statusDateDescription = LanguageUtil.getTimeDescription(
+		String modifiedDateDescription = LanguageUtil.getTimeDescription(
 			_httpServletRequest,
-			System.currentTimeMillis() - statusDate.getTime(), true);
+			System.currentTimeMillis() - modifiedDate.getTime(), true);
 
 		return LanguageUtil.format(
-			_httpServletRequest, "x-ago", statusDateDescription);
+			_httpServletRequest, "x-ago", modifiedDateDescription);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/clay/FragmentCollectionResourceVerticalCard.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/servlet/taglib/clay/FragmentCollectionResourceVerticalCard.java
@@ -122,7 +122,7 @@ public class FragmentCollectionResourceVerticalCard implements VerticalCard {
 			System.currentTimeMillis() - modifiedDate.getTime(), true);
 
 		return LanguageUtil.format(
-			httpServletRequest, "x-ago", modifiedDateDescription);
+			httpServletRequest, "modified-x-ago", modifiedDateDescription);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/util/FragmentPortletUtil.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/util/FragmentPortletUtil.java
@@ -18,6 +18,7 @@ import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.util.comparator.FragmentCollectionCreateDateComparator;
 import com.liferay.fragment.util.comparator.FragmentCollectionNameComparator;
 import com.liferay.fragment.util.comparator.FragmentCompositionFragmentEntryCreateDateComparator;
+import com.liferay.fragment.util.comparator.FragmentCompositionFragmentEntryModifiedDateComparator;
 import com.liferay.fragment.util.comparator.FragmentCompositionFragmentEntryNameComparator;
 import com.liferay.portal.kernel.util.OrderByComparator;
 
@@ -70,6 +71,11 @@ public class FragmentPortletUtil {
 		else if (orderByCol.equals("name")) {
 			orderByComparator =
 				new FragmentCompositionFragmentEntryNameComparator(orderByAsc);
+		}
+		else if (orderByCol.equals("modified-date")) {
+			orderByComparator =
+				new FragmentCompositionFragmentEntryModifiedDateComparator(
+					orderByAsc);
 		}
 
 		return orderByComparator;


### PR DESCRIPTION
Hi Team,
One of our customers reported that the modification date is not updated on fragments. I checked the code and we used the statusDate for the fragments. It seems to be intentional that we used the statusDate, but I changed it to be more in line with the web content view where the card view displays the modification date. 

Could you review these changes?
https://issues.liferay.com/browse/LPS-144447
Thank you!