### PR TITLE
[TS] LPS-149557

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
@@ -39,11 +39,13 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ModelHintsConstants;
 import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactory;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletPreferenceValueLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
@@ -441,8 +443,19 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 
 		long plid = 0;
 
+		Layout layout = null;
+
+		long portletPreferencesPlid = 0;
+
 		if (jxPortletPreferences instanceof PortletPreferencesImpl) {
 			plid = layoutPlid;
+
+			PortletPreferencesImpl jxPortletPreferencesImpl =
+				(PortletPreferencesImpl)jxPortletPreferences;
+
+			portletPreferencesPlid = jxPortletPreferencesImpl.getPlid();
+
+			layout = _layoutLocalService.fetchLayout(portletPreferencesPlid);
 		}
 
 		for (com.liferay.portal.kernel.model.PortletPreferences
@@ -459,11 +472,24 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 				continue;
 			}
 
-			_portletPreferencesLocalService.updatePreferences(
-				portletPreferencesImpl.getOwnerId(),
-				portletPreferencesImpl.getOwnerType(),
-				portletPreferencesImpl.getPlid(),
-				portletPreferencesImpl.getPortletId(), jxPortletPreferences);
+			if (layout != null) {
+				_portletPreferencesLocalService.updatePreferences(
+					portletPreferencesImpl.getOwnerId(),
+					portletPreferencesImpl.getOwnerType(),
+					portletPreferencesImpl.getPlid(),
+					portletPreferencesImpl.getPortletId(),
+					jxPortletPreferences);
+			}
+			else {
+				_portletPreferencesLocalService.updatePreferences(
+					portletPreferencesImpl.getOwnerId(),
+					portletPreferencesImpl.getOwnerType(),
+					portletPreferencesPlid,
+					portletPreferencesImpl.getPortletId(),
+					currentPortletPreferences);
+
+				break;
+			}
 		}
 	}
 
@@ -554,6 +580,9 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 	@Reference
 	private LayoutClassedModelUsageLocalService
 		_layoutClassedModelUsageLocalService;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private LayoutPageTemplateEntryLocalService


### PR DESCRIPTION
Hi team,

This is a fix for a scenario of embedded portlets via <lfr-widget-*> tags in fragment-based pages under Staging with Page Versioning enabled.

When the PortletFragmentEntryProcessor processes the portlet preferences of this kind of portlets, it updates the layout's portlet preferences with the default ones if needed, but when Page Versioning is enabled Layout Revisions are returned and their related portlet preferences have to be updated with the layout's portlet preferences.

Could you please review it?

Please, let me know if you need further clarifications.

Thanks!

https://issues.liferay.com/browse/LPS-149557

\cc @noornajj