### PR TITLE
LPS-147536 Add empty state

### DIFF
--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/js/AssetCategoryTree.es.js
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/js/AssetCategoryTree.es.js
@@ -13,6 +13,7 @@
  */
 
 import {TreeView as ClayTreeView} from '@clayui/core';
+import ClayEmptyState from '@clayui/empty-state';
 import {ClayCheckbox} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import React, {useMemo, useRef, useState} from 'react';
@@ -122,7 +123,7 @@ export function AssetCategoryTree({
 		}
 	};
 
-	return (
+	return filteredItems.length > 0 ? (
 		<ClayTreeView
 			items={filteredItems}
 			onItemsChange={(items) => onItems(items)}
@@ -187,5 +188,14 @@ export function AssetCategoryTree({
 				</ClayTreeView.Item>
 			)}
 		</ClayTreeView>
+	) : (
+		<ClayEmptyState
+			description={Liferay.Language.get(
+				'try-again-with-a-different-search'
+			)}
+			imgSrc={`${themeDisplay.getPathThemeImages()}/states/search_state.gif`}
+			small
+			title={Liferay.Language.get('no-results-found')}
+		/>
 	);
 }

--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/js/AssetCategoryTree.es.js
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/js/AssetCategoryTree.es.js
@@ -97,8 +97,10 @@ export function AssetCategoryTree({
 			data = selectedItems[0];
 		}
 
-		Liferay.Util.getOpener().Liferay.fire(itemSelectedEventName, {
-			data,
+		requestAnimationFrame(() => {
+			Liferay.Util.getOpener().Liferay.fire(itemSelectedEventName, {
+				data,
+			});
 		});
 	}, [
 		selectedKeys,

--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/js/SelectAssetCategoryInfoItem.es.js
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/js/SelectAssetCategoryInfoItem.es.js
@@ -14,85 +14,9 @@
 
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
-import {Treeview} from 'frontend-js-components-web';
 import React, {useState} from 'react';
 
 import {AssetCategoryTree} from './AssetCategoryTree.es';
-
-function getFilter(filterQuery) {
-	if (!filterQuery) {
-		return null;
-	}
-
-	const filterQueryLowerCase = filterQuery.toLowerCase();
-
-	return (node) =>
-		!node.vocabulary &&
-		node.name.toLowerCase().indexOf(filterQueryLowerCase) !== -1;
-}
-
-function visit(nodes, callback) {
-	nodes.forEach((node) => {
-		callback(node);
-
-		if (node.children) {
-			visit(node.children, callback);
-		}
-	});
-}
-
-function OldAssetCategoryTree({
-	filterQuery,
-	itemSelectedEventName,
-	items,
-	multiSelection,
-	onSelectedItemsCount,
-}) {
-	const handleSelectionChange = (selectedNodeIds) => {
-		if (multiSelection) {
-			onSelectedItemsCount(selectedNodeIds.size);
-		}
-
-		if (!selectedNodeIds.size) {
-			return;
-		}
-
-		let data = [];
-
-		visit(items, (node) => {
-			if (selectedNodeIds.has(node.id)) {
-				data.push({
-					className: node.className,
-					classNameId: node.classNameId,
-					classPK: node.id,
-					title: node.name,
-				});
-			}
-		});
-
-		if (!multiSelection) {
-			data = data[0];
-		}
-
-		Liferay.Util.getOpener().Liferay.fire(itemSelectedEventName, {
-			data,
-		});
-	};
-
-	return (
-		<Treeview
-			NodeComponent={Treeview.Card}
-			filter={getFilter(filterQuery)}
-			multiSelection={multiSelection}
-			nodes={items}
-			onSelectedNodesChange={handleSelectionChange}
-		/>
-	);
-}
-
-const Tree = Liferay.FeatureFlags['LPS-144630']
-	? AssetCategoryTree
-	: OldAssetCategoryTree;
 
 function SelectAssetCategory({
 	itemSelectedEventName,
@@ -165,7 +89,7 @@ function SelectAssetCategory({
 						id={`${namespace}categoryContainer`}
 					>
 						{items.length > 0 ? (
-							<Tree
+							<AssetCategoryTree
 								filterQuery={filterQuery}
 								itemSelectedEventName={itemSelectedEventName}
 								items={items}


### PR DESCRIPTION
Hello dear reviewer!

This PR remove the FF for the categories selector and also adapt it to work properly with the keyboard.

**After reviewing this don't forward it since we need to do a QA pass**

**You need to deploy the module** `asset-categories-item-selector-web`

More info here: https://issues.liferay.com/browse/LPS-153482

This category selector can be displayed in the following scenarios:
(Create some categories/vocabularies before testing)

**Adding a category to a navigation menu**
1. Add a navigation menu
2. Add a category

**Editing a category in a navigation menu**
1. Add a navigation menu
2. Add a category
3. Click on the category 
4. In the sidebar click the change button


**Selecting a category as preview item in a display page**
1. Add a display page of categories
2. Click preview with button
3. Choose category tab


@david-gutierrez-mesa @liulukiwi @Tim-Cao @ozysouza