### PR TITLE
LPS-157059 [App Pages] Staging of success message configuration

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateStructureRelStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateStructureRelStagedModelDataHandler.java
@@ -221,7 +221,12 @@ public class LayoutPageTemplateStructureRelStagedModelDataHandler
 						portletDataContext, layoutPageTemplateStructureRel,
 						data));
 
-			data = _processData(data, portletDataContext);
+			LayoutStructure layoutStructure = LayoutStructure.of(data);
+
+			_processImportFragmentLayoutStructureItemsData(
+				layoutStructure, portletDataContext);
+
+			data = layoutStructure.toString();
 		}
 
 		importedLayoutPageTemplateStructureRel.setData(data);
@@ -263,10 +268,9 @@ public class LayoutPageTemplateStructureRelStagedModelDataHandler
 		return _stagedModelRepository;
 	}
 
-	private String _processData(
-		String data, PortletDataContext portletDataContext) {
-
-		LayoutStructure layoutStructure = LayoutStructure.of(data);
+	private void _processImportFragmentLayoutStructureItemsData(
+		LayoutStructure layoutStructure,
+		PortletDataContext portletDataContext) {
 
 		Map<Long, Long> fragmentEntryLinkIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
@@ -294,8 +298,6 @@ public class LayoutPageTemplateStructureRelStagedModelDataHandler
 			fragmentStyledLayoutStructureItem.setFragmentEntryLinkId(
 				fragmentEntryLinkId);
 		}
-
-		return layoutStructure.toString();
 	}
 
 	private String _processReferenceStagedModels(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateStructureRelStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateStructureRelStagedModelDataHandler.java
@@ -31,6 +31,7 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
+import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.FragmentStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
@@ -39,6 +40,7 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
@@ -223,6 +225,9 @@ public class LayoutPageTemplateStructureRelStagedModelDataHandler
 
 			LayoutStructure layoutStructure = LayoutStructure.of(data);
 
+			_processImportFormLayoutStructureItemsData(
+				layoutStructure, portletDataContext);
+
 			_processImportFragmentLayoutStructureItemsData(
 				layoutStructure, portletDataContext);
 
@@ -266,6 +271,37 @@ public class LayoutPageTemplateStructureRelStagedModelDataHandler
 		getStagedModelRepository() {
 
 		return _stagedModelRepository;
+	}
+
+	private void _processImportFormLayoutStructureItemsData(
+		LayoutStructure layoutStructure,
+		PortletDataContext portletDataContext) {
+
+		List<FormStyledLayoutStructureItem> formStyledLayoutStructureItems =
+			layoutStructure.getFormStyledLayoutStructureItems();
+
+		for (FormStyledLayoutStructureItem formStyledLayoutStructureItem :
+				formStyledLayoutStructureItems) {
+
+			JSONObject successMessageJSONObject =
+				formStyledLayoutStructureItem.getSuccessMessageJSONObject();
+
+			if (successMessageJSONObject == null) {
+				continue;
+			}
+
+			JSONObject layoutJSONObject =
+				successMessageJSONObject.getJSONObject("layout");
+
+			if ((layoutJSONObject == null) ||
+				(layoutJSONObject.length() == 0)) {
+
+				continue;
+			}
+
+			layoutJSONObject.put(
+				"groupId", portletDataContext.getScopeGroupId());
+		}
 	}
 
 	private void _processImportFragmentLayoutStructureItemsData(
@@ -367,6 +403,9 @@ public class LayoutPageTemplateStructureRelStagedModelDataHandler
 
 	@Reference
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private LayoutPageTemplateStructureLocalService

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/LayoutStructure.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/LayoutStructure.java
@@ -61,6 +61,8 @@ public class LayoutStructure {
 			JSONObject itemsJSONObject =
 				layoutStructureJSONObject.getJSONObject("items");
 
+			List<FormStyledLayoutStructureItem> formStyledLayoutStructureItems =
+				new ArrayList<>();
 			Map<Long, LayoutStructureItem> fragmentLayoutStructureItems =
 				new HashMap<>(itemsJSONObject.length());
 			Map<String, LayoutStructureItem> layoutStructureItems =
@@ -84,6 +86,16 @@ public class LayoutStructure {
 						fragmentStyledLayoutStructureItem.
 							getFragmentEntryLinkId(),
 						fragmentStyledLayoutStructureItem);
+				}
+				else if (layoutStructureItem instanceof
+							FormStyledLayoutStructureItem) {
+
+					FormStyledLayoutStructureItem
+						formStyledLayoutStructureItem =
+							(FormStyledLayoutStructureItem)layoutStructureItem;
+
+					formStyledLayoutStructureItems.add(
+						formStyledLayoutStructureItem);
 				}
 			}
 
@@ -114,8 +126,8 @@ public class LayoutStructure {
 
 			return new LayoutStructure(
 				deletedItemIds, deletedLayoutStructureItems,
-				fragmentLayoutStructureItems, layoutStructureItems,
-				rootItemsJSONObject.getString("main"));
+				formStyledLayoutStructureItems, fragmentLayoutStructureItems,
+				layoutStructureItems, rootItemsJSONObject.getString("main"));
 		}
 		catch (JSONException jsonException) {
 			if (_log.isDebugEnabled()) {
@@ -129,6 +141,7 @@ public class LayoutStructure {
 	public LayoutStructure() {
 		_deletedItemIds = new HashSet<>();
 		_deletedLayoutStructureItems = new HashMap<>();
+		_formStyledLayoutStructureItems = new ArrayList<>();
 		_fragmentLayoutStructureItems = new HashMap<>();
 		_layoutStructureItems = new HashMap<>();
 		_mainItemId = StringPool.BLANK;
@@ -370,6 +383,12 @@ public class LayoutStructure {
 		}
 
 		return null;
+	}
+
+	public List<FormStyledLayoutStructureItem>
+		getFormStyledLayoutStructureItems() {
+
+		return _formStyledLayoutStructureItems;
 	}
 
 	public Map<Long, LayoutStructureItem> getFragmentLayoutStructureItems() {
@@ -684,6 +703,7 @@ public class LayoutStructure {
 	private LayoutStructure(
 		Set<String> deletedItemIds,
 		Map<String, DeletedLayoutStructureItem> deletedLayoutStructureItems,
+		List<FormStyledLayoutStructureItem> formLayoutStructureItems,
 		Map<Long, LayoutStructureItem> fragmentLayoutStructureItems,
 		Map<String, LayoutStructureItem> layoutStructureItems,
 		String mainItemId) {
@@ -693,6 +713,8 @@ public class LayoutStructure {
 		_fragmentLayoutStructureItems = fragmentLayoutStructureItems;
 		_layoutStructureItems = layoutStructureItems;
 		_mainItemId = mainItemId;
+
+		_formStyledLayoutStructureItems = formLayoutStructureItems;
 	}
 
 	private void _addColumnLayoutStructureItem(
@@ -918,6 +940,8 @@ public class LayoutStructure {
 	private final Set<String> _deletedItemIds;
 	private final Map<String, DeletedLayoutStructureItem>
 		_deletedLayoutStructureItems;
+	private final List<FormStyledLayoutStructureItem>
+		_formStyledLayoutStructureItems;
 	private final Map<Long, LayoutStructureItem> _fragmentLayoutStructureItems;
 	private final Map<String, LayoutStructureItem> _layoutStructureItems;
 	private String _mainItemId;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -64,7 +64,6 @@ import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.Theme;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
-import com.liferay.portal.kernel.service.LayoutServiceUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
@@ -922,12 +921,12 @@ public class RenderLayoutStructureDisplayContext {
 			return null;
 		}
 
+		String layoutUuid = layoutJSONObject.getString("layoutUuid");
 		long groupId = layoutJSONObject.getLong("groupId");
 		boolean privateLayout = layoutJSONObject.getBoolean("privateLayout");
-		long layoutId = layoutJSONObject.getLong("layoutId");
 
-		Layout layout = LayoutServiceUtil.fetchLayout(
-			groupId, privateLayout, layoutId);
+		Layout layout = LayoutLocalServiceUtil.fetchLayoutByUuidAndGroupId(
+			layoutUuid, groupId, privateLayout);
 
 		if (layout != null) {
 			return PortalUtil.getLayoutURL(layout, _themeDisplay);


### PR DESCRIPTION
- LPS-157059 Cache formStyleLayoutStructureItems to simplify lookup when exporting/importing
- LPS-157059 Change to get layout by uuid instead of layoutId
- LPS-157059 We are going to do more processing on import, so rename method to express what it does, and work on layout structure based on its data
- LPS-157059 Process all the form items that have a success message configured to be shown in another page of the same site by changing the configured groupId to the imported one
