### PR TITLE
LPS-152341

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/portlet/action/ApplicationsMenuLiferayLogoMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/portlet/action/ApplicationsMenuLiferayLogoMVCResourceCommand.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.PortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.util.PropsUtil;
@@ -68,6 +69,8 @@ public class ApplicationsMenuLiferayLogoMVCResourceCommand
 		if (inputStream == null) {
 			return;
 		}
+
+		resourceResponse.setContentType(ContentTypes.IMAGE_PNG);
 
 		PortletResponseUtil.write(resourceResponse, inputStream);
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-152341

### Solution overview

When we don't set a content type, the default content type will be text/html.

https://github.com/liferay/liferay-portal/blob/7.4.1-ga2/portal-impl/src/com/liferay/portlet/internal/MimeResponseImpl.java#L91-L93
https://github.com/liferay/liferay-portal/blob/7.4.1-ga2/portal-impl/src/com/liferay/portlet/internal/PortletRequestImpl.java#L544-L547

Therefore, the solution sets the content type to image/png to match the default logo's mime type.

### Open questions

When reviewing the pull request, I wondered if it would be safer to use application/octet-stream because users can customize the logo with portal properties and bundle fragments (and thus it's not guaranteed to be a image/png).

However, based on c4b13cdb4d6bbe6643726e8c60742cc02174597c, this is a hidden property with no documentation, so one could argue that it's always supposed to be a .png, simply because there's no documentation saying that any file type will be allowed for that portal property (since there is no documentation at all).

### Related issues

When reviewing the pull request, I noticed the following source formatting problems with the existing code, which are unrelated to this bugfix, but may be worth addressing at some point in the future.

* PropsKeys constant starts with "APPLICATIONS_MENU_" (with an s) but the portal property actually starts with "application.menu" (without an s)
* The method name is misspelled, where the "default" in `_getApplicationsMenuDefualtLiferayLogo` was spelled "defualt"
