### PR TITLE
LPS-150463 We can't remove filter styles that have default value in responsive viewports

### DIFF
--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/CommonStylesUtil.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/CommonStylesUtil.java
@@ -131,6 +131,21 @@ public class CommonStylesUtil {
 		return jsonArray;
 	}
 
+	public static String getCSSTemplate(String propertyKey) {
+		if (_cssTemplates != null) {
+			return _cssTemplates.get(propertyKey);
+		}
+
+		try {
+			_loadCSSTemplates();
+		}
+		catch (Exception exception) {
+			throw new RuntimeException(exception);
+		}
+
+		return _cssTemplates.get(propertyKey);
+	}
+
 	public static Object getDefaultStyleValue(String name) {
 		if (_defaultValues != null) {
 			return _defaultValues.get(name);
@@ -216,6 +231,30 @@ public class CommonStylesUtil {
 		return Validator.isNotNull(_responsiveTemplates.get(propertyKey));
 	}
 
+	private static void _loadCSSTemplates() throws Exception {
+		Map<String, String> cssTemplates = new HashMap<>();
+
+		JSONArray jsonArray = getCommonStylesJSONArray(null);
+
+		Iterator<JSONObject> iterator = jsonArray.iterator();
+
+		iterator.forEachRemaining(
+			jsonObject -> {
+				JSONArray stylesJSONArray = jsonObject.getJSONArray("styles");
+
+				Iterator<JSONObject> stylesIterator =
+					stylesJSONArray.iterator();
+
+				stylesIterator.forEachRemaining(
+					styleJSONObject -> cssTemplates.put(
+						styleJSONObject.getString("name"),
+						styleJSONObject.getString(
+							"cssTemplate", StringPool.BLANK)));
+			});
+
+		_cssTemplates = cssTemplates;
+	}
+
 	private static void _loadResponsiveTemplates() throws Exception {
 		Map<String, String> responsiveTemplates = new HashMap<>();
 
@@ -249,6 +288,7 @@ public class CommonStylesUtil {
 
 	private static List<String> _availableStyleNames;
 	private static final Map<Locale, JSONArray> _commonStyles = new HashMap<>();
+	private static Map<String, String> _cssTemplates;
 	private static Map<String, Object> _defaultValues;
 	private static List<String> _responsiveStyleNames;
 	private static Map<String, String> _responsiveTemplates;

--- a/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/util/structure/common-styles.json
+++ b/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/util/structure/common-styles.json
@@ -3,6 +3,7 @@
 		"label": "margin",
 		"styles": [
 			{
+				"cssTemplate": "margin-top: {value};",
 				"dataType": "string",
 				"defaultValue": "0",
 				"displaySize": "small",
@@ -59,6 +60,7 @@
 				]
 			},
 			{
+				"cssTemplate": "margin-bottom: {value};",
 				"dataType": "string",
 				"defaultValue": "0",
 				"displaySize": "small",
@@ -115,6 +117,7 @@
 				]
 			},
 			{
+				"cssTemplate": "margin-left: {value};",
 				"dataType": "string",
 				"defaultValue": "0",
 				"displaySize": "small",
@@ -171,6 +174,7 @@
 				]
 			},
 			{
+				"cssTemplate": "margin-right: {value};",
 				"dataType": "string",
 				"defaultValue": "0",
 				"displaySize": "small",
@@ -232,6 +236,7 @@
 		"label": "padding",
 		"styles": [
 			{
+				"cssTemplate": "padding-top: {value};",
 				"dataType": "string",
 				"defaultValue": "0",
 				"displaySize": "small",
@@ -288,6 +293,7 @@
 				]
 			},
 			{
+				"cssTemplate": "padding-bottom: {value};",
 				"dataType": "string",
 				"defaultValue": "0",
 				"displaySize": "small",
@@ -344,6 +350,7 @@
 				]
 			},
 			{
+				"cssTemplate": "padding-left: {value};",
 				"dataType": "string",
 				"defaultValue": "0",
 				"displaySize": "small",
@@ -400,6 +407,7 @@
 				]
 			},
 			{
+				"cssTemplate": "padding-right: {value};",
 				"dataType": "string",
 				"defaultValue": "0",
 				"displaySize": "small",
@@ -462,6 +470,7 @@
 		"label": "frame",
 		"styles": [
 			{
+				"cssTemplate": "width: {value};",
 				"dataType": "string",
 				"defaultValue": "",
 				"displaySize": "small",
@@ -471,6 +480,7 @@
 				"type": "text"
 			},
 			{
+				"cssTemplate": "height: {value};",
 				"dataType": "string",
 				"defaultValue": "",
 				"displaySize": "small",
@@ -480,6 +490,7 @@
 				"type": "text"
 			},
 			{
+				"cssTemplate": "min-width: {value};",
 				"dataType": "string",
 				"defaultValue": "",
 				"displaySize": "small",
@@ -489,6 +500,7 @@
 				"type": "text"
 			},
 			{
+				"cssTemplate": "max-width: {value};",
 				"dataType": "string",
 				"defaultValue": "",
 				"displaySize": "small",
@@ -498,6 +510,7 @@
 				"type": "text"
 			},
 			{
+				"cssTemplate": "min-height: {value};",
 				"dataType": "string",
 				"defaultValue": "",
 				"displaySize": "small",
@@ -507,6 +520,7 @@
 				"type": "text"
 			},
 			{
+				"cssTemplate": "max-height: {value};",
 				"dataType": "string",
 				"defaultValue": "",
 				"displaySize": "small",
@@ -516,6 +530,7 @@
 				"type": "text"
 			},
 			{
+				"cssTemplate": "overflow: {value};",
 				"dataType": "string",
 				"defaultValue": "",
 				"label": "overflow",
@@ -546,6 +561,7 @@
 				]
 			},
 			{
+				"cssTemplate": "display: {value};",
 				"dataType": "string",
 				"defaultValue": "block",
 				"label": "hide-fragment",
@@ -566,6 +582,7 @@
 		"label": "text",
 		"styles": [
 			{
+				"cssTemplate": "font-family: {value};",
 				"dataType": "string",
 				"defaultValue": "",
 				"label": "font-family",
@@ -595,6 +612,7 @@
 				]
 			},
 			{
+				"cssTemplate": "font-weight: {value};",
 				"dataType": "string",
 				"defaultValue": "",
 				"label": "font-weight",
@@ -634,6 +652,7 @@
 				]
 			},
 			{
+				"cssTemplate": "font-size: {value};",
 				"dataType": "string",
 				"defaultValue": "",
 				"label": "font-size",
@@ -663,6 +682,7 @@
 				]
 			},
 			{
+				"cssTemplate": "color: {value};",
 				"dataType": "string",
 				"label": "text-color",
 				"name": "textColor",
@@ -670,6 +690,7 @@
 				"type": "colorPicker"
 			},
 			{
+				"cssTemplate": "text-align: {value};",
 				"dataType": "string",
 				"defaultValue": "left",
 				"label": "text-align",
@@ -702,6 +723,7 @@
 		"label": "background",
 		"styles": [
 			{
+				"cssTemplate": "background-color: {value};",
 				"dataType": "string",
 				"label": "background-color",
 				"name": "backgroundColor",
@@ -709,6 +731,7 @@
 				"type": "colorPicker"
 			},
 			{
+				"cssTemplate": "background-position: 50% 50%; background-repeat:no-repeat; background-size: cover; background-image: {value};",
 				"dataType": "object",
 				"defaultValue": {
 				},
@@ -723,6 +746,7 @@
 		"label": "borders",
 		"styles": [
 			{
+				"cssTemplate": "border-style: solid; border-width: {value}px;",
 				"dataType": "number",
 				"defaultValue": 0,
 				"label": "border-width",
@@ -736,6 +760,7 @@
 				}
 			},
 			{
+				"cssTemplate": "border-radius: {value};",
 				"dataType": "string",
 				"defaultValue": "",
 				"label": "border-radius",
@@ -770,6 +795,7 @@
 				]
 			},
 			{
+				"cssTemplate": "border-color: {value};",
 				"dataType": "string",
 				"label": "border-color",
 				"name": "borderColor",
@@ -782,6 +808,7 @@
 		"label": "effects",
 		"styles": [
 			{
+				"cssTemplate": "opacity: {value};",
 				"dataType": "number",
 				"defaultValue": "",
 				"label": "opacity",
@@ -795,6 +822,7 @@
 				}
 			},
 			{
+				"cssTemplate": "box-shadow: {value};",
 				"dataType": "object",
 				"defaultValue": "",
 				"label": "shadow",

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -528,26 +528,8 @@ public class RenderLayoutStructureDisplayContext {
 
 		StringBundler styleSB = new StringBundler(59);
 
-		String backgroundColor = styledLayoutStructureItem.getBackgroundColor();
-
-		if (Validator.isNotNull(backgroundColor)) {
-			styleSB.append("background-color: ");
-			styleSB.append(getStyleFromStyleBookEntry(backgroundColor));
-			styleSB.append(StringPool.SEMICOLON);
-		}
-
 		JSONObject backgroundImageJSONObject =
 			styledLayoutStructureItem.getBackgroundImageJSONObject();
-
-		String backgroundImage = _getBackgroundImage(backgroundImageJSONObject);
-
-		if (Validator.isNotNull(backgroundImage)) {
-			styleSB.append("background-position: 50% 50%; background-repeat: ");
-			styleSB.append("no-repeat; background-size: cover; ");
-			styleSB.append("background-image: url(");
-			styleSB.append(backgroundImage);
-			styleSB.append(");");
-		}
 
 		long fileEntryId = 0;
 
@@ -586,6 +568,37 @@ public class RenderLayoutStructureDisplayContext {
 		if (fileEntryId != 0) {
 			styleSB.append("--background-image-file-entry-id:");
 			styleSB.append(fileEntryId);
+			styleSB.append(StringPool.SEMICOLON);
+		}
+
+		String backgroundImageURL = _getBackgroundImage(
+			backgroundImageJSONObject);
+
+		if (isCommonStylesFFEnabled()) {
+			if (Validator.isNotNull(backgroundImageURL)) {
+				styleSB.append("--lfr-");
+				styleSB.append(styledLayoutStructureItem.getItemId());
+				styleSB.append("-background-image: url(");
+				styleSB.append(backgroundImageURL);
+				styleSB.append(");");
+			}
+
+			return styleSB.toString();
+		}
+
+		if (Validator.isNotNull(backgroundImageURL)) {
+			styleSB.append("background-position: 50% 50%; background-repeat: ");
+			styleSB.append("no-repeat; background-size: cover; ");
+			styleSB.append("background-image: url(");
+			styleSB.append(backgroundImageURL);
+			styleSB.append(");");
+		}
+
+		String backgroundColor = styledLayoutStructureItem.getBackgroundColor();
+
+		if (Validator.isNotNull(backgroundColor)) {
+			styleSB.append("background-color: ");
+			styleSB.append(getStyleFromStyleBookEntry(backgroundColor));
 			styleSB.append(StringPool.SEMICOLON);
 		}
 

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -576,9 +576,9 @@ public class RenderLayoutStructureDisplayContext {
 
 		if (isCommonStylesFFEnabled()) {
 			if (Validator.isNotNull(backgroundImageURL)) {
-				styleSB.append("--lfr-");
+				styleSB.append("--lfr-background-image-");
 				styleSB.append(styledLayoutStructureItem.getItemId());
-				styleSB.append("-background-image: url(");
+				styleSB.append(": url(");
 				styleSB.append(backgroundImageURL);
 				styleSB.append(");");
 			}

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -60,6 +60,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -507,6 +508,12 @@ public class RenderLayoutStructureDisplayContext {
 		return _layoutStructure;
 	}
 
+	public String getLayoutStructureItemCssClass(
+		LayoutStructureItem layoutStructureItem) {
+
+		return "lfr-layout-structure-item-" + layoutStructureItem.getItemId();
+	}
+
 	public List<String> getMainChildrenItemIds() {
 		LayoutStructure layoutStructure = getLayoutStructure();
 
@@ -732,6 +739,14 @@ public class RenderLayoutStructureDisplayContext {
 			FrontendTokenMapping.TYPE_CSS_VARIABLE);
 
 		return "var(--" + cssVariable + ")";
+	}
+
+	public boolean isCommonStylesFFEnabled() {
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-132571"))) {
+			return true;
+		}
+
+		return false;
 	}
 
 	private String _getBackgroundImage(JSONObject jsonObject) throws Exception {

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
@@ -393,8 +393,9 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 		}
 
 		if (Objects.equals(styleName, "backgroundImage")) {
-			return "var(--lfr-" + styledLayoutStructureItem.getItemId() +
-				"-background-image)";
+			return "var(--lfr-background-image-" +
+				styledLayoutStructureItem.getItemId() +
+					StringPool.CLOSE_PARENTHESIS;
 		}
 
 		if (Objects.equals(styleName, "opacity")) {

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
@@ -1,0 +1,57 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.taglib.internal.servlet.taglib;
+
+import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
+import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
+import org.osgi.service.component.annotations.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+/**
+ * @author Víctor Galán
+ */
+@Component(service = DynamicInclude.class)
+public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
+	extends BaseDynamicInclude {
+
+	@Override
+	public void include(
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, String dynamicIncludeKey)
+		throws IOException {
+
+		if (!GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-132571"))) {
+			return;
+		}
+		PrintWriter printWriter = httpServletResponse.getWriter();
+
+		printWriter.print("<style data-senna-track=\"temporary\" ");
+		printWriter.print("type=\"text/css\">\n");
+
+
+		printWriter.print("</style>\n");
+	}
+
+	@Override
+	public void register(DynamicIncludeRegistry dynamicIncludeRegistry) {
+		dynamicIncludeRegistry.register(
+			"/html/common/themes/top_head.jsp#post");
+	}
+
+}

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
@@ -286,7 +286,9 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 			cssSB.append(
 				StringUtil.replace(
 					CommonStylesUtil.getCSSTemplate(styleName), "{value}",
-					_getStyleValue(frontendTokensJSONObject, value)));
+					_getStyleValue(
+						frontendTokensJSONObject, styledLayoutStructureItem,
+						styleName, value)));
 			cssSB.append(StringPool.NEW_LINE);
 		}
 
@@ -325,14 +327,59 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 
 	private String _getStyleValue(
 		JSONObject frontendTokensJSONObject,
+		StyledLayoutStructureItem styledLayoutStructureItem, String styleName,
 		String value) {
 
+		if (styleName.startsWith("margin") || styleName.startsWith("padding")) {
+			StringBundler sb = new StringBundler(5);
+
+			sb.append("var(--spacer-");
+			sb.append(value);
+			sb.append(StringPool.COMMA);
+			sb.append(_spacings.get(value));
+			sb.append("rem)");
+
+			return sb.toString();
+		}
+
+		if (Objects.equals(styleName, "backgroundImage")) {
+			return "var(--lfr-" + styledLayoutStructureItem.getItemId() +
+				"-background-image)";
+		}
+
+		if (Objects.equals(styleName, "opacity")) {
+			return String.valueOf(GetterUtil.getInteger(value, 100) / 100.0);
+		}
 
 		return _getStyleFromStyleBookEntry(frontendTokensJSONObject, value);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		LayoutStructureCommonStylesCSSTopHeadDynamicInclude.class);
+
+	private static final Map<String, String> _spacings = HashMapBuilder.put(
+		"0", "0"
+	).put(
+		"1", "0.25"
+	).put(
+		"2", "0.5"
+	).put(
+		"3", "1"
+	).put(
+		"4", "1.5"
+	).put(
+		"5", "3"
+	).put(
+		"6", "4.5"
+	).put(
+		"7", "6"
+	).put(
+		"8", "7.5"
+	).put(
+		"9", "9"
+	).put(
+		"10", "10"
+	).build();
 
 	@Reference
 	private LayoutSetLocalService _layoutSetLocalService;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
@@ -14,14 +14,55 @@
 
 package com.liferay.layout.taglib.internal.servlet.taglib;
 
+import com.liferay.frontend.token.definition.FrontendTokenDefinition;
+import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
+import com.liferay.frontend.token.definition.FrontendTokenMapping;
+import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.layout.taglib.internal.util.LayoutStructureUtil;
+import com.liferay.layout.util.structure.CommonStylesUtil;
+import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.layout.util.structure.LayoutStructureItem;
+import com.liferay.layout.util.structure.StyledLayoutStructureItem;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.servlet.taglib.BaseDynamicInclude;
 import com.liferay.portal.kernel.servlet.taglib.DynamicInclude;
-import org.osgi.service.component.annotations.Component;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.style.book.model.StyleBookEntry;
+import com.liferay.style.book.util.DefaultStyleBookEntryUtil;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.io.PrintWriter;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Víctor Galán
@@ -39,11 +80,41 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 		if (!GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-132571"))) {
 			return;
 		}
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
 		PrintWriter printWriter = httpServletResponse.getWriter();
 
-		printWriter.print("<style data-senna-track=\"temporary\" ");
+		printWriter.print("<style id=\"layout-common-styles\"");
+		printWriter.print(" data-senna-track=\"temporary\" ");
 		printWriter.print("type=\"text/css\">\n");
 
+		LayoutStructure layoutStructure =
+			LayoutStructureUtil.getLayoutStructure(
+				httpServletRequest, themeDisplay.getPlid());
+
+		if (layoutStructure == null) {
+			return;
+		}
+
+		JSONObject frontendTokensJSONObject = _getFrontendTokensJSONObject(
+			themeDisplay.getSiteGroupId(), themeDisplay.getLayout(),
+			themeDisplay.getLocale(),
+			ParamUtil.getBoolean(httpServletRequest, "styleBookEntryPreview"));
+
+		List<LayoutStructureItem> layoutStructureItems =
+			layoutStructure.getLayoutStructureItems();
+
+		for (LayoutStructureItem layoutStructureItem : layoutStructureItems) {
+			String css = _getLayoutStructureItemCSS(
+				frontendTokensJSONObject, layoutStructureItem);
+
+			if (Validator.isNotNull(css)) {
+				printWriter.print(css);
+			}
+		}
 
 		printWriter.print("</style>\n");
 	}
@@ -53,5 +124,217 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 		dynamicIncludeRegistry.register(
 			"/html/common/themes/top_head.jsp#post");
 	}
+
+	private JSONObject _createJSONObject(String json) {
+		try {
+			return JSONFactoryUtil.createJSONObject(json);
+		}
+		catch (JSONException jsonException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(jsonException);
+			}
+
+			return JSONFactoryUtil.createJSONObject();
+		}
+	}
+
+	private List<String> _getAvailableStyleNames() {
+		try {
+			return CommonStylesUtil.getAvailableStyleNames();
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return Collections.emptyList();
+		}
+	}
+
+	private JSONObject _getFrontendTokensJSONObject(
+		long groupId, Layout layout, Locale locale,
+		boolean styleBookEntryPreview) {
+
+		JSONObject frontendTokensJSONObject =
+			JSONFactoryUtil.createJSONObject();
+
+		StyleBookEntry styleBookEntry = null;
+
+		if (!styleBookEntryPreview) {
+			styleBookEntry = DefaultStyleBookEntryUtil.getDefaultStyleBookEntry(
+				layout);
+		}
+
+		JSONObject frontendTokenValuesJSONObject =
+			JSONFactoryUtil.createJSONObject();
+
+		if (styleBookEntry != null) {
+			frontendTokenValuesJSONObject = _createJSONObject(
+				styleBookEntry.getFrontendTokensValues());
+		}
+
+		FrontendTokenDefinitionRegistry frontendTokenDefinitionRegistry =
+			ServletContextUtil.getFrontendTokenDefinitionRegistry();
+
+		LayoutSet layoutSet = _layoutSetLocalService.fetchLayoutSet(
+			groupId, false);
+
+		FrontendTokenDefinition frontendTokenDefinition =
+			frontendTokenDefinitionRegistry.getFrontendTokenDefinition(
+				layoutSet.getThemeId());
+
+		if (frontendTokenDefinition == null) {
+			return JSONFactoryUtil.createJSONObject();
+		}
+
+		JSONObject frontendTokenDefinitionJSONObject = _createJSONObject(
+			frontendTokenDefinition.getJSON(locale));
+
+		JSONArray frontendTokenCategoriesJSONArray =
+			frontendTokenDefinitionJSONObject.getJSONArray(
+				"frontendTokenCategories");
+
+		for (int i = 0; i < frontendTokenCategoriesJSONArray.length(); i++) {
+			JSONObject frontendTokenCategoryJSONObject =
+				frontendTokenCategoriesJSONArray.getJSONObject(i);
+
+			JSONArray frontendTokenSetsJSONArray =
+				frontendTokenCategoryJSONObject.getJSONArray(
+					"frontendTokenSets");
+
+			for (int j = 0; j < frontendTokenSetsJSONArray.length(); j++) {
+				JSONObject frontendTokenSetJSONObject =
+					frontendTokenSetsJSONArray.getJSONObject(j);
+
+				JSONArray frontendTokensJSONArray =
+					frontendTokenSetJSONObject.getJSONArray("frontendTokens");
+
+				for (int k = 0; k < frontendTokensJSONArray.length(); k++) {
+					JSONObject frontendTokenJSONObject =
+						frontendTokensJSONArray.getJSONObject(k);
+
+					String cssVariable = StringPool.BLANK;
+
+					JSONArray mappingsJSONArray =
+						frontendTokenJSONObject.getJSONArray("mappings");
+
+					for (int l = 0; l < mappingsJSONArray.length(); l++) {
+						JSONObject mappingJSONObject =
+							mappingsJSONArray.getJSONObject(l);
+
+						if (Objects.equals(
+								mappingJSONObject.getString("type"),
+								FrontendTokenMapping.TYPE_CSS_VARIABLE)) {
+
+							cssVariable = mappingJSONObject.getString("value");
+						}
+					}
+
+					String value = StringPool.BLANK;
+
+					String name = frontendTokenJSONObject.getString("name");
+
+					JSONObject valueJSONObject =
+						frontendTokenValuesJSONObject.getJSONObject(name);
+
+					if (valueJSONObject != null) {
+						value = valueJSONObject.getString("value");
+					}
+					else {
+						value = frontendTokenJSONObject.getString(
+							"defaultValue");
+					}
+
+					frontendTokensJSONObject.put(
+						name,
+						JSONUtil.put(
+							FrontendTokenMapping.TYPE_CSS_VARIABLE, cssVariable
+						).put(
+							"value", value
+						));
+				}
+			}
+		}
+
+		return frontendTokensJSONObject;
+	}
+
+	private String _getLayoutStructureItemCSS(
+		JSONObject frontendTokensJSONObject,
+		LayoutStructureItem layoutStructureItem) {
+
+		if (!(layoutStructureItem instanceof StyledLayoutStructureItem)) {
+			return StringPool.BLANK;
+		}
+
+		StringBundler cssSB = new StringBundler(74);
+
+		StyledLayoutStructureItem styledLayoutStructureItem =
+			(StyledLayoutStructureItem)layoutStructureItem;
+
+		List<String> availableStyleNames = _getAvailableStyleNames();
+
+		JSONObject itemConfigJSONObject =
+			styledLayoutStructureItem.getItemConfigJSONObject();
+
+		JSONObject stylesJSONObject = itemConfigJSONObject.getJSONObject(
+			"styles");
+
+		for (String styleName : availableStyleNames) {
+			String value = stylesJSONObject.getString(styleName);
+
+			cssSB.append(
+				StringUtil.replace(
+					CommonStylesUtil.getCSSTemplate(styleName), "{value}",
+					_getStyleValue(frontendTokensJSONObject, value)));
+			cssSB.append(StringPool.NEW_LINE);
+		}
+
+		String css = cssSB.toString();
+
+		if (Validator.isNull(css)) {
+			return StringPool.BLANK;
+		}
+
+		StringBundler cssRuleSB = new StringBundler(5);
+
+		cssRuleSB.append(".lfr-layout-structure-item-");
+		cssRuleSB.append(layoutStructureItem.getItemId());
+		cssRuleSB.append(" {\n");
+		cssRuleSB.append(css);
+		cssRuleSB.append("}\n");
+
+		return cssRuleSB.toString();
+	}
+
+	private String _getStyleFromStyleBookEntry(
+		JSONObject frontendTokensJSONObject, String styleValue) {
+
+		JSONObject styleValueJSONObject =
+			frontendTokensJSONObject.getJSONObject(styleValue);
+
+		if (styleValueJSONObject == null) {
+			return styleValue;
+		}
+
+		String cssVariable = styleValueJSONObject.getString(
+			FrontendTokenMapping.TYPE_CSS_VARIABLE);
+
+		return "var(--" + cssVariable + ")";
+	}
+
+	private String _getStyleValue(
+		JSONObject frontendTokensJSONObject,
+		String value) {
+
+
+		return _getStyleFromStyleBookEntry(frontendTokensJSONObject, value);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LayoutStructureCommonStylesCSSTopHeadDynamicInclude.class);
+
+	@Reference
+	private LayoutSetLocalService _layoutSetLocalService;
 
 }

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
@@ -85,6 +85,12 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		Layout layout = themeDisplay.getLayout();
+
+		if (!layout.isTypeAssetDisplay() && !layout.isTypeContent()) {
+			return;
+		}
+
 		PrintWriter printWriter = httpServletResponse.getWriter();
 
 		printWriter.print("<style id=\"layout-common-styles\"");

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
@@ -164,41 +164,6 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 		}
 	}
 
-	private boolean _includeStyles(
-		StyledLayoutStructureItem styledLayoutStructureItem, String styleName,
-		String value) {
-
-		if (Validator.isNull(value) ||
-			Objects.equals(
-				value, CommonStylesUtil.getDefaultStyleValue(styleName))) {
-
-			return false;
-		}
-
-		if (!(styledLayoutStructureItem instanceof
-			ContainerStyledLayoutStructureItem)) {
-
-			return true;
-		}
-
-		ContainerStyledLayoutStructureItem containerStyledLayoutStructureItem =
-			(ContainerStyledLayoutStructureItem)styledLayoutStructureItem;
-
-		if (!Objects.equals(
-			containerStyledLayoutStructureItem.getWidthType(), "fixed")) {
-
-			return true;
-		}
-
-		if (Objects.equals(styleName, "marginLeft") ||
-			Objects.equals(styleName, "marginRight")) {
-
-			return false;
-		}
-
-		return true;
-	}
-
 	private List<String> _getAvailableStyleNames() {
 		try {
 			return CommonStylesUtil.getAvailableStyleNames();
@@ -346,7 +311,8 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 			String value = stylesJSONObject.getString(styleName);
 
 			if (!_includeStyles(
-					styledLayoutStructureItem, styleName, value)) {
+					styledLayoutStructureItem, styleName, value,
+					viewportSize)) {
 
 				continue;
 			}
@@ -436,6 +402,42 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 		}
 
 		return _getStyleFromStyleBookEntry(frontendTokensJSONObject, value);
+	}
+
+	private boolean _includeStyles(
+		StyledLayoutStructureItem styledLayoutStructureItem, String styleName,
+		String value, ViewportSize viewportSize) {
+
+		if (Validator.isNull(value) ||
+			(Objects.equals(
+				value, CommonStylesUtil.getDefaultStyleValue(styleName)) &&
+			 Objects.equals(viewportSize, ViewportSize.DESKTOP))) {
+
+			return false;
+		}
+
+		if (!(styledLayoutStructureItem instanceof
+				ContainerStyledLayoutStructureItem)) {
+
+			return true;
+		}
+
+		ContainerStyledLayoutStructureItem containerStyledLayoutStructureItem =
+			(ContainerStyledLayoutStructureItem)styledLayoutStructureItem;
+
+		if (!Objects.equals(
+				containerStyledLayoutStructureItem.getWidthType(), "fixed")) {
+
+			return true;
+		}
+
+		if (Objects.equals(styleName, "marginLeft") ||
+			Objects.equals(styleName, "marginRight")) {
+
+			return false;
+		}
+
+		return true;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
@@ -138,6 +138,41 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 		}
 	}
 
+	private boolean _includeStyles(
+		StyledLayoutStructureItem styledLayoutStructureItem, String styleName,
+		String value) {
+
+		if (Validator.isNull(value) ||
+			Objects.equals(
+				value, CommonStylesUtil.getDefaultStyleValue(styleName))) {
+
+			return false;
+		}
+
+		if (!(styledLayoutStructureItem instanceof
+			ContainerStyledLayoutStructureItem)) {
+
+			return true;
+		}
+
+		ContainerStyledLayoutStructureItem containerStyledLayoutStructureItem =
+			(ContainerStyledLayoutStructureItem)styledLayoutStructureItem;
+
+		if (!Objects.equals(
+			containerStyledLayoutStructureItem.getWidthType(), "fixed")) {
+
+			return true;
+		}
+
+		if (Objects.equals(styleName, "marginLeft") ||
+			Objects.equals(styleName, "marginRight")) {
+
+			return false;
+		}
+
+		return true;
+	}
+
 	private List<String> _getAvailableStyleNames() {
 		try {
 			return CommonStylesUtil.getAvailableStyleNames();
@@ -282,6 +317,12 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 
 		for (String styleName : availableStyleNames) {
 			String value = stylesJSONObject.getString(styleName);
+
+			if (!_includeStyles(
+					styledLayoutStructureItem, styleName, value)) {
+
+				continue;
+			}
 
 			cssSB.append(
 				StringUtil.replace(

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
@@ -95,12 +95,6 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 			return;
 		}
 
-		PrintWriter printWriter = httpServletResponse.getWriter();
-
-		printWriter.print("<style id=\"layout-common-styles\"");
-		printWriter.print(" data-senna-track=\"temporary\" ");
-		printWriter.print("type=\"text/css\">\n");
-
 		LayoutStructure layoutStructure =
 			LayoutStructureUtil.getLayoutStructure(
 				httpServletRequest, themeDisplay.getPlid());
@@ -108,6 +102,12 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 		if (layoutStructure == null) {
 			return;
 		}
+
+		PrintWriter printWriter = httpServletResponse.getWriter();
+
+		printWriter.print("<style id=\"layout-common-styles\"");
+		printWriter.print(" data-senna-track=\"temporary\" ");
+		printWriter.print("type=\"text/css\">\n");
 
 		JSONObject frontendTokensJSONObject = _getFrontendTokensJSONObject(
 			themeDisplay.getSiteGroupId(), themeDisplay.getLayout(),
@@ -127,6 +127,10 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 					_getLayoutStructureItemCSS(
 						frontendTokensJSONObject, layoutStructureItem,
 						viewportSize));
+			}
+
+			if (cssSB.length() == 0) {
+				continue;
 			}
 
 			if (Objects.equals(viewportSize, ViewportSize.DESKTOP)) {

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/LayoutStructureUtil.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/LayoutStructureUtil.java
@@ -1,0 +1,163 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.taglib.internal.util;
+
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalServiceUtil;
+import com.liferay.layout.util.structure.DropZoneLayoutStructureItem;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.layout.util.structure.LayoutStructureItem;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.impl.VirtualLayout;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.constants.SegmentsWebKeys;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Víctor Galán
+ */
+public class LayoutStructureUtil {
+
+	public static LayoutStructure getLayoutStructure(
+		HttpServletRequest httpServletRequest, long plid) {
+
+		try {
+			Layout layout = _getLayout(plid);
+
+			LayoutPageTemplateStructure layoutPageTemplateStructure =
+				LayoutPageTemplateStructureLocalServiceUtil.
+					fetchLayoutPageTemplateStructure(
+						layout.getGroupId(), layout.getPlid(), true);
+
+			String data = layoutPageTemplateStructure.getData(
+				_getSegmentsExperienceId(httpServletRequest));
+
+			if (Validator.isNull(data)) {
+				return null;
+			}
+
+			String masterLayoutData = _getMasterLayoutData(
+				layout.getMasterLayoutPlid());
+
+			if (Validator.isNull(masterLayoutData)) {
+				return LayoutStructure.of(data);
+			}
+
+			return _mergeLayoutStructure(data, masterLayoutData);
+		}
+		catch (Exception exception) {
+			_log.error("Unable to get layout structure", exception);
+
+			return null;
+		}
+	}
+
+	private static Layout _getLayout(long plid) {
+		Layout layout = LayoutLocalServiceUtil.fetchLayout(plid);
+
+		if (layout instanceof VirtualLayout) {
+			VirtualLayout virtualLayout = (VirtualLayout)layout;
+
+			layout = virtualLayout.getSourceLayout();
+		}
+
+		return layout;
+	}
+
+	private static String _getMasterLayoutData(long masterLayoutPlid) {
+		LayoutPageTemplateEntry masterLayoutPageTemplateEntry =
+			LayoutPageTemplateEntryLocalServiceUtil.
+				fetchLayoutPageTemplateEntryByPlid(masterLayoutPlid);
+
+		if (masterLayoutPageTemplateEntry == null) {
+			return null;
+		}
+
+		LayoutPageTemplateStructure masterLayoutPageTemplateStructure =
+			LayoutPageTemplateStructureLocalServiceUtil.
+				fetchLayoutPageTemplateStructure(
+					masterLayoutPageTemplateEntry.getGroupId(),
+					masterLayoutPageTemplateEntry.getPlid());
+
+		if (masterLayoutPageTemplateStructure == null) {
+			return null;
+		}
+
+		return masterLayoutPageTemplateStructure.
+			getDefaultSegmentsExperienceData();
+	}
+
+	private static long _getSegmentsExperienceId(
+		HttpServletRequest httpServletRequest) {
+
+		long selectedSegmentsExperienceId = ParamUtil.getLong(
+			httpServletRequest, "segmentsExperienceId", -1);
+
+		if (selectedSegmentsExperienceId != -1) {
+			return selectedSegmentsExperienceId;
+		}
+
+		long[] segmentsExperienceIds = GetterUtil.getLongValues(
+			httpServletRequest.getAttribute(
+				SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS),
+			new long[] {SegmentsExperienceConstants.ID_DEFAULT});
+
+		return segmentsExperienceIds[0];
+	}
+
+	private static LayoutStructure _mergeLayoutStructure(
+		String data, String masterLayoutData) {
+
+		LayoutStructure masterLayoutStructure = LayoutStructure.of(
+			masterLayoutData);
+
+		LayoutStructure layoutStructure = LayoutStructure.of(data);
+
+		for (LayoutStructureItem layoutStructureItem :
+				layoutStructure.getLayoutStructureItems()) {
+
+			masterLayoutStructure.addLayoutStructureItem(layoutStructureItem);
+		}
+
+		DropZoneLayoutStructureItem dropZoneLayoutStructureItem =
+			(DropZoneLayoutStructureItem)
+				masterLayoutStructure.getDropZoneLayoutStructureItem();
+
+		dropZoneLayoutStructureItem.addChildrenItem(
+			layoutStructure.getMainItemId());
+
+		LayoutStructureItem rootStructureItem =
+			masterLayoutStructure.getLayoutStructureItem(
+				layoutStructure.getMainItemId());
+
+		rootStructureItem.setParentItemId(
+			dropZoneLayoutStructureItem.getItemId());
+
+		return masterLayoutStructure;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		LayoutStructureUtil.class);
+
+}

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderFragmentLayoutTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderFragmentLayoutTag.java
@@ -15,26 +15,11 @@
 package com.liferay.layout.taglib.servlet.taglib;
 
 import com.liferay.fragment.constants.FragmentEntryLinkConstants;
-import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
-import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
-import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
-import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalServiceUtil;
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
-import com.liferay.layout.util.structure.DropZoneLayoutStructureItem;
+import com.liferay.layout.taglib.internal.util.LayoutStructureUtil;
 import com.liferay.layout.util.structure.LayoutStructure;
-import com.liferay.layout.util.structure.LayoutStructureItem;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.impl.VirtualLayout;
-import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.segments.constants.SegmentsExperienceConstants;
-import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.taglib.util.IncludeTag;
 
 import javax.servlet.http.HttpServletRequest;
@@ -124,19 +109,6 @@ public class RenderFragmentLayoutTag extends IncludeTag {
 			"liferay-layout:render-fragment-layout:showPreview", _showPreview);
 	}
 
-	private Layout _getLayout(HttpServletRequest httpServletRequest) {
-		Layout layout = LayoutLocalServiceUtil.fetchLayout(
-			_getPlid(httpServletRequest));
-
-		if (layout instanceof VirtualLayout) {
-			VirtualLayout virtualLayout = (VirtualLayout)layout;
-
-			layout = virtualLayout.getSourceLayout();
-		}
-
-		return layout;
-	}
-
 	private LayoutStructure _getLayoutStructure(
 		HttpServletRequest httpServletRequest) {
 
@@ -144,64 +116,10 @@ public class RenderFragmentLayoutTag extends IncludeTag {
 			return _layoutStructure;
 		}
 
-		try {
-			Layout layout = _getLayout(httpServletRequest);
+		_layoutStructure = LayoutStructureUtil.getLayoutStructure(
+			httpServletRequest, _getPlid(httpServletRequest));
 
-			LayoutPageTemplateStructure layoutPageTemplateStructure =
-				LayoutPageTemplateStructureLocalServiceUtil.
-					fetchLayoutPageTemplateStructure(
-						layout.getGroupId(), layout.getPlid(), true);
-
-			String data = layoutPageTemplateStructure.getData(
-				_getSegmentsExperienceId());
-
-			if (Validator.isNull(data)) {
-				return _layoutStructure;
-			}
-
-			String masterLayoutData = _getMasterLayoutData(httpServletRequest);
-
-			if (Validator.isNull(masterLayoutData)) {
-				_layoutStructure = LayoutStructure.of(data);
-
-				return _layoutStructure;
-			}
-
-			_layoutStructure = _mergeLayoutStructure(data, masterLayoutData);
-
-			return _layoutStructure;
-		}
-		catch (Exception exception) {
-			_log.error("Unable to get layout structure", exception);
-
-			return null;
-		}
-	}
-
-	private String _getMasterLayoutData(HttpServletRequest httpServletRequest) {
-		Layout layout = _getLayout(httpServletRequest);
-
-		LayoutPageTemplateEntry masterLayoutPageTemplateEntry =
-			LayoutPageTemplateEntryLocalServiceUtil.
-				fetchLayoutPageTemplateEntryByPlid(
-					layout.getMasterLayoutPlid());
-
-		if (masterLayoutPageTemplateEntry == null) {
-			return null;
-		}
-
-		LayoutPageTemplateStructure masterLayoutPageTemplateStructure =
-			LayoutPageTemplateStructureLocalServiceUtil.
-				fetchLayoutPageTemplateStructure(
-					masterLayoutPageTemplateEntry.getGroupId(),
-					masterLayoutPageTemplateEntry.getPlid());
-
-		if (masterLayoutPageTemplateStructure == null) {
-			return null;
-		}
-
-		return masterLayoutPageTemplateStructure.
-			getDefaultSegmentsExperienceData();
+		return _layoutStructure;
 	}
 
 	private long _getPlid(HttpServletRequest httpServletRequest) {
@@ -218,59 +136,7 @@ public class RenderFragmentLayoutTag extends IncludeTag {
 		return themeDisplay.getPlid();
 	}
 
-	private long _getSegmentsExperienceId() {
-		HttpServletRequest httpServletRequest = getRequest();
-
-		long selectedSegmentsExperienceId = ParamUtil.getLong(
-			httpServletRequest, "segmentsExperienceId", -1);
-
-		if (selectedSegmentsExperienceId != -1) {
-			return selectedSegmentsExperienceId;
-		}
-
-		long[] segmentsExperienceIds = GetterUtil.getLongValues(
-			httpServletRequest.getAttribute(
-				SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS),
-			new long[] {SegmentsExperienceConstants.ID_DEFAULT});
-
-		return segmentsExperienceIds[0];
-	}
-
-	private LayoutStructure _mergeLayoutStructure(
-		String data, String masterLayoutData) {
-
-		LayoutStructure masterLayoutStructure = LayoutStructure.of(
-			masterLayoutData);
-
-		LayoutStructure layoutStructure = LayoutStructure.of(data);
-
-		for (LayoutStructureItem layoutStructureItem :
-				layoutStructure.getLayoutStructureItems()) {
-
-			masterLayoutStructure.addLayoutStructureItem(layoutStructureItem);
-		}
-
-		DropZoneLayoutStructureItem dropZoneLayoutStructureItem =
-			(DropZoneLayoutStructureItem)
-				masterLayoutStructure.getDropZoneLayoutStructureItem();
-
-		dropZoneLayoutStructureItem.addChildrenItem(
-			layoutStructure.getMainItemId());
-
-		LayoutStructureItem rootStructureItem =
-			masterLayoutStructure.getLayoutStructureItem(
-				layoutStructure.getMainItemId());
-
-		rootStructureItem.setParentItemId(
-			dropZoneLayoutStructureItem.getItemId());
-
-		return masterLayoutStructure;
-	}
-
 	private static final String _PAGE = "/render_fragment_layout/page.jsp";
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		RenderFragmentLayoutTag.class);
 
 	private long _groupId;
 	private LayoutStructure _layoutStructure;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -181,9 +181,19 @@ public class RenderLayoutStructureTag extends IncludeTag {
 					httpServletResponse);
 
 		jspWriter.write("<div class=\"");
-		jspWriter.write(
-			renderLayoutStructureDisplayContext.getCssClass(
-				collectionStyledLayoutStructureItem));
+
+		if (renderLayoutStructureDisplayContext.isCommonStylesFFEnabled()) {
+			jspWriter.write(
+				renderLayoutStructureDisplayContext.
+					getLayoutStructureItemCssClass(
+						collectionStyledLayoutStructureItem));
+		}
+		else {
+			jspWriter.write(
+				renderLayoutStructureDisplayContext.getCssClass(
+					collectionStyledLayoutStructureItem));
+		}
+
 		jspWriter.write("\" style=\"");
 		jspWriter.write(
 			renderLayoutStructureDisplayContext.getStyle(
@@ -492,9 +502,44 @@ public class RenderLayoutStructureTag extends IncludeTag {
 		jspWriter.write(StringPool.LESS_THAN);
 		jspWriter.write(htmlTag);
 		jspWriter.write(" class=\"");
-		jspWriter.write(
-			renderLayoutStructureDisplayContext.getCssClass(
-				containerStyledLayoutStructureItem));
+
+		if (renderLayoutStructureDisplayContext.isCommonStylesFFEnabled()) {
+			jspWriter.write(
+				renderLayoutStructureDisplayContext.
+					getLayoutStructureItemCssClass(
+						containerStyledLayoutStructureItem));
+
+			if (Objects.equals(
+					containerStyledLayoutStructureItem.getWidthType(),
+					"fixed")) {
+
+				jspWriter.write(" container-fluid container-fluid-max-xl");
+			}
+
+			if (!Objects.equals(
+					containerStyledLayoutStructureItem.getDisplay(), "none")) {
+
+				if (Objects.equals(
+						containerStyledLayoutStructureItem.getContentDisplay(),
+						"flex-column")) {
+
+					jspWriter.write(" d-flex flex-column");
+				}
+				else if (Objects.equals(
+							containerStyledLayoutStructureItem.
+								getContentDisplay(),
+							"flex-row")) {
+
+					jspWriter.write(" d-flex flex-row");
+				}
+			}
+		}
+		else {
+			jspWriter.write(
+				renderLayoutStructureDisplayContext.getCssClass(
+					containerStyledLayoutStructureItem));
+		}
+
 		jspWriter.write("\" style=\"");
 		jspWriter.write(
 			renderLayoutStructureDisplayContext.getStyle(
@@ -633,9 +678,21 @@ public class RenderLayoutStructureTag extends IncludeTag {
 							collectionElementIndex);
 
 				jspWriter.write("<div class=\"");
-				jspWriter.write(
-					renderLayoutStructureDisplayContext.getCssClass(
-						fragmentStyledLayoutStructureItem));
+
+				if (renderLayoutStructureDisplayContext.
+						isCommonStylesFFEnabled()) {
+
+					jspWriter.write(
+						renderLayoutStructureDisplayContext.
+							getLayoutStructureItemCssClass(
+								fragmentStyledLayoutStructureItem));
+				}
+				else {
+					jspWriter.write(
+						renderLayoutStructureDisplayContext.getCssClass(
+							fragmentStyledLayoutStructureItem));
+				}
+
 				jspWriter.write("\" style=\"");
 				jspWriter.write(
 					renderLayoutStructureDisplayContext.getStyle(
@@ -779,9 +836,19 @@ public class RenderLayoutStructureTag extends IncludeTag {
 		}
 
 		jspWriter.write("<div class=\"");
-		jspWriter.write(
-			renderLayoutStructureDisplayContext.getCssClass(
-				rowStyledLayoutStructureItem));
+
+		if (renderLayoutStructureDisplayContext.isCommonStylesFFEnabled()) {
+			jspWriter.write(
+				renderLayoutStructureDisplayContext.
+					getLayoutStructureItemCssClass(
+						rowStyledLayoutStructureItem));
+		}
+		else {
+			jspWriter.write(
+				renderLayoutStructureDisplayContext.getCssClass(
+					rowStyledLayoutStructureItem));
+		}
+
 		jspWriter.write("\" style=\"");
 		jspWriter.write(
 			renderLayoutStructureDisplayContext.getStyle(


### PR DESCRIPTION
### References

- Story: https://issues.liferay.com/browse/LPS-147783
- Epic: https://issues.liferay.com/browse/LPS-132571

### What is the goal of this PR?
This PR moves the common styles css styles to a `<style>` tag 

### What does it look like?
- It creates a new `DynamicInclude` that is injected in the `<head>` of the page.
- Modifies the common-styles.json to add CSS styles templates for abstracting that part
- Now each layout structure item has a unique className where the styles will be applied: `lfr-layout-structure-item-<item-id>`
- When rendering each layout structure item, the css class and the styles of the common styles are not rendered, with a few exceptions:
    - Background image uses an adaptive media processor  that relies in the element having a `--background-image-file-entry-id` css variable
    - Also, the url of the background image is also added to a CSS variable `--lfr-<item-id>-background-image`, so that when the adaptive media doesn't apply (for example if the image comes from an url instead of the D&M). This is not mandatory but calculating it here is cheaper than having to move the calculation to the `DynamicInclude`.

