### PR TITLE
[TS] LPS-147833 Search executed on initial page load on page derived from site template fails

### DIFF
--- a/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
+++ b/portal-impl/src/com/liferay/portlet/sites/util/SitesImpl.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.model.LayoutType;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.Organization;
+import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
@@ -494,7 +495,9 @@ public class SitesImpl implements Sites {
 		LayoutTypePortlet sourceLayoutTypePortlet =
 			(LayoutTypePortlet)sourceLayout.getLayoutType();
 
-		List<String> sourcePortletIds = sourceLayoutTypePortlet.getPortletIds();
+		List<String> sourcePortletIds = ListUtil.toList(
+			sourceLayoutTypePortlet.getAllPortlets(),
+			Portlet.PORTLET_ID_ACCESSOR);
 
 		for (String sourcePortletId : sourcePortletIds) {
 			PortletPreferences sourcePreferences =


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-147833

Update to include static and embedded portlets, not just the explicitly added portlets, when copying portlets from a page template.