### PR TITLE
LPS-156889

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -2502,18 +2502,9 @@ public class LayoutStagedModelDataHandler
 
 				importedLayout.setTypeSettingsProperties(
 					typeSettingsUnicodeProperties);
-
-				_layoutLocalService.updateLayout(
-					importedLayout.getGroupId(),
-					importedLayout.isPrivateLayout(),
-					importedLayout.getLayoutId(),
-					importedLayout.getTypeSettings());
 			}
 
-			_layoutLocalService.updateLookAndFeel(
-				importedLayout.getGroupId(), importedLayout.isPrivateLayout(),
-				importedLayout.getLayoutId(), layout.getThemeId(),
-				layout.getColorSchemeId(), importedLayout.getCss());
+			importedLayout.persist();
 		}
 	}
 


### PR DESCRIPTION
## Motivation

https://issues.liferay.com/browse/LPS-156889

/cc @sontruongces

## Proposed solution

When debugging the issue, the root cause for this was [LPS-135975](https://issues.liferay.com/browse/LPS-135975), which causes the imported layout to lose the previously set values during the `LayoutLocalService.updateLayout` call.

The original solution from the TSE was to store the `css` in a variable so that it wouldn't get lost, and then pass that `css` variable to `LayoutLocalService.updateLookAndFeel` instead of `importedLayout.getCss()`.

The proposed solution was a little too cryptic for me, so the alternate solution used on this pull request was to avoid calling `LayoutLocalService` twice and instead just update it once with `persist`. If, however, you feel that solution is better, please let me know, and I can forward the original solution instead.

## Steps to verify

Please see linked LPS.