### PR TITLE
LPS-146715 Prevent creating items that are empty

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetTagsSelectorTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetTagsSelectorTag.java
@@ -302,12 +302,14 @@ public class AssetTagsSelectorTag extends IncludeTag {
 				List<Map<String, String>> selectedItems = new ArrayList<>();
 
 				for (String tagName : getTagNames()) {
-					selectedItems.add(
-						HashMapBuilder.put(
-							"label", tagName
-						).put(
-							"value", tagName
-						).build());
+					if (tagName != StringPool.BLANK) {
+						selectedItems.add(
+							HashMapBuilder.put(
+								"label", tagName
+							).put(
+								"value", tagName
+							).build());
+					}
 				}
 
 				return selectedItems;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-146715

The asset publisher portlet is creating documents that have blank tags. These tags if add with other tags, prevent the document form being published. A solution for this is to prevent selectedItems form creating a label and value if the tagName is blank.

Let me know if there are any questions or comments about this.
Thank you.