### PR TITLE
[TS] LPS-152888 - change redirect in the specific case where we are viewing an asset in context and use a related assets portlet

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -48,6 +48,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Portlet;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
@@ -627,9 +628,27 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 				if (Validator.isNotNull(viewURL) &&
 					!Objects.equals(viewURL, noSuchEntryRedirect)) {
 
-					viewURL = HttpComponentsUtil.setParameter(
-						viewURL, "redirect",
-						_portal.getCurrentURL(liferayPortletRequest));
+					Portlet portlet = liferayPortletRequest.getPortlet();
+					String currentURL = _portal.getCurrentURL(
+						liferayPortletRequest);
+
+					if (Objects.equals(
+							portlet.getPortletName(),
+							AssetPublisherPortletKeys.RELATED_ASSETS) &&
+						currentURL.contains(
+							liferayPortletRequest.getPortletName())) {
+
+						viewURL = HttpComponentsUtil.setParameter(
+							viewURL, "redirect",
+							liferayPortletRequest.getHttpServletRequest(
+							).getHeader(
+								"Referer"
+							));
+					}
+					else {
+						viewURL = HttpComponentsUtil.setParameter(
+							viewURL, "redirect", currentURL);
+					}
 				}
 			}
 			catch (Exception exception) {


### PR DESCRIPTION
Hi @liferay-echo,

This PR addresses a very specific case where we have a related assets portlet and an asset publisher portlet we're using to view assets in context. In the client's case, they're using the related assets portlet as a navigational tool. If you use simple navigation on the related assets portlet and click 'next' to scroll to the next asset in the related assets portlet, the redirect for the asset publisher where you are viewing the content changes to the related asset portlet itself. I've changed it so that the URL is now the referring URL rather than the current URL in this specific case so the back icon on the asset publisher works properly.

Please let me know if you have any questions about this. Thanks!