### PR TITLE
[TS] LPS-153713 Use the common pattern in filters to avoid NPE

### DIFF
--- a/modules/apps/portal/portal-upload-servlet-request-filter/src/main/java/com/liferay/portal/upload/servlet/request/filter/internal/UploadServletRequestFilter.java
+++ b/modules/apps/portal/portal-upload-servlet-request-filter/src/main/java/com/liferay/portal/upload/servlet/request/filter/internal/UploadServletRequestFilter.java
@@ -25,13 +25,12 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.servlet.filters.BasePortalFilter;
 import com.liferay.portal.upload.LiferayInputStream;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
-import javax.servlet.ServletContext;
+import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -86,12 +85,11 @@ public class UploadServletRequestFilter extends BasePortalFilter {
 				_portal.getCompanyId(httpServletRequest), portletId);
 
 			if (portlet != null) {
-				ServletContext servletContext =
-					(ServletContext)httpServletRequest.getAttribute(
-						WebKeys.CTX);
+				FilterConfig filterConfig = getFilterConfig();
 
 				InvokerPortlet invokerPortlet =
-					PortletInstanceFactoryUtil.create(portlet, servletContext);
+					PortletInstanceFactoryUtil.create(
+						portlet, filterConfig.getServletContext());
 
 				LiferayPortletConfig liferayPortletConfig =
 					(LiferayPortletConfig)invokerPortlet.getPortletConfig();


### PR DESCRIPTION
hi Team,
Could you review this?

https://issues.liferay.com/browse/LPS-154740

Best,
Attila

----

When this property is turned on I found that there is a second request in the use case explained on the LPS that will be stuck resulting in the following not returning a servletContext.
 ```
ServletContext servletContext  = (ServletContext)httpServletRequest.getAttribute(WebKeys.CTX);
``` 
because the current request will not contain the servletContext. After checking other Filters I found that the usual pattern to get the servletContext in filters is to get it through the filterConfig. I tested the use case and after using the common pattern the issue is resolved.
