### PR TITLE
LPS-96195

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -179,8 +179,13 @@ public class JournalContentDisplayContext {
 			}
 		}
 
-		_article = JournalArticleLocalServiceUtil.fetchLatestArticle(
-			articleResourcePrimKey, WorkflowConstants.STATUS_ANY, true);
+		JournalArticle article =
+			JournalArticleLocalServiceUtil.fetchLatestArticle(
+				articleResourcePrimKey, WorkflowConstants.STATUS_ANY, true);
+
+		if (article.getGroupId() == _themeDisplay.getScopeGroupId()) {
+			_article = article;
+		}
 
 		return _article;
 	}
@@ -1061,7 +1066,12 @@ public class JournalContentDisplayContext {
 				assetRendererFactory.getAssetRenderer(
 					assetEntry.getClassPK(), previewType);
 
-			return (JournalArticle)assetRenderer.getAssetObject();
+			JournalArticle article =
+				(JournalArticle)assetRenderer.getAssetObject();
+
+			if (article.getGroupId() == _themeDisplay.getScopeGroupId()) {
+				return article;
+			}
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -159,10 +159,16 @@ public class JournalContentExportImportPortletPreferencesProcessor
 			return portletPreferences;
 		}
 
-		long previousScopeGroupId = portletDataContext.getScopeGroupId();
+		if (articleGroupId != portletDataContext.getScopeGroupId()) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(
+					StringBundler.concat(
+						"Web content with group ID ", articleGroupId, " does ",
+						"not belong to the scope of the widget with scope ",
+						"group ID ", portletDataContext.getScopeGroupId()));
+			}
 
-		if (articleGroupId != previousScopeGroupId) {
-			portletDataContext.setScopeGroupId(articleGroupId);
+			return portletPreferences;
 		}
 
 		JournalArticle article = null;
@@ -189,8 +195,6 @@ public class JournalContentExportImportPortletPreferencesProcessor
 						" refers to an invalid article ID ", articleId));
 			}
 
-			portletDataContext.setScopeGroupId(previousScopeGroupId);
-
 			return portletPreferences;
 		}
 
@@ -198,8 +202,6 @@ public class JournalContentExportImportPortletPreferencesProcessor
 				portletDataContext.getParameterMap(),
 				PortletDataHandlerKeys.PORTLET_DATA) &&
 			MergeLayoutPrototypesThreadLocal.isInProgress()) {
-
-			portletDataContext.setScopeGroupId(previousScopeGroupId);
 
 			return portletPreferences;
 		}
@@ -255,8 +257,6 @@ public class JournalContentExportImportPortletPreferencesProcessor
 				throw portletDataException;
 			}
 		}
-
-		portletDataContext.setScopeGroupId(previousScopeGroupId);
 
 		return portletPreferences;
 	}

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
@@ -55,11 +55,11 @@ if (journalContentDisplayContext.isShowArticle()) {
 
 				<div class="alert alert-warning text-center">
 					<c:choose>
-						<c:when test="<%= (selectedArticle != null) && selectedArticle.isInTrash() %>">
-							<liferay-ui:message arguments="<%= HtmlUtil.escape(selectedArticle.getTitle(locale)) %>" key="the-web-content-article-x-was-moved-to-the-recycle-bin" />
-						</c:when>
 						<c:when test="<%= (selectedArticle != null) && (selectedArticle.getGroupId() != themeDisplay.getScopeGroupId()) %>">
 							<liferay-ui:message arguments="<%= HtmlUtil.escape(selectedArticle.getTitle(locale)) %>" key="the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget" />
+						</c:when>
+						<c:when test="<%= (selectedArticle != null) && selectedArticle.isInTrash() %>">
+							<liferay-ui:message arguments="<%= HtmlUtil.escape(selectedArticle.getTitle(locale)) %>" key="the-web-content-article-x-was-moved-to-the-recycle-bin" />
 						</c:when>
 						<c:when test="<%= (selectedArticle != null) && (selectedArticle.getDDMStructure() == null) %>">
 							<liferay-ui:message arguments="<%= HtmlUtil.escape(selectedArticle.getTitle(locale)) %>" key="is-temporarily-unavailable" />

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
@@ -58,6 +58,9 @@ if (journalContentDisplayContext.isShowArticle()) {
 						<c:when test="<%= (selectedArticle != null) && selectedArticle.isInTrash() %>">
 							<liferay-ui:message arguments="<%= HtmlUtil.escape(selectedArticle.getTitle(locale)) %>" key="the-web-content-article-x-was-moved-to-the-recycle-bin" />
 						</c:when>
+						<c:when test="<%= (selectedArticle != null) && (selectedArticle.getGroupId() != themeDisplay.getScopeGroupId()) %>">
+							<liferay-ui:message arguments="<%= HtmlUtil.escape(selectedArticle.getTitle(locale)) %>" key="the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget" />
+						</c:when>
 						<c:when test="<%= (selectedArticle != null) && (selectedArticle.getDDMStructure() == null) %>">
 							<liferay-ui:message arguments="<%= HtmlUtil.escape(selectedArticle.getTitle(locale)) %>" key="is-temporarily-unavailable" />
 						</c:when>

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -15495,6 +15495,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=The vocabulary could not be found.
 the-web-content=The web content
 the-web-content-article-could-not-be-created=The web content article could not be created.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget.
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin.
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content
 the-web-content-could-not-be-found=The Web Content could not be found.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=مجموعة تعبير �
 the-vocabulary-could-not-be-found=لم يتم العثور على التصنيف.
 the-web-content=محتوى الصفحة
 the-web-content-article-could-not-be-created=تعذر إنشاء مقالة محتوى الويب.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=تم نقل مقالة محتوى الويب <strong><em>{0}</em></strong> إلى "سلة المحذوفات".
 the-web-content-compared-with-the-previous-version-web-content=محتوى الصفحة مقارنة بمحتوى صفحة سابقة
 the-web-content-could-not-be-found=لم يتم العثور على المناسبة.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Категорията не може да бъде намерена.
 the-web-content=Съдържанието на страницата
 the-web-content-article-could-not-be-created=Статията за уеб съдържание не можа да бъде създадена. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Уеб съдържанието в сравнение с уеб съдържанието на предишната версия (Automatic Translation)
 the-web-content-could-not-be-found=Уеб съдържанието не може да бъде намерено.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -15491,6 +15491,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=L'expressió de visibilit
 the-vocabulary-could-not-be-found=No s'ha trobat la categoria.
 the-web-content=El contingut de la pàgina
 the-web-content-article-could-not-be-created=L'article de contingut web no s'ha pogut crear.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=L'article de contingut web <strong><em>{0}</em></strong> s'ha desplaçat a la paperera de reciclatge.
 the-web-content-compared-with-the-previous-version-web-content=El contingut de la pàgina comparat amb la versió anterior del mateix
 the-web-content-could-not-be-found=No s'ha pogut trobar el contingut web.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Kategorie nebyla nalezena.
 the-web-content=Obsah stránky
 the-web-content-article-could-not-be-created=Článek o webovém obsahu nelze vytvořit. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Porovnání obsahu stránky s její předchozí verzí
 the-web-content-could-not-be-found=Webový obsah nebyl nalezen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=The webindhold could not be found.
 the-web-content=The web content (Automatic Copy)
 the-web-content-article-could-not-be-created=Artiklen om webindhold kunne ikke oprettes. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content (Automatic Copy)
 the-web-content-could-not-be-found=The webindhold could not be found.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -15491,6 +15491,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=Der Ausdruck für die Sic
 the-vocabulary-could-not-be-found=Das Vokabular wurde nicht gefunden.
 the-web-content=Seiteninhalt
 the-web-content-article-could-not-be-created=Der Webcontent- Artikel konnte nicht erstellt werden.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=Der Web-Inhalt-Artikel <strong><em>{0}</em></strong> wurde in den Papierkorb verschoben.
 the-web-content-compared-with-the-previous-version-web-content=Vergleich des Seiteninhalt mit dem Seiteninhalt der vorhergehenden Version
 the-web-content-could-not-be-found=Der Webcontent konnte nicht gefunden werden.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Η κατηγορία δεν μπόρεσε να βρεθεί.
 the-web-content=Το περιεχόμενο της σελίδας
 the-web-content-article-could-not-be-created=Δεν ήταν δυνατή η δημιουργία του άρθρου περιεχομένου Web. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Το περιεχόμενο της σελίδας συγκρινόμενο με το περιεχόμενο των προηγούμενων εκδόσεων της σελίδας
 the-web-content-could-not-be-found=Το περιεχόμενο Web δεν βρέθηκε.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -15495,6 +15495,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=The vocabulary could not be found.
 the-web-content=The web content
 the-web-content-article-could-not-be-created=The web content article could not be created.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget.
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin.
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content
 the-web-content-could-not-be-found=The Web Content could not be found.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=The vocabulary could not be found. (Automatic Copy)
 the-web-content=The web content (Automatic Copy)
 the-web-content-article-could-not-be-created=The web content article could not be created. (Automatic Copy)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content (Automatic Copy)
 the-web-content-could-not-be-found=The Web Content could not be found. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=The vocabulary could not be found. (Automatic Copy)
 the-web-content=The web content (Automatic Copy)
 the-web-content-article-could-not-be-created=The web content article could not be created. (Automatic Copy)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content (Automatic Copy)
 the-web-content-could-not-be-found=The Web Content could not be found. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -15491,6 +15491,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=La expresión de visibili
 the-vocabulary-could-not-be-found=La categoría no ha sido encontrada.
 the-web-content=El contenido de la página
 the-web-content-article-could-not-be-created=No se pudo crear el artículo de contenido web.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=El artículo de contenido web <strong><em>{0}</em></strong> se movió a la Papelera de reciclaje.
 the-web-content-compared-with-the-previous-version-web-content=El contenido de la página comparado la versión previa del mismo
 the-web-content-could-not-be-found=No se ha encontrado el contenido web

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Seda kategooriat ei leitud.
 the-web-content=Lehe sisu
 the-web-content-article-could-not-be-created=Veebisisu artiklit ei saanud luua. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Veebisisu võrreldes eelmise versiooni veebisisuga (Automatic Translation)
 the-web-content-could-not-be-found=Veebisisu ei leitud.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Kategoria ezin izan da aurkitu.
 the-web-content=Orriaren edukia
 the-web-content-article-could-not-be-created=The web content article could not be created. (Automatic Copy)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Orriaren edukia orriaren aurreko bertsioarekin konparatuta
 the-web-content-could-not-be-found=Web edukia ezin da aurkitu.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=مشاهده عبارت (
 the-vocabulary-could-not-be-found=واژه يافت نشد.
 the-web-content=محتوای وب
 the-web-content-article-could-not-be-created=مقاله محتوای وب را نمی توان ایجاد کرد. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=محتوای وب در مقایسه با نسخه قبلی
 the-web-content-could-not-be-found=رویداد یافت نشد.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -15487,6 +15487,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=Kentälle {1} asetettu n�
 the-vocabulary-could-not-be-found=Luokitusta ei löydy.
 the-web-content=Sivun sisältö
 the-web-content-article-could-not-be-created=Verkon sisältöartikkelia ei voitu luoda.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=Web-sisältöartikkeli <strong><em>{0}</em></strong> siirrettiin Roskakoriin.
 the-web-content-compared-with-the-previous-version-web-content=Sivun sisältö verratuna edelliseen versioon sivun sisällöstä.
 the-web-content-could-not-be-found=Web-sisältöä ei löytynyt

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -15491,6 +15491,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=L'expression de visibilit
 the-vocabulary-could-not-be-found=La catégorie n'a pu être trouvée.
 the-web-content=Le contenu de page
 the-web-content-article-could-not-be-created=L'article de contenu Web n'a pas pu être créé.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=L'article de contenu web <strong><em>{0}</em></strong> a été déplacé dans la Corbeille.
 the-web-content-compared-with-the-previous-version-web-content=Le contenu de page a rivalisé avec le contenu de page de version préalable
 the-web-content-could-not-be-found=Le contenu web ne peut pas être trouvé.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=L'expression de visibilit
 the-vocabulary-could-not-be-found=La catégorie n'a pu être trouvée.
 the-web-content=Le contenu de page
 the-web-content-article-could-not-be-created=L'article de contenu Web n'a pas pu être créé.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=L'article de contenu web <strong><em>{0}</em></strong> a été déplacé dans la Corbeille.
 the-web-content-compared-with-the-previous-version-web-content=Le contenu de page a rivalisé avec le contenu de page de version préalable
 the-web-content-could-not-be-found=Le contenu web ne peut pas être trouvé.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=A categoría non foi atopada.
 the-web-content=O contido da páxina
 the-web-content-article-could-not-be-created=The web content article could not be created. (Automatic Copy)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=O contido da páxina comparado coa versión anterior do contido da páxina
 the-web-content-could-not-be-found=O contido web non foi atopado.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=केटेगरी पायी नहीं जा सकी|
 the-web-content=वेब सामग्री (Automatic Translation)
 the-web-content-article-could-not-be-created=वेब सामग्री लेख नहीं बनाया जा सका। (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=पिछले संस्करण वेब सामग्री की तुलना में वेब सामग्री (Automatic Translation)
 the-web-content-could-not-be-found=वेब कॉंटेंट पाया नहीं जा सका|

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Kategoriju nije moguće pronaći.
 the-web-content=Sadržaj stranice
 the-web-content-article-could-not-be-created=The web content article could not be created. (Automatic Copy)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Sadržaja stranice u odnosu na prethodnu verziju sadržaja stranice
 the-web-content-could-not-be-found=Web Sadržaj nije mogao biti pronađen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -15492,6 +15492,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=A {1} mezőhöz beállít
 the-vocabulary-could-not-be-found=A szótár nem található.
 the-web-content=A webes tartalom
 the-web-content-article-could-not-be-created=A webes tartalom cikke nem hozható létre.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=A webes tartalom <strong><em>{0}</em></strong> cikke a Lomtárba került.
 the-web-content-compared-with-the-previous-version-web-content=A webes tartalom összehasonlítva a webes tartalom előző verziójával
 the-web-content-could-not-be-found=A webes tartalom nem található.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Kategori ini tidak dapat ditemukan.
 the-web-content=Isi Halaman
 the-web-content-article-could-not-be-created=Artikel konten web tak bisa dibuat. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Konten halaman dibandingkan dengan konten halaman yang versi sebelumnya
 the-web-content-could-not-be-found=Konten Web tidak dapat ditemukan.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -15490,6 +15490,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=L'espressione di visibili
 the-vocabulary-could-not-be-found=Vocabolario non trovato.
 the-web-content=Contenuto Web
 the-web-content-article-could-not-be-created=Impossibile creare l'articolo sul contenuto Web. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Confronto tra il contenuto web e la sua versione precedente
 the-web-content-could-not-be-found=Non è stato possibile trovare il Contenuto Web.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=ביטוי הנראות (
 the-vocabulary-could-not-be-found=אוצר המילים לא נמצא.
 the-web-content=תוכן הדף
 the-web-content-article-could-not-be-created=לא היתה אפשרות ליצור את מאמר תוכן האינטרנט. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=מאמר התוכן מאתר אינטרנט <strong><em>{0}</em></strong> הועבר אל סל המיחזור.
 the-web-content-compared-with-the-previous-version-web-content=תוכן הדף בהשוואה לתוכן הדף בגרסתו הקודמת.
 the-web-content-could-not-be-found=תוכן האינטרנט לא נמצא

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -15491,6 +15491,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid={1}に設定された表�
 the-vocabulary-could-not-be-found=ボキャブラリが見つかりません。
 the-web-content=Webコンテンツ
 the-web-content-article-could-not-be-created=Webコンテンツの記事を作成できませんでした。
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=Webコンテンツの記事 <strong><em>{0}</em></strong> は、ごみ箱に移動されました。
 the-web-content-compared-with-the-previous-version-web-content=前のバージョンのWebコンテンツと現在のWebコンテンツを比較
 the-web-content-could-not-be-found=Webコンテンツが見つかりません。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=The vocabulary could not be found. (Automatic Copy)
 the-web-content=The web content (Automatic Copy)
 the-web-content-article-could-not-be-created=The web content article could not be created. (Automatic Copy)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content (Automatic Copy)
 the-web-content-could-not-be-found=The Web Content could not be found. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -15488,6 +15488,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=종류는 발견될 수 없었다.
 the-web-content=페이지 내용
 the-web-content-article-could-not-be-created=웹 콘텐츠 문서를 만들 수 없습니다. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=페이지 내용은 이전 버전 페이지 내용과 비교했다
 the-web-content-could-not-be-found=웹 내용은 찾아낼 수 없었다.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=ບໍ່ສາມາດຊອກຫາໝວດໝູ່ໄດ້
 the-web-content=ເນື້ອຫາໃນໜ້າ
 the-web-content-article-could-not-be-created=The web content article could not be created. (Automatic Copy)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=ໜ້າເນື້ອຫາໄດ້ປຽບທຽບກັບໜ້າເນື້ອຫາເວີເຊີ້ນກ່ອນໜ້ານີ້
 the-web-content-could-not-be-found=ບໍ່ສາມາດຊອກຫາຫົວຂໍ້ໄດ້

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Žodyno rasti nepavyko. (Automatic Translation)
 the-web-content=Žiniatinklio turinys (Automatic Translation)
 the-web-content-article-could-not-be-created=Nepavyko sukurti žiniatinklio turinio straipsnio. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Žiniatinklio turinys, palyginti su ankstesnės versijos žiniatinklio turiniu (Automatic Translation)
 the-web-content-could-not-be-found=Nepavyko rasti žiniatinklio turinio. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Perbendaharaan kata tidak dapat dijumpai. (Automatic Translation)
 the-web-content=Kandungan web (Automatic Translation)
 the-web-content-article-could-not-be-created=Artikel kandungan web tidak dapat dicipta. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Kandungan web berbanding dengan kandungan web versi terdahulu (Automatic Translation)
 the-web-content-could-not-be-found=Kandungan Web tidak dijumpai. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=Synlighetsuttrykket ({0})
 the-vocabulary-could-not-be-found=Kategorien ble ikke funnet.
 the-web-content=Sideinnholdet
 the-web-content-article-could-not-be-created=Webinnholdartikkelen kunne ikke lagres.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=Webinnholdsartikkelen <strong><em>{0}</em></strong> ble flyttet til søppelkassa.
 the-web-content-compared-with-the-previous-version-web-content=Sidens innhold sammenlignet med den tidligere versjonens innhold
 the-web-content-could-not-be-found=Web-innholdet ble ikke funnet.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -15492,6 +15492,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=De weergave-expressie ({0
 the-vocabulary-could-not-be-found=De categorie werd niet gevonden.
 the-web-content=De pagina-inhoud
 the-web-content-article-could-not-be-created=Webinhoudartikel maken mislukt.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=Het webinhoudartikel <strong><em>{0}</em></strong> werd verplaatst naar de prullenbak.
 the-web-content-compared-with-the-previous-version-web-content=De pagina-inhoud in vergelijking met de vorige versie
 the-web-content-could-not-be-found=De webcontent werd niet gevonden.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -15492,6 +15492,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=De categorie kon niet worden gevonden.
 the-web-content=De pagina-inhoud
 the-web-content-article-could-not-be-created=The web content article could not be created. (Automatic Copy)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=De pagina-inhoud die met de vorige versie wordt vergeleken
 the-web-content-could-not-be-found=Web Content kon niet worden gevonden.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Nie odnaleziono kategorii.
 the-web-content=Zawartość strony
 the-web-content-article-could-not-be-created=Nie można utworzyć artykułu o zawartości sieci Web. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Treść strony w porównaniu do poprzedniej wersji treści strony
 the-web-content-could-not-be-found=Podana zawartość strony nie została odnaleziona.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=A expressão ({0}), que c
 the-vocabulary-could-not-be-found=A categoria não pode ser encontrada.
 the-web-content=O conteúdo da página
 the-web-content-article-could-not-be-created=O artigo de conteúdo da web não pôde ser criado.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=O artigo <strong><em>{0}</em></strong> foi movido para a Lixeira.
 the-web-content-compared-with-the-previous-version-web-content=O conteúdo da página comparado com o conteúdo da página da versão anterior
 the-web-content-could-not-be-found=O conteúdo web não pode ser encontrado.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -15491,6 +15491,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=A expressão de visibilid
 the-vocabulary-could-not-be-found=O vocabulário não pôde ser encontrado.
 the-web-content=O conteúdo web
 the-web-content-article-could-not-be-created=O artigo de conteúdo da web não pôde ser criado. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=O conteúdo web comparado com o conteúdo web da versão anterior
 the-web-content-could-not-be-found=O conteúdo web não pode ser encontrado.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Categoria nu a putut fi gasita.
 the-web-content=Continutul de pagina
 the-web-content-article-could-not-be-created=Imposibil de creat articolul de conținut Web. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Continutul de pagina comparat cu continutul de pagina anterior
 the-web-content-could-not-be-found=Continutul Wen nu a putut fi gasit

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Категория не найдена.
 the-web-content=Содержимое страницы
 the-web-content-article-could-not-be-created=Статья веб-контента не может быть создана. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Контент страницы в сравнении с предыдущей версией страницы
 the-web-content-could-not-be-found=Сетевой контент не найден.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Kategória sa nenašla.
 the-web-content=Obsah stránky
 the-web-content-article-could-not-be-created=Článok o webovom obsahu sa nepodarilo vytvoriť. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Porovnanie obsahu stránky s predchádzajúcou verziou
 the-web-content-could-not-be-found=Webový obsah sa nenašiel.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Kategorije ni moč najti.
 the-web-content=Vsebina strani
 the-web-content-article-could-not-be-created=Članka spletne vsebine ni bilo mogoče ustvariti. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Spletna vsebina v primerjavi s prejšnjo različico spletne vsebine (Automatic Translation)
 the-web-content-could-not-be-found=Spletne vsebine ni moč najti

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Категорија није пронађена.
 the-web-content=Садржај странице
 the-web-content-article-could-not-be-created=The web content article could not be created. (Automatic Copy)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Садржај странице у односу на претходне верзије садржаја странице
 the-web-content-could-not-be-found=Веб садржај није могао бити пронађен.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=The vocabulary could not be found. (Automatic Copy)
 the-web-content=The web content (Automatic Copy)
 the-web-content-article-could-not-be-created=The web content article could not be created. (Automatic Copy)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content (Automatic Copy)
 the-web-content-could-not-be-found=Veb sadržaj nije mogao biti pronađen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=Synlighetsuttrycket ({0})
 the-vocabulary-could-not-be-found=Kategorin kunde inte hittas.
 the-web-content=Sidans innehåll
 the-web-content-article-could-not-be-created=Det gick inte att skapa webbinnehållsartikel.
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=Webbinnehållsartikeln <strong><em>{0}</em></strong> har flyttats till papperskorgen.
 the-web-content-compared-with-the-previous-version-web-content=Sidans innehåll jämfört med den föregående sidans innehåll
 the-web-content-could-not-be-found=Artikeln hittades inte.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=புலம் {1} க�
 the-vocabulary-could-not-be-found=Vocabulary காணப்படவில்லை.
 the-web-content=வலை உள்ளடக்கம்
 the-web-content-article-could-not-be-created=The web content article could not be created. (Automatic Copy)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=<strong><em>{0}</em></strong> web content articles ரீசைகிள் பின்னுக்கு மாற்றப்பட்டது.
 the-web-content-compared-with-the-previous-version-web-content=The web content compared with the previous version web content (Automatic Copy)
 the-web-content-could-not-be-found=Web Content காணப்படவில்லை.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=การมองเห�
 the-vocabulary-could-not-be-found=ไม่พบคำศัพท์
 the-web-content=เนื้อหาเว็บ (Automatic Translation)
 the-web-content-article-could-not-be-created=ไม่สามารถสร้างบทความเนื้อหาเว็บได้ (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=บทความเนื้อหาเว็บ <strong><em>{0}</em> </strong> ถูกย้ายไปยังถังรีไซเคิล
 the-web-content-compared-with-the-previous-version-web-content=เนื้อหาเว็บเปรียบเทียบกับเนื้อหาเว็บเวอร์ชันก่อนหน้า (Automatic Translation)
 the-web-content-could-not-be-found=ไม่พบเนื้อหาบนเว็บ (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Kategori bulunamadı.
 the-web-content=Sayfa İçeriği
 the-web-content-article-could-not-be-created=Web içeriği makalesi oluşturulamadı. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Önceki sürüm web içeriğiyle karşılaştırıldığında web içeriği (Automatic Translation)
 the-web-content-could-not-be-found=Web İçeriği bulunamadı.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Категорія не знайдена.
 the-web-content=Зміст сторінки
 the-web-content-article-could-not-be-created=Не вдалося створити статтю веб-вмісту. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=Веб-вміст у порівнянні з веб-вмістом попередньої версії (Automatic Translation)
 the-web-content-could-not-be-found=Події не знайдено.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -15489,6 +15489,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=The visibility expression
 the-vocabulary-could-not-be-found=Chuyên mục không tìm thấy.
 the-web-content=Nội dung trang
 the-web-content-article-could-not-be-created=Không thể tạo bài viết nội dung web. (Automatic Translation)
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=The web content article <strong><em>{0}</em></strong> was moved to the Recycle Bin. (Automatic Copy)
 the-web-content-compared-with-the-previous-version-web-content=So sánh nội dung trang hiện tại với phiên bản trước
 the-web-content-could-not-be-found=Bài viết không được tìm thấy.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -15491,6 +15491,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=设置为字段{1}的可�
 the-vocabulary-could-not-be-found=找不到相应类别。
 the-web-content=web 内容
 the-web-content-article-could-not-be-created=无法创建该 Web 内容文章。
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=Web 内容文章 <strong><em>{0}</em></strong> 已移动到回收站中。
 the-web-content-compared-with-the-previous-version-web-content=web 内容与上一个版本的 web 内容相比
 the-web-content-could-not-be-found=无法找到 Web 内容。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -15490,6 +15490,7 @@ the-visibility-expression-x-set-for-field-x-is-invalid=為欄位 {1} 設定的�
 the-vocabulary-could-not-be-found=找不到字彙。
 the-web-content=頁面內容
 the-web-content-article-could-not-be-created=網站內容文章不能被建立。
+the-web-content-article-x-does-not-belong-to-the-scope-of-this-widget=The web content article <strong><em>{0}</em></strong> does not belong to the scope of this widget. (Automatic Copy)
 the-web-content-article-x-was-moved-to-the-recycle-bin=網站內容文章 <strong><em>{0}</em></strong> 已被移至資源回收桶。
 the-web-content-compared-with-the-previous-version-web-content=頁面內容相較於先前版本頁面內容
 the-web-content-could-not-be-found=找不到網站內容。


### PR DESCRIPTION
Hi Echo Team,

Please see the discussion on [PTR-2951](https://issues.liferay.com/browse/PTR-2951) for context about why we are treating this as a bug.

Admittedly, I deviated a little bit in my implementation of this from what we had agreed on in [PTR-2951](https://issues.liferay.com/browse/PTR-2951). This is because, after the discussion in [PTR-2951](https://issues.liferay.com/browse/PTR-2951) concluded, I investigated how the Wiki Display Portlet solved this issue, so that I could model my implementation on that. It turns out that the Wiki Display Portlet does NOT unset the configuration for the Wiki Page when the scope is changed. Instead, it simply refuses to show the Wiki Page if the groupId of the Wiki Page does not match the scopeGroupId of the portlet.

Therefore, I tried to implement similar behavior here for the Web Content Display Portlet.

Also, this solution does not require an upgrade process as we had previously discussed on [PTR-2951](https://issues.liferay.com/browse/PTR-2951), because with this solution, the PortletPreferences are not considered as "invalid" if there is a mismatch between the scopeGroupId and the configured article's groupId. Instead, such a mismatch is handled when rendering the Web Content Display Portlet.

I also added a commit to avoid exporting the configured Web Content Article as a dependency of the Web Content Display Portlet in this mismatch case, to prevent the bug reported on [https://issues.liferay.com/browse/LPS-149713](LPS-149713).

Please, let me know if you have any questions or disagreements about this.