### PR TITLE
[TS] LPS-150021 |  View Usage for web contents show results from multiple scopes, where only the copy of the web content is used

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/asset/util/JournalArticleLayoutClassedModelUsageRecorder.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/asset/util/JournalArticleLayoutClassedModelUsageRecorder.java
@@ -105,7 +105,7 @@ public class JournalArticleLayoutClassedModelUsageRecorder
 
 		List<JournalContentSearch> contentSearches =
 			_journalContentSearchLocalService.getArticleContentSearches(
-				article.getArticleId());
+				article.getGroupId(), article.getArticleId());
 
 		for (JournalContentSearch contentSearch : contentSearches) {
 			Layout layout = _layoutLocalService.fetchLayout(


### PR DESCRIPTION
hi Team,
Could you review this?

https://issues.liferay.com/browse/LPS-150021

Best,
Attila

-----

**Reproduction steps:**

1. Set up a clean portal instance
2. Create a blank site named SiteA
3. Create a web content named ContentA
4. Create a widget page named PageA
5. Add a web content display portlet on PageA showing ContentA
6. Export the entire SiteA site, download the LAR file
7. Create a new site names SiteB
8. Import the LAR file in SiteB
9. Go to the web content list in SiteB and select "View Usages" of ContentA

 **Expected result:** Only one usage is shown: the one in SiteB
 **Actual result:** two usages are shown: one in SiteA and one in SiteB (you can check the links in the "View in Page" option on the usage entry)

The modification was required to avoid conflict of usage count between the same article in different scopes. If an article is imported to a site in the same portal the article will keep the ArticleId but it will be a different article from the original.

After the modification, I re-tested by importing the export to a new site, only the relevant usages were shown. I also tested if the search could find usages in different scopes by creating an article in the global scope and using it in both site A and site B. Even after my modification, the usages were shown correctly for the article in the global scope.