### PR TITLE
LPS-152091 Render dynamic AssetVocabularySiteNavigationMenuItem

### DIFF
--- a/modules/apps/site-navigation/site-navigation-api/bnd.bnd
+++ b/modules/apps/site-navigation/site-navigation-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site Navigation API
 Bundle-SymbolicName: com.liferay.site.navigation.api
-Bundle-Version: 6.1.1
+Bundle-Version: 6.2.0
 Export-Package:\
 	com.liferay.site.navigation.constants,\
 	com.liferay.site.navigation.exception,\

--- a/modules/apps/site-navigation/site-navigation-api/src/main/java/com/liferay/site/navigation/type/SiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-api/src/main/java/com/liferay/site/navigation/type/SiteNavigationMenuItemType.java
@@ -28,6 +28,8 @@ import com.liferay.site.navigation.model.SiteNavigationMenuItem;
 
 import java.io.IOException;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import javax.portlet.PortletURL;
@@ -59,6 +61,19 @@ public interface SiteNavigationMenuItemType {
 		RenderRequest renderRequest, RenderResponse renderResponse) {
 
 		return null;
+	}
+
+	public default List<SiteNavigationMenuItem>
+			getChildrenSiteNavigationMenuItems(
+				HttpServletRequest httpServletRequest,
+				SiteNavigationMenuItem siteNavigationMenuItem)
+		throws Exception {
+
+		if (isDynamic()) {
+			return Collections.emptyList();
+		}
+
+		throw new UnsupportedOperationException();
 	}
 
 	public default String getIcon() {
@@ -110,6 +125,18 @@ public interface SiteNavigationMenuItemType {
 		throws Exception {
 
 		return StringPool.BLANK;
+	}
+
+	public default List<SiteNavigationMenuItem> getSiteNavigationMenuItems(
+			HttpServletRequest httpServletRequest,
+			SiteNavigationMenuItem siteNavigationMenuItem)
+		throws Exception {
+
+		if (isDynamic()) {
+			return Collections.emptyList();
+		}
+
+		throw new UnsupportedOperationException();
 	}
 
 	public default String getStatusIcon(

--- a/modules/apps/site-navigation/site-navigation-api/src/main/resources/com/liferay/site/navigation/type/packageinfo
+++ b/modules/apps/site-navigation/site-navigation-api/src/main/resources/com/liferay/site/navigation/type/packageinfo
@@ -1,1 +1,1 @@
-version 1.6.0
+version 1.7.0

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/build.gradle
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/build.gradle
@@ -6,6 +6,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:asset:asset-vocabulary-item-selector-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
@@ -209,52 +209,10 @@ public class AssetVocabularySiteNavigationMenuItemType
 			return Arrays.asList(siteNavigationMenuItem);
 		}
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)httpServletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
-		if (themeDisplay == null) {
-			return Collections.emptyList();
-		}
-
-		List<SiteNavigationMenuItem> siteNavigationMenuItems =
-			new ArrayList<>();
-
-		for (AssetCategory assetCategory :
-				_assetCategoryLocalService.getVocabularyCategories(
-					0,
-					GetterUtil.getLong(
-						typeSettingsUnicodeProperties.get("classPK")),
-					QueryUtil.ALL_POS, QueryUtil.ALL_POS, null)) {
-
-			SiteNavigationMenuItem assetCategorySiteNavigationMenuItem =
-				siteNavigationMenuItem.cloneWithOriginalValues();
-
-			assetCategorySiteNavigationMenuItem.setTypeSettings(
-				UnicodePropertiesBuilder.create(
-					true
-				).put(
-					"assetVocabularyId",
-					String.valueOf(assetCategory.getVocabularyId())
-				).put(
-					"classPK", String.valueOf(assetCategory.getCategoryId())
-				).put(
-					"groupId", String.valueOf(assetCategory.getGroupId())
-				).put(
-					"regularURL",
-					_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
-						AssetCategory.class.getName(),
-						assetCategory.getCategoryId(), themeDisplay)
-				).put(
-					"title", assetCategory.getTitle(themeDisplay.getLocale())
-				).put(
-					"type", "asset-category"
-				).buildString());
-
-			siteNavigationMenuItems.add(assetCategorySiteNavigationMenuItem);
-		}
-
-		return siteNavigationMenuItems;
+		return _getChildrenSiteNavigationMenuItems(
+			0, GetterUtil.getLong(typeSettingsUnicodeProperties.get("classPK")),
+			httpServletRequest,
+			siteNavigationMenuItem.getSiteNavigationMenuItemId());
 	}
 
 	@Override
@@ -427,6 +385,62 @@ public class AssetVocabularySiteNavigationMenuItemType
 		_jspRenderer.renderJSP(
 			_servletContext, httpServletRequest, httpServletResponse,
 			"/edit_asset_vocabulary_type.jsp");
+	}
+
+	private List<SiteNavigationMenuItem> _getChildrenSiteNavigationMenuItems(
+			long parentCategoryId, long vocabularyId,
+			HttpServletRequest httpServletRequest,
+			long vocabularySiteNavigationMenuItemId)
+		throws Exception {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)httpServletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		if (themeDisplay == null) {
+			return Collections.emptyList();
+		}
+
+		SiteNavigationMenuItem vocabularySiteNavigationMenuItem =
+			_siteNavigationMenuItemLocalService.getSiteNavigationMenuItem(
+				vocabularySiteNavigationMenuItemId);
+
+		List<SiteNavigationMenuItem> siteNavigationMenuItems =
+			new ArrayList<>();
+
+		for (AssetCategory assetCategory :
+				_assetCategoryLocalService.getVocabularyCategories(
+					parentCategoryId, vocabularyId, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null)) {
+
+			SiteNavigationMenuItem assetCategorySiteNavigationMenuItem =
+				vocabularySiteNavigationMenuItem.cloneWithOriginalValues();
+
+			assetCategorySiteNavigationMenuItem.setTypeSettings(
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"assetVocabularyId",
+					String.valueOf(assetCategory.getVocabularyId())
+				).put(
+					"classPK", String.valueOf(assetCategory.getCategoryId())
+				).put(
+					"groupId", String.valueOf(assetCategory.getGroupId())
+				).put(
+					"regularURL",
+					_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
+						AssetCategory.class.getName(),
+						assetCategory.getCategoryId(), themeDisplay)
+				).put(
+					"title", assetCategory.getTitle(themeDisplay.getLocale())
+				).put(
+					"type", "asset-category"
+				).buildString());
+
+			siteNavigationMenuItems.add(assetCategorySiteNavigationMenuItem);
+		}
+
+		return siteNavigationMenuItems;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
@@ -303,6 +303,12 @@ public class AssetVocabularySiteNavigationMenuItemType
 				siteNavigationMenuItem.getTypeSettings()
 			).build();
 
+		if (Objects.equals(
+				typeSettingsUnicodeProperties.get("type"), "asset-category")) {
+
+			return typeSettingsUnicodeProperties.get("title");
+		}
+
 		String defaultTitle = typeSettingsUnicodeProperties.getProperty(
 			"title");
 

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
@@ -413,6 +413,24 @@ public class AssetVocabularySiteNavigationMenuItemType
 	}
 
 	@Override
+	public boolean isBrowsable(SiteNavigationMenuItem siteNavigationMenuItem) {
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		if (Objects.equals(
+				typeSettingsUnicodeProperties.get("type"), "asset-category") &&
+			Validator.isNotNull(
+				typeSettingsUnicodeProperties.get("regularURL"))) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	@Override
 	public boolean isDynamic() {
 		return true;
 	}

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
@@ -25,6 +25,7 @@ import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.frontend.taglib.servlet.taglib.util.JSPRenderer;
 import com.liferay.item.selector.ItemSelector;
 import com.liferay.petra.portlet.url.builder.PortletURLBuilder;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -42,6 +43,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.site.navigation.menu.item.asset.vocabulary.internal.constants.AssetVocabularySiteNavigationMenuTypeConstants;
@@ -218,6 +220,32 @@ public class AssetVocabularySiteNavigationMenuItemType
 			).build();
 
 		return typeSettingsUnicodeProperties.get("title");
+	}
+
+	@Override
+	public String getRegularURL(
+		HttpServletRequest httpServletRequest,
+		SiteNavigationMenuItem siteNavigationMenuItem) {
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		if (Objects.equals(
+				typeSettingsUnicodeProperties.get("type"),
+				"asset-vocabulary")) {
+
+			return StringPool.BLANK;
+		}
+
+		String regularURL = typeSettingsUnicodeProperties.get("regularURL");
+
+		if (Validator.isNull(regularURL)) {
+			return StringPool.BLANK;
+		}
+
+		return regularURL;
 	}
 
 	@Override

--- a/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
+++ b/modules/apps/site-navigation/site-navigation-menu-item-asset-vocabulary/src/main/java/com/liferay/site/navigation/menu/item/asset/vocabulary/internal/type/AssetVocabularySiteNavigationMenuItemType.java
@@ -141,6 +141,37 @@ public class AssetVocabularySiteNavigationMenuItemType
 	}
 
 	@Override
+	public List<SiteNavigationMenuItem> getChildrenSiteNavigationMenuItems(
+			HttpServletRequest httpServletRequest,
+			SiteNavigationMenuItem siteNavigationMenuItem)
+		throws Exception {
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			UnicodePropertiesBuilder.fastLoad(
+				siteNavigationMenuItem.getTypeSettings()
+			).build();
+
+		if (Objects.equals(
+				typeSettingsUnicodeProperties.get("type"),
+				"asset-vocabulary")) {
+
+			return _getChildrenSiteNavigationMenuItems(
+				0,
+				GetterUtil.getLong(
+					typeSettingsUnicodeProperties.get("classPK")),
+				httpServletRequest,
+				siteNavigationMenuItem.getSiteNavigationMenuItemId());
+		}
+
+		return _getChildrenSiteNavigationMenuItems(
+			GetterUtil.getLong(typeSettingsUnicodeProperties.get("classPK")),
+			GetterUtil.getLong(
+				typeSettingsUnicodeProperties.get("assetVocabularyId")),
+			httpServletRequest,
+			siteNavigationMenuItem.getSiteNavigationMenuItemId());
+	}
+
+	@Override
 	public String getIcon() {
 		return "vocabulary";
 	}

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/NavItemUtil.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/NavItemUtil.java
@@ -126,14 +126,28 @@ public class NavItemUtil {
 					continue;
 				}
 
-				navItems.add(
-					new SiteNavigationMenuNavItem(
-						httpServletRequest, themeDisplay,
-						siteNavigationMenuItem));
+				if (!siteNavigationMenuItemType.isDynamic()) {
+					navItems.add(
+						new SiteNavigationMenuNavItem(
+							httpServletRequest, themeDisplay,
+							siteNavigationMenuItem));
+
+					continue;
+				}
+
+				for (SiteNavigationMenuItem dynamicSiteNavigationMenuItem :
+						siteNavigationMenuItemType.getSiteNavigationMenuItems(
+							httpServletRequest, siteNavigationMenuItem)) {
+
+					navItems.add(
+						new SiteNavigationMenuNavItem(
+							httpServletRequest, themeDisplay,
+							dynamicSiteNavigationMenuItem));
+				}
 			}
-			catch (PortalException portalException) {
+			catch (Exception exception) {
 				if (_log.isDebugEnabled()) {
-					_log.debug(portalException);
+					_log.debug(exception);
 				}
 			}
 		}

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/NavItemUtil.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/NavItemUtil.java
@@ -22,7 +22,9 @@ import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.NavItem;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.navigation.model.SiteNavigationMenuItem;
@@ -122,6 +124,13 @@ public class NavItemUtil {
 					!siteNavigationMenuItemType.hasPermission(
 						themeDisplay.getPermissionChecker(),
 						siteNavigationMenuItem)) {
+
+					continue;
+				}
+
+				if (siteNavigationMenuItemType.isDynamic() &&
+					!GetterUtil.getBoolean(
+						PropsUtil.get("feature.flag.LPS-146502"))) {
 
 					continue;
 				}

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/SiteNavigationMenuNavItem.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/SiteNavigationMenuNavItem.java
@@ -25,6 +25,7 @@ import com.liferay.site.navigation.type.SiteNavigationMenuItemType;
 
 import java.io.Serializable;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -64,11 +65,27 @@ public class SiteNavigationMenuNavItem extends NavItem {
 	}
 
 	@Override
-	public List<NavItem> getChildren() {
-		return NavItemUtil.getChildNavItems(
-			_httpServletRequest,
-			_siteNavigationMenuItem.getSiteNavigationMenuId(),
-			_siteNavigationMenuItem.getSiteNavigationMenuItemId());
+	public List<NavItem> getChildren() throws Exception {
+		if (!_siteNavigationMenuItemType.isDynamic()) {
+			return NavItemUtil.getChildNavItems(
+				_httpServletRequest,
+				_siteNavigationMenuItem.getSiteNavigationMenuId(),
+				_siteNavigationMenuItem.getSiteNavigationMenuItemId());
+		}
+
+		List<NavItem> children = new ArrayList<>();
+
+		for (SiteNavigationMenuItem dynamicSiteNavigationMenuItem :
+				_siteNavigationMenuItemType.getChildrenSiteNavigationMenuItems(
+					_httpServletRequest, _siteNavigationMenuItem)) {
+
+			children.add(
+				new SiteNavigationMenuNavItem(
+					_httpServletRequest, _themeDisplay,
+					dynamicSiteNavigationMenuItem));
+		}
+
+		return children;
 	}
 
 	@Override

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/SiteNavigationMenuNavItem.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/SiteNavigationMenuNavItem.java
@@ -19,6 +19,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.theme.NavItem;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PropsUtil;
 import com.liferay.site.navigation.model.SiteNavigationMenuItem;
 import com.liferay.site.navigation.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.site.navigation.type.SiteNavigationMenuItemType;
@@ -71,6 +73,10 @@ public class SiteNavigationMenuNavItem extends NavItem {
 				_httpServletRequest,
 				_siteNavigationMenuItem.getSiteNavigationMenuId(),
 				_siteNavigationMenuItem.getSiteNavigationMenuItemId());
+		}
+
+		if (!GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-146502"))) {
+			return Collections.emptyList();
 		}
 
 		List<NavItem> children = new ArrayList<>();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-152091

Follow: https://github.com/brianchandotcom/liferay-portal/pull/116722#issuecomment-1112358524

Previous PR: https://github.com/liferay-echo/liferay-portal/pull/7932

To implement a dynamic menu item based on a vocabulary we have thought of two possibilities:

- Implement the necessary model listeners to replicate in the items menu table the changes that have occurred to the vocabulary and its categories.
- Generate the hierarchy of menu items corresponding to the vocabulary dynamically and on-demand.

The two possible approaches have been analyzed in terms of simplicity and performance.
Regarding simplicity, the second approach has seemed much clearly simpler than the first.
To analyze a performance comparison between one approach and the other, we have thought that the steps to generate the menu would be the following depending on the approach:

1. Generate the hierarchy previously with the model listeners:
- We should get the tiered menu hierarchy from the SiteNavigationMenuItem table.
- For each of the items we would need at least its title localized with the appropriate language. In order to get that, the title should be maintained updated for all the available locales in the typeSettings of all the menu items in which an element could be. The alternative is to also obtain the AssetCategory of the corresponding table. Both solutions seem to be expensive.

2. Generate the hierarchy on-demand:
- Only the item corresponding to the vocabulary would be obtained from the SiteNavigationMenuItem table, while the hierarchy would be obtained directly from the AsseyCategory table, directly having everything necessary to render the menu item.

We believe that the performance difference between getting the hierarchy of the SiteNavigationMenuItem table or the AssetCategory table will depend mainly on the number of records. And in the second step, getting the needed item properties, the second approach is better.
It seems reasonable to us to assume that in a real installation there tend to be more SiteNavigationMenuItem records than AssetCategory if we take the first approach. This is because, in addition to the other existing menu item types, a category could be repeated N times in the SiteNavigationMenuItem table.

For these reasons, in this implementation, the second approach has been chosen, dynamically generating the menu hierarchy corresponding to a vocabulary.

Attached to the related task there is a big vocabulary (Fruits.lar) that could be useful for testing purposes.

Thanks a lot! ❤️ 