### PR TITLE
LPS-148700 Fix ResourcePermission deletion for DDMTemplate - LPS-145396 Subtask

### DIFF
--- a/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/exportimport/staged/model/repository/TemplateEntryStagedModelRepository.java
+++ b/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/exportimport/staged/model/repository/TemplateEntryStagedModelRepository.java
@@ -90,7 +90,7 @@ public class TemplateEntryStagedModelRepository
 	public void deleteStagedModel(TemplateEntry templateEntry)
 		throws PortalException {
 
-		_ddmTemplateLocalService.deleteDDMTemplate(
+		_ddmTemplateLocalService.deleteTemplate(
 			templateEntry.getDDMTemplateId());
 
 		_templateEntryLocalService.deleteTemplateEntry(templateEntry);

--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/portlet/action/DeleteTemplateEntryMVCActionCommand.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/portlet/action/DeleteTemplateEntryMVCActionCommand.java
@@ -64,7 +64,7 @@ public class DeleteTemplateEntryMVCActionCommand
 				_templateEntryLocalService.deleteTemplateEntry(
 					deleteTemplateEntryId);
 
-			_ddmTemplateLocalService.deleteDDMTemplate(
+			_ddmTemplateLocalService.deleteTemplate(
 				templateEntry.getDDMTemplateId());
 		}
 	}


### PR DESCRIPTION
When we delete some types of objects in Liferay, we are not deleting their ResourcePermission records, leaving some database wrong references.

For more information see parent LPS-145396

This subtask addresses the issue for Echo team code

/cc @tinatian
