### PR TITLE
LPS-145253 Isolates Page Editor Create Page Template Modal

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/create-layout-page-template-entry-modal/components/CreateLayoutPageTemplateEntryModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/create-layout-page-template-entry-modal/components/CreateLayoutPageTemplateEntryModal.js
@@ -128,7 +128,11 @@ const CreateLayoutPageTemplateEntryModal = ({observer, onClose}) => {
 	);
 
 	return (
-		<ClayModal observer={observer} size="md">
+		<ClayModal
+			containerProps={{className: 'cadmin'}}
+			observer={observer}
+			size="md"
+		>
 			<ClayModal.Header>
 				{Liferay.Language.get('create-page-template')}
 			</ClayModal.Header>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-145253

Theme styles shouldn't apply to Page Editor Create Page Template Modal.

![create-page-template](https://user-images.githubusercontent.com/788266/149215836-03d84119-12e4-4dca-8759-a8a6dc7fcd92.jpg)

