### PR TITLE
LPS-144632 Use the new ClayTreeView component

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/package.json
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/button": "3.40.0",
+		"@clayui/core": "3.44.1",
 		"@clayui/drop-down": "3.43.0",
 		"@clayui/icon": "3.40.0",
 		"@clayui/loading-indicator": "3.40.0",

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/NavigationMenuItemsTree.es.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/NavigationMenuItemsTree.es.js
@@ -12,22 +12,105 @@
  * details.
  */
 
-import {Treeview} from 'frontend-js-components-web';
-import React from 'react';
-
-import NavigationMenuItemsTreeNode from './NavigationMenuItemsTreeNode';
+import {TreeView as ClayTreeView} from '@clayui/core';
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
+import React, {useEffect} from 'react';
 
 export default function NavigationMenuItemsTree({
 	selectedSiteNavigationMenuItemId,
 	siteNavigationMenuItems,
 }) {
+	const selectedKeys = new Set([selectedSiteNavigationMenuItemId]);
+
+	const removeEmptyChildren = (item) => {
+		if (item.children.length === 0) {
+			delete item.children;
+		}
+		else {
+			item.children.forEach(removeEmptyChildren);
+		}
+	};
+
+	useEffect(() => {
+		siteNavigationMenuItems.forEach((siteNavigationMenuItem) => {
+			removeEmptyChildren(siteNavigationMenuItem);
+		});
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, []);
+
 	return (
 		<div className="navigation-menu-items-tree">
-			<Treeview
-				NodeComponent={NavigationMenuItemsTreeNode}
-				initialSelectedNodeIds={[selectedSiteNavigationMenuItemId]}
-				nodes={siteNavigationMenuItems}
-			/>
+			<ClayTreeView
+				displayType="dark"
+				expandedKeys={selectedKeys}
+				expanderIcons={{
+					close: <ClayIcon symbol="hr" />,
+					open: <ClayIcon symbol="plus" />,
+				}}
+				items={siteNavigationMenuItems}
+			>
+				{(item) => {
+					const hasUrl = item.url && item.url !== '#';
+
+					return (
+						<ClayTreeView.Item>
+							<ClayTreeView.ItemStack
+								className={classNames(
+									'navigation-menu-items-tree-node',
+									{selected: selectedKeys.has(item.id)}
+								)}
+							>
+								<ClayIcon
+									symbol={item.url ? 'page' : 'folder'}
+								/>
+
+								{hasUrl ? (
+									<a
+										className="d-block h-100 w-100"
+										href={item.url}
+										onMouseDownCapture={() => {
+											Liferay.Util.navigate(item.url);
+										}}
+									>
+										{item.name}
+									</a>
+								) : (
+									<p className="m-0">{item.name}</p>
+								)}
+							</ClayTreeView.ItemStack>
+
+							<ClayTreeView.Group items={item.children}>
+								{(item) => (
+									<ClayTreeView.Item>
+										<ClayIcon
+											symbol={
+												item.url ? 'page' : 'folder'
+											}
+										/>
+
+										{hasUrl ? (
+											<a
+												className="d-block h-100 w-100"
+												href={item.url}
+												onMouseDownCapture={() => {
+													Liferay.Util.navigate(
+														item.url
+													);
+												}}
+											>
+												{item.name}
+											</a>
+										) : (
+											<p className="m-0">{item.name}</p>
+										)}
+									</ClayTreeView.Item>
+								)}
+							</ClayTreeView.Group>
+						</ClayTreeView.Item>
+					);
+				}}
+			</ClayTreeView>
 		</div>
 	);
 }


### PR DESCRIPTION
In this change, we're switching to the new Clay TreeView component
instead of using the one in `frontend-js-components-web`

**Test plan**
- Fetch this branch
- Deploy the `product-navigation-product-menu-web` OSGi module
- Assert the Page Tree is working as expected with Navigation Menus