### PR TITLE
LPS-146056 Hide Display Page panel in Depots

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/JournalDisplayPageFormNavigatorEntry.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/JournalDisplayPageFormNavigatorEntry.java
@@ -17,7 +17,12 @@ package com.liferay.journal.web.internal.frontend.taglib.form.navigator;
 import com.liferay.frontend.taglib.form.navigator.FormNavigatorEntry;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 
 import javax.servlet.ServletContext;
 
@@ -41,7 +46,7 @@ public class JournalDisplayPageFormNavigatorEntry
 
 	@Override
 	public boolean isVisible(User user, JournalArticle article) {
-		if (isGlobalScopeArticle(article)) {
+		if (isGlobalScopeArticle(article) || _isDepotArticle(article)) {
 			return false;
 		}
 
@@ -70,5 +75,31 @@ public class JournalDisplayPageFormNavigatorEntry
 	protected String getJspPath() {
 		return "/article/display_page.jsp";
 	}
+
+	private Group _getGroup(JournalArticle article) {
+		if ((article != null) && (article.getId() > 0)) {
+			return _groupLocalService.fetchGroup(article.getGroupId());
+		}
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+		return themeDisplay.getScopeGroup();
+	}
+
+	private boolean _isDepotArticle(JournalArticle article) {
+		Group group = _getGroup(article);
+
+		if ((group != null) && group.isDepot()) {
+			return true;
+		}
+
+		return false;
+	}
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-146056

It is not possible to create Display Pages in Depots, so it doesn't
make sense to display the panel. Hide it both for depots and the
global scope.

The bug is reproducible in 7.3.x as well, so this needs to be
backported if you're ok with it.