### PR TITLE
LPS-153896

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRenderer.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRenderer.java
@@ -91,8 +91,11 @@ public class LayoutAssetRenderer extends BaseJSPAssetRenderer<Layout> {
 		sb.append(":</strong> ");
 		sb.append(_layout.getHTMLTitle(locale));
 
+		int layoutStatus = _layout.getStatus();
+
 		if (_layout.isTypeContent() &&
-			(_layout.getStatus() == WorkflowConstants.STATUS_PENDING)) {
+			((layoutStatus == WorkflowConstants.STATUS_PENDING) ||
+			 (layoutStatus == WorkflowConstants.STATUS_DENIED))) {
 
 			return HtmlUtil.stripHtml(sb.toString());
 		}
@@ -116,7 +119,11 @@ public class LayoutAssetRenderer extends BaseJSPAssetRenderer<Layout> {
 				WebKeys.THEME_DISPLAY);
 
 		try {
-			if (_layout.getStatus() != WorkflowConstants.STATUS_PENDING) {
+			int layoutStatus = _layout.getStatus();
+
+			if ((layoutStatus != WorkflowConstants.STATUS_PENDING) &&
+				(layoutStatus != WorkflowConstants.STATUS_DENIED)) {
+
 				return PortalUtil.getLayoutFriendlyURL(_layout, themeDisplay);
 			}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-153896

### Solution overview

The issue occurs because the workflow state is still "denied" after resubmitting the task.

When reviewing the solution, I wasn't sure whether to only have "pending" and "denied" use the preview URL (current implementation), or if everything other than "approved" should use the preview URL (another way to interpret workflow statuses, in case there are custom workflow states added by customers).

Please let me know if you have any questions.