### PR TITLE
LPS-155301 Basic Web Content classTypeId upgrade

### DIFF
--- a/modules/apps/journal/journal-service/bnd.bnd
+++ b/modules/apps/journal/journal-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal Service
 Bundle-SymbolicName: com.liferay.journal.service
 Bundle-Version: 7.0.75
-Liferay-Require-SchemaVersion: 4.3.0
+Liferay-Require-SchemaVersion: 4.3.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/registry/JournalServiceUpgradeStepRegistrator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/registry/JournalServiceUpgradeStepRegistrator.java
@@ -322,7 +322,7 @@ public class JournalServiceUpgradeStepRegistrator
 			"4.3.0", "4.3.1",
 			new ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess(
 				_assetEntryLocalService, _companyLocalService,
-				_groupLocalService, _ddmStructureLocalService));
+				_ddmStructureLocalService, _groupLocalService));
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/registry/JournalServiceUpgradeStepRegistrator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/registry/JournalServiceUpgradeStepRegistrator.java
@@ -63,6 +63,7 @@ import com.liferay.journal.internal.upgrade.v4_0_0.JournalArticleDDMFieldsUpgrad
 import com.liferay.journal.internal.upgrade.v4_1_0.JournalArticleExternalReferenceCodeUpgradeProcess;
 import com.liferay.journal.internal.upgrade.v4_2_0.JournalFeedUpgradeProcess;
 import com.liferay.journal.internal.upgrade.v4_3_0.JournalFolderExternalReferenceCodeUpgradeProcess;
+import com.liferay.journal.internal.upgrade.v4_3_1.ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.util.JournalConverter;
 import com.liferay.portal.change.tracking.store.CTStoreFactory;
@@ -289,8 +290,10 @@ public class JournalServiceUpgradeStepRegistrator
 
 		registry.register("3.4.0", "3.4.1", new DummyUpgradeStep());
 
+		registry.register("3.4.1", "3.4.2", new DummyUpgradeStep());
+
 		registry.register(
-			"3.4.1", "3.5.0",
+			"3.4.2", "3.5.0",
 			new JournalArticleContentUpgradeProcess(
 				_journalContentCompatibilityConverter));
 
@@ -314,6 +317,12 @@ public class JournalServiceUpgradeStepRegistrator
 		registry.register(
 			"4.2.0", "4.3.0",
 			new JournalFolderExternalReferenceCodeUpgradeProcess());
+
+		registry.register(
+			"4.3.0", "4.3.1",
+			new ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess(
+				_assetEntryLocalService, _companyLocalService,
+				_groupLocalService, _ddmStructureLocalService));
 	}
 
 	@Reference(unbind = "-")

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
@@ -43,13 +43,13 @@ public class ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess
 	public ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess(
 		AssetEntryLocalService assetEntryLocalService,
 		CompanyLocalService companyLocalService,
-		GroupLocalService groupLocalService,
-		DDMStructureLocalService ddmStructureLocalService) {
+		DDMStructureLocalService ddmStructureLocalService,
+		GroupLocalService groupLocalService) {
 
 		_assetEntryLocalService = assetEntryLocalService;
 		_companyLocalService = companyLocalService;
-		_groupLocalService = groupLocalService;
 		_ddmStructureLocalService = ddmStructureLocalService;
+		_groupLocalService = groupLocalService;
 	}
 
 	@Override

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
@@ -1,0 +1,221 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.internal.upgrade.v4_3_1;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.model.AssetEntryTable;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+/**
+ * @author Georgel Pop
+ */
+public class ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess
+	extends UpgradeProcess {
+
+	public ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess(
+		AssetEntryLocalService assetEntryLocalService,
+		CompanyLocalService companyLocalService,
+		GroupLocalService groupLocalService,
+		DDMStructureLocalService ddmStructureLocalService) {
+
+		_assetEntryLocalService = assetEntryLocalService;
+		_companyLocalService = companyLocalService;
+		_groupLocalService = groupLocalService;
+		_ddmStructureLocalService = ddmStructureLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_updateDefaultDraftArticleAssets();
+	}
+
+	private boolean _isUpgradeNeeded(long classNameId) throws Exception {
+		if (hasColumnType(
+				AssetEntryTable.INSTANCE.getName(), "companyId", "LONG null") &&
+			hasColumnType(
+				AssetEntryTable.INSTANCE.getName(), "classNameId",
+				"LONG null")) {
+
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						StringBundler.concat(
+							"select count(*) from AssetEntry where ",
+							"classTypeId = 0 and classNameId = ", classNameId));
+				ResultSet resultSet = preparedStatement.executeQuery()) {
+
+				if (resultSet.next()) {
+					int count = resultSet.getInt(1);
+
+					if (count > 0) {
+						return true;
+					}
+				}
+
+				return false;
+			}
+		}
+
+		return false;
+	}
+
+	private void _updateDefaultDraftArticleAssets() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			long classNameId = PortalUtil.getClassNameId(
+				JournalArticle.class.getName());
+
+			if (_isUpgradeNeeded(classNameId)) {
+				_companyLocalService.forEachCompanyId(
+					companyId -> _updateDefaultDraftArticleAssets(
+						companyId, classNameId));
+			}
+			else {
+				if (_log.isInfoEnabled()) {
+					_log.info(
+						StringBundler.concat(
+							"No need to upgrade asset entries with ",
+							"classNameId = ", classNameId,
+							" and classTypeId = 0"));
+				}
+			}
+		}
+	}
+
+	private void _updateDefaultDraftArticleAssets(
+			long companyId, long classNameId)
+		throws Exception {
+
+		Group companyGroup = _groupLocalService.getCompanyGroup(companyId);
+		String structureKey = "BASIC-WEB-CONTENT";
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+			companyGroup.getGroupId(),
+			PortalUtil.getClassNameId(JournalArticle.class.getName()),
+			structureKey);
+
+		long basicWebContentStructureId;
+
+		if (ddmStructure != null) {
+			basicWebContentStructureId = ddmStructure.getStructureId();
+
+			if (hasColumnType(
+					AssetEntryTable.INSTANCE.getName(), "classTypeId",
+					"LONG null") &&
+				hasColumnType(
+					AssetEntryTable.INSTANCE.getName(), "companyId",
+					"LONG null") &&
+				hasColumnType(
+					AssetEntryTable.INSTANCE.getName(), "classNameId",
+					"LONG null")) {
+
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"update AssetEntry set classTypeId = ? where ",
+								"classTypeId = ? and companyId = ? and ",
+								"classNameId = ?"))) {
+
+					preparedStatement.setLong(1, basicWebContentStructureId);
+					preparedStatement.setLong(2, 0);
+					preparedStatement.setLong(3, companyId);
+					preparedStatement.setLong(4, classNameId);
+
+					preparedStatement.executeUpdate();
+				}
+				catch (SQLException sqlException) {
+					if (_log.isWarnEnabled()) {
+						_log.warn(sqlException);
+					}
+				}
+			}
+			else {
+				try (PreparedStatement preparedStatement =
+						connection.prepareStatement(
+							StringBundler.concat(
+								"select resourcePrimKey, indexable from ",
+								"JournalArticle where companyId = ", companyId,
+								" and ddmtemplatekey = 'BASIC-WEB-CONTENT' "));
+					ResultSet resultSet = preparedStatement.executeQuery()) {
+
+					while (resultSet.next()) {
+						long resourcePrimKey = resultSet.getLong(
+							"resourcePrimKey");
+
+						AssetEntry assetEntry =
+							_assetEntryLocalService.fetchEntry(
+								JournalArticle.class.getName(),
+								resourcePrimKey);
+
+						if (assetEntry == null) {
+							if (_log.isWarnEnabled()) {
+								_log.warn(
+									StringBundler.concat(
+										"Journal article with resource ",
+										"primary key ", resourcePrimKey,
+										" does not have associated asset ",
+										"entry"));
+							}
+
+							continue;
+						}
+
+						long classTypeId = assetEntry.getClassTypeId();
+
+						if (classTypeId != basicWebContentStructureId) {
+							assetEntry.setClassTypeId(
+								basicWebContentStructureId);
+
+							_assetEntryLocalService.updateAssetEntry(
+								assetEntry);
+						}
+					}
+				}
+			}
+		}
+		else {
+			if (_log.isWarnEnabled()) {
+				_log.warn(
+					StringBundler.concat(
+						"No DDMStructure with structure key ", structureKey,
+						" found in Global site", companyGroup.getGroupId(),
+						" for companyId ", companyId));
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.class);
+
+	private final AssetEntryLocalService _assetEntryLocalService;
+	private final CompanyLocalService _companyLocalService;
+	private final DDMStructureLocalService _ddmStructureLocalService;
+	private final GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
@@ -134,6 +134,11 @@ public class ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess
 
 		long basicWebContentStructureId = ddmStructure.getStructureId();
 
+		/*
+		LPS-155301 Query is for performance, but we cannot guarantee that the
+		table will be changed in the future, so use Actionable Dynamic Query as
+		fallback in case it does
+		 */
 		if (hasColumnType(
 				AssetEntryTable.INSTANCE.getName(), "companyId", "LONG null") &&
 			hasColumnType(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
@@ -126,26 +126,26 @@ public class ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess
 			basicWebContentStructureId = ddmStructure.getStructureId();
 
 			if (hasColumnType(
-					AssetEntryTable.INSTANCE.getName(), "classTypeId",
-					"LONG null") &&
-				hasColumnType(
 					AssetEntryTable.INSTANCE.getName(), "companyId",
 					"LONG null") &&
 				hasColumnType(
 					AssetEntryTable.INSTANCE.getName(), "classNameId",
+					"LONG null") &&
+				hasColumnType(
+					AssetEntryTable.INSTANCE.getName(), "classTypeId",
 					"LONG null")) {
 
 				try (PreparedStatement preparedStatement =
 						connection.prepareStatement(
 							StringBundler.concat(
 								"update AssetEntry set classTypeId = ? where ",
-								"classTypeId = ? and companyId = ? and ",
-								"classNameId = ?"))) {
+								"companyId = ? and classNameId = ? and ",
+								"classTypeId = ?"))) {
 
 					preparedStatement.setLong(1, basicWebContentStructureId);
-					preparedStatement.setLong(2, 0);
-					preparedStatement.setLong(3, companyId);
-					preparedStatement.setLong(4, classNameId);
+					preparedStatement.setLong(2, companyId);
+					preparedStatement.setLong(3, classNameId);
+					preparedStatement.setLong(4, 0);
 
 					preparedStatement.executeUpdate();
 				}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
@@ -91,12 +91,7 @@ public class ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess
 			long classNameId = PortalUtil.getClassNameId(
 				JournalArticle.class.getName());
 
-			if (_isUpgradeNeeded(classNameId)) {
-				_companyLocalService.forEachCompanyId(
-					companyId -> _updateDefaultDraftArticleAssets(
-						companyId, classNameId));
-			}
-			else {
+			if (!_isUpgradeNeeded(classNameId)) {
 				if (_log.isInfoEnabled()) {
 					_log.info(
 						StringBundler.concat(
@@ -104,7 +99,13 @@ public class ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess
 							"classNameId = ", classNameId,
 							" and classTypeId = 0"));
 				}
+
+				return;
 			}
+
+			_companyLocalService.forEachCompanyId(
+				companyId -> _updateDefaultDraftArticleAssets(
+					companyId, classNameId));
 		}
 	}
 
@@ -120,92 +121,84 @@ public class ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess
 			PortalUtil.getClassNameId(JournalArticle.class.getName()),
 			structureKey);
 
-		long basicWebContentStructureId;
-
-		if (ddmStructure != null) {
-			basicWebContentStructureId = ddmStructure.getStructureId();
-
-			if (hasColumnType(
-					AssetEntryTable.INSTANCE.getName(), "companyId",
-					"LONG null") &&
-				hasColumnType(
-					AssetEntryTable.INSTANCE.getName(), "classNameId",
-					"LONG null") &&
-				hasColumnType(
-					AssetEntryTable.INSTANCE.getName(), "classTypeId",
-					"LONG null")) {
-
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"update AssetEntry set classTypeId = ? where ",
-								"companyId = ? and classNameId = ? and ",
-								"classTypeId = ?"))) {
-
-					preparedStatement.setLong(1, basicWebContentStructureId);
-					preparedStatement.setLong(2, companyId);
-					preparedStatement.setLong(3, classNameId);
-					preparedStatement.setLong(4, 0);
-
-					preparedStatement.executeUpdate();
-				}
-				catch (SQLException sqlException) {
-					if (_log.isWarnEnabled()) {
-						_log.warn(sqlException);
-					}
-				}
-			}
-			else {
-				try (PreparedStatement preparedStatement =
-						connection.prepareStatement(
-							StringBundler.concat(
-								"select resourcePrimKey, indexable from ",
-								"JournalArticle where companyId = ", companyId,
-								" and ddmtemplatekey = 'BASIC-WEB-CONTENT' "));
-					ResultSet resultSet = preparedStatement.executeQuery()) {
-
-					while (resultSet.next()) {
-						long resourcePrimKey = resultSet.getLong(
-							"resourcePrimKey");
-
-						AssetEntry assetEntry =
-							_assetEntryLocalService.fetchEntry(
-								JournalArticle.class.getName(),
-								resourcePrimKey);
-
-						if (assetEntry == null) {
-							if (_log.isWarnEnabled()) {
-								_log.warn(
-									StringBundler.concat(
-										"Journal article with resource ",
-										"primary key ", resourcePrimKey,
-										" does not have associated asset ",
-										"entry"));
-							}
-
-							continue;
-						}
-
-						long classTypeId = assetEntry.getClassTypeId();
-
-						if (classTypeId != basicWebContentStructureId) {
-							assetEntry.setClassTypeId(
-								basicWebContentStructureId);
-
-							_assetEntryLocalService.updateAssetEntry(
-								assetEntry);
-						}
-					}
-				}
-			}
-		}
-		else {
+		if (ddmStructure == null) {
 			if (_log.isWarnEnabled()) {
 				_log.warn(
 					StringBundler.concat(
 						"No DDMStructure with structure key ", structureKey,
 						" found in Global site", companyGroup.getGroupId(),
 						" for companyId ", companyId));
+			}
+
+			return;
+		}
+
+		long basicWebContentStructureId = ddmStructure.getStructureId();
+
+		if (hasColumnType(
+				AssetEntryTable.INSTANCE.getName(), "companyId", "LONG null") &&
+			hasColumnType(
+				AssetEntryTable.INSTANCE.getName(), "classNameId",
+				"LONG null") &&
+			hasColumnType(
+				AssetEntryTable.INSTANCE.getName(), "classTypeId",
+				"LONG null")) {
+
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						StringBundler.concat(
+							"update AssetEntry set classTypeId = ? where ",
+							"companyId = ? and classNameId = ? and ",
+							"classTypeId = ?"))) {
+
+				preparedStatement.setLong(1, basicWebContentStructureId);
+				preparedStatement.setLong(2, companyId);
+				preparedStatement.setLong(3, classNameId);
+				preparedStatement.setLong(4, 0);
+
+				preparedStatement.executeUpdate();
+			}
+			catch (SQLException sqlException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(sqlException);
+				}
+			}
+		}
+		else {
+			try (PreparedStatement preparedStatement =
+					connection.prepareStatement(
+						StringBundler.concat(
+							"select resourcePrimKey, indexable from ",
+							"JournalArticle where companyId = ", companyId,
+							" and ddmtemplatekey = 'BASIC-WEB-CONTENT' "));
+				ResultSet resultSet = preparedStatement.executeQuery()) {
+
+				while (resultSet.next()) {
+					long resourcePrimKey = resultSet.getLong("resourcePrimKey");
+
+					AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+						JournalArticle.class.getName(), resourcePrimKey);
+
+					if (assetEntry == null) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(
+								StringBundler.concat(
+									"Journal article with resource primary ",
+									"key ", resourcePrimKey, " does not have ",
+									"associated asset entry"));
+						}
+
+						continue;
+					}
+
+					long classTypeId = assetEntry.getClassTypeId();
+
+					if (classTypeId != basicWebContentStructureId) {
+						assetEntry.setClassTypeId(basicWebContentStructureId);
+
+						_assetEntryLocalService.updateAssetEntry(assetEntry);
+					}
+				}
 			}
 		}
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.sql.PreparedStatement;
-import java.sql.ResultSet;
 import java.sql.SQLException;
 
 /**
@@ -165,41 +164,35 @@ public class ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess
 			}
 		}
 		else {
-			try (PreparedStatement preparedStatement =
-					connection.prepareStatement(
-						StringBundler.concat(
-							"select resourcePrimKey, indexable from ",
-							"JournalArticle where companyId = ", companyId,
-							" and ddmtemplatekey = 'BASIC-WEB-CONTENT' "));
-				ResultSet resultSet = preparedStatement.executeQuery()) {
+			ActionableDynamicQuery actionableDynamicQuery =
+				_assetEntryLocalService.getActionableDynamicQuery();
 
-				while (resultSet.next()) {
-					long resourcePrimKey = resultSet.getLong("resourcePrimKey");
+			actionableDynamicQuery.setAddCriteriaMethod(
+				dynamicQuery -> {
+					Property companyIdProperty = PropertyFactoryUtil.forName(
+						"companyId");
 
-					AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
-						JournalArticle.class.getName(), resourcePrimKey);
+					dynamicQuery.add(companyIdProperty.eq(companyId));
 
-					if (assetEntry == null) {
-						if (_log.isWarnEnabled()) {
-							_log.warn(
-								StringBundler.concat(
-									"Journal article with resource primary ",
-									"key ", resourcePrimKey, " does not have ",
-									"associated asset entry"));
-						}
+					Property classNameIdProperty = PropertyFactoryUtil.forName(
+						"classNameId");
 
-						continue;
-					}
+					dynamicQuery.add(classNameIdProperty.eq(classNameId));
 
-					long classTypeId = assetEntry.getClassTypeId();
+					Property classTypeIdProperty = PropertyFactoryUtil.forName(
+						"classTypeId");
 
-					if (classTypeId != basicWebContentStructureId) {
-						assetEntry.setClassTypeId(basicWebContentStructureId);
+					dynamicQuery.add(classTypeIdProperty.eq(0L));
+				});
 
-						_assetEntryLocalService.updateAssetEntry(assetEntry);
-					}
-				}
-			}
+			actionableDynamicQuery.setPerformActionMethod(
+				(AssetEntry assetEntry) -> {
+					assetEntry.setClassTypeId(basicWebContentStructureId);
+
+					_assetEntryLocalService.updateAssetEntry(assetEntry);
+				});
+
+			actionableDynamicQuery.performActions();
 		}
 	}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
@@ -21,6 +21,9 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.Property;
+import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -58,29 +61,26 @@ public class ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess
 	}
 
 	private boolean _isUpgradeNeeded(long classNameId) throws Exception {
-		if (hasColumnType(
-				AssetEntryTable.INSTANCE.getName(), "companyId", "LONG null") &&
-			hasColumnType(
-				AssetEntryTable.INSTANCE.getName(), "classNameId",
-				"LONG null")) {
+		ActionableDynamicQuery actionableDynamicQuery =
+			_assetEntryLocalService.getActionableDynamicQuery();
 
-			try (PreparedStatement preparedStatement =
-					connection.prepareStatement(
-						StringBundler.concat(
-							"select count(*) from AssetEntry where ",
-							"classTypeId = 0 and classNameId = ", classNameId));
-				ResultSet resultSet = preparedStatement.executeQuery()) {
+		actionableDynamicQuery.setAddCriteriaMethod(
+			dynamicQuery -> {
+				Property classNameIdProperty = PropertyFactoryUtil.forName(
+					"classNameId");
 
-				if (resultSet.next()) {
-					int count = resultSet.getInt(1);
+				dynamicQuery.add(classNameIdProperty.eq(classNameId));
 
-					if (count > 0) {
-						return true;
-					}
-				}
+				Property classTypeIdProperty = PropertyFactoryUtil.forName(
+					"classTypeId");
 
-				return false;
-			}
+				dynamicQuery.add(classTypeIdProperty.eq(0L));
+			});
+
+		long count = actionableDynamicQuery.performCount();
+
+		if (count > 0) {
+			return true;
 		}
 
 		return false;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_3_1/ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess.java
@@ -115,7 +115,7 @@ public class ArticleAssetsBasicWebContentClassTypeIdUpgradeProcess
 		Group companyGroup = _groupLocalService.getCompanyGroup(companyId);
 		String structureKey = "BASIC-WEB-CONTENT";
 
-		DDMStructure ddmStructure = _ddmStructureLocalService.getStructure(
+		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
 			companyGroup.getGroupId(),
 			PortalUtil.getClassNameId(JournalArticle.class.getName()),
 			structureKey);


### PR DESCRIPTION
- LPS-155301 Fix upgrade in assetentry where classTypeId egual 0 for JournalArticle with structure key = "BASIC-WEB-CONTENT"
- LPS-155301 Reorder
- LPS-155301 Use the same order as in the table
- LPS-155301 Even though we want to improve performance, it would be best to check with actionable dynamic query the count in this place, since we have all at hand
- LPS-155301 Avoid possible NPE
- LPS-155301 Early returns
- LPS-155301 Simplify by using only one actionable query
- LPS-155301 Mention why we have two cases. The first one is for performance issues, but the table might have changed, so use dynamic query as fallback for this
