### PR TITLE
LPS-158538 Intermediate backward compatible nodes of FieldSet type should be skipped

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
@@ -64,6 +64,7 @@ import com.liferay.portal.kernel.xml.Element;
 import java.io.IOException;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -379,6 +380,17 @@ public class JournalTransformer {
 			}
 
 			TemplateNode firstChildTemplateNode = childTemplateNodes.get(0);
+
+			if (Objects.equals(
+					firstChildTemplateNode.getType(),
+					DDMFormFieldTypeConstants.FIELDSET)) {
+
+				backwardsCompatibilityTemplateNodes.addAll(
+					includeBackwardsCompatibilityTemplateNodes(
+						Arrays.asList(firstChildTemplateNode), parentOffset));
+
+				continue;
+			}
 
 			firstChildTemplateNode =
 				(TemplateNode)firstChildTemplateNode.clone();

--- a/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/transformer/JournalTransformerTest.java
+++ b/modules/apps/journal/journal-service/src/test/java/com/liferay/journal/internal/transformer/JournalTransformerTest.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -71,6 +72,19 @@ public class JournalTransformerTest {
 	}
 
 	@Test
+	public void testIncludeBackwardsCompatibilityTemplateNodesParentStructureWithFieldSet() {
+		JournalTransformer journalTransformer = new JournalTransformer();
+
+		List<TemplateNode> includeBackwardsCompatibilityTemplateNodes =
+			journalTransformer.includeBackwardsCompatibilityTemplateNodes(
+				_getInitTemplateNodesParentStructureWithFieldSet(), 0);
+
+		Assert.assertEquals(
+			_getExpectedParentStructureWithFieldSetTemplateNodes(),
+			includeBackwardsCompatibilityTemplateNodes);
+	}
+
+	@Test
 	public void testIncludeBackwardsCompatibilityTemplateNodesWithSiblings() {
 		JournalTransformer journalTransformer = new JournalTransformer();
 
@@ -107,6 +121,20 @@ public class JournalTransformerTest {
 
 		return new TemplateNode(
 			null, name, value, type, Collections.emptyMap());
+	}
+
+	private List<TemplateNode>
+		_getExpectedParentStructureWithFieldSetTemplateNodes() {
+
+		TemplateNode textTemplateNode1 = _createTemplateNode(
+			"TextField1", DDMFormFieldTypeConstants.TEXT, "TextField1");
+
+		TemplateNode textTemplateNode2 = _createTemplateNode(
+			"TextField2", DDMFormFieldTypeConstants.TEXT, "TextField2");
+
+		textTemplateNode1.appendChild(textTemplateNode2);
+
+		return Arrays.asList(textTemplateNode1);
 	}
 
 	private List<TemplateNode> _getExpectedSiblingsTemplateNodes() {
@@ -364,6 +392,31 @@ public class JournalTransformerTest {
 		textFieldSetTemplateNode2.appendChild(textTemplateNode2);
 
 		return ListUtil.fromArray(textFieldSetTemplateNode1);
+	}
+
+	private List<TemplateNode>
+		_getInitTemplateNodesParentStructureWithFieldSet() {
+
+		TemplateNode parentStructureFieldSetTemplateNode = _createTemplateNode(
+			"parentStructureFieldSet", DDMFormFieldTypeConstants.FIELDSET);
+
+		TemplateNode parentFieldSetTemplateNode = _createTemplateNode(
+			_TEXT_FIELD_SET_NAME, DDMFormFieldTypeConstants.FIELDSET);
+
+		parentStructureFieldSetTemplateNode.appendChild(
+			parentFieldSetTemplateNode);
+
+		TemplateNode textTemplateNode1 = _createTemplateNode(
+			"TextField1", DDMFormFieldTypeConstants.TEXT, "TextField1");
+
+		parentFieldSetTemplateNode.appendChild(textTemplateNode1);
+
+		TemplateNode textTemplateNode2 = _createTemplateNode(
+			"TextField2", DDMFormFieldTypeConstants.TEXT, "TextField2");
+
+		parentFieldSetTemplateNode.appendChild(textTemplateNode2);
+
+		return ListUtil.fromArray(parentStructureFieldSetTemplateNode);
 	}
 
 	private List<TemplateNode> _getInitTemplateNodesWithSiblings() {


### PR DESCRIPTION
Motivation
=======
[LPS-158538](https://issues.liferay.com/browse/LPS-158538)
Given 
1. a Parent Structure with a Nested Field
2. a Child Structure of Parent Structure
3. a Template for Child Structure
4. and a Web Content of the Child Structure

When this an upgrade is performed from 7.3 to master
Then the values of the Parent Structure's Fields can't be reached by the old template

Proposed Solution
========
By skipping the intermediate nodes that are FieldSets, we insert the original nested fields top level Fields into the `backwardsCompatibilityTemplateNodes`

Steps to Verify
========
1. Start up a 7.3 bundle
1. Create a structure with a text field (e.g. Text) and embed another text field inside it (e.g. Nested Text).
1. Create another structure and set the previously created structure as it's parent
1. Add a text field to the new structure as well
1. Create a template for the child structure to display both the parent structure's fields and it's own field, eg:
```
   #if (Text26j5.getData())??>
   	${Text26j5.getData()}
   	<#if (Text26j5.Text1c4v.getData())??>
   	    ${Text26j5.Text1c4v.getData()}
       </#if>
   </#if>
   <#if (Text1ef0.getData())??>
   	${Text1ef0.getData()}
   </#if>
```
1. Create a web content from the child structure and fill all the fields
1. Display the web content on a page
1. Upgrade the portal to master
1. Start up the master bundle
1. Check the page where the web content is placed

**Expected behaviour:** All field values are displayed from the Web Content
**Actual behaviour:** Only the child structure's own field is displayed from the Web Content