### PR TITLE
[TS] LPS-156378 Inject corresponding portlet request and portlet attributes in case when they don't exist yet

### DIFF
--- a/modules/apps/fragment/fragment-impl/build.gradle
+++ b/modules/apps/fragment/fragment-impl/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentObjectFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentObjectFragmentRenderer.java
@@ -14,6 +14,8 @@
 
 package com.liferay.fragment.internal.renderer;
 
+import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
+import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
@@ -35,17 +37,32 @@ import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.portlet.InvokerPortlet;
+import com.liferay.portal.kernel.portlet.LiferayRenderRequest;
+import com.liferay.portal.kernel.portlet.PortletConfigFactoryUtil;
+import com.liferay.portal.kernel.portlet.PortletInstanceFactoryUtil;
+import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.Tuple;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portlet.RenderRequestFactory;
+import com.liferay.portlet.RenderResponseFactory;
 
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.ResourceBundle;
+
+import javax.portlet.PortletConfig;
+import javax.portlet.PortletMode;
+import javax.portlet.PortletRequest;
+import javax.portlet.WindowState;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -172,6 +189,52 @@ public class ContentObjectFragmentRenderer implements FragmentRenderer {
 				"you-do-not-have-permission-to-access-the-requested-resource");
 
 			return;
+		}
+
+		AssetRendererFactory<?> assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
+				className);
+
+		PortletRequest portletRequest =
+			(PortletRequest)httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_REQUEST);
+
+		if ((portletRequest == null) && (assetRendererFactory != null)) {
+			Portlet portlet = _portletLocalService.getPortletById(
+				assetRendererFactory.getPortletId());
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			try {
+				InvokerPortlet invokerPortlet =
+					PortletInstanceFactoryUtil.create(
+						portlet, httpServletRequest.getServletContext());
+
+				PortletConfig portletConfig = PortletConfigFactoryUtil.create(
+					portlet, httpServletRequest.getServletContext());
+
+				LiferayRenderRequest liferayRenderRequest =
+					RenderRequestFactory.create(
+						httpServletRequest, portlet, invokerPortlet,
+						portletConfig.getPortletContext(), WindowState.NORMAL,
+						PortletMode.VIEW,
+						PortletPreferencesFactoryUtil.fromDefaultXML(
+							portlet.getDefaultPreferences()),
+						themeDisplay.getPlid());
+
+				httpServletRequest.setAttribute(
+					JavaConstants.JAVAX_PORTLET_REQUEST, liferayRenderRequest);
+
+				httpServletRequest.setAttribute(
+					JavaConstants.JAVAX_PORTLET_RESPONSE,
+					RenderResponseFactory.create(
+						themeDisplay.getResponse(), liferayRenderRequest));
+			}
+			catch (Exception exception) {
+				_log.error(exception);
+			}
 		}
 
 		if (infoItemRenderer instanceof InfoItemTemplatedRenderer) {
@@ -343,5 +406,8 @@ public class ContentObjectFragmentRenderer implements FragmentRenderer {
 
 	@Reference
 	private InfoItemServiceTracker _infoItemServiceTracker;
+
+	@Reference
+	private PortletLocalService _portletLocalService;
 
 }


### PR DESCRIPTION
Motivation
=======
RenderRequest is frequently used to create URLs through AssetRenderers. Fragments don't have access to a renderRequest, which hinders the transition of specialised templates from widget pages to content pages
[LPS-156378](https://issues.liferay.com/browse/LPS-156378)

Proposed Solution
========
Using the logic implemented in [LPS-123118](https://issues.liferay.com/browse/LPS-123118) for Content Display Objects we can generate a renderRequest for the ContentObjectFragment

Steps to Verify:
----------------

1. Go to Content & Data -> Web Content and switch to Structures tab
2. Create a new structure called "test structure" with a text field
3. Switch to "Templates" tab and create a new template linked to the structure "test structure" called "test template" and set the freemarker code to: `Hello ${renderRequest}`
5. Switch to "Web Content" tab, click "+" and choose the new structure
6. Add random content to the article and click Publish
7. Go to the homepage
8. Click the Edit icon to enter the page edit mode
9. From the "Fragments and Widgets" menu drag the "Content Display" fragment and drop it on the page
10. Configure the Fragment to display the article

Thanks,
Balázs