### PR TITLE
LPS-144389 UI improvements for the Simulator Device

### DIFF
--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/product_navigation_simulation_device.js
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/product_navigation_simulation_device.js
@@ -77,6 +77,8 @@ AUI.add(
 
 		var WIN = A.config.win;
 
+		var RESIZABLE_DEVICE_CSS_CLASS = 'resizable-device';
+
 		var createIframeURL = () => {
 			const url = new URL(WIN.location.href);
 			const searchParams = new URLSearchParams(url.search);
@@ -392,6 +394,10 @@ AUI.add(
 									STR_BOUNDING_BOX
 								);
 
+								dialogBoundingBox.removeClass(
+									RESIZABLE_DEVICE_CSS_CLASS
+								);
+
 								dialogWindow.align(
 									simulationDeviceNode,
 									DIALOG_ALIGN_POINTS
@@ -461,9 +467,18 @@ AUI.add(
 						var dialogBoundingBox = dialog.get(STR_BOUNDING_BOX);
 
 						dialogBoundingBox.toggleClass(STR_ROTATED, rotation);
+						dialogBoundingBox.removeClass(
+							RESIZABLE_DEVICE_CSS_CLASS
+						);
 
 						if (!device.preventTransition) {
 							dialog.sizeanim.set(STR_PREVENT_TRANSITION, false);
+						}
+
+						if (device.resizable && !device.skin) {
+							dialogBoundingBox.addClass(
+								RESIZABLE_DEVICE_CSS_CLASS
+							);
 						}
 
 						dialog.setAttrs(dialogAttrs);

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
@@ -112,11 +112,13 @@
 			custom: {
 				height: '#<portlet:namespace />height',
 				resizable: true,
+				skin: 'custom',
 				width: '#<portlet:namespace />width',
 			},
 			desktop: {
 				height: 1050,
 				selected: true,
+				skin: 'desktop',
 				width: 1300,
 			},
 			smartphone: {

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/simulation_device.jsp
@@ -91,13 +91,13 @@
 			</clay:row>
 
 			<clay:row
-				cssClass="custom-devices hide mt-3"
+				cssClass="custom-devices flex-nowrap hide mt-3"
 				hidden="hidden"
 				id='<%= liferayPortletResponse.getNamespace() + "customDeviceContainer" %>'
 			>
-				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "height") + " (px):" %>' name="height" size="4" value="600" wrapperCssClass="flex-grow-1 mr-3" />
+				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "height") + " (px):" %>' name="height" size="4" type="number" value="600" wrapperCssClass="flex-grow-1 mr-3" />
 
-				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "width") + " (px):" %>' name="width" size="4" value="600" wrapperCssClass="flex-grow-1" />
+				<aui:input cssClass="input-sm" inlineField="<%= true %>" label='<%= LanguageUtil.get(request, "width") + " (px):" %>' name="width" size="4" type="number" value="600" wrapperCssClass="flex-grow-1" />
 			</clay:row>
 		</clay:container-fluid>
 	</div>

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_device.scss
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_device.scss
@@ -89,7 +89,8 @@ html#{$cadmin-selector} {
 			border-radius: 16px;
 		}
 
-		&.custom {
+		&.custom,
+		&.resizable-device {
 			background-color: var(--btn-outline-primary-hover-border-color);
 			padding: 2px;
 

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_device.scss
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_device.scss
@@ -95,6 +95,47 @@ html#{$cadmin-selector} {
 
 			&.show {
 				overflow: visible;
+
+				.yui3-resize-handle {
+					display: none;
+
+					&-tl,
+					&-tr,
+					&-bl,
+					&-br {
+						display: block;
+					}
+				}
+
+				.yui3-resize-handle-inner {
+					&-tl,
+					&-tr,
+					&-bl,
+					&-br {
+						background-repeat: no-repeat;
+						background-image: url(/o/frontend-js-aui-web/aui/resize-base/assets/skins/sam/arrows.png);
+						display: block;
+						height: 15px;
+						overflow: hidden;
+						text-indent: -99999em;
+						width: 15px;
+					}
+
+					&-bl {
+						bottom: 0px;
+						right: -18px;
+					}
+
+					&-tl {
+						bottom: -15px;
+						right: -18px;
+					}
+
+					&-tr {
+						bottom: -15px;
+						right: 0px;
+					}
+				}
 			}
 		}
 	}

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_device.scss
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/resources/META-INF/resources/css/simulation_panel/_simulation_device.scss
@@ -70,8 +70,32 @@ html#{$cadmin-selector} {
 		}
 
 		&.smartphone,
-		&.tablet {
+		&.tablet,
+		&.desktop {
 			background: #333;
+		}
+
+		&.smartphone,
+		&.tablet,
+		&.desktop,
+		&.custom {
+			.modal-body.dialog-iframe-bd {
+				margin-top: 0;
+			}
+		}
+
+		&.desktop {
+			padding: 24px;
+			border-radius: 16px;
+		}
+
+		&.custom {
+			background-color: var(--btn-outline-primary-hover-border-color);
+			padding: 2px;
+
+			&.show {
+				overflow: visible;
+			}
 		}
 	}
 }


### PR DESCRIPTION
[Jira task](https://issues.liferay.com/browse/LPS-144389)

### Motivation
- Desktop device has no skin, a thin border can help to focus on the simulator screen
- Custom device has no skin, a thin border can help to focus on the simulator screen
- Resizable device corner handles are missing due to conflict with `cadmin` improvements
- Custom device drops the `custom` css class on resize using the inputs
- Custom device inputs are not from type number, so can not be controlled with keyboard arrows and accept non digits chars

### Solution proposed
- New desktop skin with a border, in the same visual way than tablet & mobile
- New custom skin with a border similar to the Edit image resize/cropping border
- CSS fix to show again the handlers for resizing (they only appear on hover)
- Add `resizable-device` css class to custom skin when a resize event occurs using the inputs
- Add `type="number"` to the custom device inputs

### Steps to verify
- Navigate to a page
- Open the simulator
- Verify the desktop skin
- Verify the custom skin
- Use the inputs to modify the custom size
- Use the mouse to resize the custom device using the handlers, they'll appear on hover