### PR TITLE
LPS-150991

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/asset/full_content.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/asset/full_content.jsp
@@ -19,7 +19,7 @@
 <liferay-util:html-top
 	outputKey="blogs_css"
 >
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/blogs/css/common_main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/blogs/css/common_main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <liferay-util:dynamic-include key="com.liferay.blogs.web#/blogs/asset/full_content.jsp#pre" />

--- a/modules/apps/document-library/document-library-preview-image/src/main/resources/META-INF/resources/preview/view.jsp
+++ b/modules/apps/document-library/document-library-preview-image/src/main/resources/META-INF/resources/preview/view.jsp
@@ -35,7 +35,7 @@ String previewURL = DLURLHelperUtil.getPreviewURL(fileVersion.getFileEntry(), fi
 <liferay-util:html-top
 	outputKey="document_library_preview_image_css"
 >
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/preview/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/preview/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <c:choose>

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_full_content.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/asset/file_entry_full_content.jsp
@@ -27,7 +27,7 @@ DLViewFileVersionDisplayContext dlViewFileVersionDisplayContext = dlDisplayConte
 <liferay-util:html-top
 	outputKey="document_library_preview_css"
 >
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/document_library/css/document_library_preview.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/document_library/css/document_library_preview.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <c:choose>

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/site_settings/open_graph.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/site_settings/open_graph.jsp
@@ -21,7 +21,7 @@ OpenGraphSettingsDisplayContext openGraphSettingsDisplayContext = (OpenGraphSett
 %>
 
 <liferay-util:html-top>
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <aui:field-wrapper cssClass="form-group">

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layouts_tree/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/layouts_tree/page.jsp
@@ -32,7 +32,7 @@ String treeId = (String)request.getAttribute("liferay-layout:layouts-tree:treeId
 %>
 
 <liferay-util:html-top>
-	<link href="<%= PortalUtil.getStaticResourceURL(request, application.getContextPath() + "/layouts_tree/css/layouts_tree.css") %>" rel="stylesheet" type="text/css" />
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/layouts_tree/css/layouts_tree.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
 <aui:script position='<%= (String)request.getAttribute("liferay-layout:layouts-tree:scriptPosition") %>' use='<%= (String)request.getAttribute("liferay-layout:layouts-tree:modules") %>'>


### PR DESCRIPTION
## Motivation

https://issues.liferay.com/browse/LPS-150991
https://issues.liferay.com/browse/PTR-3050

## Proposed solution

Searching in the source code, we found several dozen instances where something called getStaticResourceURL and getContextPath, without also calling getPathProxy.

```bash
git ls-files -- '*.java' | xargs grep -Fl 'getStaticResourceURL' | xargs grep -Fl 'getContextPath()' | xargs grep -L 'getPathProxy()'
git ls-files -- '*.jsp*' | xargs grep -Fl 'getStaticResourceURL' | xargs grep -Fl 'getContextPath()' | xargs grep -L 'getPathProxy()'
```

I asked the TSE to open [PTR-3050](https://issues.liferay.com/browse/PTR-3050) in order to get a perspective on how to best fix the issue, and the conclusion was that we should fix all instances where we see the pattern appear, rather than fix the API itself to automatically account for potentially incomplete parameter values (as is done with ComboServlet).

After preparing the pull request https://github.com/liferay-core-infra/liferay-portal/pull/964, the core infrastructure team recommended that we split up the pull request by reviewer. According to the DXP Product Teams page, Echo is responsible for Asset Framework, Sites, and Page Administration, and so we're sending some of the changes here.

## Steps to verify

The TSE was not able to figure out how to reproduce the issue in all the instances where the pattern appears, but they were able to identify steps to reproduce for all of the issues fixed in this pull request. They have shared a Google Drive document describing what we need to access in the portal in order to see the issue introduced by that file having an erroneous pattern.

https://docs.google.com/document/d/1dmiP23za68PAbbvxp-GrTO_EkRQ6Di0Z1-cqlDZXNts/edit