### PR TITLE
LPS-144633 Migrate Treeview component in site-navigation-item-selector-web

### DIFF
--- a/modules/apps/site-navigation/site-navigation-item-selector-web/package.json
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/package.json
@@ -1,6 +1,7 @@
 {
 	"dependencies": {
 		"@clayui/button": "3.40.0",
+		"@clayui/core": "3.45.1",
 		"@clayui/form": "3.45.0",
 		"@clayui/layout": "3.40.0",
 		"frontend-js-components-web": "*",


### PR DESCRIPTION
In this change, we're migrating from our previous
[Treeview](https://github.com/liferay/liferay-portal/blob/c5a9a72d3a58a504233e4cc799652fc9f544ba5e/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.js) component to the new [ClayTreeView](https://github.com/liferay/clay/blob/d7340f875372ba7ac11752aedd70f4343100241b/packages/clay-core/src/tree-view/TreeView.tsx) component.

**Test plan**:
- Fetch this branch
- Deploy the site-navigation-item-selector-web OSGi module
- Navigate to Site Builder > Navigation Menus
- Create a new Navigation Menu
- Navigate to Site Builder > Pages
- Create a new (Blank) Page
- Drag and Drop the "Menu Display Widget" on the page
- Click on the elipsis menu on the right and choose "Configuration"
- Under the "Menu Items to Show" section, select the first drop down
  menu, and choose "Select Parent"
- Click on the "Menu Item" button
- Select a Navigation Menu