### PR TITLE
LPS 146790 Can create a collection with no asset types configured

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/Source.js
@@ -186,7 +186,6 @@ export default function ({classTypes, namespace}) {
 		if (classTypeSelected) {
 			selectedSubtype = subtypeSelector[classTypeSelected.className];
 		}
-
 		toggleSaveButton(
 			assetSelector.value === '' || selectedSubtype?.value === ''
 		);
@@ -355,6 +354,13 @@ export default function ({classTypes, namespace}) {
 
 		if (fromBox.attr('id') === id || toBox.attr('id') === id) {
 			toggleSubclasses();
+
+			if (document.getElementById(id).options.length === 0) {
+				toggleSaveButton(true);
+			}
+			else {
+				toggleSaveButton(false);
+			}
 		}
 	});
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/BlogsEntry.macro
@@ -30,6 +30,28 @@ definition {
 				navTab = "${navTab}",
 				uploadFileName = "${uploadFileName}");
 		}
+
+		if (isSet(entryInlineImageURL)) {
+			var key_uploadFileName = StringUtil.replace("${uploadFileName}", ".jpg", "");
+
+			Click(
+				locator1 = "BlogsEntry#CONTENT_INLINE_IMAGE",
+				value1 = "${uploadFileName}");
+
+			Click(locator1 = "AlloyEditor#TEXT_FORMATTING_LINK");
+
+			Type(
+				locator1 = "AlloyEditor#TEXT_FORMATTING_LINK_INPUT",
+				value1 = "${entryInlineImageURL}");
+
+			Click(locator1 = "AlloyEditor#TEXT_FORMATTING_LINK_INPUT_CONFIRM");
+
+			Click(
+				locator1 = "BlogsEntry#CONTENT_INLINE_IMAGE",
+				value1 = "${uploadFileName}");
+
+			AssertVisible(locator1 = "AlloyEditor#IMAGE_TOOLBAR");
+		}
 	}
 
 	macro addCustomAbstract {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AlloyEditor.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uisections/AlloyEditor.path
@@ -36,6 +36,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>IMAGE_TOOLBAR</td>
+	<td>//div[contains(@class,'ae-toolbar') and contains(@class,'alloy-editor')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td></td>
 	<td></td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsImage.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/collaboration/blogs/BlogsImage.testcase
@@ -33,7 +33,7 @@ definition {
 		}
 	}
 
-	@description = "This test checks that an inline image can be added to a blog."
+	@description = "This is a usecase for LPS-110117. This test checks that an inline image can be added to a blog."
 	@priority = "4"
 	@refactordone
 	@uitest
@@ -44,6 +44,7 @@ definition {
 
 		BlogsEntry.addContentWithInlineImage(
 			entryContent = "Blogs Entry Content",
+			entryInlineImageURL = "www.liferay.com",
 			navTab = "Upload Image",
 			uploadFileName = "Document_1.jpg");
 


### PR DESCRIPTION
Motivation
=======
It shouldn't be possible to create a manual collection of asset types if there are no asset types selected
[LPS-146790](https://issues.liferay.com/browse/LPS-146790)

Proposed Solution
========
When creating a new collection of multiple asset types, there are all assets type selected by default and the save button for that collection is enabled. When there are no asset types selected the save button should be disabled but it isn't. The proposed solution consists in disabling the save button when there are no asset types selected for that collection.

Steps to Verify:
----------------
1. Go to Site Builder > Collections
2. Create a manual collection
3. Item Type -> Multiple item types -> Select types...
4. Move all the asset types from the 'Selected' box to the 'Available' box
5. Check if the save button is disabled so it's not possible to create the collection
