### PR TITLE
LPS-156031

### DIFF
--- a/modules/apps/client-extension/client-extension-api/bnd.bnd
+++ b/modules/apps/client-extension/client-extension-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Client Extension API
 Bundle-SymbolicName: com.liferay.client.extension.api
-Bundle-Version: 4.0.1
+Bundle-Version: 4.1.0
 Export-Package:\
 	com.liferay.client.extension.constants,\
 	com.liferay.client.extension.exception,\

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryRelLocalService.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryRelLocalService.java
@@ -137,6 +137,9 @@ public interface ClientExtensionEntryRelLocalService
 
 	public void deleteClientExtensionEntryRels(long classNameId, long classPK);
 
+	public void deleteClientExtensionEntryRels(
+		long classNameId, long classPK, String type);
+
 	/**
 	 * @throws PortalException
 	 */

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryRelLocalServiceUtil.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryRelLocalServiceUtil.java
@@ -135,6 +135,12 @@ public class ClientExtensionEntryRelLocalServiceUtil {
 		getService().deleteClientExtensionEntryRels(classNameId, classPK);
 	}
 
+	public static void deleteClientExtensionEntryRels(
+		long classNameId, long classPK, String type) {
+
+		getService().deleteClientExtensionEntryRels(classNameId, classPK, type);
+	}
+
 	/**
 	 * @throws PortalException
 	 */

--- a/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryRelLocalServiceWrapper.java
+++ b/modules/apps/client-extension/client-extension-api/src/main/java/com/liferay/client/extension/service/ClientExtensionEntryRelLocalServiceWrapper.java
@@ -140,6 +140,14 @@ public class ClientExtensionEntryRelLocalServiceWrapper
 			classNameId, classPK);
 	}
 
+	@Override
+	public void deleteClientExtensionEntryRels(
+		long classNameId, long classPK, String type) {
+
+		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
+			classNameId, classPK, type);
+	}
+
 	/**
 	 * @throws PortalException
 	 */

--- a/modules/apps/client-extension/client-extension-api/src/main/resources/com/liferay/client/extension/service/packageinfo
+++ b/modules/apps/client-extension/client-extension-api/src/main/resources/com/liferay/client/extension/service/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
@@ -58,7 +58,7 @@ public class ClientExtensionsServicePreAction extends Action {
 
 		Layout layout = themeDisplay.getLayout();
 
-		if (layout == null) {
+		if ((layout == null) || layout.isTypeControlPanel()) {
 			return;
 		}
 

--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/impl/ClientExtensionEntryRelLocalServiceImpl.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/impl/ClientExtensionEntryRelLocalServiceImpl.java
@@ -68,6 +68,14 @@ public class ClientExtensionEntryRelLocalServiceImpl
 	}
 
 	@Override
+	public void deleteClientExtensionEntryRels(
+		long classNameId, long classPK, String type) {
+
+		clientExtensionEntryRelPersistence.removeByC_C_T(
+			classNameId, classPK, type);
+	}
+
+	@Override
 	public ClientExtensionEntryRel fetchClientExtensionEntryRel(
 		long classNameId, long classPK, String type) {
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
@@ -88,6 +88,23 @@ public class LayoutLookAndFeelDisplayContext {
 		).build();
 	}
 
+	public String getFaviconCETExternalReferenceCode() {
+		Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
+
+		ClientExtensionEntryRel clientExtensionEntryRel =
+			ClientExtensionEntryRelLocalServiceUtil.
+				fetchClientExtensionEntryRel(
+					PortalUtil.getClassNameId(Layout.class),
+					selLayout.getPlid(),
+					ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
+
+		if (clientExtensionEntryRel != null) {
+			return clientExtensionEntryRel.getCETExternalReferenceCode();
+		}
+
+		return StringPool.BLANK;
+	}
+
 	public String getFaviconTitle() {
 		return FaviconUtil.getFaviconTitle(
 			_cetManager, _layoutsAdminDisplayContext.getSelLayout(),

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalServiceUtil;
@@ -94,8 +95,14 @@ public class LayoutLookAndFeelDisplayContext {
 	}
 
 	public String getFaviconURL() {
-		return FaviconUtil.getFaviconURL(
+		String faviconURL = FaviconUtil.getFaviconURL(
 			_cetManager, _layoutsAdminDisplayContext.getSelLayout());
+
+		if (Validator.isNotNull(faviconURL)) {
+			return faviconURL;
+		}
+
+		return _layoutsAdminDisplayContext.getThemeFavicon();
 	}
 
 	public Map<String, Object> getGlobalCSSCETsConfigurationProps() {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
@@ -122,10 +122,13 @@ public class LayoutLookAndFeelDisplayContext {
 		return _layoutsAdminDisplayContext.getThemeFavicon();
 	}
 
-	public Map<String, Object> getGlobalCSSCETsConfigurationProps() {
+	public Map<String, Object> getGlobalCSSCETsConfigurationProps(
+		String className, long classPK) {
+
 		return HashMapBuilder.<String, Object>put(
 			"globalCSSCETs",
 			_getClientExtensionEntryRelsJSONArray(
+				className, classPK,
 				ClientExtensionEntryConstants.TYPE_GLOBAL_CSS)
 		).put(
 			"globalCSSCETSelectorURL",
@@ -146,10 +149,13 @@ public class LayoutLookAndFeelDisplayContext {
 		).build();
 	}
 
-	public Map<String, Object> getGlobalJSCETsConfigurationProps() {
+	public Map<String, Object> getGlobalJSCETsConfigurationProps(
+		String className, long classPK) {
+
 		return HashMapBuilder.<String, Object>put(
 			"globalJSCETs",
 			_getClientExtensionEntryRelsJSONArray(
+				className, classPK,
 				ClientExtensionEntryConstants.TYPE_GLOBAL_JS)
 		).put(
 			"globalJSCETSelectorURL",
@@ -435,15 +441,15 @@ public class LayoutLookAndFeelDisplayContext {
 			selLayout.getLayoutSet(), _themeDisplay.getLocale());
 	}
 
-	private JSONArray _getClientExtensionEntryRelsJSONArray(String type) {
-		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
+	private JSONArray _getClientExtensionEntryRelsJSONArray(
+		String className, long classPK, String type) {
 
-		Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
+		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
 		List<ClientExtensionEntryRel> clientExtensionEntryRels =
 			ClientExtensionEntryRelLocalServiceUtil.getClientExtensionEntryRels(
-				PortalUtil.getClassNameId(Layout.class), selLayout.getPlid(),
-				type, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+				PortalUtil.getClassNameId(className), classPK, type,
+				QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		CETManager cetManager = (CETManager)_httpServletRequest.getAttribute(
 			CETManager.class.getName());

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -504,6 +504,23 @@ public class LayoutsAdminDisplayContext {
 		return StringPool.BLANK;
 	}
 
+	public String getFaviconCETExternalReferenceCode() {
+		LayoutSet setLayoutSet = getSelLayoutSet();
+
+		ClientExtensionEntryRel clientExtensionEntryRel =
+			ClientExtensionEntryRelLocalServiceUtil.
+				fetchClientExtensionEntryRel(
+					PortalUtil.getClassNameId(LayoutSet.class),
+					setLayoutSet.getLayoutSetId(),
+					ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
+
+		if (clientExtensionEntryRel != null) {
+			return clientExtensionEntryRel.getCETExternalReferenceCode();
+		}
+
+		return StringPool.BLANK;
+	}
+
 	public String getFaviconTitle() {
 		return FaviconUtil.getFaviconTitle(
 			getSelLayoutSet(), themeDisplay.getLocale());

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -503,13 +503,13 @@ public class LayoutsAdminDisplayContext {
 		return StringPool.BLANK;
 	}
 
-	public String getFaviconImage() {
-		return FaviconUtil.getFaviconURL(_cetManager, getSelLayoutSet());
-	}
-
 	public String getFaviconTitle() {
 		return FaviconUtil.getFaviconTitle(
 			getSelLayoutSet(), themeDisplay.getLocale());
+	}
+
+	public String getFaviconURL() {
+		return FaviconUtil.getFaviconURL(_cetManager, getSelLayoutSet());
 	}
 
 	public String getFileEntryItemSelectorURL() {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -90,6 +90,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -509,7 +510,14 @@ public class LayoutsAdminDisplayContext {
 	}
 
 	public String getFaviconURL() {
-		return FaviconUtil.getFaviconURL(_cetManager, getSelLayoutSet());
+		String faviconURL = FaviconUtil.getFaviconURL(
+			_cetManager, getSelLayoutSet());
+
+		if (Validator.isNotNull(faviconURL)) {
+			return faviconURL;
+		}
+
+		return getThemeFavicon();
 	}
 
 	public String getFileEntryItemSelectorURL() {
@@ -1235,6 +1243,11 @@ public class LayoutsAdminDisplayContext {
 				return cetItemSelectorURL.toString();
 			}
 		).build();
+	}
+
+	public String getThemeFavicon() {
+		return themeDisplay.getPathThemeImages() + "/" +
+			PropsUtil.get(PropsKeys.THEME_SHORTCUT_ICON);
 	}
 
 	public String getTitle(boolean privatePages) {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
@@ -17,6 +17,7 @@ package com.liferay.layout.admin.web.internal.portlet.action;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntryRel;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
@@ -289,9 +290,26 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 			actionRequest, "faviconCETExternalReferenceCode");
 
 		if (Validator.isNotNull(faviconCETExternalReferenceCode)) {
-			_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
-				userId, _portal.getClassNameId(Layout.class), layout.getPlid(),
-				faviconCETExternalReferenceCode,
+			ClientExtensionEntryRel clientExtensionEntryRel =
+				_clientExtensionEntryRelLocalService.
+					fetchClientExtensionEntryRelByExternalReferenceCode(
+						layout.getCompanyId(), faviconCETExternalReferenceCode);
+
+			if (clientExtensionEntryRel == null) {
+				_clientExtensionEntryRelLocalService.
+					deleteClientExtensionEntryRels(
+						_portal.getClassNameId(Layout.class), layout.getPlid(),
+						ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
+
+				_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
+					userId, _portal.getClassNameId(Layout.class),
+					layout.getPlid(), faviconCETExternalReferenceCode,
+					ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
+			}
+		}
+		else {
+			_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
+				_portal.getClassNameId(Layout.class), layout.getPlid(),
 				ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
 		}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
@@ -285,9 +285,6 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 			ActionRequest actionRequest, Layout layout, long userId)
 		throws PortalException {
 
-		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
-			_portal.getClassNameId(Layout.class), layout.getPlid());
-
 		String faviconCETExternalReferenceCode = ParamUtil.getString(
 			actionRequest, "faviconCETExternalReferenceCode");
 
@@ -297,6 +294,10 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 				faviconCETExternalReferenceCode,
 				ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
 		}
+
+		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
+			_portal.getClassNameId(Layout.class), layout.getPlid(),
+			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS);
 
 		String[] globalCSSCETExternalReferenceCodes = ParamUtil.getStringValues(
 			actionRequest, "globalCSSCETExternalReferenceCodes");
@@ -309,6 +310,10 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 				globalCSSCETExternalReferenceCode,
 				ClientExtensionEntryConstants.TYPE_GLOBAL_CSS);
 		}
+
+		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
+			_portal.getClassNameId(Layout.class), layout.getPlid(),
+			ClientExtensionEntryConstants.TYPE_GLOBAL_JS);
 
 		String[] globalJSCETExternalReferenceCodes = ParamUtil.getStringValues(
 			actionRequest, "globalJSCETExternalReferenceCodes");

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
@@ -15,6 +15,7 @@
 package com.liferay.layout.admin.web.internal.portlet.action;
 
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntryRel;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
@@ -134,10 +135,29 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 			actionRequest, "faviconCETExternalReferenceCode");
 
 		if (Validator.isNotNull(faviconCETExternalReferenceCode)) {
-			_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
-				themeDisplay.getUserId(),
-				_portal.getClassNameId(LayoutSet.class),
-				layoutSet.getLayoutSetId(), faviconCETExternalReferenceCode,
+			ClientExtensionEntryRel clientExtensionEntryRel =
+				_clientExtensionEntryRelLocalService.
+					fetchClientExtensionEntryRelByExternalReferenceCode(
+						layoutSet.getCompanyId(),
+						faviconCETExternalReferenceCode);
+
+			if (clientExtensionEntryRel == null) {
+				_clientExtensionEntryRelLocalService.
+					deleteClientExtensionEntryRels(
+						_portal.getClassNameId(LayoutSet.class),
+						layoutSet.getLayoutSetId(),
+						ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
+
+				_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
+					themeDisplay.getUserId(),
+					_portal.getClassNameId(LayoutSet.class),
+					layoutSet.getLayoutSetId(), faviconCETExternalReferenceCode,
+					ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
+			}
+		}
+		else {
+			_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
+				themeDisplay.getCompanyId(), layoutSet.getLayoutSetId(),
 				ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
 		}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
@@ -130,9 +130,6 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 			themeDisplay.getPermissionChecker(), layoutSet.getGroupId(),
 			ActionKeys.MANAGE_LAYOUTS);
 
-		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
-			themeDisplay.getCompanyId(), layoutSet.getLayoutSetId());
-
 		String faviconCETExternalReferenceCode = ParamUtil.getString(
 			actionRequest, "faviconCETExternalReferenceCode");
 
@@ -143,6 +140,10 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 				layoutSet.getLayoutSetId(), faviconCETExternalReferenceCode,
 				ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
 		}
+
+		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
+			themeDisplay.getCompanyId(), layoutSet.getLayoutSetId(),
+			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS);
 
 		String[] globalCSSCETExternalReferenceCodes = ParamUtil.getStringValues(
 			actionRequest, "globalCSSCETExternalReferenceCodes");
@@ -155,6 +156,10 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 				layoutSet.getLayoutSetId(), globalCSSCETExternalReferenceCode,
 				ClientExtensionEntryConstants.TYPE_GLOBAL_CSS);
 		}
+
+		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
+			themeDisplay.getCompanyId(), layoutSet.getLayoutSetId(),
+			ClientExtensionEntryConstants.TYPE_GLOBAL_JS);
 
 		String[] globalJSCETExternalReferenceCodes = ParamUtil.getStringValues(
 			actionRequest, "globalJSCETExternalReferenceCodes");

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/ChangeFaviconButtonPropsTransformer.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/ChangeFaviconButtonPropsTransformer.js
@@ -30,7 +30,6 @@ export default function propsTransformer({
 						const faviconCETExternalReferenceCode = document.getElementById(
 							`${portletNamespace}faviconCETExternalReferenceCode`
 						);
-
 						const faviconFileEntryId = document.getElementById(
 							`${portletNamespace}faviconFileEntryId`
 						);
@@ -57,8 +56,10 @@ export default function propsTransformer({
 							) {
 								faviconCETExternalReferenceCode.value =
 									itemValue.cetExternalReferenceCode;
+								faviconFileEntryId.value = 0;
 							}
 							else {
+								faviconCETExternalReferenceCode.value = '';
 								faviconFileEntryId.value =
 									itemValue.fileEntryId;
 							}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/ClearFaviconButtonPropsTransformer.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/ClearFaviconButtonPropsTransformer.js
@@ -22,6 +22,10 @@ export default function propsTransformer({
 		onClick() {
 			const {faviconTitleValue} = additionalProps;
 
+			const faviconCETExternalReferenceCode = document.getElementById(
+				`${portletNamespace}faviconCETExternalReferenceCode`
+			);
+
 			const faviconFileEntryId = document.getElementById(
 				`${portletNamespace}faviconFileEntryId`
 			);
@@ -34,8 +38,14 @@ export default function propsTransformer({
 				`${portletNamespace}faviconTitle`
 			);
 
-			if (faviconFileEntryId && faviconImage && faviconTitle) {
-				faviconFileEntryId.value = '0';
+			if (
+				faviconCETExternalReferenceCode &&
+				faviconFileEntryId &&
+				faviconImage &&
+				faviconTitle
+			) {
+				faviconCETExternalReferenceCode.value = '';
+				faviconFileEntryId.value = 0;
 				faviconImage.classList.add('d-none');
 				faviconTitle.innerHTML = faviconTitleValue;
 			}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/javascript.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/javascript.jsp
@@ -43,7 +43,7 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 	<clay:sheet-section>
 		<react:component
 			module="js/layout/look_and_feel/GlobalJSCETsConfiguration"
-			props="<%= layoutLookAndFeelDisplayContext.getGlobalJSCETsConfigurationProps() %>"
+			props="<%= layoutLookAndFeelDisplayContext.getGlobalJSCETsConfigurationProps(Layout.class.getName(), selLayout.getPlid()) %>"
 		/>
 	</clay:sheet-section>
 </c:if>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
@@ -158,7 +158,7 @@ else {
 		<div>
 			<react:component
 				module="js/layout/look_and_feel/GlobalCSSCETsConfiguration"
-				props="<%= layoutLookAndFeelDisplayContext.getGlobalCSSCETsConfigurationProps() %>"
+				props="<%= layoutLookAndFeelDisplayContext.getGlobalCSSCETsConfigurationProps(Layout.class.getName(), selLayout.getPlid()) %>"
 			/>
 		</div>
 	</clay:sheet-section>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/look_and_feel.jsp
@@ -37,13 +37,13 @@ PortletURL redirectURL = layoutsAdminDisplayContext.getRedirectURL();
 
 <aui:model-context bean="<%= selLayout %>" model="<%= Layout.class %>" />
 
-<aui:input name="devices" type="hidden" value="regular" />
-<aui:input name="faviconCETExternalReferenceCode" type="hidden" />
-<aui:input name="faviconFileEntryId" type="hidden" />
-
 <%
 LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLookAndFeelDisplayContext(request, layoutsAdminDisplayContext, liferayPortletResponse);
 %>
+
+<aui:input name="devices" type="hidden" value="regular" />
+<aui:input name="faviconCETExternalReferenceCode" type="hidden" value="<%= layoutLookAndFeelDisplayContext.getFaviconCETExternalReferenceCode() %>" />
+<aui:input name="faviconFileEntryId" type="hidden" value="<%= selLayout.getFaviconFileEntryId() %>" />
 
 <clay:sheet-section>
 	<h3 class="sheet-subtitle"><liferay-ui:message key="favicon" /></h3>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/favicon.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/favicon.jsp
@@ -21,7 +21,7 @@ LayoutSet selLayoutSet = layoutsAdminDisplayContext.getSelLayoutSet();
 %>
 
 <div class="form-group">
-	<img alt="<%= HtmlUtil.escape(layoutsAdminDisplayContext.getFaviconTitle()) %>" class="mb-2" height="16" id="<portlet:namespace />faviconImage" src="<%= layoutsAdminDisplayContext.getFaviconImage() %>" width="16" />
+	<img alt="<%= HtmlUtil.escape(layoutsAdminDisplayContext.getFaviconTitle()) %>" class="mb-2" height="16" id="<portlet:namespace />faviconImage" src="<%= layoutsAdminDisplayContext.getFaviconURL() %>" width="16" />
 
 	<p>
 		<b><liferay-ui:message key="favicon-name" />:</b> <span id="<portlet:namespace />faviconTitle"><%= layoutsAdminDisplayContext.getFaviconTitle() %></span>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/favicon.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/favicon.jsp
@@ -27,7 +27,7 @@ LayoutSet selLayoutSet = layoutsAdminDisplayContext.getSelLayoutSet();
 		<b><liferay-ui:message key="favicon-name" />:</b> <span id="<portlet:namespace />faviconTitle"><%= layoutsAdminDisplayContext.getFaviconTitle() %></span>
 	</p>
 
-	<aui:input name="faviconCETExternalReferenceCode" type="hidden" />
+	<aui:input name="faviconCETExternalReferenceCode" type="hidden" value="<%= layoutsAdminDisplayContext.getFaviconCETExternalReferenceCode() %>" />
 	<aui:input name="faviconFileEntryId" type="hidden" value="<%= selLayoutSet.getFaviconFileEntryId() %>" />
 
 	<aui:button name="selectFaviconButton" value="change-favicon" />
@@ -35,6 +35,21 @@ LayoutSet selLayoutSet = layoutsAdminDisplayContext.getSelLayoutSet();
 	<aui:button disabled="<%= !layoutsAdminDisplayContext.isClearFaviconButtonEnabled() %>" name="clearFaviconButton" value="clear" />
 
 	<aui:script sandbox="<%= true %>">
+		const clearFaviconButton = document.getElementById(
+			'<portlet:namespace />clearFaviconButton'
+		);
+		const faviconCETExternalReferenceCode = document.getElementById(
+			'<portlet:namespace />faviconCETExternalReferenceCode'
+		);
+		const faviconFileEntryId = document.getElementById(
+			'<portlet:namespace />faviconFileEntryId'
+		);
+		const faviconImage = document.getElementById(
+			'<portlet:namespace />faviconImage'
+		);
+		const faviconTitle = document.getElementById(
+			'<portlet:namespace />faviconTitle'
+		);
 		const selectLayoutButton = document.getElementById(
 			'<portlet:namespace />selectFaviconButton'
 		);
@@ -44,20 +59,6 @@ LayoutSet selLayoutSet = layoutsAdminDisplayContext.getSelLayoutSet();
 
 			Liferay.Util.openSelectionModal({
 				onSelect: function (selectedItem) {
-					const faviconCETExternalReferenceCode = document.getElementById(
-						'<portlet:namespace />faviconCETExternalReferenceCode'
-					);
-
-					const faviconFileEntryId = document.getElementById(
-						'<portlet:namespace />faviconFileEntryId'
-					);
-					const faviconImage = document.getElementById(
-						'<portlet:namespace />faviconImage'
-					);
-					const faviconTitle = document.getElementById(
-						'<portlet:namespace />faviconTitle'
-					);
-
 					if (
 						faviconCETExternalReferenceCode &&
 						faviconFileEntryId &&
@@ -74,8 +75,10 @@ LayoutSet selLayoutSet = layoutsAdminDisplayContext.getSelLayoutSet();
 						) {
 							faviconCETExternalReferenceCode.value =
 								itemValue.cetExternalReferenceCode;
+							faviconFileEntryId.value = 0;
 						}
 						else {
+							faviconCETExternalReferenceCode.value = '';
 							faviconFileEntryId.value = itemValue.fileEntryId;
 						}
 
@@ -96,22 +99,16 @@ LayoutSet selLayoutSet = layoutsAdminDisplayContext.getSelLayoutSet();
 			});
 		});
 
-		const clearFaviconButton = document.getElementById(
-			'<portlet:namespace />clearFaviconButton'
-		);
-		const faviconFileEntryId = document.getElementById(
-			'<portlet:namespace />faviconFileEntryId'
-		);
-		const faviconImage = document.getElementById(
-			'<portlet:namespace />faviconImage'
-		);
-		const faviconTitle = document.getElementById(
-			'<portlet:namespace />faviconTitle'
-		);
-
-		if (clearFaviconButton && faviconFileEntryId && faviconImage && faviconTitle) {
+		if (
+			faviconCETExternalReferenceCode &&
+			clearFaviconButton &&
+			faviconFileEntryId &&
+			faviconImage &&
+			faviconTitle
+		) {
 			clearFaviconButton.addEventListener('click', (event) => {
-				faviconFileEntryId.value = '0';
+				faviconCETExternalReferenceCode.value = '';
+				faviconFileEntryId.value = 0;
 				faviconImage.classList.add('d-none');
 				faviconTitle.innerHTML =
 					'<liferay-ui:message key="favicon-from-theme" />';

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/javascript.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/javascript.jsp
@@ -37,7 +37,7 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 	<clay:sheet-section>
 		<react:component
 			module="js/layout/look_and_feel/GlobalJSCETsConfiguration"
-			props="<%= layoutLookAndFeelDisplayContext.getGlobalJSCETsConfigurationProps() %>"
+			props="<%= layoutLookAndFeelDisplayContext.getGlobalJSCETsConfigurationProps(LayoutSet.class.getName(), selLayoutSet.getLayoutSetId()) %>"
 		/>
 	</clay:sheet-section>
 </c:if>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/look_and_feel.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/look_and_feel.jsp
@@ -18,6 +18,8 @@
 
 <%
 LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLookAndFeelDisplayContext(request, layoutsAdminDisplayContext, liferayPortletResponse);
+
+LayoutSet selLayoutSet = layoutsAdminDisplayContext.getSelLayoutSet();
 %>
 
 <liferay-ui:error-marker
@@ -25,7 +27,7 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 	value="look-and-feel"
 />
 
-<aui:model-context bean="<%= layoutsAdminDisplayContext.getSelLayoutSet() %>" model="<%= Layout.class %>" />
+<aui:model-context bean="<%= selLayoutSet %>" model="<%= Layout.class %>" />
 
 <aui:input name="devices" type="hidden" value="regular" />
 
@@ -39,7 +41,7 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 	<clay:sheet-section>
 		<react:component
 			module="js/layout/look_and_feel/GlobalCSSCETsConfiguration"
-			props="<%= layoutLookAndFeelDisplayContext.getGlobalCSSCETsConfigurationProps() %>"
+			props="<%= layoutLookAndFeelDisplayContext.getGlobalCSSCETsConfigurationProps(LayoutSet.class.getName(), selLayoutSet.getLayoutSetId()) %>"
 		/>
 	</clay:sheet-section>
 </c:if>


### PR DESCRIPTION
- LPS-156031 Don't execute it on control panel
- LPS-156031 Rename
- LPS-156031 Uses default theme favicon
- LPS-156031 Adds new method to delete client extension entry rels by classNameId, classPk and type
- LPS-156031 Auto
- LPS-156031 baseline
- LPS-156031 Delete only the global css and global js extensions
- LPS-156031 Reset favicon only when it is necessary
- LPS-156031 We should pass the className and classPK, since we are using it for layouts and layout sets
