### PR TITLE
LPS-151745

### DIFF
--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/FragmentStyledLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/FragmentStyledLayoutStructureItem.java
@@ -18,10 +18,18 @@ import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
 import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
 import com.liferay.petra.lang.HashUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.PortletIdCodec;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.permission.PortletPermissionUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsValues;
 
 import java.util.Objects;
 
@@ -93,6 +101,56 @@ public class FragmentStyledLayoutStructureItem
 
 	public boolean isIndexed() {
 		return _indexed;
+	}
+
+	@Override
+	public boolean isVisible(ThemeDisplay themeDisplay) {
+		if (PropsValues.LAYOUT_SHOW_PORTLET_ACCESS_DENIED) {
+			return true;
+		}
+
+		FragmentEntryLink fragmentEntryLink =
+			FragmentEntryLinkLocalServiceUtil.fetchFragmentEntryLink(
+				getFragmentEntryLinkId());
+
+		if (fragmentEntryLink == null) {
+			return true;
+		}
+
+		JSONObject fragmentEntryJSONObject = null;
+
+		try {
+			fragmentEntryJSONObject = JSONFactoryUtil.createJSONObject(
+				fragmentEntryLink.getEditableValues());
+		}
+		catch (JSONException jsonException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(jsonException, jsonException);
+			}
+
+			return true;
+		}
+
+		String portletId = PortletIdCodec.encode(
+			fragmentEntryJSONObject.getString("portletId"),
+			fragmentEntryJSONObject.getString("instanceId"));
+
+		if (Validator.isNull(portletId)) {
+			return true;
+		}
+
+		try {
+			return PortletPermissionUtil.contains(
+				themeDisplay.getPermissionChecker(), themeDisplay.getLayout(),
+				portletId, ActionKeys.VIEW);
+		}
+		catch (PortalException portalException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(portalException, portalException);
+			}
+
+			return true;
+		}
 	}
 
 	public void setFragmentEntryLinkId(long fragmentEntryLinkId) {

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/LayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/LayoutStructureItem.java
@@ -18,6 +18,7 @@ import com.liferay.petra.lang.HashUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 
 import java.util.ArrayList;
@@ -121,6 +122,10 @@ public abstract class LayoutStructureItem {
 	@Override
 	public int hashCode() {
 		return HashUtil.hash(0, getItemId());
+	}
+
+	public boolean isVisible(ThemeDisplay themeDisplay) {
+		return true;
 	}
 
 	public void setChildrenItemIds(List<String> childrenItemIds) {

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -299,6 +299,10 @@ public class RenderLayoutStructureDisplayContext {
 			StyledLayoutStructureItem styledLayoutStructureItem)
 		throws Exception {
 
+		if (!styledLayoutStructureItem.isVisible(_themeDisplay)) {
+			return "d-none";
+		}
+
 		StringBundler cssClassSB = new StringBundler(35);
 
 		String align = styledLayoutStructureItem.getAlign();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-151745

### Steps to reproduce

1. Add the following property into the portal-ext.properties and startup the server
```java
layout.show.portlet.access.denied=false
```
1. Add Blogs widget into Home page and configure its Look and Feel to have a Border Width of 5
1. Revoke the VIEW permission for the Guest role
1. Logout

**Expected Behavior**: The portlet is not visible
**Actual Behavior**: The portlet is not visible, but you see a border where the portlet is meant to be

![](https://issues.liferay.com/secure/attachment/450349/actualResult.png)


### Solution notes

The original pull request https://github.com/liferay-ts-reviewer/liferay-portal/pull/43 included all of the logic inside of `RenderLayoutStructureDisplayContext`, but I felt that moving the implementation details of how portlets are stored in the configuration made more sense in `FragmentStyledLayoutStructureItem`.

If you prefer the original solution, or if you feel there is a better place to add this permission check logic, please let me know.