### PR TITLE
LPS-154833 Frontend tests undo/redo stylebooks

### DIFF
--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/LayoutPreview.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/LayoutPreview.js
@@ -41,6 +41,8 @@ export default function LayoutPreview() {
 			const root = iframeRef.current.contentDocument.documentElement;
 
 			if (root) {
+				root.removeAttribute('style');
+
 				Object.values(frontendTokensValues).forEach(
 					({cssVariableMapping, value}) => {
 						root.style.setProperty(

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/StyleBookContext.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/StyleBookContext.js
@@ -98,12 +98,10 @@ function internalSaveTokenValues({dispatch, frontendTokensValues, tokens}) {
 				value: DRAFT_STATUS.draftSaved,
 			});
 
-			if (Object.keys(tokens).length !== 0) {
-				dispatch({
-					tokens,
-					type: SET_TOKEN_VALUES,
-				});
-			}
+			dispatch({
+				tokens,
+				type: SET_TOKEN_VALUES,
+			});
 		})
 		.catch((error) => {
 			if (process.env.NODE_ENV === 'development') {

--- a/modules/apps/style-book/style-book-web/test/style-book-editor/reducer.test.js
+++ b/modules/apps/style-book/style-book-web/test/style-book-editor/reducer.test.js
@@ -1,0 +1,222 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {
+	ADD_REDO_ACTION,
+	ADD_UNDO_ACTION,
+	LOADING,
+	SET_DRAFT_STATUS,
+	SET_PREVIEW_LAYOUT,
+	SET_PREVIEW_LAYOUT_TYPE,
+	SET_TOKEN_VALUES,
+	UPDATE_UNDO_REDO_HISTORY,
+} from '../../src/main/resources/META-INF/resources/js/style-book-editor/constants/actionTypes';
+import reducer from '../../src/main/resources/META-INF/resources/js/style-book-editor/reducer';
+
+const STATE = {
+	draftStatus: null,
+	frontendTokensValues: {
+		testColor1: {
+			cssVariableMapping: 'test-color-1',
+			label: 'Test Color 1',
+			value: '#AAAAAA',
+		},
+	},
+	loading: true,
+	previewLayout: {},
+	previewLayoutType: null,
+	redoHistory: [
+		{
+			name: 'testColor3',
+			value: {
+				cssVariableMapping: 'test-color-3',
+				label: 'Test Color 3',
+				value: '#111111',
+			},
+		},
+	],
+	undoHistory: [
+		{
+			name: 'testColor1',
+			value: {
+				cssVariableMapping: 'test-color-1',
+				label: 'Test Color 1',
+				value: '#BBBBBB',
+			},
+		},
+	],
+};
+
+describe('reducer', () => {
+	it('saves needed state when dispatching LOADING action', () => {
+		const {loading} = reducer(STATE, {
+			type: LOADING,
+			value: false,
+		});
+
+		expect(loading).toBe(false);
+	});
+
+	it('saves needed state when dispatching SET_DRAFT_STATUS action', () => {
+		const {draftStatus} = reducer(STATE, {
+			type: SET_DRAFT_STATUS,
+			value: 'saving',
+		});
+
+		expect(draftStatus).toBe('saving');
+	});
+
+	it('saves needed state when dispatching SET_PREVIEW_LAYOUT action', () => {
+		const layout = {
+			name: 'hello world',
+			private: false,
+			url: 'my-url',
+		};
+
+		const {previewLayout} = reducer(STATE, {
+			layout,
+			type: SET_PREVIEW_LAYOUT,
+		});
+
+		expect(previewLayout).toBe(layout);
+	});
+
+	it('saves needed state when dispatching SET_PREVIEW_LAYOUT_TYPE action', () => {
+		const {previewLayoutType} = reducer(STATE, {
+			layoutType: 'layoutTest',
+			type: SET_PREVIEW_LAYOUT_TYPE,
+		});
+
+		expect(previewLayoutType).toBe('layoutTest');
+	});
+
+	it('saves needed state when dispatching SET_TOKEN_VALUES action', () => {
+		const tokens = {
+			testColor2: {
+				cssVariableMapping: 'test-color-2',
+				label: 'Test Color 2',
+				value: '#BBBBBB',
+			},
+		};
+
+		const {frontendTokensValues} = reducer(STATE, {
+			tokens,
+			type: SET_TOKEN_VALUES,
+		});
+
+		expect(frontendTokensValues).toEqual({
+			...frontendTokensValues,
+			...tokens,
+		});
+	});
+
+	it('saves needed state when dispatching ADD_UNDO_ACTION action when is a redo action', () => {
+		const token = {
+			name: 'testColor2',
+			value: {
+				cssVariableMapping: 'test-color-2',
+				label: 'Test Color 2',
+				value: '#CCCCCC',
+			},
+		};
+
+		const {redoHistory, undoHistory} = reducer(STATE, {
+			isRedo: true,
+			type: ADD_UNDO_ACTION,
+			...token,
+		});
+
+		expect(redoHistory).toEqual(STATE.redoHistory);
+		expect(undoHistory).toEqual([token, ...STATE.undoHistory]);
+	});
+
+	it('saves needed state when dispatching ADD_UNDO_ACTION action when there is no a redo action', () => {
+		const token = {
+			name: 'testColor2',
+			value: {
+				cssVariableMapping: 'test-color-2',
+				label: 'Test Color 2',
+				value: '#CCCCCC',
+			},
+		};
+
+		const {redoHistory, undoHistory} = reducer(STATE, {
+			type: ADD_UNDO_ACTION,
+			...token,
+		});
+
+		expect(redoHistory).toEqual([]);
+		expect(undoHistory).toEqual([token, ...STATE.undoHistory]);
+	});
+
+	it('saves needed state when dispatching ADD_REDO_ACTION action', () => {
+		const token = {
+			name: 'testColor2',
+			value: {
+				cssVariableMapping: 'test-color-2',
+				label: 'Test Color 2',
+				value: '#DDDDDD',
+			},
+		};
+
+		const {redoHistory} = reducer(STATE, {
+			type: ADD_REDO_ACTION,
+			...token,
+		});
+
+		expect(redoHistory).toEqual([token, ...STATE.redoHistory]);
+	});
+
+	it('saves needed state when dispatching UPDATE_UNDO_REDO_HISTORY action', () => {
+		const nextRedoHistory = [
+			{
+				name: 'testColor2',
+				value: {
+					cssVariableMapping: 'test-color-2',
+					label: 'Test Color 2',
+					value: '#DDDDDD',
+				},
+			},
+		];
+
+		const nextUndoHistory = [
+			{
+				name: 'testColor3',
+				value: {
+					cssVariableMapping: 'test-color-3',
+					label: 'Test Color 2',
+					value: '#333333',
+				},
+			},
+		];
+
+		const {redoHistory, undoHistory} = reducer(STATE, {
+			redoHistory: nextRedoHistory,
+			type: UPDATE_UNDO_REDO_HISTORY,
+			undoHistory: nextUndoHistory,
+		});
+
+		expect(redoHistory).toEqual(nextRedoHistory);
+		expect(undoHistory).toEqual(nextUndoHistory);
+	});
+
+	it('saves needed state when dispatching UPDATE_UNDO_REDO_HISTORY action and there are no previous redo/undo history', () => {
+		const {redoHistory, undoHistory} = reducer(STATE, {
+			type: UPDATE_UNDO_REDO_HISTORY,
+		});
+
+		expect(redoHistory).toEqual(STATE.redoHistory);
+		expect(undoHistory).toEqual(STATE.undoHistory);
+	});
+});

--- a/modules/apps/style-book/style-book-web/test/style-book-editor/undoHistory.test.js
+++ b/modules/apps/style-book/style-book-web/test/style-book-editor/undoHistory.test.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import '@testing-library/jest-dom/extend-expect';
+import {render} from '@testing-library/react';
+import React from 'react';
+
+import {StyleBookContextProvider} from '../../src/main/resources/META-INF/resources/js/style-book-editor/StyleBookContext';
+import UndoHistory from '../../src/main/resources/META-INF/resources/js/style-book-editor/UndoHistory';
+
+const STATE = {
+	redoHistory: [
+		{
+			label: 'Brand Color 2',
+			name: 'testColor2',
+			value: {
+				cssVariableMapping: 'test-color-2',
+				value: '#DDDDDD',
+			},
+		},
+		{
+			label: 'Test Color 1',
+			name: 'testColor1',
+			value: {
+				cssVariableMapping: 'test-color-1',
+				value: '#111111',
+			},
+		},
+	],
+	undoHistory: [
+		{
+			label: 'Test Color 3',
+			name: 'testColor3',
+			value: {
+				cssVariableMapping: 'test-color-3',
+				value: '#2e5aac',
+			},
+		},
+		{
+			label: 'Test Color 4',
+			name: 'testColor4',
+			value: {
+				cssVariableMapping: 'test-color-4',
+				value: '#6b6c7e',
+			},
+		},
+		{
+			label: 'Test Color 5',
+			name: 'testColor5',
+			value: {
+				cssVariableMapping: 'test-color-5',
+				value: '#BBBBBB',
+			},
+		},
+	],
+};
+
+function renderUndoHistory() {
+	return render(
+		<StyleBookContextProvider
+			initialState={{
+				draftStatus: 'saved',
+				frontendTokensValues: {},
+				previewLayout: {},
+				previewLayoutType: 'lalala',
+				redoHistory: STATE.redoHistory,
+				undoHistory: STATE.undoHistory,
+			}}
+		>
+			<UndoHistory />
+		</StyleBookContextProvider>
+	);
+}
+
+describe('UndoHistory', () => {
+	Liferay.Util.sub.mockImplementation((key, args) =>
+		key.replace('-x', ` ${args}`)
+	);
+
+	it('shows all redo and undo history items in the list', () => {
+		const {getByText} = renderUndoHistory();
+
+		STATE.redoHistory
+			.concat(STATE.undoHistory)
+			.forEach(({label}) =>
+				expect(getByText(`update ${label}`)).toBeInTheDocument()
+			);
+	});
+});


### PR DESCRIPTION
There is an extra commit (e1d7c649e1195a69fe8ac22e5761b509087da67a) in this PR because when updating an input for the first time and doing an undo, the css of the iframe was not updated. For this reason it's necessary to remove all the css first and then add the corresponding css and always update the frontendTokensValues when the SET_TOKEN_VALUES is executed.