### PR TITLE
LPS-152446 Users click to edit a page from the page management screen

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -486,6 +486,20 @@ public class LayoutsAdminDisplayContext {
 		return _getDraftLayoutURL(layout);
 	}
 
+	public String getEditOrViewLayoutURL(Layout layout) throws Exception {
+		if ((isConversionDraft(layout) || layout.isTypeContent()) &&
+			isShowConfigureAction(layout)) {
+
+			return getEditLayoutURL(layout);
+		}
+
+		if (isShowViewLayoutAction(layout)) {
+			return getViewLayoutURL(layout);
+		}
+
+		return StringPool.BLANK;
+	}
+
 	public String getFaviconImage() {
 		LayoutSet layoutSet = getSelLayoutSet();
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/MillerColumnsDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/MillerColumnsDisplayContext.java
@@ -252,7 +252,7 @@ public class MillerColumnsDisplayContext {
 			if (_layoutsAdminDisplayContext.isShowViewLayoutAction(layout)) {
 				layoutJSONObject.put(
 					"viewUrl",
-					_layoutsAdminDisplayContext.getViewLayoutURL(layout));
+					_layoutsAdminDisplayContext.getEditOrViewLayoutURL(layout));
 			}
 
 			layoutsJSONArray.put(layoutJSONObject);

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/flattened_view.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/flattened_view.jsp
@@ -27,7 +27,7 @@
 	>
 		<liferay-ui:search-container-column-text
 			cssClass="table-cell-expand table-cell-minw-200 table-title"
-			href="<%= layoutsAdminDisplayContext.isShowViewLayoutAction(layout) ? layoutsAdminDisplayContext.getViewLayoutURL(layout) : StringPool.BLANK %>"
+			href="<%= layoutsAdminDisplayContext.getEditOrViewLayoutURL(layout) %>"
 			name="title"
 			value="<%= layout.getName(locale) %>"
 		/>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-152446

This PR redirects the user either to the view mode of the page or to the edit mode of the page based on permissions

To test this, we would need to create a new user that can access the pages admin widget, and has only view permissions. When the user clicks on the page, they should navigate to the view mode of the page.

If a user that has permissions would do this, they would navigate to the page editor so that they can work on the page

<img width="1087" alt="Screenshot 2022-06-06 at 14 38 24" src="https://user-images.githubusercontent.com/4267448/172162100-345aa55d-17ec-4274-9117-8ca99859dc16.png">
