### PR TITLE
LPS-144570 Set drop-active-valid class when hovering over dropzone while dragging

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/useDragAndDrop.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/useDragAndDrop.js
@@ -28,6 +28,8 @@ import addPortlet from './addPortlet';
 import {LAYOUT_DATA_ITEM_TYPES} from './constants/layoutDataItemTypes';
 import {POSITIONS} from './constants/positions';
 
+const DROP_ACTIVE_VALID_CLASS = 'yui3-dd-drop-active-valid';
+
 const DROP_CLASS = 'yui3-dd-drop';
 
 const DROP_OVER_CLASS = 'yui3-dd-drop-over';
@@ -119,6 +121,7 @@ export function useDropClear(targetItem) {
 
 			if (dropTargetColumn) {
 				dropTargetColumn.classList.remove(DROP_OVER_CLASS);
+				dropTargetColumn.classList.remove(DROP_ACTIVE_VALID_CLASS);
 			}
 
 			setDropTargetColumn(null);
@@ -198,8 +201,11 @@ export function useDropTarget(targetItem) {
 		item.classList.contains(DROP_ZONE_CLASS) &&
 		!item.classList.contains(DROP_ZONE_DISABLED_CLASS);
 
-	const [, setDropTargetRef] = useDrop({
+	const [{validDrop}, setDropTargetRef] = useDrop({
 		accept: Object.values(LAYOUT_DATA_ITEM_TYPES),
+		collect: (monitor) => ({
+			validDrop: monitor.canDrop(),
+		}),
 		drop(item, monitor) {
 			setDropTargetColumn(null);
 
@@ -213,6 +219,7 @@ export function useDropTarget(targetItem) {
 
 			if (!item.disabled) {
 				dropTargetColumn.classList.remove(DROP_OVER_CLASS);
+				dropTargetColumn.classList.remove(DROP_ACTIVE_VALID_CLASS);
 
 				addPortlet({item, plid, targetItem, targetPosition});
 
@@ -243,11 +250,15 @@ export function useDropTarget(targetItem) {
 			if (dropTargetColumn !== parentTargetItem) {
 				if (dropTargetColumn) {
 					dropTargetColumn.classList.remove(DROP_OVER_CLASS);
+					dropTargetColumn.classList.remove(DROP_ACTIVE_VALID_CLASS);
 				}
 				setDropTargetColumn(parentTargetItem);
 
 				if (targetItemIsDropzone) {
 					parentTargetItem.classList.add(DROP_OVER_CLASS);
+				}
+				else if (validDrop) {
+					parentTargetItem.classList.add(DROP_ACTIVE_VALID_CLASS);
 				}
 			}
 


### PR DESCRIPTION
Hi Team,

LPS: https://issues.liferay.com/browse/LPS-144570

Issue: ".yui3-dd-drop-active-valid" class is not implemented in useDragAndDrop.js from 7.3.x, since we use React-DnD instead of dd-drop.js when dragging a new widget.  A customer reported this missing class that they use in their customization.

On 7.2.x, the "yui3-dd-drop-active-valid" class was set whenever the widget got dragged. In this PR on 7.3.x, the class is only set when the drop area is a valid target for the drag operation.
I am not 100% sure if this is the intended behavior, but this made sense to me when I was inspecting the drop areas.

Before
![missing active-valid class](https://user-images.githubusercontent.com/69793575/148225154-892f1a45-f39e-4dce-ad6b-51d3d14673c8.gif)

After
![active-valid class](https://user-images.githubusercontent.com/69793575/148225157-fdb0c4e2-6baf-436a-b02a-641202b3606f.gif)

Could you please review it?
Thank you!


