### PR TITLE
LPS-145408 Create a class of constants to centralize friendly url separators

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/display/contributor/portlet/AssetCategoryAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/display/contributor/portlet/AssetCategoryAssetDisplayPageFriendlyURLResolver.java
@@ -16,6 +16,7 @@ package com.liferay.asset.categories.admin.web.internal.info.display.contributor
 
 import com.liferay.asset.display.page.portlet.BaseAssetDisplayPageFriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -28,7 +29,7 @@ public class AssetCategoryAssetDisplayPageFriendlyURLResolver
 
 	@Override
 	public String getURLSeparator() {
-		return "/v/";
+		return FriendlyURLResolverConstants.URL_SEPARATOR_ASSET_CATEGORY;
 	}
 
 }

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageProvider.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageProvider.java
@@ -20,6 +20,7 @@ import com.liferay.info.item.InfoItemReference;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -111,7 +112,7 @@ public class AssetCategoryLayoutDisplayPageProvider
 
 	@Override
 	public String getURLSeparator() {
-		return "/v/";
+		return FriendlyURLResolverConstants.URL_SEPARATOR_ASSET_CATEGORY;
 	}
 
 	@Override

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/display/contributor/portlet/BlogsAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/display/contributor/portlet/BlogsAssetDisplayPageFriendlyURLResolver.java
@@ -16,6 +16,7 @@ package com.liferay.blogs.web.internal.info.display.contributor.portlet;
 
 import com.liferay.asset.display.page.portlet.BaseAssetDisplayPageFriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -28,7 +29,7 @@ public class BlogsAssetDisplayPageFriendlyURLResolver
 
 	@Override
 	public String getURLSeparator() {
-		return "/b/";
+		return FriendlyURLResolverConstants.URL_SEPARATOR_BLOGS_ENTRY;
 	}
 
 }

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/layout/display/page/BlogsLayoutDisplayPageProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/layout/display/page/BlogsLayoutDisplayPageProvider.java
@@ -20,6 +20,7 @@ import com.liferay.info.item.InfoItemReference;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -77,7 +78,7 @@ public class BlogsLayoutDisplayPageProvider
 
 	@Override
 	public String getURLSeparator() {
-		return "/b/";
+		return FriendlyURLResolverConstants.URL_SEPARATOR_BLOGS_ENTRY;
 	}
 
 	@Reference

--- a/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/portlet/action/GoogleDriveBackgroundTaskStatusMVCResourceCommand.java
+++ b/modules/apps/document-library-opener/document-library-opener-google-drive-web/src/main/java/com/liferay/document/library/opener/google/drive/web/internal/portlet/action/GoogleDriveBackgroundTaskStatusMVCResourceCommand.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
@@ -141,7 +142,9 @@ public class GoogleDriveBackgroundTaskStatusMVCResourceCommand
 		String googleDriveFileId, String mimeType) {
 
 		return StringBundler.concat(
-			_paths.get(mimeType), "/d/", googleDriveFileId, "/edit");
+			_paths.get(mimeType),
+			FriendlyURLResolverConstants.URL_SEPARATOR_FILE_ENTRY,
+			googleDriveFileId, "/edit");
 	}
 
 	private static final Map<String, String> _paths = MapUtil.fromArray(

--- a/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
+++ b/modules/apps/document-library/document-library-test/src/testIntegration/java/com/liferay/document/library/info/display/contributor/test/FileEntryInfoDisplayContributorTest.java
@@ -32,6 +32,7 @@ import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
@@ -92,7 +93,8 @@ public class FileEntryInfoDisplayContributorTest {
 
 					String expectedURL = StringBundler.concat(
 						"/", locale.getLanguage(), "/web/",
-						StringUtil.lowerCase(_group.getGroupKey()), "/d/",
+						StringUtil.lowerCase(_group.getGroupKey()),
+						FriendlyURLResolverConstants.URL_SEPARATOR_FILE_ENTRY,
 						fileEntry.getFileEntryId());
 
 					ThemeDisplay themeDisplay = new ThemeDisplay();
@@ -131,7 +133,8 @@ public class FileEntryInfoDisplayContributorTest {
 
 					String expectedURL = StringBundler.concat(
 						"/web/", StringUtil.lowerCase(_group.getGroupKey()),
-						"/d/", fileEntry.getFileEntryId());
+						FriendlyURLResolverConstants.URL_SEPARATOR_FILE_ENTRY,
+						fileEntry.getFileEntryId());
 
 					ThemeDisplay themeDisplay = new ThemeDisplay();
 
@@ -169,7 +172,8 @@ public class FileEntryInfoDisplayContributorTest {
 
 					String expectedURL = StringBundler.concat(
 						"/", locale.getLanguage(), "/web/",
-						StringUtil.lowerCase(_group.getGroupKey()), "/d/",
+						StringUtil.lowerCase(_group.getGroupKey()),
+						FriendlyURLResolverConstants.URL_SEPARATOR_FILE_ENTRY,
 						fileEntry.getFileEntryId());
 
 					ThemeDisplay themeDisplay = new ThemeDisplay();
@@ -208,7 +212,8 @@ public class FileEntryInfoDisplayContributorTest {
 
 					String expectedURL = StringBundler.concat(
 						"/web/", StringUtil.lowerCase(_group.getGroupKey()),
-						"/d/", fileEntry.getFileEntryId());
+						FriendlyURLResolverConstants.URL_SEPARATOR_FILE_ENTRY,
+						fileEntry.getFileEntryId());
 
 					ThemeDisplay themeDisplay = new ThemeDisplay();
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/display/contributor/portlet/DLFileEntryAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/display/contributor/portlet/DLFileEntryAssetDisplayPageFriendlyURLResolver.java
@@ -16,6 +16,7 @@ package com.liferay.document.library.web.internal.info.display.contributor.portl
 
 import com.liferay.asset.display.page.portlet.BaseAssetDisplayPageFriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -28,7 +29,7 @@ public class DLFileEntryAssetDisplayPageFriendlyURLResolver
 
 	@Override
 	public String getURLSeparator() {
-		return "/d/";
+		return FriendlyURLResolverConstants.URL_SEPARATOR_FILE_ENTRY;
 	}
 
 }

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/layout/display/page/FileEntryLayoutDisplayPageProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/layout/display/page/FileEntryLayoutDisplayPageProvider.java
@@ -18,6 +18,7 @@ import com.liferay.info.item.InfoItemReference;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.repository.LocalRepository;
 import com.liferay.portal.kernel.repository.RepositoryProvider;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -76,7 +77,7 @@ public class FileEntryLayoutDisplayPageProvider
 
 	@Override
 	public String getURLSeparator() {
-		return "/d/";
+		return FriendlyURLResolverConstants.URL_SEPARATOR_FILE_ENTRY;
 	}
 
 	@Reference

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.model.VirtualLayoutConstants;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
@@ -883,7 +884,11 @@ public class LayoutReferencesExportImportContentProcessor
 
 		Group group = _groupLocalService.getGroup(groupId);
 
-		String[] friendlyURLSeparators = {"/-/", "/b/", "/d/", "/w/"};
+		String[] friendlyURLSeparators = {
+			"/-/", FriendlyURLResolverConstants.URL_SEPARATOR_BLOGS_ENTRY,
+			FriendlyURLResolverConstants.URL_SEPARATOR_FILE_ENTRY,
+			FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE
+		};
 		String[] patterns = {"href=", "[[", "{{"};
 
 		int beginPos = -1;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/layout/admin/util/JournalArticleSitemapURLProvider.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/layout/admin/util/JournalArticleSitemapURLProvider.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -287,7 +288,8 @@ public class JournalArticleSitemapURLProvider implements SitemapURLProvider {
 				sb.append(JournalArticleConstants.CANONICAL_URL_SEPARATOR);
 			}
 			else {
-				sb.append("/w/");
+				sb.append(
+					FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE);
 			}
 
 			sb.append(journalArticle.getUrlTitle());

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/display/contributor/portlet/JournalArticleAssetDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/display/contributor/portlet/JournalArticleAssetDisplayPageFriendlyURLResolver.java
@@ -16,6 +16,7 @@ package com.liferay.journal.web.internal.info.display.contributor.portlet;
 
 import com.liferay.asset.display.page.portlet.BaseAssetDisplayPageFriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -28,7 +29,7 @@ public class JournalArticleAssetDisplayPageFriendlyURLResolver
 
 	@Override
 	public String getURLSeparator() {
-		return "/w/";
+		return FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE;
 	}
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
@@ -21,6 +21,7 @@ import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.layout.display.page.LayoutDisplayPageProvider;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -80,7 +81,7 @@ public class JournalArticleLayoutDisplayPageProvider
 
 	@Override
 	public String getURLSeparator() {
-		return "/w/";
+		return FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE;
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
@@ -46,6 +46,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -234,7 +235,8 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 		).put(
 			"DISPLAY_PAGE_URL",
 			StringBundler.concat(
-				"\"http://localhost:8080/web", _group.getFriendlyURL(), "/w/",
+				"\"http://localhost:8080/web", _group.getFriendlyURL(),
+				FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE,
 				journalArticle.getUrlTitle(), "\"")
 		).build();
 

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/display/page/portlet/portlet/ObjectEntryDisplayPageFriendlyURLResolver.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/asset/display/page/portlet/portlet/ObjectEntryDisplayPageFriendlyURLResolver.java
@@ -16,6 +16,7 @@ package com.liferay.object.web.internal.asset.display.page.portlet.portlet;
 
 import com.liferay.asset.display.page.portlet.BaseAssetDisplayPageFriendlyURLResolver;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolver;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -28,7 +29,7 @@ public class ObjectEntryDisplayPageFriendlyURLResolver
 
 	@Override
 	public String getURLSeparator() {
-		return "/l/";
+		return FriendlyURLResolverConstants.URL_SEPARATOR_OBJECT_ENTRY;
 	}
 
 }

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/layout/display/page/ObjectEntryLayoutDisplayPageProvider.java
@@ -22,6 +22,7 @@ import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 
 /**
  * @author Guilherme Camacho
@@ -80,7 +81,7 @@ public class ObjectEntryLayoutDisplayPageProvider
 
 	@Override
 	public String getURLSeparator() {
-		return "/l/";
+		return FriendlyURLResolverConstants.URL_SEPARATOR_OBJECT_ENTRY;
 	}
 
 	private final ObjectDefinition _objectDefinition;

--- a/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
+++ b/modules/apps/portal/portal-action-test/src/testIntegration/java/com/liferay/portal/action/test/UpdateLanguageActionTest.java
@@ -29,6 +29,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.VirtualLayoutConstants;
 import com.liferay.portal.kernel.portlet.FriendlyURLResolverRegistryUtil;
+import com.liferay.portal.kernel.portlet.constants.FriendlyURLResolverConstants;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.test.util.CompanyTestUtil;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -345,9 +346,11 @@ public class UpdateLanguageActionTest {
 		_testGetRedirectWithFriendlyURL(
 			i18n,
 			_getFriendlyURLSeparatorPart(
-				_sourceLocale, _FRIENDLY_URL_SEPARATOR_JOURNAL_ARTICLE),
+				_sourceLocale,
+				FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE),
 			_getFriendlyURLSeparatorPart(
-				_targetLocale, _FRIENDLY_URL_SEPARATOR_JOURNAL_ARTICLE));
+				_targetLocale,
+				FriendlyURLResolverConstants.URL_SEPARATOR_JOURNAL_ARTICLE));
 	}
 
 	private void _testGetRedirectWithFriendlyURL(
@@ -434,8 +437,6 @@ public class UpdateLanguageActionTest {
 			themeDisplay, targetURL,
 			"/" + _sourceLocale.getLanguage() + sourceURL);
 	}
-
-	private static final String _FRIENDLY_URL_SEPARATOR_JOURNAL_ARTICLE = "/w/";
 
 	private static final String _PORTLET_FRIENDLY_URL_PART_ASSET_PUBLISHER =
 		"/-/asset_publisher/instanceID/content/";

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 31.1.1
+Bundle-Version: 31.2.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/constants/FriendlyURLResolverConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/constants/FriendlyURLResolverConstants.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.kernel.portlet.constants;
+
+import com.liferay.portal.kernel.util.Portal;
+
+/**
+ * @author Guilherme Camacho
+ */
+public class FriendlyURLResolverConstants {
+
+	public static final String URL_SEPARATOR_ASSET_CATEGORY = "/v/";
+
+	public static final String URL_SEPARATOR_BLOGS_ENTRY = "/b/";
+
+	public static final String URL_SEPARATOR_FILE_ENTRY = "/d/";
+
+	public static final String URL_SEPARATOR_JOURNAL_ARTICLE = "/w/";
+
+	public static final String URL_SEPARATOR_OBJECT_ENTRY = "/l/";
+
+	public static final String URL_SEPARATOR_PORTAL_RESERVED =
+		Portal.PATH_MODULE;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/portlet/constants/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/portlet/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0


### PR DESCRIPTION
Hey guys, Brian asked me to create a class of constants to map all Friendly URL Separators there and then document /o/ as reserved (to avoid another developer use this by mistake).

Please see this [thread](https://liferay.slack.com/archives/CL9RTSZ52/p1638325668150400)

cc: @ealonso @jkappler 