### PR TITLE
[TS] LPS-157854 ConstraintViolationException during Staging (duplicate key when inserting in AssetDisplayPageEntry)

### DIFF
--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/exportimport/data/handler/AssetDisplayPageStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/exportimport/data/handler/AssetDisplayPageStagedModelDataHandler.java
@@ -128,6 +128,13 @@ public class AssetDisplayPageStagedModelDataHandler
 				importedAssetDisplayPageEntry.getClassNameId(),
 				existingClassPK);
 
+		if (existingAssetDisplayPageEntry == null) {
+			existingAssetDisplayPageEntry =
+				_stagedModelRepository.fetchStagedModelByUuidAndGroupId(
+					assetDisplayPageEntry.getUuid(),
+					portletDataContext.getScopeGroupId());
+		}
+
 		if ((existingAssetDisplayPageEntry == null) ||
 			!portletDataContext.isDataStrategyMirror()) {
 


### PR DESCRIPTION
Issue: [LPS-157854](https://issues.liferay.com/browse/LPS-157854)

---

Hi @liferay-echo,

We need to add a fallback when importing asset display pages to make sure there is no existing model. It was changed in  [LPS-131694](https://issues.liferay.com/browse/LPS-131694).

More details in [LPS-157854](https://issues.liferay.com/browse/LPS-157854).

The same approach was used, for instance, in https://github.com/liferay/liferay-portal/commit/c98ed99e8f7e8c44f39d1723aafb32a23a1f4813. 

Already discussed with @dacousalr.

Let me know if you have any questions. Thanks!