### PR TITLE
LPS-144738 | Inheriting look and feel for a single page can set themeId to classic in database and make style books unusable

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -563,7 +563,7 @@ public class ContentPageEditorDisplayContext {
 						LayoutSetLocalServiceUtil.fetchLayoutSet(
 							themeDisplay.getSiteGroupId(), false);
 
-					if (Validator.isNull(layout.getThemeId()) ||
+					if (layout.isInheritLookAndFeel() ||
 						Objects.equals(
 							layout.getThemeId(), layoutSet.getThemeId())) {
 


### PR DESCRIPTION
Hi @liferay-echo,

This solution for [LPS-144738](https://issues.liferay.com/browse/LPS-144738) has been agreed with @dacousalr in [PTR-2810](https://issues.liferay.com/browse/PTR-2810), where you can see the analysis and conclusion of the issue. 

Please let me know if you have any questions. 

Thanks!