### PR TITLE
LPS-153827

### DIFF
--- a/modules/apps/fragment/fragment-service/build.gradle
+++ b/modules/apps/fragment/fragment-service/build.gradle
@@ -13,6 +13,8 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.annotation.versioning", version: "1.1.0"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly group: "org.springframework", name: "spring-aop", version: "5.2.20.RELEASE"
+	compileOnly group: "org.springframework", name: "spring-tx", version: "5.2.20.RELEASE"
 	compileOnly project(":apps:asset:asset-info-display-api")
 	compileOnly project(":apps:asset:asset-list-api")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")
@@ -20,10 +22,12 @@ dependencies {
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:fragment:fragment-api")
+	compileOnly project(":apps:layout:layout-api")
 	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":apps:portal:portal-aop-api")
 	compileOnly project(":apps:portal:portal-dao-orm-custom-sql-api")
 	compileOnly project(":apps:portal:portal-json-validator")
+	compileOnly project(":apps:portal:portal-spring-extender-api")
 	compileOnly project(":apps:segments:segments-api")
 	compileOnly project(":apps:site-navigation:site-navigation-api")
 	compileOnly project(":apps:staging:staging-api")

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -25,6 +25,11 @@ import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
 import com.liferay.fragment.service.base.FragmentEntryLinkLocalServiceBaseImpl;
 import com.liferay.fragment.service.persistence.FragmentCollectionPersistence;
 import com.liferay.fragment.service.persistence.FragmentEntryPersistence;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.util.structure.DeletedLayoutStructureItem;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -53,17 +58,23 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.spring.extender.service.ServiceReference;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.select.Elements;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -542,6 +553,8 @@ public class FragmentEntryLinkLocalServiceImpl
 
 		fragmentEntryLink.setHtml(fragmentEntry.getHtml());
 
+		_updateLayoutPageTemplateStructure(fragmentEntryLink);
+
 		// LPS-132154 Set configuration before processing the HTML
 
 		fragmentEntryLink.setConfiguration(fragmentEntry.getConfiguration());
@@ -567,6 +580,77 @@ public class FragmentEntryLinkLocalServiceImpl
 			fragmentEntryLink);
 
 		_updateFragmentEntryLinkLayout(fragmentEntryLink);
+	}
+
+	private void _addOrRestoreDropZoneLayoutStructureItem(
+		LayoutStructure layoutStructure,
+		LayoutStructureItem parentLayoutStructureItem) {
+
+		LayoutStructureItem existingLayoutStructureItem = null;
+
+		List<DeletedLayoutStructureItem> deletedLayoutStructureItems =
+			layoutStructure.getDeletedLayoutStructureItems();
+
+		for (DeletedLayoutStructureItem deletedLayoutStructureItem :
+				deletedLayoutStructureItems) {
+
+			LayoutStructureItem layoutStructureItem =
+				layoutStructure.getLayoutStructureItem(
+					deletedLayoutStructureItem.getItemId());
+
+			if (Objects.equals(
+					layoutStructureItem.getParentItemId(),
+					parentLayoutStructureItem.getItemId())) {
+
+				existingLayoutStructureItem = layoutStructureItem;
+
+				break;
+			}
+		}
+
+		if (existingLayoutStructureItem != null) {
+			layoutStructure.unmarkLayoutStructureItemForDeletion(
+				existingLayoutStructureItem.getItemId());
+		}
+		else {
+			layoutStructure.addFragmentDropZoneLayoutStructureItem(
+				parentLayoutStructureItem.getItemId(), -1);
+		}
+	}
+
+	private Document _getDocument(String html) {
+		Document document = Jsoup.parseBodyFragment(html);
+
+		Document.OutputSettings outputSettings = new Document.OutputSettings();
+
+		outputSettings.prettyPrint(false);
+
+		document.outputSettings(outputSettings);
+
+		return document;
+	}
+
+	private LayoutStructure _getLayoutStructure(
+		FragmentEntryLink fragmentEntryLink) {
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					fragmentEntryLink.getGroupId(),
+					fragmentEntryLink.getPlid());
+
+		if (layoutPageTemplateStructure == null) {
+			return null;
+		}
+
+		String data = layoutPageTemplateStructure.getData(
+			fragmentEntryLink.getSegmentsExperienceId());
+
+		if (Validator.isNull(data)) {
+			return null;
+		}
+
+		return LayoutStructure.of(data);
 	}
 
 	private String _getProcessedHTML(
@@ -719,6 +803,73 @@ public class FragmentEntryLinkLocalServiceImpl
 		_layoutLocalService.updateLayout(layout);
 	}
 
+	private void _updateLayoutPageTemplateStructure(
+			FragmentEntryLink fragmentEntryLink)
+		throws PortalException {
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		String processedHTML =
+			_fragmentEntryProcessorRegistry.processFragmentEntryLinkHTML(
+				fragmentEntryLink,
+				new DefaultFragmentEntryProcessorContext(
+					serviceContext.getRequest(), serviceContext.getResponse(),
+					FragmentEntryLinkConstants.EDIT,
+					serviceContext.getLocale()));
+
+		Document document = _getDocument(processedHTML);
+
+		Elements elements = document.select("lfr-drop-zone");
+
+		if (elements.size() <= 0) {
+			return;
+		}
+
+		LayoutStructure layoutStructure = _getLayoutStructure(
+			fragmentEntryLink);
+
+		if (layoutStructure == null) {
+			return;
+		}
+
+		LayoutStructureItem parentLayoutStructureItem =
+			layoutStructure.getLayoutStructureItemByFragmentEntryLinkId(
+				fragmentEntryLink.getFragmentEntryLinkId());
+
+		if (parentLayoutStructureItem == null) {
+			return;
+		}
+
+		List<String> childrenItemIds =
+			parentLayoutStructureItem.getChildrenItemIds();
+
+		if (childrenItemIds.size() == elements.size()) {
+			return;
+		}
+
+		if (childrenItemIds.size() > elements.size()) {
+			List<String> childrenItemIdsToRemove = childrenItemIds.subList(
+				elements.size(), childrenItemIds.size());
+
+			childrenItemIdsToRemove.forEach(
+				itemId -> layoutStructure.markLayoutStructureItemForDeletion(
+					itemId, Collections.emptyList()));
+		}
+		else {
+			for (int i = childrenItemIds.size(); i < elements.size(); i++) {
+				_addOrRestoreDropZoneLayoutStructureItem(
+					layoutStructure, parentLayoutStructureItem);
+			}
+		}
+
+		_layoutPageTemplateStructureLocalService.
+			updateLayoutPageTemplateStructureData(
+				fragmentEntryLink.getGroupId(), fragmentEntryLink.getPlid(),
+				fragmentEntryLink.getSegmentsExperienceId(),
+				layoutStructure.toString());
+	}
+
 	private static final String[] _FRAGMENT_ENTRY_PROCESSOR_KEYS = {
 		"com.liferay.fragment.entry.processor.editable." +
 			"EditableFragmentEntryProcessor"
@@ -750,6 +901,10 @@ public class FragmentEntryLinkLocalServiceImpl
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@ServiceReference(type = LayoutPageTemplateStructureLocalService.class)
+	private LayoutPageTemplateStructureLocalService
+		_layoutPageTemplateStructureLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PropagateGroupFragmentEntryChangesMVCActionCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/PropagateGroupFragmentEntryChangesMVCActionCommandTest.java
@@ -38,6 +38,7 @@ import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
@@ -100,6 +101,8 @@ public class PropagateGroupFragmentEntryChangesMVCActionCommandTest {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId());
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
 
 		FragmentEntryLink fragmentEntryLink =
 			_fragmentEntryLinkLocalService.addFragmentEntryLink(


### PR DESCRIPTION
Hi @liferay-echo

could you please review my fix?

In case of fragmant propagation (updateLatestChanges) the template strucutre is not updated.

I used the _updateLayoutPageTemplateStructure method from the DropZoneContentPageEditorListener.
I want ot use the

       @Reference
	private LayoutPageTemplateStructureLocalService
		_layoutPageTemplateStructureLocalService;
but after the deployement in the Gogo shell the
scr:info com.liferay.fragment.service.impl.FragmentEntryLinkLocalServiceImpl
returns LayoutPageTemplateStructureLocalService UNSATISFIED
and in the portal some menus (Pages, WebContent) and functionalities (edit Page) is not working.

So, therefore is used the ServiceReference for the _layoutPageTemplateStructureLocalService

https://issues.liferay.com/browse/LPS-153827

cc @lfbesada 