### PR TITLE
LPS-150278 Prevent users from hiding input fragments

### DIFF
--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/constants/FragmentConstants.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/constants/FragmentConstants.java
@@ -30,6 +30,10 @@ public class FragmentConstants {
 
 	public static final String TYPE_COMPONENT_LABEL = "component";
 
+	public static final int TYPE_INPUT = 3;
+
+	public static final String TYPE_INPUT_LABEL = "input";
+
 	public static final int TYPE_REACT = 2;
 
 	public static final String TYPE_REACT_LABEL = "react";
@@ -47,6 +51,10 @@ public class FragmentConstants {
 			return TYPE_REACT;
 		}
 
+		if (Objects.equals(TYPE_INPUT_LABEL, label)) {
+			return TYPE_INPUT;
+		}
+
 		return TYPE_SECTION;
 	}
 
@@ -57,6 +65,10 @@ public class FragmentConstants {
 
 		if (type == TYPE_REACT) {
 			return TYPE_REACT_LABEL;
+		}
+
+		if (type == TYPE_INPUT) {
+			return TYPE_INPUT_LABEL;
 		}
 
 		return TYPE_SECTION_LABEL;

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/contributor/FragmentCollectionContributorTrackerImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/contributor/FragmentCollectionContributorTrackerImpl.java
@@ -341,7 +341,8 @@ public class FragmentCollectionContributorTrackerImpl
 	}
 
 	private static final int[] _SUPPORTED_FRAGMENT_TYPES = {
-		FragmentConstants.TYPE_COMPONENT, FragmentConstants.TYPE_SECTION
+		FragmentConstants.TYPE_COMPONENT, FragmentConstants.TYPE_INPUT,
+		FragmentConstants.TYPE_SECTION
 	};
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -18,6 +18,7 @@ import com.liferay.asset.categories.item.selector.AssetCategoryTreeNodeItemSelec
 import com.liferay.asset.categories.item.selector.criterion.AssetCategoryTreeNodeItemSelectorCriterion;
 import com.liferay.document.library.kernel.model.DLFileEntryConstants;
 import com.liferay.exportimport.kernel.staging.StagingUtil;
+import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.constants.FragmentEntryLinkConstants;
 import com.liferay.fragment.contributor.FragmentCollectionContributor;
 import com.liferay.fragment.contributor.FragmentCollectionContributorTracker;
@@ -1622,6 +1623,9 @@ public class ContentPageEditorDisplayContext {
 						"fragmentEntryLinkId",
 						String.valueOf(
 							fragmentEntryLink.getFragmentEntryLinkId())
+					).put(
+						"fragmentType",
+						FragmentConstants.getTypeLabel(fragmentEntry.getType())
 					).put(
 						"masterLayout",
 						layout.getMasterLayoutPlid() ==

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/FragmentEntryLinkUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/FragmentEntryLinkUtil.java
@@ -14,6 +14,7 @@
 
 package com.liferay.layout.content.page.editor.web.internal.util;
 
+import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.constants.FragmentEntryLinkConstants;
 import com.liferay.fragment.contributor.FragmentCollectionContributorTracker;
 import com.liferay.fragment.entry.processor.util.EditableFragmentEntryProcessorUtil;
@@ -220,6 +221,9 @@ public class FragmentEntryLinkUtil {
 			).put(
 				"fragmentEntryLinkId",
 				String.valueOf(fragmentEntryLink.getFragmentEntryLinkId())
+			).put(
+				"fragmentType",
+				FragmentConstants.getTypeLabel(fragmentEntry.getType())
 			).put(
 				"icon", icon
 			).put(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTree.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTree.js
@@ -279,6 +279,21 @@ function isItemHidden(item, selectedViewportSize) {
 	return responsiveConfig.styles.display === 'none';
 }
 
+function isHidable(item, fragmentEntryLinks, layoutData) {
+	if (!isRemovable(item, layoutData)) {
+		return false;
+	}
+
+	if (item.type !== LAYOUT_DATA_ITEM_TYPES.fragment) {
+		return true;
+	}
+
+	const fragmentEntryLink =
+		fragmentEntryLinks[item.config.fragmentEntryLinkId];
+
+	return fragmentEntryLink.fragmentType !== 'input';
+}
+
 function isRemovable(item, layoutData) {
 	if (
 		item.type === LAYOUT_DATA_ITEM_TYPES.dropZone ||
@@ -380,6 +395,7 @@ function visit(
 					dragAndDropHoveredItemId,
 					draggable: false,
 					expanded: childId === activeItemId,
+					hidable: false,
 					hidden: false,
 					hiddenAncestor: hasHiddenAncestor || hidden,
 					icon: EDITABLE_TYPE_ICONS[type],
@@ -489,6 +505,9 @@ function visit(
 		expanded:
 			item.itemId === activeItemId ||
 			dragAndDropHoveredItemId === item.itemId,
+		hidable:
+			!itemInMasterLayout &&
+			isHidable(item, fragmentEntryLinks, layoutData),
 		hidden,
 		hiddenAncestor: hasHiddenAncestor,
 		icon,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTreeNode.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTreeNode.js
@@ -320,7 +320,7 @@ function StructureTreeNodeContent({
 						node.hidden || node.hiddenAncestor,
 				})}
 			>
-				{(node.removable || node.hidden) && (
+				{(node.hidable || node.hidden) && (
 					<VisibilityButton
 						dispatch={dispatch}
 						node={node}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FieldSet.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/item-configuration-panels/FieldSet.js
@@ -39,6 +39,31 @@ export function fieldIsDisabled(item, field) {
 	);
 }
 
+function getAvailableFields(item, fields, fragmentEntryLinks, viewportSize) {
+	let availableFields = fields;
+
+	if (viewportSize !== VIEWPORT_SIZES.desktop) {
+		availableFields = fields.filter(
+			(field) => field.responsive || field.name === 'backgroundImage'
+		);
+	}
+
+	if (item.type !== LAYOUT_DATA_ITEM_TYPES.fragment) {
+		return availableFields;
+	}
+
+	const fragmentEntryLink =
+		fragmentEntryLinks[item.config.fragmentEntryLinkId];
+
+	if (fragmentEntryLink.fragmentType === 'input') {
+		availableFields = availableFields.filter(
+			(field) => field.name !== 'display'
+		);
+	}
+
+	return availableFields;
+}
+
 export function FieldSet({
 	fields,
 	item = {},
@@ -49,15 +74,14 @@ export function FieldSet({
 }) {
 	const store = useSelector((state) => state);
 
-	const {selectedViewportSize} = store;
+	const {fragmentEntryLinks, selectedViewportSize} = store;
 
-	const availableFields =
-		selectedViewportSize === VIEWPORT_SIZES.desktop
-			? fields
-			: fields.filter(
-					(field) =>
-						field.responsive || field.name === 'backgroundImage'
-			  );
+	const availableFields = getAvailableFields(
+		item,
+		fields,
+		fragmentEntryLinks,
+		selectedViewportSize
+	);
 
 	return availableFields.length > 0 && label ? (
 		<Collapse label={label} open>


### PR DESCRIPTION
Dear reviewer,

As we still don't have any fragment of type input, in order to test this, the best option is to duplicate a basic component in `fragment-collection-contributor` module and change its type from `component` to `input`.

Regards,
Sandro
❤️