### PR TITLE
LPS-148539 In case of staging, create a reference only instead of publishing the same content over and over again.

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
@@ -129,11 +129,19 @@ public class LayoutClassedModelUsageStagedModelDataHandler
 				(assetRenderer.getStatus() ==
 					WorkflowConstants.STATUS_APPROVED)) {
 
-				StagedModelDataHandlerUtil.exportReferenceStagedModel(
-					portletDataContext, layoutClassedModelUsage,
-					(StagedModel)assetRenderer.getAssetObject(),
-					PortletDataContext.REFERENCE_TYPE_DEPENDENCY,
-					assetRendererFactory.getPortletId());
+				if (ExportImportThreadLocal.isStagingInProcess()) {
+					portletDataContext.addReferenceElement(
+						layoutClassedModelUsage, element,
+						(StagedModel)assetRenderer.getAssetObject(),
+						PortletDataContext.REFERENCE_TYPE_WEAK, true);
+				}
+				else {
+					StagedModelDataHandlerUtil.exportReferenceStagedModel(
+						portletDataContext, layoutClassedModelUsage,
+						(StagedModel)assetRenderer.getAssetObject(),
+						PortletDataContext.REFERENCE_TYPE_DEPENDENCY,
+						assetRendererFactory.getPortletId());
+				}
 			}
 		}
 


### PR DESCRIPTION
Hey guys,

This is a performance fix,
I'd like to prevent LayoutClassedModelUsageStagedModelDataHandler to publish the same content over and over again.

In 99.9% of the time a reference should be enough, which is used to build the new primary keys map, so the LayoutClassedModelUsage can use the new ID during import.

It is possible though to set up a custom publish process and deselect the related entity, in this case, the import will create a LayoutClassedModelUsage with the old primary key.
Do you think this could cause serious problems?

The next publish will fix the IDs, therefore I haven't spent more time on this corner case.
Let me know what do you think.

Thanks,
Tamas