### PR TITLE
[TS] LPS-154364 - remove disabled class when toggling

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
@@ -65,6 +65,10 @@
 						input.disabled = disableOnChecked
 							? !toggle.checked
 							: toggle.checked;
+
+						if (!input.disabled) {
+							input.classList.remove('disabled');
+						}
 					}
 				}
 			);

--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/view.jsp
@@ -68,6 +68,15 @@
 
 						if (!input.disabled) {
 							input.classList.remove('disabled');
+
+							if (input.labels.length > 0) {
+								input.labels[0].classList.remove('disabled');
+							}
+						}
+						else {
+							if (input.labels.length > 0) {
+								input.labels[0].classList.add('disabled');
+							}
 						}
 					}
 				}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-154364

Hi @liferay-echo!

This fix is meant to address an issue in the Look & Feel configuration menu. When one of the "Same For All" toggles is switched on and saved, the next time you re-open the menu all of the fields except the topmost field will be disabled. However, when toggling "Same For All" off, the fields keep their 'disabled' appearance (e.g. cursor is still a 'forbidden action' icon) despite technically being re-enabled (you can click into the fields and add values).

To address this, I've added a step to the toggling method where we remove the 'disabled' class from our classlist in the case of toggling disabled off. Please let me know if you have any questions, thanks!