### PR TITLE
 [TS] LPS-149390 - Shared url on social bookmarks has long params

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -520,7 +520,7 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 				viewFullContentURL.toString());
 
 			if (Validator.isNotNull(viewURL)) {
-				return viewURL;
+				return StringUtil.split(viewURL, "?")[0];
 			}
 		}
 		catch (Exception exception) {
@@ -529,7 +529,7 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 			}
 		}
 
-		return viewFullContentURL.toString();
+		return StringUtil.split(viewFullContentURL.toString(), "?")[0];
 	}
 
 	@Override


### PR DESCRIPTION
LPS-149390 Shared url on social bookmarks on an asset with no display page has long params, caused by LPS-145876

When using _urlImpl we cut the params using this method https://github.com/liferay/liferay-portal/blob/592af9d2d922f428016b391a35ff5adfa7fc2a02/modules/apps/social/social-bookmarks-taglib/src/main/java/com/liferay/social/bookmarks/taglib/servlet/taglib/SocialBookmarksTag.java#L204 with includeQueryString = false