### PR TITLE
[TS] LPS-154572 Do not show alert when editing default values

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -79,7 +79,10 @@ export default function _JournalPortlet({
 			`${namespace}titleMapAsXML`
 		);
 
-		if (!titleInputComponent?.getValue(defaultLanguageId)) {
+		if (
+			!editingDefaultValues &&
+			!titleInputComponent?.getValue(defaultLanguageId)
+		) {
 			showAlert(
 				Liferay.Util.sub(
 					Liferay.Language.get(


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-154572

Issue:
When editing a Structure with "Edit with default values" and missing the title the UI shows an error message:
"Error: Please enter a valid title for the default language: en-US."
"Editing default values" should not throw an error message in case of a missing title because it is not a required field.

Solution:
We only throw the error message when publishing a Web content with missing title.

Please review my PR!

Best regards,
Évi