### PR TITLE
LPS-153160 Include Google Maps JavaScript API script only once

### DIFF
--- a/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/map/map-google-maps/src/main/resources/META-INF/resources/view.jsp
@@ -38,17 +38,25 @@ name = AUIUtil.getNamespace(liferayPortletRequest, liferayPortletResponse) + nam
 
 			Liferay.fire('gmapsReady');
 		};
+
+		if (!Liferay.Maps.gmapsReady) {
+			var apiURL =
+				'<%= protocol %>' +
+				'://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&callback=Liferay.Maps.onGMapsReady';
+
+			<c:if test="<%= Validator.isNotNull(googleMapDisplayContext.getGoogleMapsAPIKey()) %>">
+				apiURL += '&key=' + '<%= googleMapDisplayContext.getGoogleMapsAPIKey() %>';
+			</c:if>
+
+			var script = document.createElement('script');
+
+			script.setAttribute('src', apiURL);
+
+			document.head.appendChild(script);
+
+			script = null;
+		}
 	</script>
-
-	<%
-	String apiURL = protocol + "://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&callback=Liferay.Maps.onGMapsReady";
-
-	if (Validator.isNotNull(googleMapDisplayContext.getGoogleMapsAPIKey())) {
-		apiURL += "&key=" + googleMapDisplayContext.getGoogleMapsAPIKey();
-	}
-	%>
-
-	<script src="<%= apiURL %>" type="text/javascript"></script>
 </liferay-util:html-top>
 
 <aui:script require="<%= bootstrapRequire %>">


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

This fix solves the issue on 7.3.x because, on master, Geolocation, along with the other DDM fields is rendered with React.

I initially sent the pull to the liferay-forms team, but they said that they are not responsible for the map-google-maps module.
They suggested that perhaps it belongs to your team.
https://github.com/liferay-forms/liferay-portal-ee/pull/126#issuecomment-1122746781

Please let me know if that is not the case.

I cannot reach your liferay-portal-ee repo, so I'm sending this to liferay-portal.

Thank you and best regards,
István