### PR TITLE
[TECHNICAL SUPPORT] LPS-144573 Web Content with URL link that only has locale cannot be published due to wrong layout reference validation

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -31,6 +31,7 @@ import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutFriendlyURL;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.StagedModel;
@@ -335,6 +336,24 @@ public class LayoutReferencesExportImportContentProcessor
 
 					locale = LocaleUtil.fromLanguageId(
 						localePath.substring(1), true, false);
+				}
+				else {
+					String urlWithoutSlash = url.substring(1);
+
+					Locale localeFromUrl = LocaleUtil.fromLanguageId(
+						urlWithoutSlash, true, false);
+
+					if (localeFromUrl != null) {
+						Layout firstLayout =
+							_layoutLocalService.fetchFirstLayout(
+								group.getGroupId(), false,
+								LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
+								false);
+
+						if (firstLayout != null) {
+							url = firstLayout.getFriendlyURL();
+						}
+					}
 				}
 
 				if (locale != null) {
@@ -986,6 +1005,22 @@ public class LayoutReferencesExportImportContentProcessor
 
 				locale = LocaleUtil.fromLanguageId(
 					localePath.substring(1), true, false);
+			}
+			else {
+				String urlWithoutSlash = url.substring(1);
+
+				Locale localeFromUrl = LocaleUtil.fromLanguageId(
+					urlWithoutSlash, true, false);
+
+				if (localeFromUrl != null) {
+					Layout firstLayout = _layoutLocalService.fetchFirstLayout(
+						groupId, false,
+						LayoutConstants.DEFAULT_PARENT_LAYOUT_ID, false);
+
+					if (firstLayout != null) {
+						url = firstLayout.getFriendlyURL();
+					}
+				}
 			}
 
 			if (locale != null) {


### PR DESCRIPTION
Hi @liferay-echo ,

I'm forwarding pull request https://github.com/liferay-staging/liferay-portal/pull/27 to you. It seems like the "/" link is handled differently at the moment: the processing is simply skipped. This solution works another way: when there's language key, like "/en", it searches for the default page.

Please review the changes.

cc: @NemethNorbert

Thanks,
Vendel