### PR TITLE
[TS] LPS-155498 In getClassPK return the plid which is the primary key for Layout

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRenderer.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRenderer.java
@@ -58,7 +58,7 @@ public class LayoutAssetRenderer extends BaseJSPAssetRenderer<Layout> {
 
 	@Override
 	public long getClassPK() {
-		return _layout.getLayoutId();
+		return _layout.getPlid();
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRendererFactory.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRendererFactory.java
@@ -75,7 +75,7 @@ public class LayoutAssetRendererFactory
 		assetEntry.setCreateDate(layout.getCreateDate());
 		assetEntry.setClassNameId(
 			_portal.getClassNameId(Layout.class.getName()));
-		assetEntry.setClassPK(layout.getLayoutId());
+		assetEntry.setClassPK(layout.getPlid());
 		assetEntry.setTitle(layout.getHTMLTitle(LocaleUtil.getSiteDefault()));
 
 		return assetEntry;


### PR DESCRIPTION
Previous PR: https://github.com/liferay-zulu/liferay-portal/pull/195
Zulu team approved it from workflow side.

Hi Team,

https://issues.liferay.com/browse/LPP-45343

Issue:
The issue occurs upon opening the new Notification of a newly created page after deleting the previously created pages. I found that the id (plid) of the Notification we're trying to open, does not match the id in the exception.
In one of the methods, we call LayoutAssetRenderer.getClassPK() which should refer to the Primary Key of the Layout in the database, which instead returned the "layoutId". In most cases the getClassPK() method returns the primary key correctly (ex.: BlogsEntryAssetRenderer where it returns entryId which is its PK).
For the Layout the primary key in the DB is "plid".
So naturally the request failed with the "NoSuchLayoutException: No Layout exists with the primary key xy" exception, because we tried to open a layout that did not exist.

Solution:
In getClassPK() I changed the "layoutId" to "plid" which is the primary key for Layout in the DB. I also changed it in LayoutAssetRendererFactory, which had the same issue in getAssetEntry().
I did not found other cases where this would throw this exception: "NoSuchLayoutException".

I tested the fix in my local environment and the new notification can be opened correctly and the layout can be used as it is intended. (We can review and approve it, add fragments to it, update it, add content to it, etc, etc ).

Please review my PR!

Best regards,
Évi