### PR TITLE
LPS-145232 Search field in the frontend first by key and then by name

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/collection/provider/AssetEntriesWithSameAssetCategoryRelatedInfoItemCollectionProvider.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/collection/provider/AssetEntriesWithSameAssetCategoryRelatedInfoItemCollectionProvider.java
@@ -255,6 +255,8 @@ public class AssetEntriesWithSameAssetCategoryRelatedInfoItemCollectionProvider
 		InfoField.FinalStep finalStep = InfoField.builder(
 		).infoFieldType(
 			SelectInfoFieldType.INSTANCE
+		).uniqueId(
+			"item_types"
 		).name(
 			"item_types"
 		).attribute(

--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/AssetCategoryInfoItemFields.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/AssetCategoryInfoItemFields.java
@@ -14,6 +14,7 @@
 
 package com.liferay.asset.categories.admin.web.internal.info.item;
 
+import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.type.TextInfoFieldType;
 import com.liferay.info.localized.InfoLocalizedValue;
@@ -27,6 +28,8 @@ public interface AssetCategoryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetCategory.class.getSimpleName() + "_displayPageURL"
 		).name(
 			"description"
 		).labelInfoLocalizedValue(
@@ -37,6 +40,8 @@ public interface AssetCategoryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetCategory.class.getSimpleName() + "_displayPageURL"
 		).name(
 			"displayPageURL"
 		).labelInfoLocalizedValue(
@@ -47,6 +52,8 @@ public interface AssetCategoryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetCategory.class.getSimpleName() + "_name"
 		).name(
 			"name"
 		).labelInfoLocalizedValue(
@@ -57,6 +64,8 @@ public interface AssetCategoryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetCategory.class.getSimpleName() + "_vocabulary"
 		).name(
 			"vocabulary"
 		).labelInfoLocalizedValue(

--- a/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageInfoItemFieldValuesProvider.java
+++ b/modules/apps/asset/asset-categories-service/src/main/java/com/liferay/asset/categories/internal/layout/display/page/AssetCategoryLayoutDisplayPageInfoItemFieldValuesProvider.java
@@ -74,6 +74,8 @@ public class AssetCategoryLayoutDisplayPageInfoItemFieldValuesProvider
 					InfoField.builder(
 					).infoFieldType(
 						TextInfoFieldType.INSTANCE
+					).uniqueId(
+						AssetCategory.class.getSimpleName() + "_vocabulary"
 					).name(
 						"vocabulary"
 					).labelInfoLocalizedValue(
@@ -98,6 +100,8 @@ public class AssetCategoryLayoutDisplayPageInfoItemFieldValuesProvider
 					InfoField.builder(
 					).infoFieldType(
 						TextInfoFieldType.INSTANCE
+					).uniqueId(
+						AssetCategory.class.getSimpleName() + "_group"
 					).name(
 						"group"
 					).labelInfoLocalizedValue(

--- a/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/AssetEntryInfoItemFields.java
+++ b/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/AssetEntryInfoItemFields.java
@@ -14,6 +14,7 @@
 
 package com.liferay.asset.info.internal.item;
 
+import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.type.ImageInfoFieldType;
 import com.liferay.info.field.type.TextInfoFieldType;
@@ -28,6 +29,8 @@ public interface AssetEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetEntry.class.getSimpleName() + "_createDate"
 		).name(
 			"createDate"
 		).labelInfoLocalizedValue(
@@ -38,6 +41,8 @@ public interface AssetEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetEntry.class.getSimpleName() + "_description"
 		).name(
 			"description"
 		).labelInfoLocalizedValue(
@@ -48,6 +53,8 @@ public interface AssetEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetEntry.class.getSimpleName() + "_displayPageURL"
 		).name(
 			"displayPageURL"
 		).labelInfoLocalizedValue(
@@ -58,6 +65,8 @@ public interface AssetEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetEntry.class.getSimpleName() + "_expirationDate"
 		).name(
 			"expirationDate"
 		).labelInfoLocalizedValue(
@@ -68,6 +77,8 @@ public interface AssetEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetEntry.class.getSimpleName() + "_modifiedDate"
 		).name(
 			"modifiedDate"
 		).labelInfoLocalizedValue(
@@ -78,6 +89,8 @@ public interface AssetEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetEntry.class.getSimpleName() + "_summary"
 		).name(
 			"summary"
 		).labelInfoLocalizedValue(
@@ -88,6 +101,8 @@ public interface AssetEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetEntry.class.getSimpleName() + "_title"
 		).name(
 			"title"
 		).labelInfoLocalizedValue(
@@ -97,6 +112,8 @@ public interface AssetEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetEntry.class.getSimpleName() + "_url"
 		).name(
 			"url"
 		).labelInfoLocalizedValue(
@@ -106,6 +123,8 @@ public interface AssetEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetEntry.class.getSimpleName() + "_userName"
 		).name(
 			"userName"
 		).labelInfoLocalizedValue(
@@ -115,6 +134,8 @@ public interface AssetEntryInfoItemFields {
 	public static final InfoField userProfileImageInfoField = InfoField.builder(
 	).infoFieldType(
 		ImageInfoFieldType.INSTANCE
+	).uniqueId(
+		AssetEntry.class.getSimpleName() + "_userProfileImage"
 	).name(
 		"userProfileImage"
 	).labelInfoLocalizedValue(
@@ -125,6 +146,8 @@ public interface AssetEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetEntry.class.getSimpleName() + "_viewName"
 		).name(
 			"viewName"
 		).labelInfoLocalizedValue(

--- a/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/asset/asset-info-impl/src/main/java/com/liferay/asset/info/internal/item/provider/AssetEntryInfoItemFieldSetProviderImpl.java
@@ -34,6 +34,7 @@ import com.liferay.info.item.field.reader.InfoItemFieldReaderFieldSetProvider;
 import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.info.type.categorization.Category;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -91,6 +92,10 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 					InfoField.builder(
 					).infoFieldType(
 						CategoriesInfoFieldType.INSTANCE
+					).uniqueId(
+						AssetVocabulary.class.getSimpleName() +
+							StringPool.UNDERLINE +
+								assetVocabulary.getVocabularyId()
 					).name(
 						assetVocabulary.getName()
 					).labelInfoLocalizedValue(
@@ -200,6 +205,10 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 					InfoField.builder(
 					).infoFieldType(
 						CategoriesInfoFieldType.INSTANCE
+					).uniqueId(
+						AssetVocabulary.class.getSimpleName() +
+							StringPool.UNDERLINE +
+								assetVocabulary.getVocabularyId()
 					).name(
 						assetVocabulary.getName()
 					).labelInfoLocalizedValue(
@@ -293,6 +302,8 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 		InfoField.builder(
 		).infoFieldType(
 			CategoriesInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetCategory.class.getSimpleName() + "_categories"
 		).name(
 			"categories"
 		).labelInfoLocalizedValue(
@@ -312,6 +323,8 @@ public class AssetEntryInfoItemFieldSetProviderImpl
 		InfoField.builder(
 		).infoFieldType(
 			TagsInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetTag.class.getSimpleName() + "_tagNames"
 		).name(
 			"tagNames"
 		).labelInfoLocalizedValue(

--- a/modules/apps/blogs/blogs-reading-time/src/main/java/com/liferay/blogs/reading/time/internal/info/display/contributor/BlogsEntryReadingTimeInfoItemFieldReader.java
+++ b/modules/apps/blogs/blogs-reading-time/src/main/java/com/liferay/blogs/reading/time/internal/info/display/contributor/BlogsEntryReadingTimeInfoItemFieldReader.java
@@ -38,6 +38,8 @@ public class BlogsEntryReadingTimeInfoItemFieldReader
 		return InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_readingTime"
 		).name(
 			"readingTime"
 		).labelInfoLocalizedValue(

--- a/modules/apps/blogs/blogs-reading-time/src/main/java/com/liferay/blogs/reading/time/internal/info/display/contributor/BlogsEntrySimpleReadingTimeInfoItemFieldReader.java
+++ b/modules/apps/blogs/blogs-reading-time/src/main/java/com/liferay/blogs/reading/time/internal/info/display/contributor/BlogsEntrySimpleReadingTimeInfoItemFieldReader.java
@@ -38,6 +38,8 @@ public class BlogsEntrySimpleReadingTimeInfoItemFieldReader
 		return InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_simpleReadingTime"
 		).name(
 			"simpleReadingTime"
 		).labelInfoLocalizedValue(

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/BlogsEntryInfoItemFields.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/info/item/BlogsEntryInfoItemFields.java
@@ -14,6 +14,7 @@
 
 package com.liferay.blogs.web.internal.info.item;
 
+import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.type.DateInfoFieldType;
 import com.liferay.info.field.type.ImageInfoFieldType;
@@ -30,6 +31,8 @@ public interface BlogsEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_authorName"
 		).name(
 			"authorName"
 		).labelInfoLocalizedValue(
@@ -40,6 +43,8 @@ public interface BlogsEntryInfoItemFields {
 		authorProfileImageInfoField = InfoField.builder(
 		).infoFieldType(
 			ImageInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_authorProfileImage"
 		).name(
 			"authorProfileImage"
 		).labelInfoLocalizedValue(
@@ -50,6 +55,8 @@ public interface BlogsEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_content"
 		).name(
 			"content"
 		).labelInfoLocalizedValue(
@@ -60,6 +67,8 @@ public interface BlogsEntryInfoItemFields {
 		coverImageCaptionInfoField = InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_coverImageCaption"
 		).name(
 			"coverImageCaption"
 		).labelInfoLocalizedValue(
@@ -70,6 +79,8 @@ public interface BlogsEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			ImageInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_coverImage"
 		).name(
 			"coverImage"
 		).labelInfoLocalizedValue(
@@ -80,6 +91,8 @@ public interface BlogsEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_createDate"
 		).name(
 			"createDate"
 		).labelInfoLocalizedValue(
@@ -90,6 +103,8 @@ public interface BlogsEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_description"
 		).name(
 			"description"
 		).labelInfoLocalizedValue(
@@ -100,6 +115,8 @@ public interface BlogsEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_displayDate"
 		).name(
 			"displayDate"
 		).labelInfoLocalizedValue(
@@ -110,6 +127,8 @@ public interface BlogsEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			URLInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_displayPageURL"
 		).name(
 			"displayPageURL"
 		).labelInfoLocalizedValue(
@@ -120,6 +139,8 @@ public interface BlogsEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_modifiedDate"
 		).name(
 			"modifiedDate"
 		).labelInfoLocalizedValue(
@@ -130,6 +151,8 @@ public interface BlogsEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_publishDate"
 		).name(
 			"publishDate"
 		).labelInfoLocalizedValue(
@@ -140,6 +163,8 @@ public interface BlogsEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			ImageInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_smallImage"
 		).name(
 			"smallImage"
 		).labelInfoLocalizedValue(
@@ -150,6 +175,8 @@ public interface BlogsEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_subtitle"
 		).name(
 			"subtitle"
 		).labelInfoLocalizedValue(
@@ -160,6 +187,8 @@ public interface BlogsEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			BlogsEntry.class.getSimpleName() + "_title"
 		).name(
 			"title"
 		).labelInfoLocalizedValue(

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/info/display/contributor/AssetCategoryFriendlyURLInfoItemFieldReader.java
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/info/display/contributor/AssetCategoryFriendlyURLInfoItemFieldReader.java
@@ -46,6 +46,8 @@ public class AssetCategoryFriendlyURLInfoItemFieldReader
 		return InfoField.builder(
 		).infoFieldType(
 			URLInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetCategory.class.getSimpleName() + "_friendlyURL"
 		).name(
 			"friendlyURL"
 		).labelInfoLocalizedValue(

--- a/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/info/display/contributor/AssetCategoryMainImageInfoItemFieldReader.java
+++ b/modules/apps/commerce/commerce-product-asset-categories-web/src/main/java/com/liferay/commerce/product/asset/categories/web/internal/info/display/contributor/AssetCategoryMainImageInfoItemFieldReader.java
@@ -50,6 +50,8 @@ public class AssetCategoryMainImageInfoItemFieldReader
 		return InfoField.builder(
 		).infoFieldType(
 			ImageInfoFieldType.INSTANCE
+		).uniqueId(
+			AssetCategory.class.getSimpleName() + "_mainImage"
 		).name(
 			"mainImage"
 		).labelInfoLocalizedValue(

--- a/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItemTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/test/java/com/liferay/content/dashboard/web/internal/item/FileEntryContentDashboardItemTest.java
@@ -200,6 +200,8 @@ public class FileEntryContentDashboardItemTest {
 					InfoField.builder(
 					).infoFieldType(
 						DateInfoFieldType.INSTANCE
+					).uniqueId(
+						FileEntry.class.getSimpleName() + "_description"
 					).name(
 						"description"
 					).labelInfoLocalizedValue(

--- a/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/info/item/provider/test/FileEntryInfoItemFieldValuesProviderTest.java
+++ b/modules/apps/document-library/document-library-web-test/src/testIntegration/java/com/liferay/document/library/web/internal/info/item/provider/test/FileEntryInfoItemFieldValuesProviderTest.java
@@ -155,6 +155,8 @@ public class FileEntryInfoItemFieldValuesProviderTest {
 			return InfoField.builder(
 			).infoFieldType(
 				TextInfoFieldType.INSTANCE
+			).uniqueId(
+				_INFO_FIELD_NAME
 			).name(
 				_INFO_FIELD_NAME
 			).labelInfoLocalizedValue(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/collection/provider/BasicDocumentSingleFormVariationInfoCollectionProvider.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/collection/provider/BasicDocumentSingleFormVariationInfoCollectionProvider.java
@@ -217,6 +217,8 @@ public class BasicDocumentSingleFormVariationInfoCollectionProvider
 		InfoField.FinalStep<?> finalStep = InfoField.builder(
 		).infoFieldType(
 			SelectInfoFieldType.INSTANCE
+		).uniqueId(
+			Field.ASSET_TAG_NAMES
 		).name(
 			Field.ASSET_TAG_NAMES
 		).attribute(

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/FileEntryInfoItemFields.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/info/item/FileEntryInfoItemFields.java
@@ -20,6 +20,7 @@ import com.liferay.info.field.type.ImageInfoFieldType;
 import com.liferay.info.field.type.TextInfoFieldType;
 import com.liferay.info.field.type.URLInfoFieldType;
 import com.liferay.info.localized.InfoLocalizedValue;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 
 /**
  * @author Alejandro Tardín
@@ -31,6 +32,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_authorName"
 		).name(
 			"authorName"
 		).labelInfoLocalizedValue(
@@ -41,6 +44,8 @@ public class FileEntryInfoItemFields {
 		authorProfileImageInfoField = InfoField.builder(
 		).infoFieldType(
 			ImageInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_authorProfileImage"
 		).name(
 			"authorProfileImage"
 		).labelInfoLocalizedValue(
@@ -51,6 +56,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_createDate"
 		).name(
 			"createDate"
 		).labelInfoLocalizedValue(
@@ -61,6 +68,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_description"
 		).name(
 			"description"
 		).labelInfoLocalizedValue(
@@ -71,6 +80,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			URLInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_displayPageURL"
 		).name(
 			"displayPageURL"
 		).labelInfoLocalizedValue(
@@ -81,6 +92,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			URLInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_downloadURL"
 		).name(
 			"downloadURL"
 		).labelInfoLocalizedValue(
@@ -91,6 +104,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_fileName"
 		).name(
 			"fileName"
 		).labelInfoLocalizedValue(
@@ -101,6 +116,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			ImageInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_fileURL"
 		).name(
 			"fileURL"
 		).labelInfoLocalizedValue(
@@ -111,6 +128,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_mimeType"
 		).name(
 			"mimeType"
 		).labelInfoLocalizedValue(
@@ -121,6 +140,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_modifiedDate"
 		).name(
 			"modifiedDate"
 		).labelInfoLocalizedValue(
@@ -131,6 +152,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			ImageInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_previewImage"
 		).name(
 			"previewImage"
 		).labelInfoLocalizedValue(
@@ -141,6 +164,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			URLInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_previewURL"
 		).name(
 			"previewURL"
 		).labelInfoLocalizedValue(
@@ -151,6 +176,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_publishDate"
 		).name(
 			"publishDate"
 		).labelInfoLocalizedValue(
@@ -161,6 +188,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_size"
 		).name(
 			"size"
 		).labelInfoLocalizedValue(
@@ -170,6 +199,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_title"
 		).name(
 			"title"
 		).labelInfoLocalizedValue(
@@ -179,6 +210,8 @@ public class FileEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			FileEntry.class.getSimpleName() + "_version"
 		).name(
 			"version"
 		).labelInfoLocalizedValue(

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/field/converter/DDMFormFieldInfoFieldConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/field/converter/DDMFormFieldInfoFieldConverterImpl.java
@@ -17,6 +17,7 @@ package com.liferay.dynamic.data.mapping.web.internal.info.field.converter;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.info.field.converter.DDMFormFieldInfoFieldConverter;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.LocalizedValue;
 import com.liferay.dynamic.data.mapping.storage.constants.FieldConstants;
 import com.liferay.info.field.InfoField;
@@ -30,6 +31,7 @@ import com.liferay.info.field.type.RadioInfoFieldType;
 import com.liferay.info.field.type.SelectInfoFieldType;
 import com.liferay.info.field.type.TextInfoFieldType;
 import com.liferay.info.localized.InfoLocalizedValue;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Objects;
@@ -52,6 +54,9 @@ public class DDMFormFieldInfoFieldConverterImpl
 			InfoField.builder(
 			).infoFieldType(
 				_getInfoFieldType(ddmFormField)
+			).uniqueId(
+				DDMStructure.class.getSimpleName() + StringPool.UNDERLINE +
+					ddmFormField.getName()
 			).name(
 				ddmFormField.getName()
 			)

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/item/provider/DDMTemplateInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/item/provider/DDMTemplateInfoItemFieldSetProviderImpl.java
@@ -64,6 +64,8 @@ public class DDMTemplateInfoItemFieldSetProviderImpl
 						ddmTemplate -> InfoField.builder(
 						).infoFieldType(
 							TextInfoFieldType.INSTANCE
+						).uniqueId(
+							_getTemplateFieldName(ddmTemplate)
 						).name(
 							_getTemplateFieldName(ddmTemplate)
 						).labelInfoLocalizedValue(

--- a/modules/apps/expando/expando-web/src/main/java/com/liferay/expando/web/internal/info/field/reader/ExpandoInfoItemFieldReader.java
+++ b/modules/apps/expando/expando-web/src/main/java/com/liferay/expando/web/internal/info/field/reader/ExpandoInfoItemFieldReader.java
@@ -70,6 +70,8 @@ public class ExpandoInfoItemFieldReader
 		return InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			getName()
 		).name(
 			getName()
 		).labelInfoLocalizedValue(

--- a/modules/apps/info/info-api/bnd.bnd
+++ b/modules/apps/info/info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Info API
 Bundle-SymbolicName: com.liferay.info.api
-Bundle-Version: 11.1.1
+Bundle-Version: 12.0.0
 Export-Package:\
 	com.liferay.info.collection.provider,\
 	com.liferay.info.constants,\

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/field/InfoField.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/field/InfoField.java
@@ -47,6 +47,8 @@ public class InfoField<T extends InfoFieldType> implements InfoFieldSetEntry {
 			builder(
 			).infoFieldType(
 				infoFieldType
+			).uniqueId(
+				name
 			).name(
 				name
 			).labelInfoLocalizedValue(
@@ -68,6 +70,8 @@ public class InfoField<T extends InfoFieldType> implements InfoFieldSetEntry {
 			builder(
 			).infoFieldType(
 				infoFieldType
+			).uniqueId(
+				name
 			).name(
 				name
 			).labelInfoLocalizedValue(
@@ -126,6 +130,11 @@ public class InfoField<T extends InfoFieldType> implements InfoFieldSetEntry {
 	}
 
 	@Override
+	public String getUniqueId() {
+		return _builder._uniqueId;
+	}
+
+	@Override
 	public int hashCode() {
 		int hash = HashUtil.hash(0, _builder._infoFieldType);
 
@@ -151,12 +160,12 @@ public class InfoField<T extends InfoFieldType> implements InfoFieldSetEntry {
 
 	public static class Builder {
 
-		public <T extends InfoFieldType> NameStep<T> infoFieldType(
+		public <T extends InfoFieldType> UniqueIdStep<T> infoFieldType(
 			T infoFieldType) {
 
 			_infoFieldType = infoFieldType;
 
-			return new NameStep<>(this);
+			return new UniqueIdStep<>(this);
 		}
 
 		private Builder() {
@@ -170,6 +179,7 @@ public class InfoField<T extends InfoFieldType> implements InfoFieldSetEntry {
 		private boolean _localizable;
 		private boolean _multivalued;
 		private String _name;
+		private String _uniqueId;
 
 	}
 
@@ -229,6 +239,22 @@ public class InfoField<T extends InfoFieldType> implements InfoFieldSetEntry {
 		}
 
 		private NameStep(Builder builder) {
+			_builder = builder;
+		}
+
+		private final Builder _builder;
+
+	}
+
+	public static class UniqueIdStep<T extends InfoFieldType> {
+
+		public NameStep<T> uniqueId(String uniqueId) {
+			_builder._uniqueId = uniqueId;
+
+			return new NameStep<>(_builder);
+		}
+
+		private UniqueIdStep(Builder builder) {
 			_builder = builder;
 		}
 

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/field/InfoFieldSetEntry.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/field/InfoFieldSetEntry.java
@@ -29,4 +29,8 @@ public interface InfoFieldSetEntry {
 
 	public String getName();
 
+	public default String getUniqueId() {
+		return getName();
+	}
+
 }

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/item/InfoItemFieldValues.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/item/InfoItemFieldValues.java
@@ -62,7 +62,13 @@ public class InfoItemFieldValues {
 
 	public InfoFieldValue<Object> getInfoFieldValue(String infoFieldName) {
 		Collection<InfoFieldValue<Object>> infoFieldValues =
-			_builder._infoFieldValuesMap.get(infoFieldName);
+			_builder._infoFieldValuesByIdMap.getOrDefault(
+				infoFieldName, Collections.emptyList());
+
+		if (infoFieldValues.isEmpty()) {
+			infoFieldValues = _builder._infoFieldValuesByNameMap.getOrDefault(
+				infoFieldName, Collections.emptyList());
+		}
 
 		if (infoFieldValues != null) {
 			Iterator<InfoFieldValue<Object>> iterator =
@@ -83,7 +89,15 @@ public class InfoItemFieldValues {
 	public Collection<InfoFieldValue<Object>> getInfoFieldValues(
 		String infoFieldName) {
 
-		return _builder._infoFieldValuesMap.getOrDefault(
+		Collection<InfoFieldValue<Object>> infoFieldValues =
+			_builder._infoFieldValuesByIdMap.getOrDefault(
+				infoFieldName, Collections.emptyList());
+
+		if (!infoFieldValues.isEmpty()) {
+			return infoFieldValues;
+		}
+
+		return _builder._infoFieldValuesByNameMap.getOrDefault(
 			infoFieldName, Collections.emptyList());
 	}
 
@@ -101,6 +115,7 @@ public class InfoItemFieldValues {
 			InfoField infoField = infoFieldValue.getInfoField();
 
 			map.put(infoField.getName(), infoFieldValue.getValue(locale));
+			map.put(infoField.getUniqueId(), infoFieldValue.getValue(locale));
 		}
 
 		return map;
@@ -124,10 +139,13 @@ public class InfoItemFieldValues {
 			InfoField infoField = infoFieldValue.getInfoField();
 
 			Collection<InfoFieldValue<Object>> infoFieldValues =
-				_infoFieldValuesMap.computeIfAbsent(
+				_infoFieldValuesByNameMap.computeIfAbsent(
 					infoField.getName(), key -> new ArrayList<>());
 
 			infoFieldValues.add(infoFieldValue);
+
+			_infoFieldValuesByIdMap.put(
+				infoField.getUniqueId(), infoFieldValues);
 
 			return this;
 		}
@@ -161,7 +179,9 @@ public class InfoItemFieldValues {
 		private final Collection<InfoFieldValue<Object>> _infoFieldValues =
 			new LinkedHashSet<>();
 		private final Map<String, Collection<InfoFieldValue<Object>>>
-			_infoFieldValuesMap = new HashMap<>();
+			_infoFieldValuesByIdMap = new HashMap<>();
+		private final Map<String, Collection<InfoFieldValue<Object>>>
+			_infoFieldValuesByNameMap = new HashMap<>();
 		private InfoItemReference _infoItemReference;
 
 	}

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/field/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/field/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 2.0.0

--- a/modules/apps/info/info-api/src/test/java/com/liferay/info/field/type/TextInfoFieldTypeTest.java
+++ b/modules/apps/info/info-api/src/test/java/com/liferay/info/field/type/TextInfoFieldTypeTest.java
@@ -39,6 +39,8 @@ public class TextInfoFieldTypeTest {
 		InfoField<TextInfoFieldType> infoField = InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			"test-field"
 		).name(
 			"test-field"
 		).attribute(
@@ -56,6 +58,8 @@ public class TextInfoFieldTypeTest {
 		InfoField<TextInfoFieldType> infoField = InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			"test-field"
 		).name(
 			"test-field"
 		).attribute(
@@ -73,6 +77,8 @@ public class TextInfoFieldTypeTest {
 		InfoField<TextInfoFieldType> infoField = InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			"test-field"
 		).name(
 			"test-field"
 		).build();

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/display/contributor/InfoDisplayContributorWrapper.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/display/contributor/InfoDisplayContributorWrapper.java
@@ -48,6 +48,7 @@ import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.info.item.provider.InfoItemFormVariationsProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
 import com.liferay.info.localized.InfoLocalizedValue;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
@@ -277,6 +278,9 @@ public class InfoDisplayContributorWrapper
 						InfoField.builder(
 						).infoFieldType(
 							_getInfoFieldTypeType(infoDisplayField.getType())
+						).uniqueId(
+							InfoDisplayField.class.getSimpleName() +
+								StringPool.UNDERLINE + infoDisplayField.getKey()
 						).name(
 							infoDisplayField.getKey()
 						).labelInfoLocalizedValue(
@@ -332,6 +336,8 @@ public class InfoDisplayContributorWrapper
 						InfoField infoField = InfoField.builder(
 						).infoFieldType(
 							TextInfoFieldType.INSTANCE
+						).uniqueId(
+							InfoDisplayField.class.getName() + fieldName
 						).name(
 							fieldName
 						).labelInfoLocalizedValue(

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/item/field/reader/InfoItemFieldReaderTrackerImpl.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/item/field/reader/InfoItemFieldReaderTrackerImpl.java
@@ -29,6 +29,7 @@ import com.liferay.osgi.service.tracker.collections.map.ServiceReferenceMapperFa
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.petra.reflect.GenericUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -190,6 +191,9 @@ public class InfoItemFieldReaderTrackerImpl
 			return InfoField.builder(
 			).infoFieldType(
 				infoFieldType
+			).uniqueId(
+				InfoDisplayContributorField.class.getSimpleName() +
+					StringPool.UNDERLINE + getKey()
 			).name(
 				getKey()
 			).labelInfoLocalizedValue(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/collection/provider/BasicWebContentSingleFormVariationInfoCollectionProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/collection/provider/BasicWebContentSingleFormVariationInfoCollectionProvider.java
@@ -133,6 +133,8 @@ public class BasicWebContentSingleFormVariationInfoCollectionProvider
 			InfoField.builder(
 			).infoFieldType(
 				TextInfoFieldType.INSTANCE
+			).uniqueId(
+				Field.TITLE
 			).name(
 				Field.TITLE
 			).labelInfoLocalizedValue(
@@ -275,6 +277,8 @@ public class BasicWebContentSingleFormVariationInfoCollectionProvider
 		InfoField.FinalStep<?> finalStep = InfoField.builder(
 		).infoFieldType(
 			SelectInfoFieldType.INSTANCE
+		).uniqueId(
+			Field.ASSET_TAG_NAMES
 		).name(
 			Field.ASSET_TAG_NAMES
 		).attribute(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/JournalArticleInfoItemFields.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/JournalArticleInfoItemFields.java
@@ -20,6 +20,7 @@ import com.liferay.info.field.type.ImageInfoFieldType;
 import com.liferay.info.field.type.TextInfoFieldType;
 import com.liferay.info.field.type.URLInfoFieldType;
 import com.liferay.info.localized.InfoLocalizedValue;
+import com.liferay.journal.model.JournalArticle;
 
 /**
  * @author Jorge Ferrer
@@ -30,6 +31,8 @@ public interface JournalArticleInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_authorName"
 		).name(
 			"authorName"
 		).labelInfoLocalizedValue(
@@ -40,6 +43,8 @@ public interface JournalArticleInfoItemFields {
 		authorProfileImageInfoField = InfoField.builder(
 		).infoFieldType(
 			ImageInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_authorProfileImage"
 		).name(
 			"authorProfileImage"
 		).labelInfoLocalizedValue(
@@ -50,6 +55,8 @@ public interface JournalArticleInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_createDate"
 		).name(
 			"createDate"
 		).labelInfoLocalizedValue(
@@ -60,6 +67,8 @@ public interface JournalArticleInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_description"
 		).name(
 			"description"
 		).attribute(
@@ -74,6 +83,8 @@ public interface JournalArticleInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_displayDate"
 		).name(
 			"displayDate"
 		).labelInfoLocalizedValue(
@@ -84,6 +95,8 @@ public interface JournalArticleInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			URLInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_displayPageURL"
 		).name(
 			"displayPageURL"
 		).labelInfoLocalizedValue(
@@ -94,6 +107,8 @@ public interface JournalArticleInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_expirationDate"
 		).name(
 			"expirationDate"
 		).labelInfoLocalizedValue(
@@ -104,6 +119,8 @@ public interface JournalArticleInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_lastEditorName"
 		).name(
 			"lastEditorName"
 		).labelInfoLocalizedValue(
@@ -114,6 +131,8 @@ public interface JournalArticleInfoItemFields {
 		lastEditorProfileImageInfoField = InfoField.builder(
 		).infoFieldType(
 			ImageInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_lastEditorProfileImage"
 		).name(
 			"lastEditorProfileImage"
 		).labelInfoLocalizedValue(
@@ -124,6 +143,8 @@ public interface JournalArticleInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_modifiedDate"
 		).name(
 			"modifiedDate"
 		).labelInfoLocalizedValue(
@@ -134,6 +155,8 @@ public interface JournalArticleInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_publishDate"
 		).name(
 			"publishDate"
 		).labelInfoLocalizedValue(
@@ -144,6 +167,8 @@ public interface JournalArticleInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			ImageInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_smallImage"
 		).name(
 			"smallImage"
 		).labelInfoLocalizedValue(
@@ -154,6 +179,8 @@ public interface JournalArticleInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			JournalArticle.class.getSimpleName() + "_title"
 		).name(
 			"title"
 		).labelInfoLocalizedValue(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFieldValuesProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFieldValuesProvider.java
@@ -335,6 +335,8 @@ public class JournalArticleInfoItemFieldValuesProvider
 			InfoField.builder(
 			).infoFieldType(
 				TextInfoFieldType.INSTANCE
+			).uniqueId(
+				fieldName
 			).name(
 				fieldName
 			).labelInfoLocalizedValue(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/LayoutInfoItemFields.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/LayoutInfoItemFields.java
@@ -18,6 +18,7 @@ import com.liferay.info.field.InfoField;
 import com.liferay.info.field.type.TextInfoFieldType;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.localized.InfoLocalizedValue;
+import com.liferay.portal.kernel.model.Layout;
 
 /**
  * @author Adolfo Pérez
@@ -28,6 +29,8 @@ public class LayoutInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			Layout.class.getSimpleName() + "_name"
 		).name(
 			"name"
 		).labelInfoLocalizedValue(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/util/InfoFieldUtil.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/util/InfoFieldUtil.java
@@ -140,6 +140,8 @@ public class InfoFieldUtil {
 		return InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			fragmentEntryLinkId + StringPool.COLON + name
 		).name(
 			fragmentEntryLinkId + StringPool.COLON + name
 		).labelInfoLocalizedValue(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetCollectionFieldMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetCollectionFieldMVCResourceCommand.java
@@ -451,7 +451,11 @@ public class GetCollectionFieldMVCResourceCommand
 
 			InfoField infoField = infoFieldValue.getInfoField();
 
-			displayObjectJSONObject.put(infoField.getName(), value);
+			displayObjectJSONObject.put(
+				infoField.getName(), value
+			).put(
+				infoField.getUniqueId(), value
+			);
 		}
 
 		InfoItemReference infoItemReference =

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetInfoItemMappingFieldsMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetInfoItemMappingFieldsMVCResourceCommand.java
@@ -145,10 +145,12 @@ public class GetInfoItemMappingFieldsMVCResourceCommand
 				if (_isFieldMappable(infoField, fieldType)) {
 					defaultFieldSetFieldsJSONArray.put(
 						JSONUtil.put(
-							"key", infoField.getName()
+							"key", infoField.getUniqueId()
 						).put(
 							"label",
 							infoField.getLabel(themeDisplay.getLocale())
+						).put(
+							"name", infoField.getName()
 						).put(
 							"type", infoFieldType.getName()
 						));
@@ -167,10 +169,12 @@ public class GetInfoItemMappingFieldsMVCResourceCommand
 				for (InfoField infoField : infoFields) {
 					fieldSetFieldsJSONArray.put(
 						JSONUtil.put(
-							"key", infoField.getName()
+							"key", infoField.getUniqueId()
 						).put(
 							"label",
 							infoField.getLabel(themeDisplay.getLocale())
+						).put(
+							"name", infoField.getName()
 						).put(
 							"type",
 							() -> {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/MappingContentUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/MappingContentUtil.java
@@ -82,9 +82,11 @@ public class MappingContentUtil {
 
 				defaultFieldSetFieldsJSONArray.put(
 					JSONUtil.put(
-						"key", infoField.getName()
+						"key", infoField.getUniqueId()
 					).put(
 						"label", infoField.getLabel(locale)
+					).put(
+						"name", infoField.getName()
 					).put(
 						"type",
 						() -> {
@@ -104,9 +106,11 @@ public class MappingContentUtil {
 				for (InfoField infoField : infoFieldSet.getAllInfoFields()) {
 					fieldSetFieldsJSONArray.put(
 						JSONUtil.put(
-							"key", infoField.getName()
+							"key", infoField.getUniqueId()
 						).put(
 							"label", infoField.getLabel(locale)
+						).put(
+							"name", infoField.getName()
 						).put(
 							"type",
 							() -> {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getSelectedField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/getSelectedField.js
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+const cache = {};
+
+/**
+ * Returns the selected field from the given key or return null.
+ * This also check try to add a prefix to look for a specific field since older
+ * Liferay versions didn't prefix ddm structure and vocabulary fields.
+ *
+ * @param {object} data
+ * @param {Array}: data.fields Array of available fields for a given info type.
+ * @param {string}: [data.mappingFieldsKey] Key used to store the mapping fields.
+ * @param {string}: data.value Field key.
+ * @return {object}
+ */
+export default function getSelectedField({fields, mappingFieldsKey, value}) {
+	if (!value || !fields?.length) {
+		return null;
+	}
+
+	const cacheKey = `${mappingFieldsKey}${value}`;
+
+	if (mappingFieldsKey && cache[cacheKey]) {
+		return cache[cacheKey];
+	}
+
+	const flattenField = fields.flatMap((fieldSet) => fieldSet.fields);
+
+	const selectedField =
+		flattenField.find((field) => field.key === value) ||
+		flattenField.find((field) => field.name === value);
+
+	if (selectedField) {
+		if (mappingFieldsKey) {
+			cache[cacheKey] = selectedField;
+		}
+
+		return selectedField;
+	}
+
+	return null;
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/MappingSelector.js
@@ -29,6 +29,7 @@ import isMapped from '../../app/utils/editable-value/isMapped';
 import isMappedToInfoItem from '../../app/utils/editable-value/isMappedToInfoItem';
 import isMappedToStructure from '../../app/utils/editable-value/isMappedToStructure';
 import getMappingFieldsKey from '../../app/utils/getMappingFieldsKey';
+import getSelectedField from '../../app/utils/getSelectedField';
 import itemSelectorValueToInfoItem from '../../app/utils/item-selector-value/itemSelectorValueToInfoItem';
 import {useId} from '../../app/utils/useId';
 import ItemSelector from './ItemSelector';
@@ -453,6 +454,8 @@ function MappingFieldSelect({fieldType, fields, onValueSelect, value}) {
 
 	const hasWarnings = fields && fields.length === 0;
 
+	const selectedField = getSelectedField({fields, value});
+
 	return (
 		<ClayForm.Group
 			className={classNames('mt-3', {'has-warning': hasWarnings})}
@@ -467,7 +470,7 @@ function MappingFieldSelect({fieldType, fields, onValueSelect, value}) {
 				disabled={!(fields && !!fields.length)}
 				id={mappingSelectorFieldSelectId}
 				onChange={onValueSelect}
-				value={value}
+				value={selectedField?.key}
 			>
 				{fields && !!fields.length && (
 					<>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTree.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTree.js
@@ -37,6 +37,7 @@ import isMappedToCollection from '../../../../../app/utils/editable-value/isMapp
 import getLayoutDataItemLabel from '../../../../../app/utils/getLayoutDataItemLabel';
 import getMappingFieldsKey from '../../../../../app/utils/getMappingFieldsKey';
 import {getResponsiveConfig} from '../../../../../app/utils/getResponsiveConfig';
+import getSelectedField from '../../../../../app/utils/getSelectedField';
 import PageStructureSidebarSection from './PageStructureSidebarSection';
 import StructureTreeNode from './StructureTreeNode';
 
@@ -213,17 +214,18 @@ function getMappedFieldLabel(
 	const {selectedMappingTypes} = config;
 
 	if (!infoItem && !selectedMappingTypes && !collectionConfig) {
-		for (const [key, value] of Object.entries(mappingFields)) {
-			if (key.startsWith(editable.classNameId)) {
-				const field = value
-					.flatMap((fieldSet) => fieldSet.fields)
-					.find(
-						(field) =>
-							field.key ===
-							(editable.mappedField ||
-								editable.fieldId ||
-								editable.collectionFieldId)
-					);
+		for (const [mappingFieldsKey, fields] of Object.entries(
+			mappingFields
+		)) {
+			if (mappingFieldsKey.startsWith(editable.classNameId)) {
+				const field = getSelectedField({
+					fields,
+					mappingFieldsKey,
+					value:
+						editable.mappedField ||
+						editable.fieldId ||
+						editable.collectionFieldId,
+				});
 
 				return field?.label;
 			}
@@ -241,15 +243,14 @@ function getMappedFieldLabel(
 	const fields = mappingFields[key];
 
 	if (fields) {
-		const field = fields
-			.flatMap((fieldSet) => fieldSet.fields)
-			.find(
-				(field) =>
-					field.key ===
-					(editable.mappedField ||
-						editable.fieldId ||
-						editable.collectionFieldId)
-			);
+		const field = getSelectedField({
+			fields,
+			mappingFieldsKey: key,
+			value:
+				editable.mappedField ||
+				editable.fieldId ||
+				editable.collectionFieldId,
+		});
 
 		return field?.label;
 	}

--- a/modules/apps/layout/layout-reports-test/src/testIntegration/java/com/liferay/layout/reports/web/internal/portlet/action/test/LayoutReportsDataMVCResourceCommandTest.java
+++ b/modules/apps/layout/layout-reports-test/src/testIntegration/java/com/liferay/layout/reports/web/internal/portlet/action/test/LayoutReportsDataMVCResourceCommandTest.java
@@ -470,6 +470,8 @@ public class LayoutReportsDataMVCResourceCommandTest {
 					InfoField.builder(
 					).infoFieldType(
 						TextInfoFieldType.INSTANCE
+					).uniqueId(
+						"title"
 					).name(
 						"title"
 					).build(),

--- a/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/internal/template/test/LayoutSEOTemplateProcessorTest.java
+++ b/modules/apps/layout/layout-seo-test/src/testIntegration/java/com/liferay/layout/seo/internal/template/test/LayoutSEOTemplateProcessorTest.java
@@ -148,6 +148,8 @@ public class LayoutSEOTemplateProcessorTest {
 				InfoField.builder(
 				).infoFieldType(
 					TextInfoFieldType.INSTANCE
+				).uniqueId(
+					"description"
 				).name(
 					"description"
 				).labelInfoLocalizedValue(
@@ -159,6 +161,8 @@ public class LayoutSEOTemplateProcessorTest {
 				InfoField.builder(
 				).infoFieldType(
 					TextInfoFieldType.INSTANCE
+				).uniqueId(
+					"Text45966564"
 				).name(
 					"Text45966564"
 				).labelInfoLocalizedValue(
@@ -170,6 +174,8 @@ public class LayoutSEOTemplateProcessorTest {
 				InfoField.builder(
 				).infoFieldType(
 					TextInfoFieldType.INSTANCE
+				).uniqueId(
+					"title"
 				).name(
 					"title"
 				).labelInfoLocalizedValue(

--- a/modules/apps/layout/layout-seo-web-test/src/testIntegration/java/com/liferay/layout/seo/web/internal/servlet/taglib/test/OpenGraphTopHeadDynamicIncludeTest.java
+++ b/modules/apps/layout/layout-seo-web-test/src/testIntegration/java/com/liferay/layout/seo/web/internal/servlet/taglib/test/OpenGraphTopHeadDynamicIncludeTest.java
@@ -1843,6 +1843,8 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 					InfoField.builder(
 					).infoFieldType(
 						TextInfoFieldType.INSTANCE
+					).uniqueId(
+						"description"
 					).name(
 						"description"
 					).build(),
@@ -1852,6 +1854,8 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 					InfoField.builder(
 					).infoFieldType(
 						TextInfoFieldType.INSTANCE
+					).uniqueId(
+						"title"
 					).name(
 						"title"
 					).build(),
@@ -1861,6 +1865,8 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 					InfoField.builder(
 					).infoFieldType(
 						TextInfoFieldType.INSTANCE
+					).uniqueId(
+						"mappedDescriptionFieldName"
 					).name(
 						"mappedDescriptionFieldName"
 					).build(),
@@ -1870,6 +1876,8 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 					InfoField.builder(
 					).infoFieldType(
 						TextInfoFieldType.INSTANCE
+					).uniqueId(
+						"mappedTitleFieldName"
 					).name(
 						"mappedTitleFieldName"
 					).build(),
@@ -1879,6 +1887,8 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 					InfoField.builder(
 					).infoFieldType(
 						TextInfoFieldType.INSTANCE
+					).uniqueId(
+						"mappedTitleFieldName"
 					).name(
 						"mappedTitleFieldName"
 					).build(),
@@ -1888,6 +1898,8 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 					InfoField.builder(
 					).infoFieldType(
 						ImageInfoFieldType.INSTANCE
+					).uniqueId(
+						"mappedImageFieldName"
 					).name(
 						"mappedImageFieldName"
 					).build(),
@@ -1897,6 +1909,8 @@ public class OpenGraphTopHeadDynamicIncludeTest {
 					InfoField.builder(
 					).infoFieldType(
 						TextInfoFieldType.INSTANCE
+					).uniqueId(
+						"mappedImageAltFieldName"
 					).name(
 						"mappedImageAltFieldName"
 					).build(),

--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/internal/info/collection/provider/ObjectEntrySingleFormVariationInfoCollectionProvider.java
@@ -152,6 +152,8 @@ public class ObjectEntrySingleFormVariationInfoCollectionProvider
 							InfoField.builder(
 							).infoFieldType(
 								SelectInfoFieldType.INSTANCE
+							).uniqueId(
+								objectField.getName()
 							).name(
 								objectField.getName()
 							).attribute(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/ObjectEntryInfoItemFields.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/ObjectEntryInfoItemFields.java
@@ -20,6 +20,7 @@ import com.liferay.info.field.type.ImageInfoFieldType;
 import com.liferay.info.field.type.TextInfoFieldType;
 import com.liferay.info.field.type.URLInfoFieldType;
 import com.liferay.info.localized.InfoLocalizedValue;
+import com.liferay.object.model.ObjectEntry;
 
 /**
  * @author Jorge Ferrer
@@ -30,6 +31,8 @@ public interface ObjectEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			ObjectEntry.class.getSimpleName() + "_createDate"
 		).name(
 			"createDate"
 		).labelInfoLocalizedValue(
@@ -40,6 +43,8 @@ public interface ObjectEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			URLInfoFieldType.INSTANCE
+		).uniqueId(
+			ObjectEntry.class.getSimpleName() + "_displayPageURL"
 		).name(
 			"displayPageURL"
 		).labelInfoLocalizedValue(
@@ -50,6 +55,8 @@ public interface ObjectEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			ObjectEntry.class.getSimpleName() + "_modifiedDate"
 		).name(
 			"modifiedDate"
 		).labelInfoLocalizedValue(
@@ -60,6 +67,8 @@ public interface ObjectEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			DateInfoFieldType.INSTANCE
+		).uniqueId(
+			ObjectEntry.class.getSimpleName() + "_publishDate"
 		).name(
 			"publishDate"
 		).labelInfoLocalizedValue(
@@ -70,6 +79,8 @@ public interface ObjectEntryInfoItemFields {
 		InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			ObjectEntry.class.getSimpleName() + "_userName"
 		).name(
 			"userName"
 		).labelInfoLocalizedValue(
@@ -79,6 +90,8 @@ public interface ObjectEntryInfoItemFields {
 	public static final InfoField userProfileImageInfoField = InfoField.builder(
 	).infoFieldType(
 		ImageInfoFieldType.INSTANCE
+	).uniqueId(
+		ObjectEntry.class.getSimpleName() + "_userProfileImage"
 	).name(
 		"userProfileImage"
 	).labelInfoLocalizedValue(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -189,6 +189,9 @@ public class ObjectEntryInfoItemFieldValuesProvider
 						InfoField.builder(
 						).infoFieldType(
 							_getInfoFieldType(objectField)
+						).uniqueId(
+							ObjectField.class.getSimpleName() +
+								StringPool.UNDERLINE + objectField.getName()
 						).name(
 							objectField.getName()
 						).labelInfoLocalizedValue(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -34,6 +34,7 @@ import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.web.internal.info.item.ObjectEntryInfoItemFields;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -239,6 +240,9 @@ public class ObjectEntryInfoItemFormProvider
 						InfoField.builder(
 						).infoFieldType(
 							_getInfoFieldType(objectField)
+						).uniqueId(
+							ObjectField.class.getSimpleName() +
+								StringPool.UNDERLINE + objectField.getName()
 						).name(
 							objectField.getName()
 						).labelInfoLocalizedValue(

--- a/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/item/provider/TemplateInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/item/provider/TemplateInfoItemFieldSetProviderImpl.java
@@ -100,6 +100,9 @@ public class TemplateInfoItemFieldSetProviderImpl
 		return InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			PortletDisplayTemplate.DISPLAY_STYLE_PREFIX +
+				templateEntry.getTemplateEntryId()
 		).name(
 			PortletDisplayTemplate.DISPLAY_STYLE_PREFIX +
 				templateEntry.getTemplateEntryId()

--- a/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/transformer/TemplateDisplayTemplateTransformer.java
+++ b/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/transformer/TemplateDisplayTemplateTransformer.java
@@ -93,6 +93,7 @@ public class TemplateDisplayTemplateTransformer {
 				infoFieldValue, themeDisplay);
 
 			contextObjects.put(infoField.getName(), templateNode);
+			contextObjects.put(infoField.getUniqueId(), templateNode);
 		}
 
 		TemplateHandler templateHandler =

--- a/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/display/context/InformationTemplatesEditDDMTemplateDisplayContext.java
+++ b/modules/apps/template/template-web/src/main/java/com/liferay/template/web/internal/display/context/InformationTemplatesEditDDMTemplateDisplayContext.java
@@ -189,14 +189,14 @@ public class InformationTemplatesEditDDMTemplateDisplayContext
 
 			for (InfoField<?> infoField : infoFieldSet.getAllInfoFields()) {
 				if (!StringUtil.startsWith(
-						infoField.getName(),
+						infoField.getUniqueId(),
 						PortletDisplayTemplate.DISPLAY_STYLE_PREFIX)) {
 
 					InfoFieldType infoFieldType = infoField.getInfoFieldType();
 
 					templateVariableGroup.addFieldVariable(
 						infoField.getLabel(_themeDisplay.getLocale()),
-						TemplateNode.class, infoField.getName(),
+						TemplateNode.class, infoField.getUniqueId(),
 						infoField.getLabel(_themeDisplay.getLocale()),
 						infoFieldType.getName(), infoField.isMultivalued(),
 						_templateVariableCodeHandler);

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/importer/XLIFFInfoFormTranslationImporter.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/importer/XLIFFInfoFormTranslationImporter.java
@@ -119,6 +119,8 @@ public class XLIFFInfoFormTranslationImporter
 		return InfoField.builder(
 		).infoFieldType(
 			TextInfoFieldType.INSTANCE
+		).uniqueId(
+			value
 		).name(
 			value
 		).labelInfoLocalizedValue(

--- a/modules/dxp/apps/analytics/analytics-reports-layout-display-page-test/src/testIntegration/java/com/liferay/analytics/reports/layout/display/page/internal/info/item/test/LayoutDisplayPageObjectProviderAnalyticsReportsInfoItemTest.java
+++ b/modules/dxp/apps/analytics/analytics-reports-layout-display-page-test/src/testIntegration/java/com/liferay/analytics/reports/layout/display/page/internal/info/item/test/LayoutDisplayPageObjectProviderAnalyticsReportsInfoItemTest.java
@@ -457,6 +457,8 @@ public class LayoutDisplayPageObjectProviderAnalyticsReportsInfoItemTest {
 					InfoField.builder(
 					).infoFieldType(
 						DateInfoFieldType.INSTANCE
+					).uniqueId(
+						"createDate"
 					).name(
 						"createDate"
 					).labelInfoLocalizedValue(
@@ -468,6 +470,8 @@ public class LayoutDisplayPageObjectProviderAnalyticsReportsInfoItemTest {
 					InfoField.builder(
 					).infoFieldType(
 						TextInfoFieldType.INSTANCE
+					).uniqueId(
+						"title"
 					).name(
 						"title"
 					).labelInfoLocalizedValue(


### PR DESCRIPTION
I'm opening this here for feedback about the things that affect echo team. There is still pending work for adapting translations to these changes.

### Related tickets
- https://issues.liferay.com/browse/LPS-145232
- https://issues.liferay.com/browse/PTR-2847

### What's the goal of this PR

This PR adds a mandatory builder step in `InfoField` class that require to add an uniqueId. Also in `InfoItemFieldValues` it takes into account the name and it search first by id and then by name. This way stored info field names will still work. Also in the page editor we take into account old names to show the mapping selector and the mapping information correctly for pages created before this change.

### Some questions

- Should we make the builder step optional? This is a breaking change. It will force implementors to take into account, so in my opinion it is fine to make this breaking change, but I believe is debatable.
- Do you think current uniqueId are unique enough? I have used the model class simple name which I think it is enough but I want to hear more opinions about that :P 
