### PR TITLE
LPS-155873 Export/Import of cssClasses in fragments added to a page

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 39.1.1
+Bundle-Version: 39.2.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageCollectionDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageCollectionDefinition.java
@@ -127,6 +127,38 @@ public class PageCollectionDefinition implements Serializable {
 	protected CollectionViewport[] collectionViewports;
 
 	@Schema(
+		description = "A list of CSS Classes that are applied to the element."
+	)
+	public String[] getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(String[] cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	@JsonIgnore
+	public void setCssClasses(
+		UnsafeSupplier<String[], Exception> cssClassesUnsafeSupplier) {
+
+		try {
+			cssClasses = cssClassesUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "A list of CSS Classes that are applied to the element."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String[] cssClasses;
+
+	@Schema(
 		description = "Whether to show all items when pagination is disabled."
 	)
 	public Boolean getDisplayAllItems() {
@@ -587,6 +619,30 @@ public class PageCollectionDefinition implements Serializable {
 				sb.append(String.valueOf(collectionViewports[i]));
 
 				if ((i + 1) < collectionViewports.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (cssClasses != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"cssClasses\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < cssClasses.length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(cssClasses[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < cssClasses.length) {
 					sb.append(", ");
 				}
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageFormDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageFormDefinition.java
@@ -61,6 +61,38 @@ public class PageFormDefinition implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(PageFormDefinition.class, json);
 	}
 
+	@Schema(
+		description = "A list of CSS Classes that are applied to the element."
+	)
+	public String[] getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(String[] cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	@JsonIgnore
+	public void setCssClasses(
+		UnsafeSupplier<String[], Exception> cssClassesUnsafeSupplier) {
+
+		try {
+			cssClasses = cssClassesUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "A list of CSS Classes that are applied to the element."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String[] cssClasses;
+
 	@Schema(description = "The page form's configuration.")
 	@Valid
 	public FormConfig getFormConfig() {
@@ -207,6 +239,30 @@ public class PageFormDefinition implements Serializable {
 		StringBundler sb = new StringBundler();
 
 		sb.append("{");
+
+		if (cssClasses != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"cssClasses\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < cssClasses.length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(cssClasses[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < cssClasses.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
 
 		if (formConfig != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageFragmentInstanceDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageFragmentInstanceDefinition.java
@@ -63,6 +63,38 @@ public class PageFragmentInstanceDefinition implements Serializable {
 			PageFragmentInstanceDefinition.class, json);
 	}
 
+	@Schema(
+		description = "A list of CSS Classes that are applied to the element."
+	)
+	public String[] getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(String[] cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	@JsonIgnore
+	public void setCssClasses(
+		UnsafeSupplier<String[], Exception> cssClassesUnsafeSupplier) {
+
+		try {
+			cssClasses = cssClassesUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "A list of CSS Classes that are applied to the element."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String[] cssClasses;
+
 	@Schema(description = "The fragment of the page fragment instance.")
 	@Valid
 	public Fragment getFragment() {
@@ -313,6 +345,30 @@ public class PageFragmentInstanceDefinition implements Serializable {
 		StringBundler sb = new StringBundler();
 
 		sb.append("{");
+
+		if (cssClasses != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"cssClasses\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < cssClasses.length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(cssClasses[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < cssClasses.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
 
 		if (fragment != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageRowDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageRowDefinition.java
@@ -61,6 +61,38 @@ public class PageRowDefinition implements Serializable {
 		return ObjectMapperUtil.unsafeReadValue(PageRowDefinition.class, json);
 	}
 
+	@Schema(
+		description = "A list of CSS Classes that are applied to the element."
+	)
+	public String[] getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(String[] cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	@JsonIgnore
+	public void setCssClasses(
+		UnsafeSupplier<String[], Exception> cssClassesUnsafeSupplier) {
+
+		try {
+			cssClasses = cssClassesUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "A list of CSS Classes that are applied to the element."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String[] cssClasses;
+
 	@Schema(description = "The fragment style of a Page row.")
 	@Valid
 	public FragmentStyle getFragmentStyle() {
@@ -393,6 +425,30 @@ public class PageRowDefinition implements Serializable {
 		StringBundler sb = new StringBundler();
 
 		sb.append("{");
+
+		if (cssClasses != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"cssClasses\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < cssClasses.length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(cssClasses[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < cssClasses.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
 
 		if (fragmentStyle != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageSectionDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageSectionDefinition.java
@@ -162,6 +162,38 @@ public class PageSectionDefinition implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected BackgroundImage backgroundImage;
 
+	@Schema(
+		description = "A list of CSS Classes that are applied to the element."
+	)
+	public String[] getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(String[] cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	@JsonIgnore
+	public void setCssClasses(
+		UnsafeSupplier<String[], Exception> cssClassesUnsafeSupplier) {
+
+		try {
+			cssClasses = cssClassesUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "A list of CSS Classes that are applied to the element."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String[] cssClasses;
+
 	@Schema(description = "The fragment link of the page section.")
 	@Valid
 	public FragmentLink getFragmentLink() {
@@ -403,6 +435,30 @@ public class PageSectionDefinition implements Serializable {
 			sb.append("\"backgroundImage\": ");
 
 			sb.append(String.valueOf(backgroundImage));
+		}
+
+		if (cssClasses != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"cssClasses\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < cssClasses.length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(cssClasses[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < cssClasses.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		if (fragmentLink != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageWidgetInstanceDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PageWidgetInstanceDefinition.java
@@ -63,6 +63,38 @@ public class PageWidgetInstanceDefinition implements Serializable {
 			PageWidgetInstanceDefinition.class, json);
 	}
 
+	@Schema(
+		description = "A list of CSS Classes that are applied to the element."
+	)
+	public String[] getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(String[] cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	@JsonIgnore
+	public void setCssClasses(
+		UnsafeSupplier<String[], Exception> cssClassesUnsafeSupplier) {
+
+		try {
+			cssClasses = cssClassesUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "A list of CSS Classes that are applied to the element."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String[] cssClasses;
+
 	@Schema(description = "The fragment style of the page widget instance.")
 	@Valid
 	public FragmentStyle getFragmentStyle() {
@@ -188,6 +220,30 @@ public class PageWidgetInstanceDefinition implements Serializable {
 		StringBundler sb = new StringBundler();
 
 		sb.append("{");
+
+		if (cssClasses != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"cssClasses\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < cssClasses.length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(cssClasses[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < cssClasses.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
 
 		if (fragmentStyle != null) {
 			if (sb.length() > 1) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 24.2.0
+version 24.3.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageCollectionDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageCollectionDefinition.java
@@ -80,6 +80,27 @@ public class PageCollectionDefinition implements Cloneable, Serializable {
 
 	protected CollectionViewport[] collectionViewports;
 
+	public String[] getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(String[] cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	public void setCssClasses(
+		UnsafeSupplier<String[], Exception> cssClassesUnsafeSupplier) {
+
+		try {
+			cssClasses = cssClassesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String[] cssClasses;
+
 	public Boolean getDisplayAllItems() {
 		return displayAllItems;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageFormDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageFormDefinition.java
@@ -34,6 +34,27 @@ public class PageFormDefinition implements Cloneable, Serializable {
 		return PageFormDefinitionSerDes.toDTO(json);
 	}
 
+	public String[] getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(String[] cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	public void setCssClasses(
+		UnsafeSupplier<String[], Exception> cssClassesUnsafeSupplier) {
+
+		try {
+			cssClasses = cssClassesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String[] cssClasses;
+
 	public FormConfig getFormConfig() {
 		return formConfig;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageFragmentInstanceDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageFragmentInstanceDefinition.java
@@ -35,6 +35,27 @@ public class PageFragmentInstanceDefinition implements Cloneable, Serializable {
 		return PageFragmentInstanceDefinitionSerDes.toDTO(json);
 	}
 
+	public String[] getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(String[] cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	public void setCssClasses(
+		UnsafeSupplier<String[], Exception> cssClassesUnsafeSupplier) {
+
+		try {
+			cssClasses = cssClassesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String[] cssClasses;
+
 	public Fragment getFragment() {
 		return fragment;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageRowDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageRowDefinition.java
@@ -34,6 +34,27 @@ public class PageRowDefinition implements Cloneable, Serializable {
 		return PageRowDefinitionSerDes.toDTO(json);
 	}
 
+	public String[] getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(String[] cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	public void setCssClasses(
+		UnsafeSupplier<String[], Exception> cssClassesUnsafeSupplier) {
+
+		try {
+			cssClasses = cssClassesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String[] cssClasses;
+
 	public FragmentStyle getFragmentStyle() {
 		return fragmentStyle;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageSectionDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageSectionDefinition.java
@@ -102,6 +102,27 @@ public class PageSectionDefinition implements Cloneable, Serializable {
 
 	protected BackgroundImage backgroundImage;
 
+	public String[] getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(String[] cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	public void setCssClasses(
+		UnsafeSupplier<String[], Exception> cssClassesUnsafeSupplier) {
+
+		try {
+			cssClasses = cssClassesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String[] cssClasses;
+
 	public FragmentLink getFragmentLink() {
 		return fragmentLink;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageWidgetInstanceDefinition.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PageWidgetInstanceDefinition.java
@@ -34,6 +34,27 @@ public class PageWidgetInstanceDefinition implements Cloneable, Serializable {
 		return PageWidgetInstanceDefinitionSerDes.toDTO(json);
 	}
 
+	public String[] getCssClasses() {
+		return cssClasses;
+	}
+
+	public void setCssClasses(String[] cssClasses) {
+		this.cssClasses = cssClasses;
+	}
+
+	public void setCssClasses(
+		UnsafeSupplier<String[], Exception> cssClassesUnsafeSupplier) {
+
+		try {
+			cssClasses = cssClassesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String[] cssClasses;
+
 	public FragmentStyle getFragmentStyle() {
 		return fragmentStyle;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageCollectionDefinitionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageCollectionDefinitionSerDes.java
@@ -99,6 +99,32 @@ public class PageCollectionDefinitionSerDes {
 			sb.append("]");
 		}
 
+		if (pageCollectionDefinition.getCssClasses() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"cssClasses\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < pageCollectionDefinition.getCssClasses().length;
+				 i++) {
+
+				sb.append("\"");
+
+				sb.append(_escape(pageCollectionDefinition.getCssClasses()[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < pageCollectionDefinition.getCssClasses().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (pageCollectionDefinition.getDisplayAllItems() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -304,6 +330,15 @@ public class PageCollectionDefinitionSerDes {
 					pageCollectionDefinition.getCollectionViewports()));
 		}
 
+		if (pageCollectionDefinition.getCssClasses() == null) {
+			map.put("cssClasses", null);
+		}
+		else {
+			map.put(
+				"cssClasses",
+				String.valueOf(pageCollectionDefinition.getCssClasses()));
+		}
+
 		if (pageCollectionDefinition.getDisplayAllItems() == null) {
 			map.put("displayAllItems", null);
 		}
@@ -464,6 +499,12 @@ public class PageCollectionDefinitionSerDes {
 						).toArray(
 							size -> new CollectionViewport[size]
 						));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "cssClasses")) {
+				if (jsonParserFieldValue != null) {
+					pageCollectionDefinition.setCssClasses(
+						toStrings((Object[])jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "displayAllItems")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageFormDefinitionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageFormDefinitionSerDes.java
@@ -57,6 +57,32 @@ public class PageFormDefinitionSerDes {
 
 		sb.append("{");
 
+		if (pageFormDefinition.getCssClasses() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"cssClasses\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < pageFormDefinition.getCssClasses().length;
+				 i++) {
+
+				sb.append("\"");
+
+				sb.append(_escape(pageFormDefinition.getCssClasses()[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < pageFormDefinition.getCssClasses().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (pageFormDefinition.getFormConfig() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -134,6 +160,15 @@ public class PageFormDefinitionSerDes {
 
 		Map<String, String> map = new TreeMap<>();
 
+		if (pageFormDefinition.getCssClasses() == null) {
+			map.put("cssClasses", null);
+		}
+		else {
+			map.put(
+				"cssClasses",
+				String.valueOf(pageFormDefinition.getCssClasses()));
+		}
+
 		if (pageFormDefinition.getFormConfig() == null) {
 			map.put("formConfig", null);
 		}
@@ -189,7 +224,13 @@ public class PageFormDefinitionSerDes {
 			PageFormDefinition pageFormDefinition, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "formConfig")) {
+			if (Objects.equals(jsonParserFieldName, "cssClasses")) {
+				if (jsonParserFieldValue != null) {
+					pageFormDefinition.setCssClasses(
+						toStrings((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "formConfig")) {
 				if (jsonParserFieldValue != null) {
 					pageFormDefinition.setFormConfig(
 						FormConfigSerDes.toDTO((String)jsonParserFieldValue));

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageFragmentInstanceDefinitionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageFragmentInstanceDefinitionSerDes.java
@@ -63,6 +63,36 @@ public class PageFragmentInstanceDefinitionSerDes {
 
 		sb.append("{");
 
+		if (pageFragmentInstanceDefinition.getCssClasses() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"cssClasses\": ");
+
+			sb.append("[");
+
+			for (int i = 0;
+				 i < pageFragmentInstanceDefinition.getCssClasses().length;
+				 i++) {
+
+				sb.append("\"");
+
+				sb.append(
+					_escape(pageFragmentInstanceDefinition.getCssClasses()[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) <
+						pageFragmentInstanceDefinition.getCssClasses().length) {
+
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (pageFragmentInstanceDefinition.getFragment() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -215,6 +245,15 @@ public class PageFragmentInstanceDefinitionSerDes {
 
 		Map<String, String> map = new TreeMap<>();
 
+		if (pageFragmentInstanceDefinition.getCssClasses() == null) {
+			map.put("cssClasses", null);
+		}
+		else {
+			map.put(
+				"cssClasses",
+				String.valueOf(pageFragmentInstanceDefinition.getCssClasses()));
+		}
+
 		if (pageFragmentInstanceDefinition.getFragment() == null) {
 			map.put("fragment", null);
 		}
@@ -304,7 +343,13 @@ public class PageFragmentInstanceDefinitionSerDes {
 			PageFragmentInstanceDefinition pageFragmentInstanceDefinition,
 			String jsonParserFieldName, Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "fragment")) {
+			if (Objects.equals(jsonParserFieldName, "cssClasses")) {
+				if (jsonParserFieldValue != null) {
+					pageFragmentInstanceDefinition.setCssClasses(
+						toStrings((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "fragment")) {
 				if (jsonParserFieldValue != null) {
 					pageFragmentInstanceDefinition.setFragment(
 						FragmentSerDes.toDTO((String)jsonParserFieldValue));

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageRowDefinitionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageRowDefinitionSerDes.java
@@ -58,6 +58,30 @@ public class PageRowDefinitionSerDes {
 
 		sb.append("{");
 
+		if (pageRowDefinition.getCssClasses() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"cssClasses\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < pageRowDefinition.getCssClasses().length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(pageRowDefinition.getCssClasses()[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < pageRowDefinition.getCssClasses().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (pageRowDefinition.getFragmentStyle() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -210,6 +234,15 @@ public class PageRowDefinitionSerDes {
 
 		Map<String, String> map = new TreeMap<>();
 
+		if (pageRowDefinition.getCssClasses() == null) {
+			map.put("cssClasses", null);
+		}
+		else {
+			map.put(
+				"cssClasses",
+				String.valueOf(pageRowDefinition.getCssClasses()));
+		}
+
 		if (pageRowDefinition.getFragmentStyle() == null) {
 			map.put("fragmentStyle", null);
 		}
@@ -317,7 +350,13 @@ public class PageRowDefinitionSerDes {
 			PageRowDefinition pageRowDefinition, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "fragmentStyle")) {
+			if (Objects.equals(jsonParserFieldName, "cssClasses")) {
+				if (jsonParserFieldValue != null) {
+					pageRowDefinition.setCssClasses(
+						toStrings((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "fragmentStyle")) {
 				if (jsonParserFieldValue != null) {
 					pageRowDefinition.setFragmentStyle(
 						FragmentStyleSerDes.toDTO(

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageSectionDefinitionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageSectionDefinitionSerDes.java
@@ -94,6 +94,32 @@ public class PageSectionDefinitionSerDes {
 				String.valueOf(pageSectionDefinition.getBackgroundImage()));
 		}
 
+		if (pageSectionDefinition.getCssClasses() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"cssClasses\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < pageSectionDefinition.getCssClasses().length;
+				 i++) {
+
+				sb.append("\"");
+
+				sb.append(_escape(pageSectionDefinition.getCssClasses()[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < pageSectionDefinition.getCssClasses().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (pageSectionDefinition.getFragmentLink() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -220,6 +246,15 @@ public class PageSectionDefinitionSerDes {
 				String.valueOf(pageSectionDefinition.getBackgroundImage()));
 		}
 
+		if (pageSectionDefinition.getCssClasses() == null) {
+			map.put("cssClasses", null);
+		}
+		else {
+			map.put(
+				"cssClasses",
+				String.valueOf(pageSectionDefinition.getCssClasses()));
+		}
+
 		if (pageSectionDefinition.getFragmentLink() == null) {
 			map.put("fragmentLink", null);
 		}
@@ -313,6 +348,12 @@ public class PageSectionDefinitionSerDes {
 					pageSectionDefinition.setBackgroundImage(
 						BackgroundImageSerDes.toDTO(
 							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "cssClasses")) {
+				if (jsonParserFieldValue != null) {
+					pageSectionDefinition.setCssClasses(
+						toStrings((Object[])jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "fragmentLink")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageWidgetInstanceDefinitionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PageWidgetInstanceDefinitionSerDes.java
@@ -61,6 +61,35 @@ public class PageWidgetInstanceDefinitionSerDes {
 
 		sb.append("{");
 
+		if (pageWidgetInstanceDefinition.getCssClasses() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"cssClasses\": ");
+
+			sb.append("[");
+
+			for (int i = 0;
+				 i < pageWidgetInstanceDefinition.getCssClasses().length; i++) {
+
+				sb.append("\"");
+
+				sb.append(
+					_escape(pageWidgetInstanceDefinition.getCssClasses()[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) <
+						pageWidgetInstanceDefinition.getCssClasses().length) {
+
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
 		if (pageWidgetInstanceDefinition.getFragmentStyle() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -135,6 +164,15 @@ public class PageWidgetInstanceDefinitionSerDes {
 
 		Map<String, String> map = new TreeMap<>();
 
+		if (pageWidgetInstanceDefinition.getCssClasses() == null) {
+			map.put("cssClasses", null);
+		}
+		else {
+			map.put(
+				"cssClasses",
+				String.valueOf(pageWidgetInstanceDefinition.getCssClasses()));
+		}
+
 		if (pageWidgetInstanceDefinition.getFragmentStyle() == null) {
 			map.put("fragmentStyle", null);
 		}
@@ -186,7 +224,13 @@ public class PageWidgetInstanceDefinitionSerDes {
 			PageWidgetInstanceDefinition pageWidgetInstanceDefinition,
 			String jsonParserFieldName, Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "fragmentStyle")) {
+			if (Objects.equals(jsonParserFieldName, "cssClasses")) {
+				if (jsonParserFieldValue != null) {
+					pageWidgetInstanceDefinition.setCssClasses(
+						toStrings((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "fragmentStyle")) {
 				if (jsonParserFieldValue != null) {
 					pageWidgetInstanceDefinition.setFragmentStyle(
 						FragmentStyleSerDes.toDTO(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -3221,6 +3221,13 @@ components:
                     items:
                         $ref: "#/components/schemas/CollectionViewport"
                     type: array
+                cssClasses:
+                    # @review
+                    description:
+                        A list of CSS Classes that are applied to the element.
+                    items:
+                        type: string
+                    type: array
                 displayAllItems:
                     # @review
                     description:
@@ -3433,6 +3440,13 @@ components:
             description:
                 Represent a definition of a Page form.
             properties:
+                cssClasses:
+                    # @review
+                    description:
+                        A list of CSS Classes that are applied to the element.
+                    items:
+                        type: string
+                    type: array
                 formConfig:
                     # @review
                     description:
@@ -3470,6 +3484,13 @@ components:
             description:
                 Represents a definition of a Page Fragment Instance.
             properties:
+                cssClasses:
+                    # @review
+                    description:
+                        A list of CSS Classes that are applied to the element.
+                    items:
+                        type: string
+                    type: array
                 fragment:
                     allOf:
                         - $ref: "#/components/schemas/Fragment"
@@ -3526,6 +3547,13 @@ components:
             description:
                 Represents a definition of a Page row.
             properties:
+                cssClasses:
+                    # @review
+                    description:
+                        A list of CSS Classes that are applied to the element.
+                    items:
+                        type: string
+                    type: array
                 fragmentStyle:
                     allOf:
                         - $ref: "#/components/schemas/FragmentStyle"
@@ -3640,6 +3668,13 @@ components:
                                 - $ref: "#/components/schemas/FragmentInlineValue"
                                 - $ref: "#/components/schemas/FragmentMappedValue"
                     type: object
+                cssClasses:
+                    # @review
+                    description:
+                        A list of CSS Classes that are applied to the element.
+                    items:
+                        type: string
+                    type: array
                 fragmentLink:
                     allOf:
                         - $ref: "#/components/schemas/FragmentLink"
@@ -3915,6 +3950,13 @@ components:
             description:
                 Represents a definition of a Page Widget instance.
             properties:
+                cssClasses:
+                    # @review
+                    description:
+                        A list of CSS Classes that are applied to the element.
+                    items:
+                        type: string
+                    type: array
                 fragmentStyle:
                     allOf:
                         - $ref: "#/components/schemas/FragmentStyle"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/CollectionLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/CollectionLayoutStructureItemMapper.java
@@ -27,13 +27,16 @@ import com.liferay.layout.responsive.ViewportSize;
 import com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -97,6 +100,18 @@ public class CollectionLayoutStructureItemMapper
 							collectionStyledLayoutStructureItem.
 								getTemplateKey();
 
+						setCssClasses(
+							() -> {
+								Set<String> cssClasses =
+									collectionStyledLayoutStructureItem.
+										getCssClasses();
+
+								if (SetUtil.isEmpty(cssClasses)) {
+									return null;
+								}
+
+								return ArrayUtil.toStringArray(cssClasses);
+							});
 						setCollectionViewports(
 							_getCollectionViewports(
 								collectionStyledLayoutStructureItem));

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/CollectionLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/CollectionLayoutStructureItemMapper.java
@@ -27,16 +27,13 @@ import com.liferay.layout.responsive.ViewportSize;
 import com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.MapUtil;
-import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -100,32 +97,9 @@ public class CollectionLayoutStructureItemMapper
 							collectionStyledLayoutStructureItem.
 								getTemplateKey();
 
-						setCssClasses(
-							() -> {
-								Set<String> cssClasses =
-									collectionStyledLayoutStructureItem.
-										getCssClasses();
-
-								if (SetUtil.isEmpty(cssClasses)) {
-									return null;
-								}
-
-								return ArrayUtil.toStringArray(cssClasses);
-							});
 						setCollectionViewports(
 							_getCollectionViewports(
 								collectionStyledLayoutStructureItem));
-						setFragmentStyle(
-							() -> {
-								JSONObject itemConfigJSONObject =
-									collectionStyledLayoutStructureItem.
-										getItemConfigJSONObject();
-
-								return toFragmentStyle(
-									itemConfigJSONObject.getJSONObject(
-										"styles"),
-									saveMappingConfiguration);
-							});
 						setFragmentViewports(
 							() -> getFragmentViewPorts(
 								collectionStyledLayoutStructureItem.

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/ContainerLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/ContainerLayoutStructureItemMapper.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsUtil;
 
 import java.util.Set;
 
@@ -78,6 +79,13 @@ public class ContainerLayoutStructureItemMapper
 
 						setCssClasses(
 							() -> {
+								if (!GetterUtil.getBoolean(
+										PropsUtil.get(
+											"feature.flag.LPS-147511"))) {
+
+									return null;
+								}
+
 								Set<String> cssClasses =
 									containerStyledLayoutStructureItem.
 										getCssClasses();

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/ContainerLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/ContainerLayoutStructureItemMapper.java
@@ -34,9 +34,13 @@ import com.liferay.layout.page.template.util.ShadowConverter;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -72,6 +76,18 @@ public class ContainerLayoutStructureItemMapper
 							containerStyledLayoutStructureItem.isIndexed();
 						layout = _toLayout(containerStyledLayoutStructureItem);
 
+						setCssClasses(
+							() -> {
+								Set<String> cssClasses =
+									containerStyledLayoutStructureItem.
+										getCssClasses();
+
+								if (SetUtil.isEmpty(cssClasses)) {
+									return null;
+								}
+
+								return ArrayUtil.toStringArray(cssClasses);
+							});
 						setFragmentStyle(
 							() -> {
 								JSONObject itemConfigJSONObject =

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/FormLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/FormLayoutStructureItemMapper.java
@@ -22,7 +22,11 @@ import com.liferay.headless.delivery.dto.v1_0.PageFormDefinition;
 import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.SetUtil;
+
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -59,6 +63,18 @@ public class FormLayoutStructureItemMapper
 						};
 						indexed = formStyledLayoutStructureItem.isIndexed();
 
+						setCssClasses(
+							() -> {
+								Set<String> cssClasses =
+									formStyledLayoutStructureItem.
+										getCssClasses();
+
+								if (SetUtil.isEmpty(cssClasses)) {
+									return null;
+								}
+
+								return ArrayUtil.toStringArray(cssClasses);
+							});
 						setFragmentStyle(
 							() -> {
 								JSONObject itemConfigJSONObject =

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/FormLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/FormLayoutStructureItemMapper.java
@@ -23,8 +23,10 @@ import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.util.PropsUtil;
 
 import java.util.Set;
 
@@ -65,6 +67,13 @@ public class FormLayoutStructureItemMapper
 
 						setCssClasses(
 							() -> {
+								if (!GetterUtil.getBoolean(
+										PropsUtil.get(
+											"feature.flag.LPS-147511"))) {
+
+									return null;
+								}
+
 								Set<String> cssClasses =
 									formStyledLayoutStructureItem.
 										getCssClasses();

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/FragmentLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/FragmentLayoutStructureItemMapper.java
@@ -103,6 +103,7 @@ public class FragmentLayoutStructureItemMapper
 				definition =
 					PageWidgetInstanceDefinitionUtil.
 						toPageWidgetInstanceDefinition(
+							fragmentStyledLayoutStructureItem.getCssClasses(),
 							fragmentEntryLink,
 							toFragmentStyle(
 								itemConfigJSONObject.getJSONObject("styles"),

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/PageFragmentInstanceDefinitionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/PageFragmentInstanceDefinitionMapper.java
@@ -60,11 +60,13 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -122,6 +124,18 @@ public class PageFragmentInstanceDefinitionMapper {
 					pageFragmentInstanceDefinitionFragmentViewports;
 				indexed = fragmentStyledLayoutStructureItem.isIndexed();
 				widgetInstances = _getWidgetInstances(fragmentEntryLink);
+
+				setCssClasses(
+					() -> {
+						Set<String> cssClasses =
+							fragmentStyledLayoutStructureItem.getCssClasses();
+
+						if (SetUtil.isEmpty(cssClasses)) {
+							return null;
+						}
+
+						return ArrayUtil.toStringArray(cssClasses);
+					});
 			}
 		};
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/PageFragmentInstanceDefinitionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/PageFragmentInstanceDefinitionMapper.java
@@ -69,6 +69,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsUtil;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -127,6 +128,12 @@ public class PageFragmentInstanceDefinitionMapper {
 
 				setCssClasses(
 					() -> {
+						if (!GetterUtil.getBoolean(
+								PropsUtil.get("feature.flag.LPS-147511"))) {
+
+							return null;
+						}
+
 						Set<String> cssClasses =
 							fragmentStyledLayoutStructureItem.getCssClasses();
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/RowLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/RowLayoutStructureItemMapper.java
@@ -22,11 +22,14 @@ import com.liferay.layout.responsive.ViewportSize;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -65,6 +68,18 @@ public class RowLayoutStructureItemMapper
 						verticalAlignment =
 							rowStyledLayoutStructureItem.getVerticalAlignment();
 
+						setCssClasses(
+							() -> {
+								Set<String> cssClasses =
+									rowStyledLayoutStructureItem.
+										getCssClasses();
+
+								if (SetUtil.isEmpty(cssClasses)) {
+									return null;
+								}
+
+								return ArrayUtil.toStringArray(cssClasses);
+							});
 						setFragmentStyle(
 							() -> {
 								JSONObject itemConfigJSONObject =

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/RowLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/RowLayoutStructureItemMapper.java
@@ -23,8 +23,10 @@ import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.SetUtil;
+import com.liferay.portal.util.PropsUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -70,6 +72,13 @@ public class RowLayoutStructureItemMapper
 
 						setCssClasses(
 							() -> {
+								if (!GetterUtil.getBoolean(
+										PropsUtil.get(
+											"feature.flag.LPS-147511"))) {
+
+									return null;
+								}
+
 								Set<String> cssClasses =
 									rowStyledLayoutStructureItem.
 										getCssClasses();

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/PageWidgetInstanceDefinitionUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/PageWidgetInstanceDefinitionUtil.java
@@ -20,8 +20,10 @@ import com.liferay.headless.delivery.dto.v1_0.FragmentViewport;
 import com.liferay.headless.delivery.dto.v1_0.PageWidgetInstanceDefinition;
 import com.liferay.headless.delivery.internal.dto.v1_0.mapper.WidgetInstanceMapper;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsUtil;
 
 import java.util.Set;
 
@@ -51,7 +53,10 @@ public class PageWidgetInstanceDefinitionUtil {
 
 				setCssClasses(
 					() -> {
-						if (SetUtil.isEmpty(cssClassesSet)) {
+						if (!GetterUtil.getBoolean(
+								PropsUtil.get("feature.flag.LPS-147511")) ||
+							SetUtil.isEmpty(cssClassesSet)) {
+
 							return null;
 						}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/PageWidgetInstanceDefinitionUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/PageWidgetInstanceDefinitionUtil.java
@@ -19,7 +19,11 @@ import com.liferay.headless.delivery.dto.v1_0.FragmentStyle;
 import com.liferay.headless.delivery.dto.v1_0.FragmentViewport;
 import com.liferay.headless.delivery.dto.v1_0.PageWidgetInstanceDefinition;
 import com.liferay.headless.delivery.internal.dto.v1_0.mapper.WidgetInstanceMapper;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Set;
 
 /**
  * @author Jürgen Kappler
@@ -28,7 +32,7 @@ import com.liferay.portal.kernel.util.Validator;
 public class PageWidgetInstanceDefinitionUtil {
 
 	public static PageWidgetInstanceDefinition toPageWidgetInstanceDefinition(
-		FragmentEntryLink fragmentEntryLink,
+		Set<String> cssClassesSet, FragmentEntryLink fragmentEntryLink,
 		FragmentStyle pageWidgetInstanceDefinitionFragmentStyle,
 		FragmentViewport[] pageWidgetInstanceDefinitionFragmentViewports,
 		String portletId, WidgetInstanceMapper widgetInstanceMapper) {
@@ -44,6 +48,15 @@ public class PageWidgetInstanceDefinitionUtil {
 					pageWidgetInstanceDefinitionFragmentViewports;
 				widgetInstance = widgetInstanceMapper.getWidgetInstance(
 					fragmentEntryLink, portletId);
+
+				setCssClasses(
+					() -> {
+						if (SetUtil.isEmpty(cssClassesSet)) {
+							return null;
+						}
+
+						return ArrayUtil.toStringArray(cssClassesSet);
+					});
 			}
 		};
 	}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/CollectionLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/CollectionLayoutStructureItemImporter.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -81,6 +82,14 @@ public class CollectionLayoutStructureItemImporter
 		if (collectionConfig != null) {
 			collectionStyledLayoutStructureItem.setCollectionJSONObject(
 				_getCollectionConfigAsJSONObject(collectionConfig));
+		}
+
+		if (definitionMap.containsKey("cssClasses")) {
+			List<String> cssClasses = (List<String>)definitionMap.get(
+				"cssClasses");
+
+			collectionStyledLayoutStructureItem.setCssClasses(
+				new HashSet<>(cssClasses));
 		}
 
 		if (definitionMap.containsKey("collectionViewports")) {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/CollectionLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/CollectionLayoutStructureItemImporter.java
@@ -37,7 +37,6 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Validator;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -82,14 +81,6 @@ public class CollectionLayoutStructureItemImporter
 		if (collectionConfig != null) {
 			collectionStyledLayoutStructureItem.setCollectionJSONObject(
 				_getCollectionConfigAsJSONObject(collectionConfig));
-		}
-
-		if (definitionMap.containsKey("cssClasses")) {
-			List<String> cssClasses = (List<String>)definitionMap.get(
-				"cssClasses");
-
-			collectionStyledLayoutStructureItem.setCssClasses(
-				new HashSet<>(cssClasses));
 		}
 
 		if (definitionMap.containsKey("collectionViewports")) {
@@ -158,18 +149,6 @@ public class CollectionLayoutStructureItemImporter
 
 		collectionStyledLayoutStructureItem.setTemplateKey(
 			(String)definitionMap.get("templateKey"));
-
-		Map<String, Object> fragmentStyleMap =
-			(Map<String, Object>)definitionMap.get("fragmentStyle");
-
-		if (fragmentStyleMap != null) {
-			JSONObject jsonObject = JSONUtil.put(
-				"styles",
-				toStylesJSONObject(
-					layoutStructureItemImporterContext, fragmentStyleMap));
-
-			collectionStyledLayoutStructureItem.updateItemConfig(jsonObject);
-		}
 
 		if (definitionMap.containsKey("fragmentViewports")) {
 			List<Map<String, Object>> fragmentViewports =

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/ContainerLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/ContainerLayoutStructureItemImporter.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsUtil;
 
 import java.util.HashSet;
 import java.util.List;
@@ -109,7 +110,9 @@ public class ContainerLayoutStructureItemImporter
 			stylesJSONObject.put("backgroundImage", jsonObject);
 		}
 
-		if (definitionMap.containsKey("cssClasses")) {
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-147511")) &&
+			definitionMap.containsKey("cssClasses")) {
+
 			List<String> cssClasses = (List<String>)definitionMap.get(
 				"cssClasses");
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/ContainerLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/ContainerLayoutStructureItemImporter.java
@@ -37,6 +37,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -106,6 +107,14 @@ public class ContainerLayoutStructureItemImporter
 			}
 
 			stylesJSONObject.put("backgroundImage", jsonObject);
+		}
+
+		if (definitionMap.containsKey("cssClasses")) {
+			List<String> cssClasses = (List<String>)definitionMap.get(
+				"cssClasses");
+
+			containerStyledLayoutStructureItem.setCssClasses(
+				new HashSet<>(cssClasses));
 		}
 
 		Map<String, Object> containerHtmlProperties =

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/FormLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/FormLayoutStructureItemImporter.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -59,6 +60,14 @@ public class FormLayoutStructureItemImporter
 
 		if (definitionMap == null) {
 			return formStyledLayoutStructureItem;
+		}
+
+		if (definitionMap.containsKey("cssClasses")) {
+			List<String> cssClasses = (List<String>)definitionMap.get(
+				"cssClasses");
+
+			formStyledLayoutStructureItem.setCssClasses(
+				new HashSet<>(cssClasses));
 		}
 
 		Map<String, Object> sourceMap = (Map<String, Object>)definitionMap.get(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/FormLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/FormLayoutStructureItemImporter.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.util.PropsUtil;
 
 import java.util.HashSet;
 import java.util.List;
@@ -62,7 +63,9 @@ public class FormLayoutStructureItemImporter
 			return formStyledLayoutStructureItem;
 		}
 
-		if (definitionMap.containsKey("cssClasses")) {
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-147511")) &&
+			definitionMap.containsKey("cssClasses")) {
+
 			List<String> cssClasses = (List<String>)definitionMap.get(
 				"cssClasses");
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/FragmentLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/FragmentLayoutStructureItemImporter.java
@@ -63,6 +63,7 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsUtil;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
@@ -119,7 +120,9 @@ public class FragmentLayoutStructureItemImporter
 			return fragmentStyledLayoutStructureItem;
 		}
 
-		if (definitionMap.containsKey("cssClasses")) {
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-147511")) &&
+			definitionMap.containsKey("cssClasses")) {
+
 			List<String> cssClasses = (List<String>)definitionMap.get(
 				"cssClasses");
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/FragmentLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/FragmentLayoutStructureItemImporter.java
@@ -67,6 +67,7 @@ import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Locale;
@@ -116,6 +117,14 @@ public class FragmentLayoutStructureItemImporter
 
 		if (definitionMap == null) {
 			return fragmentStyledLayoutStructureItem;
+		}
+
+		if (definitionMap.containsKey("cssClasses")) {
+			List<String> cssClasses = (List<String>)definitionMap.get(
+				"cssClasses");
+
+			fragmentStyledLayoutStructureItem.setCssClasses(
+				new HashSet<>(cssClasses));
 		}
 
 		Map<String, Object> fragmentStyleMap =

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/RowLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/RowLayoutStructureItemImporter.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -57,6 +58,14 @@ public class RowLayoutStructureItemImporter
 
 		if (definitionMap == null) {
 			return rowStyledLayoutStructureItem;
+		}
+
+		if (definitionMap.containsKey("cssClasses")) {
+			List<String> cssClasses = (List<String>)definitionMap.get(
+				"cssClasses");
+
+			rowStyledLayoutStructureItem.setCssClasses(
+				new HashSet<>(cssClasses));
 		}
 
 		rowStyledLayoutStructureItem.setGutters(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/RowLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/RowLayoutStructureItemImporter.java
@@ -22,6 +22,7 @@ import com.liferay.layout.util.structure.RowStyledLayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.util.PropsUtil;
 
 import java.util.HashSet;
 import java.util.List;
@@ -60,7 +61,9 @@ public class RowLayoutStructureItemImporter
 			return rowStyledLayoutStructureItem;
 		}
 
-		if (definitionMap.containsKey("cssClasses")) {
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-147511")) &&
+			definitionMap.containsKey("cssClasses")) {
+
 			List<String> cssClasses = (List<String>)definitionMap.get(
 				"cssClasses");
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/WidgetLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/WidgetLayoutStructureItemImporter.java
@@ -20,6 +20,7 @@ import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.headless.delivery.dto.v1_0.PageElement;
 import com.liferay.layout.page.template.admin.web.internal.headless.delivery.dto.v1_0.structure.importer.helper.PortletConfigurationImporterHelper;
 import com.liferay.layout.page.template.admin.web.internal.headless.delivery.dto.v1_0.structure.importer.helper.PortletPermissionsImporterHelper;
+import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.string.StringPool;
@@ -37,6 +38,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -68,16 +70,25 @@ public class WidgetLayoutStructureItemImporter
 			return null;
 		}
 
-		LayoutStructureItem fragmentStyledLayoutStructureItem =
-			layoutStructure.addFragmentStyledLayoutStructureItem(
-				fragmentEntryLink.getFragmentEntryLinkId(),
-				layoutStructureItemImporterContext.getParentItemId(),
-				layoutStructureItemImporterContext.getPosition());
+		FragmentStyledLayoutStructureItem fragmentStyledLayoutStructureItem =
+			(FragmentStyledLayoutStructureItem)
+				layoutStructure.addFragmentStyledLayoutStructureItem(
+					fragmentEntryLink.getFragmentEntryLinkId(),
+					layoutStructureItemImporterContext.getParentItemId(),
+					layoutStructureItemImporterContext.getPosition());
 
 		Map<String, Object> definitionMap = getDefinitionMap(
 			pageElement.getDefinition());
 
 		if (definitionMap != null) {
+			if (definitionMap.containsKey("cssClasses")) {
+				List<String> cssClasses = (List<String>)definitionMap.get(
+					"cssClasses");
+
+				fragmentStyledLayoutStructureItem.setCssClasses(
+					new HashSet<>(cssClasses));
+			}
+
 			Map<String, Object> fragmentStyleMap =
 				(Map<String, Object>)definitionMap.get("fragmentStyle");
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/WidgetLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/WidgetLayoutStructureItemImporter.java
@@ -33,9 +33,11 @@ import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsUtil;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.HashSet;
@@ -81,7 +83,10 @@ public class WidgetLayoutStructureItemImporter
 			pageElement.getDefinition());
 
 		if (definitionMap != null) {
-			if (definitionMap.containsKey("cssClasses")) {
+			if (GetterUtil.getBoolean(
+					PropsUtil.get("feature.flag.LPS-147511")) &&
+				definitionMap.containsKey("cssClasses")) {
+
 				List<String> cssClasses = (List<String>)definitionMap.get(
 					"cssClasses");
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/WidgetLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/WidgetLayoutStructureItemImporter.java
@@ -83,42 +83,42 @@ public class WidgetLayoutStructureItemImporter
 			pageElement.getDefinition());
 
 		if (definitionMap != null) {
-			if (GetterUtil.getBoolean(
-					PropsUtil.get("feature.flag.LPS-147511")) &&
-				definitionMap.containsKey("cssClasses")) {
+			return fragmentStyledLayoutStructureItem;
+		}
 
-				List<String> cssClasses = (List<String>)definitionMap.get(
-					"cssClasses");
+		if (GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-147511")) &&
+			definitionMap.containsKey("cssClasses")) {
 
-				fragmentStyledLayoutStructureItem.setCssClasses(
-					new HashSet<>(cssClasses));
-			}
+			List<String> cssClasses = (List<String>)definitionMap.get(
+				"cssClasses");
 
-			Map<String, Object> fragmentStyleMap =
-				(Map<String, Object>)definitionMap.get("fragmentStyle");
+			fragmentStyledLayoutStructureItem.setCssClasses(
+				new HashSet<>(cssClasses));
+		}
 
-			if (fragmentStyleMap != null) {
+		Map<String, Object> fragmentStyleMap =
+			(Map<String, Object>)definitionMap.get("fragmentStyle");
+
+		if (fragmentStyleMap != null) {
+			JSONObject jsonObject = JSONUtil.put(
+				"styles",
+				toStylesJSONObject(
+					layoutStructureItemImporterContext, fragmentStyleMap));
+
+			fragmentStyledLayoutStructureItem.updateItemConfig(jsonObject);
+		}
+
+		if (definitionMap.containsKey("fragmentViewports")) {
+			List<Map<String, Object>> fragmentViewports =
+				(List<Map<String, Object>>)definitionMap.get(
+					"fragmentViewports");
+
+			for (Map<String, Object> fragmentViewport : fragmentViewports) {
 				JSONObject jsonObject = JSONUtil.put(
-					"styles",
-					toStylesJSONObject(
-						layoutStructureItemImporterContext, fragmentStyleMap));
+					(String)fragmentViewport.get("id"),
+					toFragmentViewportStylesJSONObject(fragmentViewport));
 
 				fragmentStyledLayoutStructureItem.updateItemConfig(jsonObject);
-			}
-
-			if (definitionMap.containsKey("fragmentViewports")) {
-				List<Map<String, Object>> fragmentViewports =
-					(List<Map<String, Object>>)definitionMap.get(
-						"fragmentViewports");
-
-				for (Map<String, Object> fragmentViewport : fragmentViewports) {
-					JSONObject jsonObject = JSONUtil.put(
-						(String)fragmentViewport.get("id"),
-						toFragmentViewportStylesJSONObject(fragmentViewport));
-
-					fragmentStyledLayoutStructureItem.updateItemConfig(
-						jsonObject);
-				}
 			}
 		}
 


### PR DESCRIPTION
- LPS-155873 Adds new property that contains a list of CSS Classes that will be applied on top ot the element when being rendered in a page. For now, don't create a new external property since it's only a list of string
- LPS-155873 buildR
- LPS-155873 Take into account CSS Classes when exporting page definitions
- LPS-155873 Take into account CSS Classes when importing page definitions
- LPS-155873 CollectionStructureItem doesn't contain styles, so clean it up
- LPS-155873 Hide under FF
- LPS-155873 Early return, just like with the other importers
