### PR TITLE
LPS-144626 Adds ClayTreeView implementation to AssetCategoriesNavigationTreeView

### DIFF
--- a/modules/apps/asset/asset-taglib/package.json
+++ b/modules/apps/asset/asset-taglib/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"@clayui/core": "3.46.0",
 		"@clayui/button": "3.40.0",
 		"@clayui/data-provider": "3.45.0",
 		"@clayui/form": "3.45.0",

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
@@ -12,6 +12,8 @@
  * details.
  */
 
+import {TreeView as ClayTreeView} from '@clayui/core';
+import ClayIcon from '@clayui/icon';
 import {Treeview} from 'frontend-js-components-web';
 import React from 'react';
 
@@ -31,6 +33,56 @@ function findCategory(categoryId, categories = []) {
 
 	return null;
 }
+
+const NewAssetCategoriesNavigationTreeView = ({
+	selectedCategoryId,
+	vocabularies,
+}) => {
+	const handleSelectionChange = (event, item) => {
+		event.preventDefault();
+
+		if (selectedCategoryId === item.id) {
+			return;
+		}
+
+		Liferay.Util.navigate(item.url);
+	};
+
+	return (
+		<ClayTreeView
+			items={vocabularies}
+			selectedKeys={
+				new Set(selectedCategoryId ? [selectedCategoryId] : [])
+			}
+		>
+			{(item) => (
+				<ClayTreeView.Item>
+					<ClayTreeView.ItemStack
+						onClick={(event) => handleSelectionChange(event, item)}
+					>
+						<ClayIcon symbol={item.icon} />
+
+						{item.name}
+					</ClayTreeView.ItemStack>
+
+					<ClayTreeView.Group items={item.children}>
+						{(item) => (
+							<ClayTreeView.Item
+								onClick={(event) =>
+									handleSelectionChange(event, item)
+								}
+							>
+								<ClayIcon symbol={item.icon} />
+
+								{item.name}
+							</ClayTreeView.Item>
+						)}
+					</ClayTreeView.Group>
+				</ClayTreeView.Item>
+			)}
+		</ClayTreeView>
+	);
+};
 
 const AssetCategoriesNavigationTreeView = ({
 	selectedCategoryId,
@@ -59,4 +111,6 @@ const AssetCategoriesNavigationTreeView = ({
 	);
 };
 
-export default AssetCategoriesNavigationTreeView;
+export default Liferay.__FF__.enableClayTreeView
+	? NewAssetCategoriesNavigationTreeView
+	: AssetCategoriesNavigationTreeView;


### PR DESCRIPTION
Hey guys,

This PR adds the `<ClayTreeView />` to the `<AssetCategoriesNavigationTreeView />` component. It is also necessary to activate the feature flag that was implemented #7185.

The selected item is not being expanded yet because we depend on the next release of Clay which includes this fix https://github.com/liferay/clay/pull/4664 but as it is on FF there is no problem and it will also be fixed as soon as the new release is entered.

Any suggestions are welcome, let me know if I missed anything.