### PR TITLE
LPS-144363 When you select more than one child category for parent category one the first of them is added as a menu item. 

### DIFF
--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageMultiSelectionProvider.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageMultiSelectionProvider.java
@@ -124,20 +124,20 @@ public class AssetCategoryLayoutDisplayPageMultiSelectionProvider
 				long parentCategoryId = _getNearestAncestorCategoryId(
 					assetCategory, categoryIds);
 
-				if (parentCategoryIdInfoItemReferences.containsKey(
+				if (!parentCategoryIdInfoItemReferences.containsKey(
 						parentCategoryId)) {
 
-					List<InfoItemReference> children =
-						parentCategoryIdInfoItemReferences.get(
-							parentCategoryId);
-
-					children.add(infoItemReference);
+					parentCategoryIdInfoItemReferences.put(
+						parentCategoryId,
+						ListUtil.fromArray(infoItemReference));
 
 					continue;
 				}
 
-				parentCategoryIdInfoItemReferences.put(
-					parentCategoryId, ListUtil.fromArray(infoItemReference));
+				List<InfoItemReference> children =
+					parentCategoryIdInfoItemReferences.get(parentCategoryId);
+
+				children.add(infoItemReference);
 			}
 
 			hierarchicalInfoItemReferences.addAll(

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageMultiSelectionProvider.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageMultiSelectionProvider.java
@@ -127,6 +127,12 @@ public class AssetCategoryLayoutDisplayPageMultiSelectionProvider
 				if (parentCategoryIdInfoItemReferences.containsKey(
 						parentCategoryId)) {
 
+					List<InfoItemReference> children =
+						parentCategoryIdInfoItemReferences.get(
+							parentCategoryId);
+
+					children.add(infoItemReference);
+
 					continue;
 				}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-144363

Simplifying the logic in [this](https://github.com/liferay/liferay-portal/commit/4c1d067114e1fd17d4cb849495f4e129a5441df9) way causes that when you select more than one child category for parent category one the first of them is added as a menu item. This commits returns the original logic but looks for the easiest understanding.