### PR TITLE
LPS-146807

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFolderFinderImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFolderFinderImpl.java
@@ -181,11 +181,11 @@ public class JournalFolderFinderImpl
 				queryPos.add(WorkflowConstants.STATUS_IN_TRASH);
 			}
 
-			queryPos.add(queryDefinition.getStatus());
-
 			if (folderId >= 0) {
 				queryPos.add(folderId);
 			}
+
+			queryPos.add(queryDefinition.getStatus());
 
 			int count = 0;
 
@@ -350,11 +350,11 @@ public class JournalFolderFinderImpl
 				queryPos.add(WorkflowConstants.STATUS_IN_TRASH);
 			}
 
-			queryPos.add(queryDefinition.getStatus());
-
 			if (folderId >= 0) {
 				queryPos.add(folderId);
 			}
+
+			queryPos.add(queryDefinition.getStatus());
 
 			queryPos.add(LocaleUtil.toLanguageId(locale));
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFolderFinderImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalFolderFinderImpl.java
@@ -176,13 +176,13 @@ public class JournalFolderFinderImpl
 
 			queryPos.add(groupId);
 
+			if (folderId >= 0) {
+				queryPos.add(folderId);
+			}
+
 			if (queryDefinition.getOwnerUserId() > 0) {
 				queryPos.add(queryDefinition.getOwnerUserId());
 				queryPos.add(WorkflowConstants.STATUS_IN_TRASH);
-			}
-
-			if (folderId >= 0) {
-				queryPos.add(folderId);
 			}
 
 			queryPos.add(queryDefinition.getStatus());
@@ -345,13 +345,13 @@ public class JournalFolderFinderImpl
 
 			queryPos.add(groupId);
 
+			if (folderId >= 0) {
+				queryPos.add(folderId);
+			}
+
 			if (queryDefinition.getOwnerUserId() > 0) {
 				queryPos.add(queryDefinition.getOwnerUserId());
 				queryPos.add(WorkflowConstants.STATUS_IN_TRASH);
-			}
-
-			if (folderId >= 0) {
-				queryPos.add(folderId);
 			}
 
 			queryPos.add(queryDefinition.getStatus());

--- a/modules/apps/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -413,15 +413,29 @@
 	</sql>
 	<sql id="com.liferay.journal.service.persistence.JournalFolderFinder.countA_ByG_U_F">
 		<![CDATA[
-			SELECT
-				COUNT(DISTINCT JournalArticle.articleId) AS COUNT_VALUE
-			FROM
-				JournalArticle
-			WHERE
-				(JournalArticle.groupId = ?) AND
-				(JournalArticle.classNameId = 0) AND
-				([$OWNER_USER_ID$] [$OWNER_USER_ID_AND_OR_CONNECTOR$] ([$STATUS$]))
-				[$ARTICLE_FOLDER_ID$]
+			 SELECT
+			COUNT(DISTINCT JournalArticle.articleId) AS COUNT_VALUE
+			 FROM
+				(
+					SELECT
+					   JournalArticle.groupId AS groupId, JournalArticle.articleId AS articleId, MAX(JournalArticle.version) AS version
+					FROM
+					   JournalArticle
+					WHERE
+						(JournalArticle.groupId = ?) AND
+						(JournalArticle.classNameId = 0)
+						[$ARTICLE_FOLDER_ID$]
+					GROUP BY
+						JournalArticle.groupId, JournalArticle.folderId, JournalArticle.articleId
+				) TEMP_TABLE
+
+		  INNER JOIN
+			 JournalArticle ON
+				(TEMP_TABLE.groupId = JournalArticle.groupId) AND
+				(TEMP_TABLE.articleId = JournalArticle.articleId) AND
+				(TEMP_TABLE.version = JournalArticle.version)
+		  WHERE
+		[$OWNER_USER_ID$] [$OWNER_USER_ID_AND_OR_CONNECTOR$] ([$STATUS$])
 		]]>
 	</sql>
 	<sql id="com.liferay.journal.service.persistence.JournalFolderFinder.countF_ByG_F">
@@ -463,32 +477,40 @@
 	</sql>
 	<sql id="com.liferay.journal.service.persistence.JournalFolderFinder.findA_ByG_U_F_L">
 		<![CDATA[
-			SELECT
-				JournalArticle.folderId AS modelFolderId, JournalArticle.articleId AS articleId, JournalArticleLocalization.title AS title, JournalArticle.version AS version, 0 AS modelFolder, JournalArticle.displayDate AS displayDate, JournalArticle.modifiedDate AS modifiedDate
-			FROM
+	  SELECT
+		  TEMP_TABLE_2.folderId AS modelFolderId, TEMP_TABLE_2.articleId AS articleId, title, TEMP_TABLE_2.version AS version, 0 AS modelFolder, TEMP_TABLE_2.displayDate AS displayDate, TEMP_TABLE_2.modifiedDate AS modifiedDate
+	  FROM
+			(
+			 SELECT
+			 JournalArticle.*
+			 FROM
 				(
 					SELECT
-						JournalArticle.groupId AS groupId, JournalArticle.articleId AS articleId, MAX(JournalArticle.version) AS version
+					   JournalArticle.groupId AS groupId, JournalArticle.articleId AS articleId, MAX(JournalArticle.version) AS version
 					FROM
-						JournalArticle
+					   JournalArticle
 					WHERE
 						(JournalArticle.groupId = ?) AND
-						(JournalArticle.classNameId = 0) AND
-						([$OWNER_USER_ID$] [$OWNER_USER_ID_AND_OR_CONNECTOR$] ([$STATUS$]))
-						[$ARTICLE_FOLDER_ID$]
+						(JournalArticle.classNameId = 0)
+					   [$ARTICLE_FOLDER_ID$]
 					GROUP BY
 						JournalArticle.groupId, JournalArticle.folderId, JournalArticle.articleId
-				) TEMP_TABLE
-			INNER JOIN
-				JournalArticle ON
-					(TEMP_TABLE.groupId = JournalArticle.groupId) AND
-					(TEMP_TABLE.articleId = JournalArticle.articleId) AND
-					(TEMP_TABLE.version = JournalArticle.version)
-			LEFT JOIN
-				JournalArticleLocalization ON
-					(JournalArticle.id_ = JournalArticleLocalization.articlePK) AND
-					(JournalArticleLocalization.languageId = ?)
-		]]>
+				) TEMP_TABLE_1
+
+		  INNER JOIN
+			 JournalArticle ON
+				(TEMP_TABLE_1.groupId = JournalArticle.groupId) AND
+				(TEMP_TABLE_1.articleId = JournalArticle.articleId) AND
+				(TEMP_TABLE_1.version = JournalArticle.version)
+		  WHERE
+		  [$OWNER_USER_ID$] [$OWNER_USER_ID_AND_OR_CONNECTOR$] ([$STATUS$])
+			) TEMP_TABLE_2
+
+	  LEFT JOIN
+		 JournalArticleLocalization ON
+			(TEMP_TABLE_2.id_ = JournalArticleLocalization.articlePK) AND
+			(JournalArticleLocalization.languageId = ?)
+]]>
 	</sql>
 	<sql id="com.liferay.journal.service.persistence.JournalFolderFinder.findF_ByNoAssets">
 		<![CDATA[

--- a/modules/apps/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/journal/journal-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -414,7 +414,7 @@
 	<sql id="com.liferay.journal.service.persistence.JournalFolderFinder.countA_ByG_U_F">
 		<![CDATA[
 			 SELECT
-			COUNT(DISTINCT JournalArticle.articleId) AS COUNT_VALUE
+				COUNT(DISTINCT JournalArticle.articleId) AS COUNT_VALUE
 			 FROM
 				(
 					SELECT

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalFolderFinderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/persistence/test/JournalFolderFinderTest.java
@@ -24,17 +24,23 @@ import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryDefinition;
 import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.spring.orm.LastSessionRecorderHelperUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.TransactionalTestRule;
 
+import java.util.HashMap;
 import java.util.List;
 
 import org.junit.Assert;
@@ -71,12 +77,26 @@ public class JournalFolderFinderTest {
 			_group.getGroupId(), _folder1.getFolderId(), "Article 1",
 			StringPool.BLANK);
 
-		JournalArticle article = JournalTestUtil.addArticle(
+		JournalArticle article2 = JournalTestUtil.addArticle(
 			_group.getGroupId(), _folder1.getFolderId(), "Article 2",
 			StringPool.BLANK);
 
+		JournalArticle article3 = JournalTestUtil.addArticleWithWorkflow(
+			_group.getGroupId(), 0, "Article 3", "", true);
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				article3.getGroupId(), TestPropsValues.getUserId());
+
+		JournalArticleLocalServiceUtil.updateStatus(
+			TestPropsValues.getUserId(), article3,
+			WorkflowConstants.STATUS_SCHEDULED, article3.getUrlTitle(),
+			serviceContext, new HashMap<>());
+
+		JournalTestUtil.updateArticleWithWorkflow(article3, true);
+
 		JournalArticleLocalServiceUtil.moveArticleToTrash(
-			TestPropsValues.getUserId(), article);
+			TestPropsValues.getUserId(), article2);
 	}
 
 	@Test
@@ -103,6 +123,40 @@ public class JournalFolderFinderTest {
 			2,
 			_journalFolderFinder.countF_A_ByG_F(
 				_group.getGroupId(), _folder1.getFolderId(), queryDefinition));
+	}
+
+	@Test
+	public void testFilterFindF_A_ByG_F_L() throws Exception {
+		QueryDefinition<Object> queryDefinition = new QueryDefinition<>();
+
+		PermissionThreadLocal.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+
+		queryDefinition.setStatus(WorkflowConstants.STATUS_APPROVED);
+
+		List<Object> results = _journalFolderFinder.filterFindF_A_ByG_F_L(
+			_group.getGroupId(), 0, LocaleUtil.US, queryDefinition);
+
+		for (Object result : results) {
+			if (result instanceof JournalArticle) {
+				JournalArticle article = (JournalArticle)result;
+
+				JournalArticle latestArticle =
+					JournalArticleLocalServiceUtil.fetchLatestArticle(
+						article.getResourcePrimKey());
+
+				Assert.assertEquals(
+					results.toString(), article.getTitle(),
+					latestArticle.getTitle());
+			}
+		}
+
+		queryDefinition.setStatus(WorkflowConstants.STATUS_SCHEDULED);
+
+		results = _journalFolderFinder.filterFindF_A_ByG_F_L(
+			_group.getGroupId(), 0, LocaleUtil.US, queryDefinition);
+
+		Assert.assertTrue(results.isEmpty());
 	}
 
 	@Test


### PR DESCRIPTION
Original comments from @javalosjr96:

> Ticket:
> https://issues.liferay.com/browse/LPS-146807
> 
> Issue:
> Scheduled Articles continue to be displayed with scheduled filter when edited to be published
> 
> Cause:
> The WHERE clause for Journal Status in the SQL query `findA_ByG_U_F_L` was not filtering results correctly.
> 
> Fix:
> Use WHERE clause outside of other criteria for search. 
> 
> NOTE:
> I checked out a failed test on my branch, I ran the test locally and it passed.