### PR TITLE
LPS-156509 [App Pages] Integration tests for success message

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
@@ -445,6 +445,50 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 	}
 
 	@Test
+	public void testImportExportLayoutPageTemplateEntryFormContainerWithEmbeddedSuccessMessage()
+		throws Exception {
+
+		File expectedFile = _generateZipFile(
+			"form/success_message_embedded/expected", null, null);
+		File inputFile = _generateZipFile(
+			"form/success_message_embedded/input", null, null);
+
+		_validateImportExport(expectedFile, inputFile);
+	}
+
+	@Test
+	public void testImportExportLayoutPageTemplateEntryFormContainerWithLayoutSuccessMessage()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group1);
+
+		Map<String, String> stringValuesMap = HashMapBuilder.put(
+			"FRIENDLY_URL", layout.getFriendlyURL()
+		).put(
+			"SITE_KEY", String.valueOf(_group1.getGroupKey())
+		).build();
+
+		File expectedFile = _generateZipFile(
+			"form/success_message_layout/expected", null, stringValuesMap);
+		File inputFile = _generateZipFile(
+			"form/success_message_layout/input", null, stringValuesMap);
+
+		_validateImportExport(expectedFile, inputFile);
+	}
+
+	@Test
+	public void testImportExportLayoutPageTemplateEntryFormContainerWithURLSuccessMessage()
+		throws Exception {
+
+		File expectedFile = _generateZipFile(
+			"form/success_message_url/expected", null, null);
+		File inputFile = _generateZipFile(
+			"form/success_message_url/input", null, null);
+
+		_validateImportExport(expectedFile, inputFile);
+	}
+
+	@Test
 	public void testImportExportLayoutPageTemplateEntryFragmentCssClasses()
 		throws Exception {
 

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
@@ -448,44 +448,59 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 	public void testImportExportLayoutPageTemplateEntryFormContainerWithEmbeddedSuccessMessage()
 		throws Exception {
 
-		File expectedFile = _generateZipFile(
-			"form/success_message_embedded/expected", null, null);
-		File inputFile = _generateZipFile(
-			"form/success_message_embedded/input", null, null);
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					"feature.flag.LPS-149720", Boolean.TRUE.toString())) {
 
-		_validateImportExport(expectedFile, inputFile);
+			File expectedFile = _generateZipFile(
+				"form/success_message_embedded/expected", null, null);
+			File inputFile = _generateZipFile(
+				"form/success_message_embedded/input", null, null);
+
+			_validateImportExport(expectedFile, inputFile);
+		}
 	}
 
 	@Test
 	public void testImportExportLayoutPageTemplateEntryFormContainerWithLayoutSuccessMessage()
 		throws Exception {
 
-		Layout layout = LayoutTestUtil.addTypeContentLayout(_group1);
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					"feature.flag.LPS-149720", Boolean.TRUE.toString())) {
 
-		Map<String, String> stringValuesMap = HashMapBuilder.put(
-			"FRIENDLY_URL", layout.getFriendlyURL()
-		).put(
-			"SITE_KEY", String.valueOf(_group1.getGroupKey())
-		).build();
+			Layout layout = LayoutTestUtil.addTypeContentLayout(_group1);
 
-		File expectedFile = _generateZipFile(
-			"form/success_message_layout/expected", null, stringValuesMap);
-		File inputFile = _generateZipFile(
-			"form/success_message_layout/input", null, stringValuesMap);
+			Map<String, String> stringValuesMap = HashMapBuilder.put(
+				"FRIENDLY_URL", layout.getFriendlyURL()
+			).put(
+				"SITE_KEY", String.valueOf(_group1.getGroupKey())
+			).build();
 
-		_validateImportExport(expectedFile, inputFile);
+			File expectedFile = _generateZipFile(
+				"form/success_message_layout/expected", null, stringValuesMap);
+			File inputFile = _generateZipFile(
+				"form/success_message_layout/input", null, stringValuesMap);
+
+			_validateImportExport(expectedFile, inputFile);
+		}
 	}
 
 	@Test
 	public void testImportExportLayoutPageTemplateEntryFormContainerWithURLSuccessMessage()
 		throws Exception {
 
-		File expectedFile = _generateZipFile(
-			"form/success_message_url/expected", null, null);
-		File inputFile = _generateZipFile(
-			"form/success_message_url/input", null, null);
+		try (PropsTemporarySwapper propsTemporarySwapper =
+				new PropsTemporarySwapper(
+					"feature.flag.LPS-149720", Boolean.TRUE.toString())) {
 
-		_validateImportExport(expectedFile, inputFile);
+			File expectedFile = _generateZipFile(
+				"form/success_message_url/expected", null, null);
+			File inputFile = _generateZipFile(
+				"form/success_message_url/input", null, null);
+
+			_validateImportExport(expectedFile, inputFile);
+		}
 	}
 
 	@Test

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/expected/page-templates/test-page-template-collection/page-template-collection.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/expected/page-templates/test-page-template-collection/page-template-collection.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template Collection"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,0 +1,32 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"formConfig": {
+						"formReference": {
+							"className": "com.liferay.object.model.ObjectDefinition#00000",
+							"classType": 0
+						},
+						"formSuccessSubmissionResult": {
+							"message": {
+								"value_i18n": {
+									"en_US": "Thanks",
+									"es_ES": "Gracias"
+								}
+							}
+						}
+					},
+					"indexed": true
+				},
+				"type": "Form"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"colorSchemeName": "01",
+		"themeName": "Classic"
+	},
+	"version": 1.1
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/expected/page-templates/test-page-template-collection/test-page-template/page-template.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/expected/page-templates/test-page-template-collection/test-page-template/page-template.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/input/page-templates/test-page-template-collection/page-template-collection.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/input/page-templates/test-page-template-collection/page-template-collection.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template Collection"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,0 +1,32 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"formConfig": {
+						"formReference": {
+							"className": "com.liferay.object.model.ObjectDefinition#00000",
+							"classType": 0
+						},
+						"formSuccessSubmissionResult": {
+							"message": {
+								"value_i18n": {
+									"en_US": "Thanks",
+									"es_ES": "Gracias"
+								}
+							}
+						}
+					},
+					"indexed": true
+				},
+				"type": "Form"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"colorSchemeName": "01",
+		"themeName": "Classic"
+	},
+	"version": 1.1
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/input/page-templates/test-page-template-collection/test-page-template/page-template.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/input/page-templates/test-page-template-collection/test-page-template/page-template.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/expected/page-templates/test-page-template-collection/page-template-collection.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/expected/page-templates/test-page-template-collection/page-template-collection.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template Collection"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,0 +1,43 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"formConfig": {
+						"formReference": {
+							"className": "com.liferay.object.model.ObjectDefinition#00000",
+							"classType": 0
+						},
+						"formSuccessSubmissionResult": {
+							"itemReference": {
+								"className": "com.liferay.portal.kernel.model.Layout",
+								"fields": [
+									{
+										"fieldName": "friendlyURL",
+										"fieldValue": "£{FRIENDLY_URL}"
+									},
+									{
+										"fieldName": "privatePage",
+										"fieldValue": "false"
+									},
+									{
+										"fieldName": "siteKey",
+										"fieldValue": "£{SITE_KEY}"
+									}
+								]
+							}
+						}
+					},
+					"indexed": true
+				},
+				"type": "Form"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"colorSchemeName": "01",
+		"themeName": "Classic"
+	},
+	"version": 1.1
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/expected/page-templates/test-page-template-collection/test-page-template/page-template.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/expected/page-templates/test-page-template-collection/test-page-template/page-template.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/input/page-templates/test-page-template-collection/page-template-collection.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/input/page-templates/test-page-template-collection/page-template-collection.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template Collection"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,0 +1,43 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"formConfig": {
+						"formReference": {
+							"className": "com.liferay.object.model.ObjectDefinition#00000",
+							"classType": 0
+						},
+						"formSuccessSubmissionResult": {
+							"itemReference": {
+								"className": "com.liferay.portal.kernel.model.Layout",
+								"fields": [
+									{
+										"fieldName": "friendlyURL",
+										"fieldValue": "£{FRIENDLY_URL}"
+									},
+									{
+										"fieldName": "privatePage",
+										"fieldValue": "false"
+									},
+									{
+										"fieldName": "siteKey",
+										"fieldValue": "£{SITE_KEY}"
+									}
+								]
+							}
+						}
+					},
+					"indexed": true
+				},
+				"type": "Form"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"colorSchemeName": "01",
+		"themeName": "Classic"
+	},
+	"version": 1.1
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/input/page-templates/test-page-template-collection/test-page-template/page-template.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/input/page-templates/test-page-template-collection/test-page-template/page-template.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/expected/page-templates/test-page-template-collection/page-template-collection.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/expected/page-templates/test-page-template-collection/page-template-collection.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template Collection"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,0 +1,32 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"formConfig": {
+						"formReference": {
+							"className": "com.liferay.object.model.ObjectDefinition#00000",
+							"classType": 0
+						},
+						"formSuccessSubmissionResult": {
+							"url": {
+								"value_i18n": {
+									"en_US": "http://www.english.com",
+									"es_ES": "http://www.spanish.com"
+								}
+							}
+						}
+					},
+					"indexed": true
+				},
+				"type": "Form"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"colorSchemeName": "01",
+		"themeName": "Classic"
+	},
+	"version": 1.1
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/expected/page-templates/test-page-template-collection/test-page-template/page-template.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/expected/page-templates/test-page-template-collection/test-page-template/page-template.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/input/page-templates/test-page-template-collection/page-template-collection.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/input/page-templates/test-page-template-collection/page-template-collection.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template Collection"
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,0 +1,32 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"formConfig": {
+						"formReference": {
+							"className": "com.liferay.object.model.ObjectDefinition#00000",
+							"classType": 0
+						},
+						"formSuccessSubmissionResult": {
+							"url": {
+								"value_i18n": {
+									"en_US": "http://www.english.com",
+									"es_ES": "http://www.spanish.com"
+								}
+							}
+						}
+					},
+					"indexed": true
+				},
+				"type": "Form"
+			}
+		],
+		"type": "Root"
+	},
+	"settings": {
+		"colorSchemeName": "01",
+		"themeName": "Classic"
+	},
+	"version": 1.1
+}

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/input/page-templates/test-page-template-collection/test-page-template/page-template.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/input/page-templates/test-page-template-collection/test-page-template/page-template.json
@@ -1,0 +1,3 @@
+{
+	"name": "Test Page Template"
+}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/FormLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/headless/delivery/dto/v1_0/structure/importer/FormLayoutStructureItemImporter.java
@@ -180,8 +180,7 @@ public class FormLayoutStructureItemImporter
 
 		JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
-		Map<String, Object> map = (Map<String, Object>)propertiesMap.get(
-			"message");
+		Map<String, Object> map = (Map<String, Object>)propertiesMap.get(key);
 
 		if (MapUtil.isEmpty(map)) {
 			return jsonObject;


### PR DESCRIPTION
- LPS-156509 We should use the key here
- LPS-156509 Copy structure of other tests, and adapt definition so that it contains one form component with a success message for some locales
- LPS-156509 Copy structure of other tests, and adapt definition so that it contains one form component with a redirection URL success message for some locales
- LPS-156509 Copy structure of other tests, and adapt definition so that it contains one form component with a redirection to a page in the site success message for some locales
- LPS-156509 Add integration tests for the three cases
- LPS-156509 Hide behind FF
