### PR TITLE
[TS] LPS-155839: Templates no longer displaying in escaped format, not necessary for how they are being used

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/servlet/taglib/clay/JournalDDMTemplateVerticalCard.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/servlet/taglib/clay/JournalDDMTemplateVerticalCard.java
@@ -70,7 +70,7 @@ public class JournalDDMTemplateVerticalCard implements VerticalCard {
 			(ThemeDisplay)_httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		return HtmlUtil.escape(_ddmTemplate.getName(themeDisplay.getLocale()));
+		return _ddmTemplate.getName(themeDisplay.getLocale());
 	}
 
 	@Override

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/clay/JournalDDMTemplateVerticalCard.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/clay/JournalDDMTemplateVerticalCard.java
@@ -129,7 +129,7 @@ public class JournalDDMTemplateVerticalCard extends BaseVerticalCard {
 
 	@Override
 	public String getTitle() {
-		return HtmlUtil.escape(_ddmTemplate.getName(themeDisplay.getLocale()));
+		return _ddmTemplate.getName(themeDisplay.getLocale());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/clay/JournalSelectDDMTemplateVerticalCard.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/clay/JournalSelectDDMTemplateVerticalCard.java
@@ -115,7 +115,7 @@ public class JournalSelectDDMTemplateVerticalCard implements VerticalCard {
 			(ThemeDisplay)_httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
-		return HtmlUtil.escape(_ddmTemplate.getName(themeDisplay.getLocale()));
+		return _ddmTemplate.getName(themeDisplay.getLocale());
 	}
 
 	@Override


### PR DESCRIPTION
Hi Team,

Can you help review this PR? 

Note: Other VerticalCards are also affected by this issue as well, but this PR focuses on cards related to DDMTemplate since the reported LPS ticket is related to DDM Templates.

Notes from @jakesliwka:
> https://issues.liferay.com/browse/LPS-155839
> 
> The issue is caused when the user creates a Template in Web Content. If the user used certain characters (such as &, ", ', < >, etc), the title of the Template would display correctly at the top, but once the user navigates back to the Templates page to view all of the templates, the titles would be displayed in escaped format.
> When viewing how the title was being called, it was called in the view_ddm_templates.jsp by creating a vertical card based off of an object referencing the DDMTemplate, automatically generating all of its content. When it is used this way, the HtmlUtil.escape is unnecessary and only directly impacts the name.
> This was tested and verified by giving the templates JavaScript names, such as "<script>alert("test");</script>" to see if it would execute, however it did not, showing that the way that the templates are being called does not require an escaped format.
> After going through and verifying everywhere else that the titles of DDMTemplates are being retrieved, most of them are used the same exact way, and those that are different are already formatted with an HtmlUtil.escape during the call. So, returning the escaped format is only impacting the name.
> This bug was tracked to JournalDDMTemplateVerticalCard.java and JournalSelectDDMTemplateVerticalCard.java where the getName function for the Templates was being used. This fixes the return statement so that it no longer returns the escaped version and allows for the template titles to be displayed properly with any characters.
> In the implementation of VerticalCardTag.java, the title returns escaped by default. So, by passing an escaped format in the getTitle method, it actually is escaping the title twice.
> 
> The issue is reproducible in other areas that utilize the VerticalCard, however only the ones that are called similar to those in view_ddm_templates.jsp


Please let us know if you have any questions or would like us to make any changes.

Thanks!