### PR TITLE
LPS-144692 Fix import web content when existing origin structure key in target site.

### DIFF
--- a/modules/apps/adaptive-media/adaptive-media-journal-web/src/main/java/com/liferay/adaptive/media/journal/web/internal/exportimport/content/processor/AMJournalArticleExportImportContentProcessor.java
+++ b/modules/apps/adaptive-media/adaptive-media-journal-web/src/main/java/com/liferay/adaptive/media/journal/web/internal/exportimport/content/processor/AMJournalArticleExportImportContentProcessor.java
@@ -23,9 +23,11 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
@@ -120,10 +122,18 @@ public class AMJournalArticleExportImportContentProcessor
 
 		JournalArticle journalArticle = (JournalArticle)stagedModel;
 
+		Map<String, String> ddmStructureKeys =
+			(Map<String, String>)portletDataContext.getNewPrimaryKeysMap(
+				DDMStructure.class + ".ddmStructureKey");
+
+		String ddmStructureKey = MapUtil.getString(
+			ddmStructureKeys, journalArticle.getDDMStructureKey(),
+			journalArticle.getDDMStructureKey());
+
 		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
 			portletDataContext.getScopeGroupId(),
-			_portal.getClassNameId(JournalArticle.class),
-			journalArticle.getDDMStructureKey(), true);
+			_portal.getClassNameId(JournalArticle.class), ddmStructureKey,
+			true);
 
 		if (ddmStructure == null) {
 			return true;

--- a/modules/apps/adaptive-media/adaptive-media-journal-web/src/main/java/com/liferay/adaptive/media/journal/web/internal/exportimport/content/processor/AMJournalArticleExportImportContentProcessor.java
+++ b/modules/apps/adaptive-media/adaptive-media-journal-web/src/main/java/com/liferay/adaptive/media/journal/web/internal/exportimport/content/processor/AMJournalArticleExportImportContentProcessor.java
@@ -17,11 +17,13 @@ package com.liferay.adaptive.media.journal.web.internal.exportimport.content.pro
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.util.Portal;
 
 import java.util.List;
 import java.util.Objects;
@@ -55,7 +57,7 @@ public class AMJournalArticleExportImportContentProcessor
 					portletDataContext, stagedModel, content,
 					exportReferencedContent, escapeContent);
 
-		if (!_hasTextHTMLDDMFormField(stagedModel)) {
+		if (!_hasTextHTMLDDMFormField(portletDataContext, stagedModel)) {
 			return replacedContent;
 		}
 
@@ -79,7 +81,7 @@ public class AMJournalArticleExportImportContentProcessor
 				replaceImportContentReferences(
 					portletDataContext, stagedModel, content);
 
-		if (!_hasTextHTMLDDMFormField(stagedModel)) {
+		if (!_hasTextHTMLDDMFormField(portletDataContext, stagedModel)) {
 			return replacedContent;
 		}
 
@@ -113,10 +115,15 @@ public class AMJournalArticleExportImportContentProcessor
 		}
 	}
 
-	private boolean _hasTextHTMLDDMFormField(StagedModel stagedModel) {
+	private boolean _hasTextHTMLDDMFormField(
+		PortletDataContext portletDataContext, StagedModel stagedModel) {
+
 		JournalArticle journalArticle = (JournalArticle)stagedModel;
 
-		DDMStructure ddmStructure = journalArticle.getDDMStructure();
+		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
+			portletDataContext.getScopeGroupId(),
+			_portal.getClassNameId(JournalArticle.class),
+			journalArticle.getDDMStructureKey(), true);
 
 		if (ddmStructure == null) {
 			return true;
@@ -142,6 +149,9 @@ public class AMJournalArticleExportImportContentProcessor
 	private AMJournalArticleContentHTMLReplacer
 		_amJournalArticleContentHTMLReplacer;
 
+	@Reference
+	private DDMStructureLocalService _ddmStructureLocalService;
+
 	@Reference(target = "(adaptive.media.format=html)")
 	private ExportImportContentProcessor<String>
 		_htmlExportImportContentProcessor;
@@ -151,5 +161,8 @@ public class AMJournalArticleExportImportContentProcessor
 	)
 	private ExportImportContentProcessor<String>
 		_journalArticleExportImportContentProcessor;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/adaptive-media/adaptive-media-journal-web/src/test/java/com/liferay/adaptive/media/journal/web/internal/exportimport/content/processor/AMJournalArticleExportImportContentProcessorTest.java
+++ b/modules/apps/adaptive-media/adaptive-media-journal-web/src/test/java/com/liferay/adaptive/media/journal/web/internal/exportimport/content/processor/AMJournalArticleExportImportContentProcessorTest.java
@@ -14,12 +14,14 @@
 
 package com.liferay.adaptive.media.journal.web.internal.exportimport.content.processor;
 
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import org.junit.Assert;
@@ -48,12 +50,17 @@ public class AMJournalArticleExportImportContentProcessorTest {
 			_amJournalArticleContentHTMLReplacer);
 		ReflectionTestUtil.setFieldValue(
 			_amJournalArticleExportImportContentProcessor,
+			"_ddmStructureLocalService", _ddmStructureLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_amJournalArticleExportImportContentProcessor,
 			"_htmlExportImportContentProcessor",
 			_htmlExportImportContentProcessor);
 		ReflectionTestUtil.setFieldValue(
 			_amJournalArticleExportImportContentProcessor,
 			"_journalArticleExportImportContentProcessor",
 			_journalArticleExportImportContentProcessor);
+		ReflectionTestUtil.setFieldValue(
+			_amJournalArticleExportImportContentProcessor, "_portal", _portal);
 
 		Mockito.when(
 			_amJournalArticleContentHTMLReplacer.replace(
@@ -187,6 +194,8 @@ public class AMJournalArticleExportImportContentProcessorTest {
 	private final AMJournalArticleExportImportContentProcessor
 		_amJournalArticleExportImportContentProcessor =
 			new AMJournalArticleExportImportContentProcessor();
+	private final DDMStructureLocalService _ddmStructureLocalService =
+		Mockito.mock(DDMStructureLocalService.class);
 	private final ExportImportContentProcessor<String>
 		_htmlExportImportContentProcessor = Mockito.mock(
 			ExportImportContentProcessor.class);
@@ -195,6 +204,7 @@ public class AMJournalArticleExportImportContentProcessorTest {
 	private final ExportImportContentProcessor<String>
 		_journalArticleExportImportContentProcessor = Mockito.mock(
 			ExportImportContentProcessor.class);
+	private final Portal _portal = Mockito.mock(Portal.class);
 	private final PortletDataContext _portletDataContext = Mockito.mock(
 		PortletDataContext.class);
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java
@@ -18,6 +18,7 @@ import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.service.DLAppService;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.Value;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.Field;
@@ -50,6 +51,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Document;
@@ -324,15 +326,10 @@ public class JournalArticleExportImportContentProcessor
 	private DDMStructure _fetchDDMStructure(
 		PortletDataContext portletDataContext, JournalArticle article) {
 
-		long formerGroupId = article.getGroupId();
-
-		article.setGroupId(portletDataContext.getScopeGroupId());
-
-		DDMStructure ddmStructure = article.getDDMStructure();
-
-		article.setGroupId(formerGroupId);
-
-		return ddmStructure;
+		return _ddmStructureLocalService.fetchStructure(
+			portletDataContext.getScopeGroupId(),
+			_portal.getClassNameId(JournalArticle.class),
+			article.getDDMStructureKey(), true);
 	}
 
 	private Fields _getDDMStructureFields(
@@ -655,6 +652,9 @@ public class JournalArticleExportImportContentProcessor
 	private ExportImportContentProcessor<DDMFormValues>
 		_ddmFormValuesExportImportContentProcessor;
 
+	@Reference
+	private DDMStructureLocalService _ddmStructureLocalService;
+
 	@Reference(target = "(model.class.name=java.lang.String)")
 	private ExportImportContentProcessor<String>
 		_defaultTextExportImportContentProcessor;
@@ -680,5 +680,8 @@ public class JournalArticleExportImportContentProcessor
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Portal _portal;
 
 }

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java
@@ -51,6 +51,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -66,6 +67,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -326,10 +328,18 @@ public class JournalArticleExportImportContentProcessor
 	private DDMStructure _fetchDDMStructure(
 		PortletDataContext portletDataContext, JournalArticle article) {
 
+		Map<String, String> ddmStructureKeys =
+			(Map<String, String>)portletDataContext.getNewPrimaryKeysMap(
+				DDMStructure.class + ".ddmStructureKey");
+
+		String ddmStructureKey = MapUtil.getString(
+			ddmStructureKeys, article.getDDMStructureKey(),
+			article.getDDMStructureKey());
+
 		return _ddmStructureLocalService.fetchStructure(
 			portletDataContext.getScopeGroupId(),
-			_portal.getClassNameId(JournalArticle.class),
-			article.getDDMStructureKey(), true);
+			_portal.getClassNameId(JournalArticle.class), ddmStructureKey,
+			true);
 	}
 
 	private Fields _getDDMStructureFields(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-144692

Original PR: https://github.com/liferay-echo/liferay-portal/pull/6880

Original PR comment:

Hi Team Echo,

Context
Please see LPS-144692 for details.

To summarize, if a Web Content with a custom structure is being imported and the resulting imported custom structure does not have a matching structure key, references to Document Library images fail to be properly processed for the imported Web Content.

Issue
The issue has to do with how the JournalArticleExportImportContentProcessor fails to retrieve the proper DDMStructure, due to the non-matching DDM Structure Keys. This results in the referenced DL images not being processed.

The proposed fixed attempts to retrieve the updated DDM Structure Key if available.

Additional Notes
This PR consists of 2 sets of commits:

Apply fix for JournalArticleExportImportContentProcessor
Apply fix for AMJournalArticleExportImportContentProcessor
For the scenario described in LPS-144692, applying the fix for JournalArticleExportImportContentProcessor already resolves the issue.

However, I also included the changes to AMJournalArticleExportImportContentProcessor, since it looks like the same issue would apply to that logic as well.

Feel free to let me know if you have any questions.
Thanks!

cc: @ericyanLr