### PR TITLE
LPS-144629 Use the new ClayTreeView component

### DIFF
--- a/modules/apps/journal/journal-web/package.json
+++ b/modules/apps/journal/journal-web/package.json
@@ -2,6 +2,7 @@
 	"dependencies": {
 		"@clayui/alert": "3.40.0",
 		"@clayui/button": "3.40.0",
+		"@clayui/core": "3.45.1",
 		"@clayui/drop-down": "3.45.0",
 		"@clayui/form": "3.45.0",
 		"@clayui/icon": "3.40.0",

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectFolderButton.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectFolderButton.es.js
@@ -67,7 +67,7 @@ class SelectFolderButton extends PortletBase {
 	 */
 	_handleSelectFolderButtonClick() {
 		openSelectionModal({
-			iframeBodyCssClass: '',
+			iframeBodyCssClass: 'cadmin',
 			onSelect: (selectedItem) => {
 				if (selectedItem) {
 					var folderData = {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Portlet.macro
@@ -364,6 +364,16 @@ definition {
 		AssertElementNotPresent(locator1 = "Treeview#NODE_COLLAPSED");
 	}
 
+	macro expandTreeNew {
+		WaitForVisible(locator1 = "Treeview#NODE_LIST");
+
+		while (IsElementPresent(locator1 = "Treeview#NODE_COLLAPSED_NEW")) {
+			Click(locator1 = "Treeview#NODE_COLLAPSED_BUTTON");
+		}
+
+		AssertElementNotPresent(locator1 = "Treeview#NODE_COLLAPSED_NEW");
+	}
+
 	macro gotoPortletOptions {
 		if (isSet(portletName)) {
 			var key_portletName = "${portletName}";

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Treeview.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Treeview.path
@@ -12,7 +12,7 @@
 <tbody>
 <tr>
 	<td>NODE_COLLAPSED</td>
-	<td>//div[contains(@class,'treeview-node-list')]/button[contains(@class,'treeview-node-list') and @aria-expanded='false'] | //div[contains(@class,'tree-collapsed')]//span[not(contains(@class,'hidden'))]//*[name()='svg'][contains(@class,'icon-plus')] | //div[contains(@class,'navigation-menu-items-tree-node')]//button[@aria-expanded='false']</td>
+	<td>//div[contains(@class,'treeview') and contains(@aria-expanded,'false')] | //div[contains(@class,'treeview')]//*[contains(@aria-expanded,'false')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -42,7 +42,7 @@
 </tr>
 <tr>
 	<td>NODE_LIST</td>
-	<td>//div[contains(@class,'treeview-node-list')] | //ul[contains(@class,'tree-pages')] | //div[contains(@class,'navigation-menu-items-tree')]</td>
+	<td>//*[@role='tree'] | //ul[contains(@class,'tree-pages')] | //div[contains(@class,'navigation-menu-items-tree')]</td>
 	<td></td>
 </tr>
 <tr>

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Treeview.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/Treeview.path
@@ -12,7 +12,17 @@
 <tbody>
 <tr>
 	<td>NODE_COLLAPSED</td>
+	<td>//div[contains(@class,'treeview-node-list')]/button[contains(@class,'treeview-node-list') and @aria-expanded='false'] | //div[contains(@class,'tree-collapsed')]//span[not(contains(@class,'hidden'))]//*[name()='svg'][contains(@class,'icon-plus')] | //div[contains(@class,'navigation-menu-items-tree-node')]//button[@aria-expanded='false']</td>
+	<td></td>
+</tr>
+<tr>
+	<td>NODE_COLLAPSED_NEW</td>
 	<td>//div[contains(@class,'treeview') and contains(@aria-expanded,'false')] | //div[contains(@class,'treeview')]//*[contains(@aria-expanded,'false')]</td>
+	<td></td>
+</tr>
+<tr>
+	<td>NODE_COLLAPSED_BUTTON</td>
+	<td>//div[contains(@class,'treeview')]//button[contains(@aria-expanded,'false')]</td>
 	<td></td>
 </tr>
 <tr>
@@ -37,7 +47,7 @@
 </tr>
 <tr>
 	<td>NODE_UNSELECTED</td>
-	<td>//div[contains(@class,'card-type-directory') and not(contains(@class,'selected'))]/div[contains(@class,'card-horizontal')]//span[contains(.,'${key_nodeName}')]</td>
+	<td>//div[contains(@class,'card-type-directory') and not(contains(@class,'selected'))]/div[contains(@class,'card-horizontal')]//span[contains(.,'${key_nodeName}')] | //*[contains(@role,'treeitem')]//*[contains(@class,'component-text') and contains(.,'${key_nodeName}')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
Resent from https://github.com/liferay-lima/liferay-portal/pull/2715
cc/ @julien

----

In this change, we're migrating from our previous
[Treeview](https://github.com/liferay/liferay-portal/blob/c5a9a72d3a58a504233e4cc799652fc9f544ba5e/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/treeview/Treeview.js) component to the new [ClayTreeView](https://github.com/liferay/clay/blob/d7340f875372ba7ac11752aedd70f4343100241b/packages/clay-core/src/tree-view/TreeView.tsx) component.

**Test plan:**

- Fetch this branch
- Deploy the journal-web OSGi module
- Navigate to Content & Data > Web Content
- Create a new Folder
- Create a new Basic Web Content
- Click on the ellipsis icon to the right of the Web Content
- Click on the "Move" option
- Click on the "Select" button
- In the modal window, choose a destination Folder