### PR TITLE
[TS] LPS-153630

### DIFF
--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetVocabularyServiceTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/service/test/AssetVocabularyServiceTest.java
@@ -545,32 +545,6 @@ public class AssetVocabularyServiceTest {
 			StringUtil.toLowerCase(title), vocabulary.getName());
 	}
 
-	@Test(expected = DuplicateVocabularyException.class)
-	public void testUpdateDuplicateVocabulary() throws Exception {
-		AssetVocabulary vocabulary = AssetTestUtil.addVocabulary(
-			_group.getGroupId(), "test1");
-
-		AssetTestUtil.addVocabulary(_group.getGroupId(), "test2");
-
-		_assetVocabularyLocalService.updateVocabulary(
-			vocabulary.getVocabularyId(), "test2", vocabulary.getTitle(),
-			vocabulary.getTitleMap(), vocabulary.getDescriptionMap(),
-			vocabulary.getSettings(),
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-	}
-
-	@Test(expected = VocabularyNameException.class)
-	public void testUpdateEmptyNameVocabulary() throws Exception {
-		AssetVocabulary vocabulary = AssetTestUtil.addVocabulary(
-			_group.getGroupId(), "test");
-
-		_assetVocabularyLocalService.updateVocabulary(
-			vocabulary.getVocabularyId(), StringPool.BLANK,
-			vocabulary.getTitle(), vocabulary.getTitleMap(),
-			vocabulary.getDescriptionMap(), vocabulary.getSettings(),
-			ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
-	}
-
 	@Rule
 	public SearchTestRule searchTestRule = new SearchTestRule();
 

--- a/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceHttp.java
@@ -1252,52 +1252,6 @@ public class AssetVocabularyServiceHttp {
 		}
 	}
 
-	public static com.liferay.asset.kernel.model.AssetVocabulary
-			updateVocabulary(
-				HttpPrincipal httpPrincipal, long vocabularyId, String name,
-				String title, java.util.Map<java.util.Locale, String> titleMap,
-				java.util.Map<java.util.Locale, String> descriptionMap,
-				String settings,
-				com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		try {
-			MethodKey methodKey = new MethodKey(
-				AssetVocabularyServiceUtil.class, "updateVocabulary",
-				_updateVocabularyParameterTypes30);
-
-			MethodHandler methodHandler = new MethodHandler(
-				methodKey, vocabularyId, name, title, titleMap, descriptionMap,
-				settings, serviceContext);
-
-			Object returnObj = null;
-
-			try {
-				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
-			}
-			catch (Exception exception) {
-				if (exception instanceof
-						com.liferay.portal.kernel.exception.PortalException) {
-
-					throw (com.liferay.portal.kernel.exception.PortalException)
-						exception;
-				}
-
-				throw new com.liferay.portal.kernel.exception.SystemException(
-					exception);
-			}
-
-			return (com.liferay.asset.kernel.model.AssetVocabulary)returnObj;
-		}
-		catch (com.liferay.portal.kernel.exception.SystemException
-					systemException) {
-
-			_log.error(systemException, systemException);
-
-			throw systemException;
-		}
-	}
-
 	private static Log _log = LogFactoryUtil.getLog(
 		AssetVocabularyServiceHttp.class);
 
@@ -1408,12 +1362,6 @@ public class AssetVocabularyServiceHttp {
 		new Class[] {
 			long.class, String.class, java.util.Map.class, java.util.Map.class,
 			String.class, com.liferay.portal.kernel.service.ServiceContext.class
-		};
-	private static final Class<?>[] _updateVocabularyParameterTypes30 =
-		new Class[] {
-			long.class, String.class, String.class, java.util.Map.class,
-			java.util.Map.class, String.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 
 }

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java
@@ -504,6 +504,7 @@ public class AssetVocabularyLocalServiceImpl
 		return assetVocabularyPersistence.update(vocabulary);
 	}
 
+	@Indexable(type = IndexableType.REINDEX)
 	@Override
 	public AssetVocabulary updateVocabulary(
 			long vocabularyId, String title, Map<Locale, String> titleMap,
@@ -511,29 +512,9 @@ public class AssetVocabularyLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		return assetVocabularyLocalService.updateVocabulary(
-			vocabularyId, titleMap.get(LocaleUtil.getSiteDefault()), title,
-			titleMap, descriptionMap, settings, serviceContext);
-	}
-
-	@Indexable(type = IndexableType.REINDEX)
-	@Override
-	public AssetVocabulary updateVocabulary(
-			long vocabularyId, String name, String title,
-			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
-			String settings, ServiceContext serviceContext)
-		throws PortalException {
-
 		AssetVocabulary vocabulary =
 			assetVocabularyPersistence.findByPrimaryKey(vocabularyId);
 
-		name = _getVocabularyName(name);
-
-		if (!StringUtil.equalsIgnoreCase(vocabulary.getName(), name)) {
-			validate(vocabulary.getGroupId(), name);
-		}
-
-		vocabulary.setName(name);
 		vocabulary.setTitleMap(titleMap);
 
 		if (Validator.isNotNull(title)) {

--- a/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyServiceImpl.java
@@ -462,21 +462,6 @@ public class AssetVocabularyServiceImpl extends AssetVocabularyServiceBaseImpl {
 			serviceContext);
 	}
 
-	@Override
-	public AssetVocabulary updateVocabulary(
-			long vocabularyId, String name, String title,
-			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
-			String settings, ServiceContext serviceContext)
-		throws PortalException {
-
-		AssetVocabularyPermission.check(
-			getPermissionChecker(), vocabularyId, ActionKeys.UPDATE);
-
-		return assetVocabularyLocalService.updateVocabulary(
-			vocabularyId, name, title, titleMap, descriptionMap, settings,
-			serviceContext);
-	}
-
 	@BeanReference(type = ClassNameLocalService.class)
 	private ClassNameLocalService _classNameLocalService;
 

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 52.1.1
+Bundle-Version: 53.0.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyLocalService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyLocalService.java
@@ -506,17 +506,11 @@ public interface AssetVocabularyLocalService
 			int visibilityType)
 		throws PortalException;
 
+	@Indexable(type = IndexableType.REINDEX)
 	public AssetVocabulary updateVocabulary(
 			long vocabularyId, String title, Map<Locale, String> titleMap,
 			Map<Locale, String> descriptionMap, String settings,
 			ServiceContext serviceContext)
-		throws PortalException;
-
-	@Indexable(type = IndexableType.REINDEX)
-	public AssetVocabulary updateVocabulary(
-			long vocabularyId, String name, String title,
-			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
-			String settings, ServiceContext serviceContext)
 		throws PortalException;
 
 	@Override

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyLocalServiceUtil.java
@@ -643,18 +643,6 @@ public class AssetVocabularyLocalServiceUtil {
 			serviceContext);
 	}
 
-	public static AssetVocabulary updateVocabulary(
-			long vocabularyId, String name, String title,
-			Map<java.util.Locale, String> titleMap,
-			Map<java.util.Locale, String> descriptionMap, String settings,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().updateVocabulary(
-			vocabularyId, name, title, titleMap, descriptionMap, settings,
-			serviceContext);
-	}
-
 	public static AssetVocabularyLocalService getService() {
 		return _service;
 	}

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyLocalServiceWrapper.java
@@ -737,20 +737,6 @@ public class AssetVocabularyLocalServiceWrapper
 	}
 
 	@Override
-	public AssetVocabulary updateVocabulary(
-			long vocabularyId, String name, String title,
-			java.util.Map<java.util.Locale, String> titleMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
-			String settings,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _assetVocabularyLocalService.updateVocabulary(
-			vocabularyId, name, title, titleMap, descriptionMap, settings,
-			serviceContext);
-	}
-
-	@Override
 	public CTPersistence<AssetVocabulary> getCTPersistence() {
 		return _assetVocabularyLocalService.getCTPersistence();
 	}

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyService.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyService.java
@@ -207,10 +207,4 @@ public interface AssetVocabularyService extends BaseService {
 			ServiceContext serviceContext)
 		throws PortalException;
 
-	public AssetVocabulary updateVocabulary(
-			long vocabularyId, String name, String title,
-			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
-			String settings, ServiceContext serviceContext)
-		throws PortalException;
-
 }

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyServiceUtil.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyServiceUtil.java
@@ -286,18 +286,6 @@ public class AssetVocabularyServiceUtil {
 			serviceContext);
 	}
 
-	public static AssetVocabulary updateVocabulary(
-			long vocabularyId, String name, String title,
-			Map<java.util.Locale, String> titleMap,
-			Map<java.util.Locale, String> descriptionMap, String settings,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().updateVocabulary(
-			vocabularyId, name, title, titleMap, descriptionMap, settings,
-			serviceContext);
-	}
-
 	public static AssetVocabularyService getService() {
 		return _service;
 	}

--- a/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/AssetVocabularyServiceWrapper.java
@@ -335,20 +335,6 @@ public class AssetVocabularyServiceWrapper
 	}
 
 	@Override
-	public AssetVocabulary updateVocabulary(
-			long vocabularyId, String name, String title,
-			java.util.Map<java.util.Locale, String> titleMap,
-			java.util.Map<java.util.Locale, String> descriptionMap,
-			String settings,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _assetVocabularyService.updateVocabulary(
-			vocabularyId, name, title, titleMap, descriptionMap, settings,
-			serviceContext);
-	}
-
-	@Override
 	public AssetVocabularyService getWrappedService() {
 		return _assetVocabularyService;
 	}

--- a/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 7.0.0


### PR DESCRIPTION
@joseluisbango originally wrote:

> As discussed in [PTR-3060](https://issues.liferay.com/browse/PTR-3060), we need to prevent the asset vocabulary name from being changed. Therefore, I have removed the update() method where you could change the name, so that it doesn't change when updating.