### PR TITLE
[TS] LPS-152739 | Site template Content pages settings lost on publish

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutMVCActionCommand.java
@@ -36,12 +36,14 @@ import com.liferay.portal.kernel.servlet.MultiSessionMessages;
 import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.transaction.Transactional;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.kernel.workflow.WorkflowHandlerRegistryUtil;
+import com.liferay.sites.kernel.util.Sites;
 
 import java.util.Collections;
 
@@ -151,9 +153,32 @@ public class PublishLayoutMVCActionCommand
 				serviceContext, Collections.emptyMap());
 		}
 		else {
+			UnicodeProperties layoutOriginalTypeSettingsUnicodeProperties =
+				layout.getTypeSettingsProperties();
+
 			_layoutCopyHelper.copyLayout(draftLayout, layout);
 
 			layout = _layoutLocalService.getLayout(layout.getPlid());
+
+			UnicodeProperties layoutTypeSettingsUnicodeProperties =
+				layout.getTypeSettingsProperties();
+
+			String layoutUpdatableProperty =
+				layoutOriginalTypeSettingsUnicodeProperties.getProperty(
+					Sites.LAYOUT_UPDATEABLE);
+
+			if (layoutUpdatableProperty != null) {
+				boolean layoutUpdatable = GetterUtil.getBoolean(
+					layoutOriginalTypeSettingsUnicodeProperties.getProperty(
+						Sites.LAYOUT_UPDATEABLE),
+					true);
+
+				layoutTypeSettingsUnicodeProperties.setProperty(
+					Sites.LAYOUT_UPDATEABLE, String.valueOf(layoutUpdatable));
+
+				layout.setTypeSettingsProperties(
+					layoutTypeSettingsUnicodeProperties);
+			}
 
 			draftLayout = _layoutLocalService.getLayout(draftLayout.getPlid());
 


### PR DESCRIPTION
hi Team,
Could you review this?

https://issues.liferay.com/browse/LPS-152739

Best,
Attila

------

The issue is an aftereffect of [LPS-95109](https://issues.liferay.com/browse/LPS-95109). After [LPS-95109](https://issues.liferay.com/browse/LPS-95109) both the draft and published page settings will be stored in the published page typeSettings(for those settings that are stored in a typeSettings) and because of this when we publish the draft the generated default value can override the changed settings. I fixed this specific use case for the site template pages by writing back the layoutUpdateable property from the original typeSettings of the published site after the merge.