### PR TITLE
LPS-157069 Limit the itemSelector to the current scope

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
@@ -72,6 +72,7 @@ LayoutItemSelectorCriterion layoutItemSelectorCriterion = new LayoutItemSelector
 
 layoutItemSelectorCriterion.setDesiredItemSelectorReturnTypes(new UUIDItemSelectorReturnType());
 layoutItemSelectorCriterion.setShowHiddenPages(true);
+layoutItemSelectorCriterion.setShowBreadcrumb(false);
 
 PortletURL itemSelectorURL = itemSelector.getItemSelectorURL(RequestBackedPortletURLFactoryUtil.create(renderRequest), eventName, layoutItemSelectorCriterion);
 


### PR DESCRIPTION
hi Team,
Could you review this?

https://issues.liferay.com/browse/LPS-157069

Best,
Attila

----

**Steps to reproduce:**
Navigate to Control Panel > Sites and create a new site
Navigate to Site menu > Site Builder > Pages and add a new page
Navigate to Site menu > Site Builder > Navigation menu and add a new navigation menu
Add the page from step 3. to the navigation menu
Click on the added navigation menu element, then on the right side, click on the Choose button
**Expected result:** The generated page selector should have the same limitation on the scope as the one on the add new navigation menu items 
**Actual result:** Users can navigate to other sites in the item selector.

Related slack thread to the topic:
https://liferay.slack.com/archives/CL9RTSZ52/p1656412961775489

This is the slector when we add a new element to the navigation menu:
![image (4)](https://user-images.githubusercontent.com/38041794/176172063-e8e10af8-e120-42bc-a55b-3518034ad215.png)

And this is the item selector when I edit an already added element:
![image (3)](https://user-images.githubusercontent.com/38041794/176172183-6e41e173-a2bb-4662-9033-b59d7b096327.png)

And this is the same item selector after the modifcaion:
![image](https://user-images.githubusercontent.com/38041794/176172454-9569986c-f8be-4ead-a849-8842b6ab8fed.png)


