### PR TITLE
LPS-155452 Fragment is not shown when publish page with an unmapped Form Container

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -59,6 +59,8 @@ import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.layoutconfiguration.util.RuntimePageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTemplate;
@@ -193,6 +195,10 @@ public class RenderLayoutStructureTag extends IncludeTag {
 						formStyledLayoutStructureItem.getClassTypeId()));
 			}
 			catch (NoSuchFormVariationException noSuchFormVariationException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(noSuchFormVariationException);
+				}
+
 				return null;
 			}
 		}
@@ -1171,6 +1177,9 @@ public class RenderLayoutStructureTag extends IncludeTag {
 			"StylesFragmentEntryProcessor";
 
 	private static final String _PAGE = "/render_layout_structure/page.jsp";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		RenderLayoutStructureTag.class);
 
 	private LayoutStructure _layoutStructure;
 	private String _mainItemId;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -172,14 +172,19 @@ public class RenderLayoutStructureTag extends IncludeTag {
 	private InfoForm _getInfoForm(
 		FormStyledLayoutStructureItem formStyledLayoutStructureItem) {
 
+		long classNameId = formStyledLayoutStructureItem.getClassNameId();
+
+		if (classNameId <= 0) {
+			return null;
+		}
+
 		InfoItemServiceTracker infoItemServiceTracker =
 			ServletContextUtil.getInfoItemServiceTracker();
 
 		InfoItemFormProvider<Object> infoItemFormProvider =
 			infoItemServiceTracker.getFirstInfoItemService(
 				InfoItemFormProvider.class,
-				PortalUtil.getClassName(
-					formStyledLayoutStructureItem.getClassNameId()));
+				PortalUtil.getClassName(classNameId));
 
 		if (infoItemFormProvider != null) {
 			try {


### PR DESCRIPTION
- LPS-155452 Avoid retrieving infoForm when it's not mapped. This can be seen when classNameId is 0
- LPS-155452 Log exception if debug is enabled
