### PR TITLE
[TS] LPS-158448 | Translated FriendlyURL incorrectly redirects to the Home page after changing the language

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -191,10 +191,10 @@ public class UpdateLanguageAction implements Action {
 			layoutURL = layoutURL.substring(0, friendlyURLSeparatorIndex);
 		}
 
+		Locale currentLocale = themeDisplay.getLocale();
+
 		if (themeDisplay.isI18n()) {
 			String i18nPath = themeDisplay.getI18nPath();
-
-			Locale currentLocale = themeDisplay.getLocale();
 
 			String currentLocalePath =
 				StringPool.SLASH + currentLocale.toLanguageTag();
@@ -219,7 +219,7 @@ public class UpdateLanguageAction implements Action {
 		}
 		else if (layoutURL.equals(StringPool.SLASH) ||
 				 isGroupFriendlyURL(
-					 layout.getGroup(), layout, layoutURL, locale)) {
+					 layout.getGroup(), layout, layoutURL, currentLocale)) {
 
 			if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 0) {
 				redirect = layoutURL;


### PR DESCRIPTION
hi Team,
Could you review this?

https://issues.liferay.com/browse/LPS-158448

Best,
Attila

------

Related PTR: [PTR-3192](https://issues.liferay.com/browse/PTR-3192)

When comparing the redirect URL with the target locale layout firendlyURL the second could never become true if the friendlyURL is actually translated. My modification uses the current locale for the isGroupFriendlyURL because the redirect URL contains the URL related to the current locale, not the target locale based on my tests.