### PR TITLE
[TS] LPS-156240

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6546,7 +6546,7 @@ public class JournalArticleLocalServiceImpl
 			assetEntry = _assetEntryLocalService.updateEntry(
 				userId, article.getGroupId(), article.getCreateDate(),
 				article.getModifiedDate(), JournalArticle.class.getName(),
-				article.getPrimaryKey(), article.getUuid(),
+				article.getResourcePrimKey(), article.getUuid(),
 				getClassTypeId(article), assetCategoryIds, assetTagNames,
 				isListable(article), false, null, null, null,
 				article.getExpirationDate(), ContentTypes.TEXT_HTML, title,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-156240

The issue is that previously we were passing along the `JournalArticle`'s `id_` in order to update the associated `AssetEntry`. This resulted in the existing `AssetEntry` not being found and a new one being created. By passing in the `resourcePrimKey` the existing `AssetEntry` is found as expected.

This code has been the same since the block was introduced many years ago but every other call to `updateEntry` in this class uses the `resourcePrimKey`. That being said please let me know if there is a reason why the `id_` should be used in this case.

Thank you.