### PR TITLE
LPS-156832 Search Bar Suggestions shows HTML as plain text

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRenderer.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRenderer.java
@@ -83,11 +83,10 @@ public class LayoutAssetRenderer extends BaseJSPAssetRenderer<Layout> {
 
 		Locale locale = getLocale(portletRequest);
 
-		StringBundler sb = new StringBundler(4);
+		StringBundler sb = new StringBundler(3);
 
-		sb.append("<strong>");
 		sb.append(LanguageUtil.get(locale, "page"));
-		sb.append(":</strong> ");
+		sb.append(": ");
 		sb.append(_layout.getHTMLTitle(locale));
 
 		if (_layout.isTypeContent() &&


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-156832

## Motivation
In the Search Bar, we're rendering the page summary and the output would be something like `<strong>Page:</strong> <script>...</script>`. Attempting to render the `<strong>` tags would output: `Page: `.

## Proposed Solution
I escaped the page title in `layout-admin-web` `LayoutAssetRenderer#getSummary` method to be able to render the `<strong>` tags that `LayoutAssetRenderer#getSummary` was adding without rendering other potential tags in a page title. 29b52269fb3bc3ac5de16c8d935f275a5deca80b

Ran `ci:test:sf` and `ci:test:relevant` at https://github.com/liferay-search/liferay-portal/pull/476
[✔️ ci:test:sf - 1 out of 1 jobs passed in 4 minutes](https://github.com/liferay-search/liferay-portal/pull/476#issuecomment-1165041921)
[✔️ ci:test:stable - 27 out of 27 jobs passed
✔️ ci:test:relevant - 182 out of 188 jobs passed in 1 hour 26 minutes](https://github.com/liferay-search/liferay-portal/pull/476#issuecomment-1165102247)

## Screenshots
Here's a screenshot of our use case in the Search Bar where we're rendering the summary with the changes in the PR applied. 

![175435902-3d69af9a-bda7-402c-81d7-1ab853051b6c](https://user-images.githubusercontent.com/4496722/175614623-716326c7-0442-4a09-805b-4e914849a00c.png)
