### PR TITLE
[TS] LPS-150759

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
@@ -14,6 +14,8 @@
 
 package com.liferay.layout.admin.web.internal.portlet.action;
 
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.portal.events.EventsProcessorUtil;
@@ -123,6 +125,16 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 
 			ServiceContext serviceContext = ServiceContextFactory.getInstance(
 				Layout.class.getName(), actionRequest);
+
+			if (layout.isTypeAssetDisplay() ||
+				(layout.isTypeContent() &&
+				 (layout.fetchDraftLayout() == null))) {
+
+				AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+					Layout.class.getName(), layout.getPlid());
+
+				serviceContext.setAssetCategoryIds(assetEntry.getCategoryIds());
+			}
 
 			String oldFriendlyURL = layout.getFriendlyURL();
 
@@ -252,6 +264,9 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 			throw modelListenerException;
 		}
 	}
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;


### PR DESCRIPTION
Hi Team,

could you please review my fix?

**Steps to reproduce:**

1. Start the bundle 
2. Create a Vocabulary, make it required for Pages
3. Create a Category in it
4. Create a Content page, select the category
5. Go to its Look and feel configuration and try to save it

**Current behavior:** You won't be able to do that, "Error:Your request failed to complete."

**Expected behavior**: You should be able to save the configuration

Solution
Based on the LayoutDetailsFormNavigatorEntry::isVisible logic we set the assetCategoryIds in the context in case the details form navigation entry is not visible.

https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/form/navigator/LayoutDetailsFormNavigatorEntry.java#L49-L57

Thanks, Roland

https://issues.liferay.com/browse/LPS-150759