### PR TITLE
[TS] LPS-148896 | Freemarker variables are not substituted in fragments with lfr-editable tags or data-lfr-editable-type attributes

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/EditableFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/EditableFragmentEntryProcessor.java
@@ -145,8 +145,7 @@ public class EditableFragmentEntryProcessor implements FragmentEntryProcessor {
 			jsonObject.put(
 				clazz.getName(),
 				getDefaultEditableValuesJSONObject(
-					fragmentEntryLink.getHtml(),
-					fragmentEntryLink.getConfiguration()));
+					html, fragmentEntryLink.getConfiguration()));
 		}
 
 		Document document = _getDocument(html);


### PR DESCRIPTION
Hi team @liferay-echo,

This is a solution for [LPS-148896](https://issues.liferay.com/browse/LPS-148896). Please see reproducing steps there and linked PTR.

Please let me know if you have any questions. 

Regards.