### PR TITLE
LPS-153699 Fix: AssetEntryItemSelector doesn't filter Document's assets by the subtype Basic Document

### DIFF
--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -102,7 +102,7 @@ public class AssetBrowserDisplayContext {
 
 		if (AssetBrowserWebConfigurationValues.SEARCH_WITH_DATABASE) {
 			long[] subtypeSelectionIds = ArrayUtil.filter(
-				new long[] {getSubtypeSelectionId()}, id -> id > 0);
+				new long[] {getSubtypeSelectionId()}, id -> id >= 0);
 
 			assetBrowserSearch.setResultsAndTotal(
 				() -> AssetEntryLocalServiceUtil.getEntries(

--- a/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
+++ b/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java
@@ -364,7 +364,7 @@ public class AssetBrowserDisplayContext {
 		}
 
 		_subtypeSelectionId = ParamUtil.getLong(
-			_httpServletRequest, "subtypeSelectionId");
+			_httpServletRequest, "subtypeSelectionId", -1);
 
 		return _subtypeSelectionId;
 	}

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -1361,7 +1361,7 @@ public class EditAssetListDisplayContext {
 		}
 	}
 
-	private static final long _DEFAULT_SUBTYPE_SELECTION_ID = 0;
+	private static final long _DEFAULT_SUBTYPE_SELECTION_ID = -1;
 
 	private AssetListEntry _assetListEntry;
 	private Long _assetListEntryId;

--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/InputAssetLinksDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/InputAssetLinksDisplayContext.java
@@ -395,7 +395,7 @@ public class InputAssetLinksDisplayContext {
 		Map<String, Object> selectorEntryData = new HashMap<>();
 
 		PortletURL assetBrowserPortletURL =
-			_getAssetEntryItemSelectorPortletURL(assetRendererFactory, 0);
+			_getAssetEntryItemSelectorPortletURL(assetRendererFactory, -1);
 
 		if (assetBrowserPortletURL != null) {
 			selectorEntryData.put("href", assetBrowserPortletURL.toString());

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/KeywordDTOConverter.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/KeywordDTOConverter.java
@@ -82,7 +82,7 @@ public class KeywordDTOConverter implements DTOConverter<AssetTag, Keyword> {
 						Hits hits = _assetEntryLocalService.search(
 							assetTag.getCompanyId(),
 							new long[] {assetTag.getGroupId()},
-							assetTag.getUserId(), null, 0, null, null, null,
+							assetTag.getUserId(), null, -1, null, null, null,
 							null, assetTag.getName(), true,
 							new int[] {
 								WorkflowConstants.STATUS_APPROVED,

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
@@ -148,7 +148,7 @@ public class TaxonomyCategoryDTOConverter
 					(int)_assetEntryLocalService.searchCount(
 						assetCategory.getCompanyId(),
 						new long[] {assetCategory.getGroupId()},
-						assetCategory.getUserId(), null, 0, null,
+						assetCategory.getUserId(), null, -1, null,
 						String.valueOf(assetCategory.getCategoryId()), null,
 						false, false,
 						new int[] {

--- a/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/asset/criterion/AssetEntryItemSelectorCriterion.java
+++ b/modules/apps/item-selector/item-selector-criteria-api/src/main/java/com/liferay/item/selector/criteria/asset/criterion/AssetEntryItemSelectorCriterion.java
@@ -91,7 +91,7 @@ public class AssetEntryItemSelectorCriterion extends BaseItemSelectorCriterion {
 	private boolean _showNonindexable;
 	private boolean _showScheduled;
 	private boolean _singleSelect;
-	private long _subtypeSelectionId;
+	private long _subtypeSelectionId = -1;
 	private String _typeSelection;
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetEntryLocalServiceImpl.java
@@ -1067,7 +1067,7 @@ public class AssetEntryLocalServiceImpl extends AssetEntryLocalServiceBaseImpl {
 
 		searchContext.setAttribute("status", statuses);
 
-		if (classTypeId > 0) {
+		if (classTypeId >= 0) {
 			searchContext.setClassTypeIds(new long[] {classTypeId});
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-153699