### PR TITLE
[TS] LPS-145308 Must reset resourcePrimKey, just like id

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ActionUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ActionUtil.java
@@ -331,6 +331,7 @@ public class ActionUtil {
 
 				article.setNew(true);
 				article.setId(0);
+				article.setResourcePrimKey(0);
 				article.setGroupId(groupId);
 				article.setClassNameId(
 					JournalArticleConstants.CLASS_NAME_ID_DEFAULT);


### PR DESCRIPTION
Hi Team,

The Image selector uses resourcePrimKey parameter to match its permission checker to a resource. In this case it is trying to check the user's permission to pseudo-journalArticle that is holding the default values of the DDMStructure. As the user doesn't have permissions to update that pseudo-journalArticle, the image upload fails.

Can you please review?
https://issues.liferay.com/browse/LPS-145308

Thanks,
Balázs