### PR TITLE
LPS-145232 Prefix DDMStructure and vocabulary info fields

### DIFF
--- a/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldSetProviderImpl.java
@@ -87,22 +87,13 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 
 		for (AssetVocabulary assetVocabulary : assetVocabularies) {
 			infoFieldValues.add(
-				new InfoFieldValue<>(
-					InfoField.builder(
-					).infoFieldType(
-						CategoriesInfoFieldType.INSTANCE
-					).name(
-						assetVocabulary.getName()
-					).labelInfoLocalizedValue(
-						InfoLocalizedValue.<String>builder(
-						).values(
-							assetVocabulary.getTitleMap()
-						).build()
-					).build(),
-					() -> _getCategories(
-						_filterByVocabularyId(
-							assetEntry.getCategories(),
-							assetVocabulary.getVocabularyId()))));
+				_createInfoFieldValue(
+					assetEntry, assetVocabulary, assetVocabulary.getName()));
+
+			infoFieldValues.add(
+				_createInfoFieldValue(
+					assetEntry, assetVocabulary,
+					_VOCABULARY_PREFIX + assetVocabulary.getName()));
 		}
 
 		infoFieldValues.add(
@@ -145,6 +136,27 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
 		}
+	}
+
+	private InfoFieldValue<Object> _createInfoFieldValue(
+		AssetEntry assetEntry, AssetVocabulary assetVocabulary, String name) {
+
+		return new InfoFieldValue<>(
+			InfoField.builder(
+			).infoFieldType(
+				CategoriesInfoFieldType.INSTANCE
+			).name(
+				name
+			).labelInfoLocalizedValue(
+				InfoLocalizedValue.<String>builder(
+				).values(
+					assetVocabulary.getTitleMap()
+				).build()
+			).build(),
+			() -> _getCategories(
+				_filterByVocabularyId(
+					assetEntry.getCategories(),
+					assetVocabulary.getVocabularyId())));
 	}
 
 	private List<AssetCategory> _filterByVisibilityType(
@@ -201,7 +213,7 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 					).infoFieldType(
 						CategoriesInfoFieldType.INSTANCE
 					).name(
-						assetVocabulary.getName()
+						_VOCABULARY_PREFIX + assetVocabulary.getName()
 					).labelInfoLocalizedValue(
 						InfoLocalizedValue.<String>builder(
 						).values(
@@ -285,6 +297,8 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 
 		return tags;
 	}
+
+	private static final String _VOCABULARY_PREFIX = "_VOCABULARY_";
 
 	@Reference
 	private AssetVocabularyLocalService _assetVocabularyLocalService;

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/info/item/provider/test/AssetEntryInfoItemFieldSetProviderTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/info/item/provider/test/AssetEntryInfoItemFieldSetProviderTest.java
@@ -108,11 +108,14 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 		InfoFieldSet infoFieldSet =
 			_assetEntryInfoItemFieldSetProvider.getInfoFieldSet(assetEntry);
 
-		InfoFieldSetEntry infoFieldSetEntry = infoFieldSet.getInfoFieldSetEntry(
+		String namespacedVocabularyName = _addNamespace(
 			assetVocabulary.getName());
 
+		InfoFieldSetEntry infoFieldSetEntry = infoFieldSet.getInfoFieldSetEntry(
+			namespacedVocabularyName);
+
 		Assert.assertEquals(
-			assetVocabulary.getName(), infoFieldSetEntry.getName());
+			namespacedVocabularyName, infoFieldSetEntry.getName());
 	}
 
 	@Test
@@ -133,11 +136,14 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 		InfoFieldSet infoFieldSet =
 			_assetEntryInfoItemFieldSetProvider.getInfoFieldSet(assetEntry);
 
-		InfoFieldSetEntry infoFieldSetEntry = infoFieldSet.getInfoFieldSetEntry(
+		String namespacedVocabularyName = _addNamespace(
 			assetVocabulary.getName());
 
+		InfoFieldSetEntry infoFieldSetEntry = infoFieldSet.getInfoFieldSetEntry(
+			namespacedVocabularyName);
+
 		Assert.assertEquals(
-			assetVocabulary.getName(), infoFieldSetEntry.getName());
+			namespacedVocabularyName, infoFieldSetEntry.getName());
 	}
 
 	@Test
@@ -161,7 +167,8 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 			_assetEntryInfoItemFieldSetProvider.getInfoFieldSet(assetEntry);
 
 		Assert.assertNull(
-			infoFieldSet.getInfoFieldSetEntry(assetVocabulary.getName()));
+			infoFieldSet.getInfoFieldSetEntry(
+				_addNamespace(assetVocabulary.getName())));
 	}
 
 	@Test
@@ -187,11 +194,14 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 				JournalArticle.class.getName(), classTypeId,
 				_group.getGroupId());
 
-		InfoFieldSetEntry infoFieldSetEntry = infoFieldSet.getInfoFieldSetEntry(
+		String namespacedVocabularyName = _addNamespace(
 			assetVocabulary.getName());
 
+		InfoFieldSetEntry infoFieldSetEntry = infoFieldSet.getInfoFieldSetEntry(
+			namespacedVocabularyName);
+
 		Assert.assertEquals(
-			assetVocabulary.getName(), infoFieldSetEntry.getName());
+			namespacedVocabularyName, infoFieldSetEntry.getName());
 	}
 
 	@Test
@@ -210,7 +220,8 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 			assetEntry.getEntryId(), assetCategory.getCategoryId());
 
 		List<InfoFieldValue<Object>> filteredInfoFieldValues =
-			_getInfoFieldValues(assetEntry, assetVocabulary.getName());
+			_getInfoFieldValues(
+				assetEntry, _addNamespace(assetVocabulary.getName()));
 
 		Category category = _getCategory(filteredInfoFieldValues);
 
@@ -268,7 +279,8 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 			new long[] {assetCategory.getCategoryId()});
 
 		List<InfoFieldValue<Object>> filteredInfoFieldValues =
-			_getInfoFieldValues(assetEntry, assetVocabulary.getName());
+			_getInfoFieldValues(
+				assetEntry, _addNamespace(assetVocabulary.getName()));
 
 		Assert.assertEquals(
 			filteredInfoFieldValues.toString(), 0,
@@ -288,7 +300,8 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 			new long[] {assetCategory.getCategoryId()});
 
 		List<InfoFieldValue<Object>> filteredInfoFieldValues =
-			_getInfoFieldValues(assetEntry, assetVocabulary.getName());
+			_getInfoFieldValues(
+				assetEntry, _addNamespace(assetVocabulary.getName()));
 
 		Assert.assertEquals(
 			filteredInfoFieldValues.toString(), 1,
@@ -351,6 +364,10 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 			null, null, visibilityTypePublic, new ServiceContext());
 	}
 
+	private String _addNamespace(String name) {
+		return _VOCABULARY_PREFIX + name;
+	}
+
 	private Category _getCategory(
 		List<InfoFieldValue<Object>> filteredInfoFieldValues) {
 
@@ -374,6 +391,8 @@ public class AssetEntryInfoItemFieldSetProviderTest {
 				return Objects.equals(fieldName, infoField.getName());
 			});
 	}
+
+	private static final String _VOCABULARY_PREFIX = "_VOCABULARY_";
 
 	@Inject
 	private AssetCategoryLocalService _assetCategoryLocalService;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/info/field/converter/DDMFormFieldInfoFieldConverter.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/info/field/converter/DDMFormFieldInfoFieldConverter.java
@@ -27,4 +27,6 @@ public interface DDMFormFieldInfoFieldConverter {
 
 	public InfoField convert(DDMFormField ddmFormField);
 
+	public InfoField convert(DDMFormField ddmFormField, String name);
+
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/info/field/converter/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/resources/com/liferay/dynamic/data/mapping/info/field/converter/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
@@ -95,7 +95,14 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 		_addNestedFields(groupedModel, ddmFormFieldValue, infoFieldValues);
 
 		_getInfoFieldValue(
-			groupedModel, ddmFormFieldValue
+			groupedModel, ddmFormFieldValue, ddmFormFieldValue.getName()
+		).map(
+			infoFieldValues::add
+		);
+
+		_getInfoFieldValue(
+			groupedModel, ddmFormFieldValue,
+			_DDM_STRUCTURE_FIELD_PREFIX + ddmFormFieldValue.getName()
 		).map(
 			infoFieldValues::add
 		);
@@ -121,7 +128,8 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 
 	private Optional<InfoFieldValue<InfoLocalizedValue<Object>>>
 		_getInfoFieldValue(
-			GroupedModel groupedModel, DDMFormFieldValue ddmFormFieldValue) {
+			GroupedModel groupedModel, DDMFormFieldValue ddmFormFieldValue,
+			String name) {
 
 		Value value = ddmFormFieldValue.getValue();
 
@@ -133,7 +141,8 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 			new InfoFieldValue<>(
 				_ddmFormFieldInfoFieldConverter.convert(
 					_ddmBeanTranslator.translate(
-						ddmFormFieldValue.getDDMFormField())),
+						ddmFormFieldValue.getDDMFormField()),
+					name),
 				InfoLocalizedValue.builder(
 				).defaultLocale(
 					value.getDefaultLocale()
@@ -271,6 +280,9 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 			return valueString;
 		}
 	}
+
+	private static final String _DDM_STRUCTURE_FIELD_PREFIX =
+		"_DDM_STRUCTURE_FIELD_";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		DDMFormValuesInfoFieldValuesProviderImpl.class);

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/field/converter/DDMFormFieldInfoFieldConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/field/converter/DDMFormFieldInfoFieldConverterImpl.java
@@ -45,6 +45,11 @@ public class DDMFormFieldInfoFieldConverterImpl
 
 	@Override
 	public InfoField convert(DDMFormField ddmFormField) {
+		return convert(ddmFormField, ddmFormField.getName());
+	}
+
+	@Override
+	public InfoField convert(DDMFormField ddmFormField, String name) {
 		LocalizedValue label = ddmFormField.getLabel();
 
 		return _addAttributes(
@@ -53,7 +58,7 @@ public class DDMFormFieldInfoFieldConverterImpl
 			).infoFieldType(
 				_getInfoFieldType(ddmFormField)
 			).name(
-				ddmFormField.getName()
+				name
 			)
 		).labelInfoLocalizedValue(
 			InfoLocalizedValue.<String>builder(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/item/provider/DDMStructureInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/item/provider/DDMStructureInfoItemFieldSetProviderImpl.java
@@ -74,7 +74,9 @@ public class DDMStructureInfoItemFieldSetProviderImpl
 
 							unsafeConsumer.accept(
 								_ddmFormFieldInfoFieldConverter.convert(
-									ddmFormField));
+									ddmFormField,
+									_DDM_STRUCTURE_FIELD_PREFIX +
+										ddmFormField.getName()));
 						}
 					}
 				}
@@ -92,6 +94,9 @@ public class DDMStructureInfoItemFieldSetProviderImpl
 				"Caught unexpected exception", portalException);
 		}
 	}
+
+	private static final String _DDM_STRUCTURE_FIELD_PREFIX =
+		"_DDM_STRUCTURE_FIELD_";
 
 	private static final String[] _SELECTABLE_DDM_STRUCTURE_FIELDS = {
 		DDMFormFieldTypeConstants.CHECKBOX,

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/info/item/provider/test/JournalArticleInfoItemFormProviderTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/info/item/provider/test/JournalArticleInfoItemFormProviderTest.java
@@ -114,6 +114,74 @@ public class JournalArticleInfoItemFormProviderTest {
 		InfoField infoField = iterator.next();
 
 		Assert.assertEquals(
+			SelectInfoFieldType.INSTANCE, infoField.getInfoFieldType());
+		Assert.assertEquals(_addDDMNamespace("boolean"), infoField.getName());
+		Assert.assertFalse(infoField.isLocalizable());
+
+		infoField = iterator.next();
+
+		Assert.assertEquals(
+			TextInfoFieldType.INSTANCE, infoField.getInfoFieldType());
+		Assert.assertEquals(_addDDMNamespace("DDM_Text"), infoField.getName());
+		Assert.assertTrue(infoField.isLocalizable());
+
+		infoField = iterator.next();
+
+		Assert.assertEquals(
+			TextInfoFieldType.INSTANCE, infoField.getInfoFieldType());
+		Assert.assertEquals(_addDDMNamespace("HTML"), infoField.getName());
+		Assert.assertTrue(infoField.isLocalizable());
+
+		Optional<Boolean> htmlAttributeOptional =
+			infoField.getAttributeOptional(TextInfoFieldType.HTML);
+
+		Assert.assertTrue(htmlAttributeOptional.get());
+
+		Optional<Boolean> multilineAttributeOptional =
+			infoField.getAttributeOptional(TextInfoFieldType.MULTILINE);
+
+		Assert.assertTrue(multilineAttributeOptional.get());
+
+		infoField = iterator.next();
+
+		Assert.assertEquals(
+			ImageInfoFieldType.INSTANCE, infoField.getInfoFieldType());
+		Assert.assertEquals(_addDDMNamespace("image"), infoField.getName());
+		Assert.assertTrue(infoField.isLocalizable());
+
+		infoField = iterator.next();
+
+		Assert.assertEquals(
+			NumberInfoFieldType.INSTANCE, infoField.getInfoFieldType());
+		Assert.assertEquals(_addDDMNamespace("integer"), infoField.getName());
+		Assert.assertTrue(infoField.isLocalizable());
+
+		infoField = iterator.next();
+
+		Assert.assertEquals(
+			TextInfoFieldType.INSTANCE, infoField.getInfoFieldType());
+		Assert.assertEquals(_addDDMNamespace("TextBox"), infoField.getName());
+		Assert.assertTrue(infoField.isLocalizable());
+
+		htmlAttributeOptional = infoField.getAttributeOptional(
+			TextInfoFieldType.HTML);
+
+		Assert.assertFalse(htmlAttributeOptional.isPresent());
+
+		multilineAttributeOptional = infoField.getAttributeOptional(
+			TextInfoFieldType.MULTILINE);
+
+		Assert.assertTrue(multilineAttributeOptional.get());
+
+		infoField = iterator.next();
+
+		Assert.assertEquals(
+			CategoriesInfoFieldType.INSTANCE, infoField.getInfoFieldType());
+		Assert.assertEquals(_VOCABULARY_PREFIX + "topic", infoField.getName());
+
+		infoField = iterator.next();
+
+		Assert.assertEquals(
 			TextInfoFieldType.INSTANCE, infoField.getInfoFieldType());
 		Assert.assertEquals("authorName", infoField.getName());
 		Assert.assertFalse(infoField.isLocalizable());
@@ -128,13 +196,6 @@ public class JournalArticleInfoItemFormProviderTest {
 		infoField = iterator.next();
 
 		Assert.assertEquals(
-			SelectInfoFieldType.INSTANCE, infoField.getInfoFieldType());
-		Assert.assertEquals("boolean", infoField.getName());
-		Assert.assertFalse(infoField.isLocalizable());
-
-		infoField = iterator.next();
-
-		Assert.assertEquals(
 			CategoriesInfoFieldType.INSTANCE, infoField.getInfoFieldType());
 		Assert.assertEquals("categories", infoField.getName());
 		Assert.assertFalse(infoField.isLocalizable());
@@ -143,18 +204,11 @@ public class JournalArticleInfoItemFormProviderTest {
 
 		Assert.assertEquals(
 			TextInfoFieldType.INSTANCE, infoField.getInfoFieldType());
-		Assert.assertEquals("DDM_Text", infoField.getName());
-		Assert.assertTrue(infoField.isLocalizable());
-
-		infoField = iterator.next();
-
-		Assert.assertEquals(
-			TextInfoFieldType.INSTANCE, infoField.getInfoFieldType());
 		Assert.assertEquals("description", infoField.getName());
 		Assert.assertTrue(infoField.isLocalizable());
 
-		Optional<Boolean> htmlAttributeOptional =
-			infoField.getAttributeOptional(TextInfoFieldType.HTML);
+		htmlAttributeOptional = infoField.getAttributeOptional(
+			TextInfoFieldType.HTML);
 
 		Assert.assertTrue(htmlAttributeOptional.get());
 
@@ -178,37 +232,6 @@ public class JournalArticleInfoItemFormProviderTest {
 			DateInfoFieldType.INSTANCE, infoField.getInfoFieldType());
 		Assert.assertEquals("expirationDate", infoField.getName());
 		Assert.assertFalse(infoField.isLocalizable());
-
-		infoField = iterator.next();
-
-		Assert.assertEquals(
-			TextInfoFieldType.INSTANCE, infoField.getInfoFieldType());
-		Assert.assertEquals("HTML", infoField.getName());
-		Assert.assertTrue(infoField.isLocalizable());
-
-		htmlAttributeOptional = infoField.getAttributeOptional(
-			TextInfoFieldType.HTML);
-
-		Assert.assertTrue(htmlAttributeOptional.get());
-
-		Optional<Boolean> multilineAttributeOptional =
-			infoField.getAttributeOptional(TextInfoFieldType.MULTILINE);
-
-		Assert.assertTrue(multilineAttributeOptional.get());
-
-		infoField = iterator.next();
-
-		Assert.assertEquals(
-			ImageInfoFieldType.INSTANCE, infoField.getInfoFieldType());
-		Assert.assertEquals("image", infoField.getName());
-		Assert.assertTrue(infoField.isLocalizable());
-
-		infoField = iterator.next();
-
-		Assert.assertEquals(
-			NumberInfoFieldType.INSTANCE, infoField.getInfoFieldType());
-		Assert.assertEquals("integer", infoField.getName());
-		Assert.assertTrue(infoField.isLocalizable());
 
 		infoField = iterator.next();
 
@@ -249,32 +272,8 @@ public class JournalArticleInfoItemFormProviderTest {
 
 		Assert.assertEquals(
 			TextInfoFieldType.INSTANCE, infoField.getInfoFieldType());
-		Assert.assertEquals("TextBox", infoField.getName());
-		Assert.assertTrue(infoField.isLocalizable());
-
-		htmlAttributeOptional = infoField.getAttributeOptional(
-			TextInfoFieldType.HTML);
-
-		Assert.assertFalse(htmlAttributeOptional.isPresent());
-
-		multilineAttributeOptional = infoField.getAttributeOptional(
-			TextInfoFieldType.MULTILINE);
-
-		Assert.assertTrue(multilineAttributeOptional.get());
-
-		infoField = iterator.next();
-
-		Assert.assertEquals(
-			TextInfoFieldType.INSTANCE, infoField.getInfoFieldType());
 		Assert.assertEquals("title", infoField.getName());
 		Assert.assertTrue(infoField.isLocalizable());
-
-		infoField = iterator.next();
-
-		Assert.assertEquals(
-			CategoriesInfoFieldType.INSTANCE, infoField.getInfoFieldType());
-		Assert.assertEquals(
-			"topic", StringUtil.toLowerCase(infoField.getName()));
 
 		Assert.assertFalse(iterator.hasNext());
 	}
@@ -306,7 +305,7 @@ public class JournalArticleInfoItemFormProviderTest {
 			infoItemFieldValues.getInfoFieldValues();
 
 		Assert.assertEquals(
-			infoFieldValues.toString(), 19, infoFieldValues.size());
+			infoFieldValues.toString(), 27, infoFieldValues.size());
 
 		InfoFieldValue<Object> descriptionInfoFieldValue =
 			infoItemFieldValues.getInfoFieldValue("description");
@@ -329,7 +328,7 @@ public class JournalArticleInfoItemFormProviderTest {
 			titleInfoFieldValue.getValue(LocaleUtil.SPAIN));
 
 		InfoFieldValue<Object> ddmTextInfoFieldValue =
-			infoItemFieldValues.getInfoFieldValue("DDM_Text");
+			infoItemFieldValues.getInfoFieldValue(_addDDMNamespace("DDM_Text"));
 
 		Assert.assertEquals(
 			"Some text",
@@ -339,7 +338,8 @@ public class JournalArticleInfoItemFormProviderTest {
 			ddmTextInfoFieldValue.getValue(LocaleUtil.SPAIN));
 
 		Collection<InfoFieldValue<Object>> ddmTextInfoFieldValues =
-			infoItemFieldValues.getInfoFieldValues("DDM_Text");
+			infoItemFieldValues.getInfoFieldValues(
+				_addDDMNamespace("DDM_Text"));
 
 		Iterator<InfoFieldValue<Object>> ddmTextInfoFieldValuesIterator =
 			ddmTextInfoFieldValues.iterator();
@@ -364,10 +364,11 @@ public class JournalArticleInfoItemFormProviderTest {
 			"Un poco más de texto",
 			secondDDMTextInfoFieldValue.getValue(LocaleUtil.SPAIN));
 
-		Assert.assertNotNull(infoItemFieldValues.getInfoFieldValue("boolean"));
+		Assert.assertNotNull(
+			infoItemFieldValues.getInfoFieldValue(_addDDMNamespace("boolean")));
 
 		InfoFieldValue<Object> imageInfoFieldValue =
-			infoItemFieldValues.getInfoFieldValue("image");
+			infoItemFieldValues.getInfoFieldValue(_addDDMNamespace("image"));
 
 		WebImage webImage = (WebImage)imageInfoFieldValue.getValue(
 			LocaleUtil.getDefault());
@@ -384,21 +385,26 @@ public class JournalArticleInfoItemFormProviderTest {
 
 		Assert.assertNotNull(webImage.getUrl());
 
-		Assert.assertNotNull(infoItemFieldValues.getInfoFieldValue("integer"));
+		Assert.assertNotNull(
+			infoItemFieldValues.getInfoFieldValue(_addDDMNamespace("integer")));
 
 		InfoFieldValue<Object> textBoxInfoFieldValue =
-			infoItemFieldValues.getInfoFieldValue("TextBox");
+			infoItemFieldValues.getInfoFieldValue(_addDDMNamespace("TextBox"));
 
 		Assert.assertEquals(
 			"A lot of text",
 			textBoxInfoFieldValue.getValue(LocaleUtil.getDefault()));
 
 		InfoFieldValue<Object> htmlInfoFieldValue =
-			infoItemFieldValues.getInfoFieldValue("HTML");
+			infoItemFieldValues.getInfoFieldValue(_addDDMNamespace("HTML"));
 
 		Assert.assertEquals(
 			"<p><strong>Bold text</strong></p>",
 			htmlInfoFieldValue.getValue(LocaleUtil.getDefault()));
+	}
+
+	private String _addDDMNamespace(String name) {
+		return _DDM_STRUCTURE_FIELD_PREFIX + name;
 	}
 
 	private JournalArticle _getJournalArticle() throws Exception {
@@ -463,6 +469,11 @@ public class JournalArticleInfoItemFormProviderTest {
 	private String _readFileToString(String s) throws Exception {
 		return new String(FileUtil.getBytes(getClass(), s));
 	}
+
+	private static final String _DDM_STRUCTURE_FIELD_PREFIX =
+		"_DDM_STRUCTURE_FIELD_";
+
+	private static final String _VOCABULARY_PREFIX = "_VOCABULARY_";
 
 	@Inject(filter = "ddm.form.deserializer.type=json")
 	private DDMFormDeserializer _ddmFormDeserializer;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getSelectedField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getSelectedField.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const cache = {};
+
+/**
+ * Returns the selected field from the given key or return null.
+ * This also check try to add a prefix to look for a specific field since older
+ * Liferay versions didn't prefix ddm structure and vocabulary fields.
+ *
+ * @param {object} data
+ * @param {Array}: data.fields Array of available fields for a given info type.
+ * @param {string}: [data.mappingFieldsKey] Key used to store the mapping fields.
+ * @param {string}: data.value Field key.
+ * @return {object}
+ */
+export default function getSelectedField({fields, mappingFieldsKey, value}) {
+	if (!value || !fields?.length) {
+		return null;
+	}
+
+	const cacheKey = `${mappingFieldsKey}${value}`;
+
+	if (mappingFieldsKey && cache[cacheKey]) {
+		return cache[cacheKey];
+	}
+
+	const PREFIXES = ['', '_DDM_STRUCTURE_FIELD_', '_VOCABULARY_'];
+
+	const flattenField = fields.flatMap((fieldSet) => fieldSet.fields);
+
+	for (const prefix of PREFIXES) {
+		const prefixedValue = `${prefix}${value}`;
+
+		const selectedField = flattenField.find(
+			(field) => field.key === prefixedValue
+		);
+
+		if (selectedField) {
+			if (mappingFieldsKey) {
+				cache[cacheKey] = selectedField;
+			}
+
+			return selectedField;
+		}
+	}
+
+	return null;
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingSelector.js
@@ -29,6 +29,7 @@ import isMapped from '../../app/utils/editable-value/isMapped';
 import isMappedToInfoItem from '../../app/utils/editable-value/isMappedToInfoItem';
 import isMappedToStructure from '../../app/utils/editable-value/isMappedToStructure';
 import getMappingFieldsKey from '../../app/utils/getMappingFieldsKey';
+import getSelectedField from '../../app/utils/getSelectedField';
 import itemSelectorValueToInfoItem from '../../app/utils/item-selector-value/itemSelectorValueToInfoItem';
 import {useId} from '../../app/utils/useId';
 import ItemSelector from './ItemSelector';
@@ -453,6 +454,8 @@ function MappingFieldSelect({fieldType, fields, onValueSelect, value}) {
 
 	const hasWarnings = fields && fields.length === 0;
 
+	const selectedField = getSelectedField({fields, value});
+
 	return (
 		<ClayForm.Group
 			className={classNames('mt-3', {'has-warning': hasWarnings})}
@@ -467,7 +470,7 @@ function MappingFieldSelect({fieldType, fields, onValueSelect, value}) {
 				disabled={!(fields && !!fields.length)}
 				id={mappingSelectorFieldSelectId}
 				onChange={onValueSelect}
-				value={value}
+				value={selectedField?.key}
 			>
 				{fields && !!fields.length && (
 					<>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTree.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTree.js
@@ -37,6 +37,7 @@ import isMappedToCollection from '../../../../../app/utils/editable-value/isMapp
 import getLayoutDataItemLabel from '../../../../../app/utils/getLayoutDataItemLabel';
 import getMappingFieldsKey from '../../../../../app/utils/getMappingFieldsKey';
 import {getResponsiveConfig} from '../../../../../app/utils/getResponsiveConfig';
+import getSelectedField from '../../../../../app/utils/getSelectedField';
 import PageStructureSidebarSection from './PageStructureSidebarSection';
 import StructureTreeNode from './StructureTreeNode';
 
@@ -213,17 +214,18 @@ function getMappedFieldLabel(
 	const {selectedMappingTypes} = config;
 
 	if (!infoItem && !selectedMappingTypes && !collectionConfig) {
-		for (const [key, value] of Object.entries(mappingFields)) {
-			if (key.startsWith(editable.classNameId)) {
-				const field = value
-					.flatMap((fieldSet) => fieldSet.fields)
-					.find(
-						(field) =>
-							field.key ===
-							(editable.mappedField ||
-								editable.fieldId ||
-								editable.collectionFieldId)
-					);
+		for (const [mappingFieldsKey, fields] of Object.entries(
+			mappingFields
+		)) {
+			if (mappingFieldsKey.startsWith(editable.classNameId)) {
+				const field = getSelectedField({
+					fields,
+					mappingFieldsKey,
+					value:
+						editable.mappedField ||
+						editable.fieldId ||
+						editable.collectionFieldId,
+				});
 
 				return field?.label;
 			}
@@ -241,15 +243,14 @@ function getMappedFieldLabel(
 	const fields = mappingFields[key];
 
 	if (fields) {
-		const field = fields
-			.flatMap((fieldSet) => fieldSet.fields)
-			.find(
-				(field) =>
-					field.key ===
-					(editable.mappedField ||
-						editable.fieldId ||
-						editable.collectionFieldId)
-			);
+		const field = getSelectedField({
+			fields,
+			mappingFieldsKey: key,
+			value:
+				editable.mappedField ||
+				editable.fieldId ||
+				editable.collectionFieldId,
+		});
 
 		return field?.label;
 	}

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdaterImpl.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdaterImpl.java
@@ -341,7 +341,9 @@ public class JournalArticleInfoItemFieldValuesUpdaterImpl
 		for (Map.Entry<String, List<String>> entry :
 				contentFieldMap.entrySet()) {
 
-			Field field = ddmFields.get(entry.getKey());
+			String key = _removeNamespace(entry.getKey());
+
+			Field field = ddmFields.get(key);
 
 			if (field != null) {
 				field.setValues(
@@ -350,9 +352,9 @@ public class JournalArticleInfoItemFieldValuesUpdaterImpl
 						entry.getValue(),
 						value -> _getSerializable(field, value, targetLocale)));
 			}
-			else if (ddmStructure.hasField(entry.getKey())) {
+			else if (ddmStructure.hasField(key)) {
 				_addNewTranslatedDDMField(
-					ddmStructure, targetLocale, entry.getKey(), ddmFields,
+					ddmStructure, targetLocale, key, ddmFields,
 					entry.getValue());
 			}
 		}
@@ -391,6 +393,10 @@ public class JournalArticleInfoItemFieldValuesUpdaterImpl
 		return false;
 	}
 
+	private String _removeNamespace(String name) {
+		return StringUtil.removeSubstring(name, _DDM_STRUCTURE_FIELD_PREFIX);
+	}
+
 	private void _updateFieldsDisplay(Fields ddmFields, String fieldName) {
 		String fieldsDisplayValue = StringBundler.concat(
 			fieldName, DDM.INSTANCE_SEPARATOR, StringUtil.randomString());
@@ -405,6 +411,9 @@ public class JournalArticleInfoItemFieldValuesUpdaterImpl
 
 		fieldsDisplayField.setValue(StringUtil.merge(fieldsDisplayValues));
 	}
+
+	private static final String _DDM_STRUCTURE_FIELD_PREFIX =
+		"_DDM_STRUCTURE_FIELD_";
 
 	@Reference
 	private AssetEntryLocalService _assetEntryLocalService;

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Alert.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Alert.macro
@@ -1,8 +1,8 @@
 definition {
 
 	macro closeMessage {
-		if ((IsElementPresent(locator1 = "Message#${messageType}")) && (IsVisible(locator1 = "Message#${messageType}")) && (IsVisible(locator1 = "Icon#CLOSE"))) {
-			Click(locator1 = "Icon#CLOSE");
+		if ((IsElementPresent(locator1 = "Message#${messageType}")) && (IsVisible(locator1 = "Message#${messageType}")) && (IsVisible(locator1 = "Message#MESSAGE_CLOSE"))) {
+			Click(locator1 = "Message#MESSAGE_CLOSE");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Message.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Message.path
@@ -341,6 +341,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>MESSAGE_CLOSE</td>
+	<td>//div[contains(@class,'alert')]//*[*[name()='svg'][contains(@class,'lexicon-icon-times')]]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>NO_COMMENTS</td>
 	<td>//div[contains(.,'No comments yet')]</td>
 	<td></td>


### PR DESCRIPTION
This PR adds prefixes to the DDMStructure and vocabulary info fields. Also it makes sure that old non-prefixes values work fine in the page editor.


### Problematic
In version older than 7.4 it it is possible for info fields to collide. Since we didn't have any prefixes in the names, creating structure fields named `title` or `description` collided with the existing fields. This collision cause that some of the two problematic fields could not be mapped. In master it is almost impossible to 

### Solution
Solving the collision once it appears is impossible for us because we don't know which field of the two colliding we should pick. Instead of that we decided to focus on avoiding possible conflicts in the future. For doing so, we are namespacing all the fields that come from the ddmStructure and the vocabularies (all the other dynamic fields, like DDMTemplate or ExpandoFields are namespaced already). For keeping backwards compatibility what we have done is to duplicate the field values, with and without prefix.

#### Frontend
The fix for the page editor is a bit tricky, here we only have one thing, the `fieldId` (It may be the mappedField in Display pages, or the collectionFieldId inside collection display) which contains the key of the associated info field. If this value was set in a previous version (or simply a 7.4 portal version without this fix), the field key won't have the namespace. In this case, the only thing that we can do is to try to look for the field with the new namespaces. Remember that we won't be fixing collisions, so it should be only one field.

#### How to test this

AFAIK, this is only used in the Mapping feature in the Page Editor and in the Web content translation feature. **Are there more usages I'm not aware of**?

Since in master there is little chance of collision (for instance, an user may create a vocabulary called `title` or `description`) the best way to test this is downloading a 7.3 version and:

1. Create some custom WC structure and document types
2. Create some WC, Blogs and Document with the custom structures/document types
3. Translate the WC to some languages
4. Create some Pages and display pages, add fragments and mapped the content
5. Upgrade the database and run a portal with this changes deploys
6. Check that all pages and translations are equal to the ones in 7.3

Any comments are appreciated, and any better alternativas are more than welcome 🤝 