### PR TITLE
LPS-155288 Add Results Bar to the Categories Filter

### DIFF
--- a/modules/apps/asset/asset-categories-selector-web/src/main/java/com/liferay/asset/categories/selector/web/internal/display/context/AssetCategoriesSelectorDisplayContext.java
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/java/com/liferay/asset/categories/selector/web/internal/display/context/AssetCategoriesSelectorDisplayContext.java
@@ -143,6 +143,8 @@ public class AssetCategoriesSelectorDisplayContext {
 			"nodes", getCategoriesJSONArray()
 		).put(
 			"selectedCategoryIds", getSelectedCategoryIds()
+		).put(
+			"showSelectedCounter", showSelectedCounter()
 		).build();
 	}
 
@@ -279,6 +281,17 @@ public class AssetCategoriesSelectorDisplayContext {
 		return _singleSelect;
 	}
 
+	public boolean showSelectedCounter() {
+		if (_showSelectedCounter != null) {
+			return _showSelectedCounter;
+		}
+
+		_showSelectedCounter = ParamUtil.getBoolean(
+			_httpServletRequest, "showSelectedCounter");
+
+		return _showSelectedCounter;
+	}
+
 	private JSONArray _getCategoriesJSONArray(
 			long vocabularyId, long categoryId)
 		throws Exception {
@@ -377,6 +390,7 @@ public class AssetCategoriesSelectorDisplayContext {
 	private final RenderRequest _renderRequest;
 	private final RenderResponse _renderResponse;
 	private List<String> _selectedCategoryIds;
+	private Boolean _showSelectedCounter;
 	private Boolean _singleSelect;
 	private long[] _vocabularyIds;
 

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/css/tree.scss
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/css/tree.scss
@@ -1,3 +1,4 @@
+@import 'cadmin-variables';
 $spacer: 1rem;
 
 .select-category-filter {
@@ -5,4 +6,17 @@ $spacer: 1rem;
 	border-bottom: 1px solid #dee2e6;
 	margin-bottom: $spacer * 1.5;
 	padding: $spacer * 0.75;
+
+	&--with-count-feedback {
+		border-bottom: none;
+		margin-bottom: 0;
+		padding: $spacer;
+	}
+}
+
+.select-category-count-feedback {
+	align-items: center;
+	background: $cadmin-primary-l2;
+	display: flex;
+	min-height: 40px;
 }

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/css/tree.scss
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/css/tree.scss
@@ -21,6 +21,7 @@ $spacer: 1rem;
 	min-height: 40px;
 }
 
-.select-category-clear-selected {
+.select-category-clear-selected,
+.select-category-clear-selected:hover {
 	color: $cadmin-gray-900;
 }

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/css/tree.scss
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/css/tree.scss
@@ -20,3 +20,7 @@ $spacer: 1rem;
 	display: flex;
 	min-height: 40px;
 }
+
+.select-category-clear-selected {
+	color: $cadmin-gray-900;
+}

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -137,9 +137,7 @@ function SelectCategory({
 								items={items}
 								multiSelection={multiSelection}
 								onItems={setItems}
-								onSelectionChange={(selectedNodes) => {
-									setSelectedItems(selectedNodes);
-								}}
+								onSelectionChange={setSelectedItems}
 								selectedCategoryIds={selectedItems}
 							/>
 						) : (

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -30,6 +30,7 @@ function SelectCategory({
 	namespace,
 	nodes,
 	selectedCategoryIds,
+	showSelectedCounter,
 }) {
 	const [items, setItems] = useState(() => {
 		if (nodes.length === 1 && nodes[0].vocabulary && nodes[0].id !== '0') {
@@ -40,6 +41,7 @@ function SelectCategory({
 	});
 
 	const [filterQuery, setFilterQuery] = useState('');
+	const [selectedItemsCount, setSelectedItemsCount] = useState(0);
 
 	return (
 		<div className="select-category">
@@ -89,6 +91,24 @@ function SelectCategory({
 			</form>
 
 			<form name={`${namespace}selectCategoryFm`}>
+				{showSelectedCounter && !!selectedItemsCount && (
+					<ClayLayout.Container
+						className="px-4 tree-filter-count-feedback"
+						containerElement="section"
+						fluid
+					>
+						<div className="align-items-center container-fluid d-flex justify-content-between p-0">
+							<p className="m-0 text-2">
+								{selectedItemsCount + ' '}
+
+								{selectedItemsCount > 1
+									? Liferay.Language.get('items-selected')
+									: Liferay.Language.get('item-selected')}
+							</p>
+						</div>
+					</ClayLayout.Container>
+				)}
+
 				<ClayLayout.ContainerFluid containerElement="fieldset">
 					<div
 						className="category-tree"
@@ -102,6 +122,9 @@ function SelectCategory({
 								items={items}
 								multiSelection={multiSelection}
 								onItems={setItems}
+								onSelectionChange={(selectedNodes) => {
+									setSelectedItemsCount(selectedNodes.size);
+								}}
 								selectedCategoryIds={selectedCategoryIds}
 							/>
 						) : (
@@ -122,9 +145,14 @@ function SelectCategory({
 	);
 }
 
+SelectCategory.defaultProps = {
+	showSelectedCounter: false,
+};
+
 SelectCategory.propTypes = {
 	addCategoryURL: PropTypes.string,
 	moveCategory: PropTypes.bool,
+	showSelectedCounter: PropTypes.bool,
 };
 
 export default SelectCategory;

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -16,7 +16,6 @@ import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
-import ClayLink, {ClayLinkContext} from '@clayui/link';
 import classNames from 'classnames';
 import {navigate} from 'frontend-js-web';
 import PropTypes from 'prop-types';
@@ -45,18 +44,6 @@ function SelectCategory({
 	const [filterQuery, setFilterQuery] = useState('');
 	const [selectedItems, setSelectedItems] = useState(
 		new Set(selectedCategoryIds)
-	);
-
-	const handleClearSelected = ({children, href, ...otherProps}) => (
-		<a
-			{...otherProps}
-			href={href}
-			onClick={() => {
-				setSelectedItems(new Set([]));
-			}}
-		>
-			{children}
-		</a>
 	);
 
 	return (
@@ -123,17 +110,15 @@ function SelectCategory({
 								: Liferay.Language.get('item-selected')}
 						</p>
 
-						<ClayLinkContext.Provider value={handleClearSelected}>
-							<div>
-								<ClayLink
-									className="select-category-clear-selected text-3 text-weight-semi-bold"
-									displayType="secondary"
-									href="#"
-								>
-									{Liferay.Language.get('clear-all')}
-								</ClayLink>
-							</div>
-						</ClayLinkContext.Provider>
+						<ClayButton
+							className="select-category-clear-selected text-3 text-weight-semi-bold"
+							displayType="link"
+							onClick={() => {
+								setSelectedItems(new Set([]));
+							}}
+						>
+							{Liferay.Language.get('clear-all')}
+						</ClayButton>
 					</div>
 				</ClayLayout.Container>
 			)}

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -126,7 +126,7 @@ function SelectCategory({
 						<ClayLinkContext.Provider value={handleClearSelected}>
 							<div>
 								<ClayLink
-									className="text-3 text-weight-semi-bold tree-filter-clear-selected"
+									className="select-category-clear-selected text-3 text-weight-semi-bold"
 									displayType="secondary"
 									href="#"
 								>

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -16,6 +16,7 @@ import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
+import classNames from 'classnames';
 import {navigate} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useState} from 'react';
@@ -54,7 +55,9 @@ function SelectCategory({
 			)}
 
 			<form
-				className="select-category-filter"
+				className={classNames('select-category-filter', {
+					'select-category-filter--with-count-feedback': showSelectedCounter,
+				})}
 				onSubmit={(event) => event.preventDefault()}
 				role="search"
 			>
@@ -90,25 +93,25 @@ function SelectCategory({
 				</ClayLayout.ContainerFluid>
 			</form>
 
+			{showSelectedCounter && !!selectedItemsCount && (
+				<ClayLayout.Container
+					className="mb-3 px-4 select-category-count-feedback"
+					containerElement="section"
+					fluid
+				>
+					<div className="align-items-center container-fluid d-flex justify-content-between p-0">
+						<p className="m-0 text-2">
+							{selectedItemsCount + ' '}
+
+							{selectedItemsCount > 1
+								? Liferay.Language.get('items-selected')
+								: Liferay.Language.get('item-selected')}
+						</p>
+					</div>
+				</ClayLayout.Container>
+			)}
+
 			<form name={`${namespace}selectCategoryFm`}>
-				{showSelectedCounter && !!selectedItemsCount && (
-					<ClayLayout.Container
-						className="px-4 tree-filter-count-feedback"
-						containerElement="section"
-						fluid
-					>
-						<div className="align-items-center container-fluid d-flex justify-content-between p-0">
-							<p className="m-0 text-2">
-								{selectedItemsCount + ' '}
-
-								{selectedItemsCount > 1
-									? Liferay.Language.get('items-selected')
-									: Liferay.Language.get('item-selected')}
-							</p>
-						</div>
-					</ClayLayout.Container>
-				)}
-
 				<ClayLayout.ContainerFluid containerElement="fieldset">
 					<div
 						className="category-tree"

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -31,7 +31,7 @@ function SelectCategory({
 	namespace,
 	nodes,
 	selectedCategoryIds,
-	showSelectedCounter,
+	showSelectedCounter = false,
 }) {
 	const [items, setItems] = useState(() => {
 		if (nodes.length === 1 && nodes[0].vocabulary && nodes[0].id !== '0') {
@@ -157,10 +157,6 @@ function SelectCategory({
 		</div>
 	);
 }
-
-SelectCategory.defaultProps = {
-	showSelectedCounter: false,
-};
 
 SelectCategory.propTypes = {
 	addCategoryURL: PropTypes.string,

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -16,6 +16,7 @@ import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
+import ClayLink, {ClayLinkContext} from '@clayui/link';
 import classNames from 'classnames';
 import {navigate} from 'frontend-js-web';
 import PropTypes from 'prop-types';
@@ -42,7 +43,21 @@ function SelectCategory({
 	});
 
 	const [filterQuery, setFilterQuery] = useState('');
-	const [selectedItemsCount, setSelectedItemsCount] = useState(0);
+	const [selectedItems, setSelectedItems] = useState(
+		new Set(selectedCategoryIds)
+	);
+
+	const handleClearSelected = ({children, href, ...otherProps}) => (
+		<a
+			{...otherProps}
+			href={href}
+			onClick={() => {
+				setSelectedItems(new Set([]));
+			}}
+		>
+			{children}
+		</a>
+	);
 
 	return (
 		<div className="select-category">
@@ -93,7 +108,7 @@ function SelectCategory({
 				</ClayLayout.ContainerFluid>
 			</form>
 
-			{showSelectedCounter && !!selectedItemsCount && (
+			{showSelectedCounter && selectedItems.size > 0 && (
 				<ClayLayout.Container
 					className="mb-3 px-4 select-category-count-feedback"
 					containerElement="section"
@@ -101,12 +116,24 @@ function SelectCategory({
 				>
 					<div className="align-items-center container-fluid d-flex justify-content-between p-0">
 						<p className="m-0 text-2">
-							{selectedItemsCount + ' '}
+							{selectedItems.size + ' '}
 
-							{selectedItemsCount > 1
+							{selectedItems.size > 1
 								? Liferay.Language.get('items-selected')
 								: Liferay.Language.get('item-selected')}
 						</p>
+
+						<ClayLinkContext.Provider value={handleClearSelected}>
+							<div>
+								<ClayLink
+									className="text-3 text-weight-semi-bold tree-filter-clear-selected"
+									displayType="secondary"
+									href="#"
+								>
+									{Liferay.Language.get('clear-all')}
+								</ClayLink>
+							</div>
+						</ClayLinkContext.Provider>
 					</div>
 				</ClayLayout.Container>
 			)}
@@ -126,9 +153,9 @@ function SelectCategory({
 								multiSelection={multiSelection}
 								onItems={setItems}
 								onSelectionChange={(selectedNodes) => {
-									setSelectedItemsCount(selectedNodes.size);
+									setSelectedItems(selectedNodes);
 								}}
-								selectedCategoryIds={selectedCategoryIds}
+								selectedCategoryIds={selectedItems}
 							/>
 						) : (
 							<div className="border-0 pt-0 sheet taglib-empty-result-message">

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectTree.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectTree.es.js
@@ -74,6 +74,10 @@ export function SelectTree({
 	}, [items]);
 
 	useEffect(() => {
+		setSelectionChange(new Set(selectedCategoryIds));
+	}, [selectedCategoryIds]);
+
+	useEffect(() => {
 		const selectedItems = {};
 
 		selectedKeys.forEach((key) => {

--- a/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectTree.es.js
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/resources/META-INF/resources/js/SelectTree.es.js
@@ -48,6 +48,7 @@ export function SelectTree({
 	items,
 	multiSelection,
 	onItems,
+	onSelectionChange,
 	selectedCategoryIds,
 }) {
 	const [selectedKeys, setSelectionChange] = useState(
@@ -119,11 +120,16 @@ export function SelectTree({
 		}
 	};
 
+	const handleSelectionChange = (keys) => {
+		setSelectionChange(keys);
+		onSelectionChange(keys);
+	};
+
 	return filteredItems.length > 0 ? (
 		<ClayTreeView
 			items={filteredItems}
 			onItemsChange={(items) => onItems(items)}
-			onSelectionChange={(keys) => setSelectionChange(keys)}
+			onSelectionChange={handleSelectionChange}
 			selectedKeys={selectedKeys}
 			selectionMode={
 				inheritSelection

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
@@ -463,6 +463,8 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 				);
 			}
 		).setParameter(
+			"showSelectedCounter", true
+		).setParameter(
 			"singleSelect", false
 		).setParameter(
 			"vocabularyIds",


### PR DESCRIPTION
Motivation
=======
Add a Results Bar to the Categories Filter in Content Dashboard
[Link to story or ticket](https://issues.liferay.com/browse/LPS-155288)

Proposed Solution
========
We have added a new property to the SelectCategory component in order to be able to show a results bar with the number of items selected and a Clear All link.

Steps to Verify:
----------------
1. Create a vocabulary with some categories
1. Assign this categories to web contents, documents or blogs. Check that the categories tree that appears when assigning a category to an asset does not show the result bar. 
1. Go to Content Dashboard
1. Open the categories filter and check that the results bar appears when we have at least one category selected
1. Check that the Clear All link works
1. Check that the filtering works 

Screenshots (optional):
-----------------------
![Captura de pantalla 2022-06-06 a las 12 47 03](https://user-images.githubusercontent.com/3276218/172146797-7ed9c5bb-7b13-492f-ba8f-3282fa75fe9d.png)
