### PR TITLE
LPS-155177 Validate typeOptions in fragment contributors and when importing fragments

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 16.0.1
+Bundle-Version: 16.1.0
 Export-Package:\
 	com.liferay.fragment.configuration,\
 	com.liferay.fragment.constants,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/exception/FragmentEntryTypeOptionsException.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/exception/FragmentEntryTypeOptionsException.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.fragment.exception;
+
+import com.liferay.portal.kernel.exception.PortalException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class FragmentEntryTypeOptionsException extends PortalException {
+
+	public FragmentEntryTypeOptionsException() {
+	}
+
+	public FragmentEntryTypeOptionsException(String msg) {
+		super(msg);
+	}
+
+	public FragmentEntryTypeOptionsException(String msg, Throwable throwable) {
+		super(msg, throwable);
+	}
+
+	public FragmentEntryTypeOptionsException(Throwable throwable) {
+		super(throwable);
+	}
+
+}

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/validator/FragmentEntryValidator.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/validator/FragmentEntryValidator.java
@@ -15,6 +15,7 @@
 package com.liferay.fragment.validator;
 
 import com.liferay.fragment.exception.FragmentEntryConfigurationException;
+import com.liferay.fragment.exception.FragmentEntryTypeOptionsException;
 import com.liferay.portal.kernel.json.JSONObject;
 
 /**
@@ -29,5 +30,8 @@ public interface FragmentEntryValidator {
 			String configuration, JSONObject valuesJSONObject)
 		throws FragmentEntryConfigurationException {
 	}
+
+	public void validateTypeOptions(String typeOptions)
+		throws FragmentEntryTypeOptionsException;
 
 }

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/exception/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/validator/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/validator/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/contributor/FragmentCollectionContributorTrackerImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/contributor/FragmentCollectionContributorTrackerImpl.java
@@ -327,6 +327,8 @@ public class FragmentCollectionContributorTrackerImpl
 		try {
 			fragmentEntryValidator.validateConfiguration(
 				fragmentEntry.getConfiguration());
+			fragmentEntryValidator.validateTypeOptions(
+				fragmentEntry.getTypeOptions());
 
 			fragmentEntryProcessorRegistry.validateFragmentEntryHTML(
 				fragmentEntry.getHtml(), fragmentEntry.getConfiguration());

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -251,6 +251,7 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 				html, configuration);
 
 			_fragmentEntryValidator.validateConfiguration(configuration);
+			_fragmentEntryValidator.validateTypeOptions(typeOptions);
 		}
 		catch (PortalException portalException) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/fragment/fragment-service/service.xml
+++ b/modules/apps/fragment/fragment-service/service.xml
@@ -327,6 +327,7 @@
 		<exception>FragmentEntryConfiguration</exception>
 		<exception>FragmentEntryContent</exception>
 		<exception>FragmentEntryName</exception>
+		<exception>FragmentEntryTypeOptions</exception>
 		<exception>InvalidFile</exception>
 		<exception>InvalidFragmentCompositionKey</exception>
 		<exception>RequiredFragmentEntry</exception>

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/validator/FragmentEntryValidatorImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/validator/FragmentEntryValidatorImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.fragment.internal.validator;
 
 import com.liferay.fragment.exception.FragmentEntryConfigurationException;
+import com.liferay.fragment.exception.FragmentEntryTypeOptionsException;
 import com.liferay.fragment.validator.FragmentEntryValidator;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.json.validator.JSONValidator;
@@ -57,7 +58,7 @@ public class FragmentEntryValidatorImpl implements FragmentEntryValidator {
 		}
 
 		try {
-			_jsonValidator.validate(configuration);
+			_configurationJSONValidator.validate(configuration);
 
 			JSONObject configurationJSONObject =
 				JSONFactoryUtil.createJSONObject(configuration);
@@ -137,6 +138,21 @@ public class FragmentEntryValidatorImpl implements FragmentEntryValidator {
 		}
 	}
 
+	public void validateTypeOptions(String typeOptions)
+		throws FragmentEntryTypeOptionsException {
+
+		if (Validator.isNull(typeOptions)) {
+			return;
+		}
+
+		try {
+			_typeOptionsJSONValidator.validate(typeOptions);
+		}
+		catch (JSONValidatorException jsonValidatorException) {
+			throw new FragmentEntryTypeOptionsException(jsonValidatorException);
+		}
+	}
+
 	private boolean _checkValidationRules(
 		String value, JSONObject validationJSONObject) {
 
@@ -192,8 +208,13 @@ public class FragmentEntryValidatorImpl implements FragmentEntryValidator {
 			System.lineSeparator(), message);
 	}
 
-	private static final JSONValidator _jsonValidator = new JSONValidator(
-		FragmentEntryValidatorImpl.class.getResourceAsStream(
-			"dependencies/configuration-json-schema.json"));
+	private static final JSONValidator _configurationJSONValidator =
+		new JSONValidator(
+			FragmentEntryValidatorImpl.class.getResourceAsStream(
+				"dependencies/configuration-json-schema.json"));
+	private static final JSONValidator _typeOptionsJSONValidator =
+		new JSONValidator(
+			FragmentEntryValidatorImpl.class.getResourceAsStream(
+				"dependencies/type-options-json-schema.json"));
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -118,6 +118,7 @@ public class FragmentEntryLocalServiceImpl
 
 		if (WorkflowConstants.STATUS_APPROVED == status) {
 			_fragmentEntryValidator.validateConfiguration(configuration);
+			_fragmentEntryValidator.validateTypeOptions(typeOptions);
 			validateContent(html, configuration);
 		}
 
@@ -537,6 +538,8 @@ public class FragmentEntryLocalServiceImpl
 
 		_fragmentEntryValidator.validateConfiguration(
 			draftFragmentEntry.getConfiguration());
+		_fragmentEntryValidator.validateTypeOptions(
+			draftFragmentEntry.getTypeOptions());
 		validateContent(
 			draftFragmentEntry.getHtml(),
 			draftFragmentEntry.getConfiguration());
@@ -635,6 +638,7 @@ public class FragmentEntryLocalServiceImpl
 
 		if (WorkflowConstants.STATUS_APPROVED == status) {
 			_fragmentEntryValidator.validateConfiguration(configuration);
+			_fragmentEntryValidator.validateTypeOptions(typeOptions);
 			validateContent(html, configuration);
 		}
 

--- a/modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/validator/dependencies/type-options-json-schema.json
+++ b/modules/apps/fragment/fragment-service/src/main/resources/com/liferay/fragment/internal/validator/dependencies/type-options-json-schema.json
@@ -1,0 +1,13 @@
+{
+	"$id": "http://example.com/root.json",
+	"$schema": "http://json-schema.org/draft-07/schema#",
+	"additionalProperties": false,
+	"properties": {
+		"fieldTypes": {
+			"title": "The Fieldtypes Schema",
+			"type": "array"
+		}
+	},
+	"title": "Fragment type options",
+	"type": "object"
+}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155177

This PR adds JSON Schema validation for typeOptions when publishing fragments, importing them, and for contributed fragments.

To test this PR, we have to enable the FF first:

feature.flag.LPS-152938=true for the feature flag

Steps to test:

- Create a new fragment collection
- Add a new form fragment, and in configuration select some field types
- Publish the fragment
- Export the fragment, and then delete it
- Expand the zip file and locate fragment.json
- Check that typeOptions contains fieldTypes with the ones that were selected and change fieldTypes -> fieldTypes1 or something else
- Generate the zip file
- Import it in the UI

The interface will mention that there was an issue and the fragment will be imported as draft

<img width="811" alt="Screenshot 2022-06-06 at 11 07 16" src="https://user-images.githubusercontent.com/4267448/172131285-c0e945f0-bd69-42ca-966f-4a0f82cf62b7.png">


