### PR TITLE
LPS-155947

### DIFF
--- a/modules/apps/asset/asset-tags-selector-web/src/main/java/com/liferay/asset/tags/selector/web/internal/display/context/AssetTagsSelectorDisplayContext.java
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/java/com/liferay/asset/tags/selector/web/internal/display/context/AssetTagsSelectorDisplayContext.java
@@ -171,7 +171,16 @@ public class AssetTagsSelectorDisplayContext {
 				(ThemeDisplay)_httpServletRequest.getAttribute(
 					WebKeys.THEME_DISPLAY);
 
-			_groupIds = new long[] {themeDisplay.getScopeGroupId()};
+			Group group = themeDisplay.getScopeGroup();
+
+			if (group.isLayout()) {
+				_groupIds = new long[] {
+					group.getGroupId(), group.getParentGroupId()
+				};
+			}
+			else {
+				_groupIds = new long[] {group.getGroupId()};
+			}
 		}
 
 		return _groupIds;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-155947

I wasn't sure if the ancestor sites' tags should be included too, but based on the description of [LPS-131461](https://issues.liferay.com/browse/LPS-131461) I thought that ancestor sites' tags should not be included. So I only included hte direct parent groups' tags in the event that the current scope group was a Layout.

Also, is it even possible to add tags to a layout-scoped group? If it's not, we could modify this code to look something like this:
```
if (group.isLayout()) {
	group = group.getParentGroup();
}

_groupIds = new long[] {group.getGroupId()};
```
It didn't seem like it was possible for a layout-scoped group to have its own tags, but I wasn't 100% sure so I didn't feel comfortable writing the code this way.