### PR TITLE
Lps 144473

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/product/navigation/control/menu/EditDisplayPageMenuProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/product/navigation/control/menu/EditDisplayPageMenuProductNavigationControlMenuEntry.java
@@ -56,8 +56,8 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	immediate = true,
 	property = {
-		"product.navigation.control.menu.category.key=" + ProductNavigationControlMenuCategoryKeys.TOOLS,
-		"product.navigation.control.menu.entry.order:Integer=200"
+		"product.navigation.control.menu.category.key=" + ProductNavigationControlMenuCategoryKeys.USER,
+		"product.navigation.control.menu.entry.order:Integer=50"
 	},
 	service = ProductNavigationControlMenuEntry.class
 )

--- a/modules/apps/product-navigation/product-navigation-control-menu-api/bnd.bnd
+++ b/modules/apps/product-navigation/product-navigation-control-menu-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Product Navigation Control Menu API
 Bundle-SymbolicName: com.liferay.product.navigation.control.menu.api
-Bundle-Version: 7.0.5
+Bundle-Version: 7.1.0
 Export-Package:\
 	com.liferay.product.navigation.control.menu,\
 	com.liferay.product.navigation.control.menu.constants,\

--- a/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/java/com/liferay/product/navigation/control/menu/ProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/java/com/liferay/product/navigation/control/menu/ProductNavigationControlMenuEntry.java
@@ -170,7 +170,7 @@ public interface ProductNavigationControlMenuEntry {
 			HttpServletResponse httpServletResponse)
 		throws IOException;
 
-	public default boolean isRelevant() {
+	public default boolean isRelevant(HttpServletRequest httpServletRequest) {
 		return true;
 	}
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/java/com/liferay/product/navigation/control/menu/ProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/java/com/liferay/product/navigation/control/menu/ProductNavigationControlMenuEntry.java
@@ -170,6 +170,10 @@ public interface ProductNavigationControlMenuEntry {
 			HttpServletResponse httpServletResponse)
 		throws IOException;
 
+	public default boolean isRelevant() {
+		return true;
+	}
+
 	/**
 	 * Returns <code>true</code> if the Control Menu entry should be displayed
 	 * in the request's context.

--- a/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/resources/com/liferay/product/navigation/control/menu/packageinfo
+++ b/modules/apps/product-navigation/product-navigation-control-menu-api/src/main/resources/com/liferay/product/navigation/control/menu/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutHeaderProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutHeaderProductNavigationControlMenuEntry.java
@@ -118,7 +118,14 @@ public class LayoutHeaderProductNavigationControlMenuEntry
 	}
 
 	@Override
-	public boolean isRelevant() {
+	public boolean isRelevant(HttpServletRequest httpServletRequest) {
+		String layoutMode = ParamUtil.getString(
+			httpServletRequest, "p_l_mode", Constants.VIEW);
+
+		if (layoutMode.equals(Constants.EDIT)) {
+			return true;
+		}
+
 		return false;
 	}
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutHeaderProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutHeaderProductNavigationControlMenuEntry.java
@@ -118,6 +118,11 @@ public class LayoutHeaderProductNavigationControlMenuEntry
 	}
 
 	@Override
+	public boolean isRelevant() {
+		return false;
+	}
+
+	@Override
 	public boolean isShow(HttpServletRequest httpServletRequest)
 		throws PortalException {
 

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
@@ -35,7 +35,13 @@ for (ProductNavigationControlMenuCategory productNavigationControlMenuCategory :
 	productNavigationControlMenuEntriesMap.put(productNavigationControlMenuCategory, productNavigationControlMenuEntries);
 
 	if (!productNavigationControlMenuEntries.isEmpty()) {
-		hasControlMenuEntries = true;
+		for (ProductNavigationControlMenuEntry productNavigationControlMenuEntry : productNavigationControlMenuEntries) {
+			if (productNavigationControlMenuEntry.isRelevant()) {
+				hasControlMenuEntries = true;
+
+				break;
+			}
+		}
 	}
 }
 %>

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/resources/META-INF/resources/control_menu/page.jsp
@@ -36,7 +36,7 @@ for (ProductNavigationControlMenuCategory productNavigationControlMenuCategory :
 
 	if (!productNavigationControlMenuEntries.isEmpty()) {
 		for (ProductNavigationControlMenuEntry productNavigationControlMenuEntry : productNavigationControlMenuEntries) {
-			if (productNavigationControlMenuEntry.isRelevant()) {
+			if (productNavigationControlMenuEntry.isRelevant(request)) {
 				hasControlMenuEntries = true;
 
 				break;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-144473

The issue here is that an empty Control Menu panel is visible for a user without permissions
This was fixed based on a POC that was provided in PTR-2762 described in the third approach in this comment.
The fix adds a new method to provide a way to mark components as relevant or not. The LayoutHeaderProductNavigationControlMenuEntry is marked as not relevant so that the control menu panel does not show for users who do not have permissions

Update: Added a commit based on this [comment](https://issues.liferay.com/browse/PTR-2762?focusedCommentId=2598265&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-2598265) in PTR-2762 to fix regression issue described [here](https://github.com/liferay-echo/liferay-portal/pull/6843#issuecomment-1003311837)