### PR TITLE
[TS] LPS-157939 Import layout friendly URLs before layout portlets

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -994,6 +994,8 @@ public class LayoutStagedModelDataHandler
 
 		importedLayout = _layoutLocalService.updateLayout(importedLayout);
 
+		_importLayoutFriendlyURLs(portletDataContext, layout, importedLayout);
+
 		if ((Objects.equals(layout.getType(), LayoutConstants.TYPE_PORTLET) &&
 			 Validator.isNotNull(layout.getTypeSettings())) ||
 			layout.isTypeAssetDisplay() || layout.isTypeContent()) {
@@ -1003,8 +1005,6 @@ public class LayoutStagedModelDataHandler
 		}
 
 		_importAssets(portletDataContext, layout, importedLayout);
-
-		_importLayoutFriendlyURLs(portletDataContext, layout, importedLayout);
 
 		_importLayoutPageTemplateStructures(
 			portletDataContext, layout, importedLayout);


### PR DESCRIPTION
Hi Team, 

Can you help review this PR?

**Notes from @noornajj:**

> https://issues.liferay.com/browse/LPS-157939
> 
> The issue here was that a lar file couldn't be imported when it had two pages with the same name and created off of a page template. 
> 
> I found the issue was occurring when _importLayoutPortlets was being called and the friendlyURLMap is being retrieved. Since the friendly URLs are not imported yet, an empty friendlyURLMap was being passed and a default URL was generated based off of the page's name. 
> 
> This was causing a duplicate error to occur since the two pages being imported had the same name as well as an OptimisticLockException.
> 
> To fix the issue I reordered the imports so that _importLayoutFriendlyURLs called before _importLayoutPortlets

Please let us know if you have any questions.
Thanks!