### PR TITLE
[TS] LPS-152888 - Incorrect redirect on asset publisher in specific scenarios

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -1038,6 +1038,18 @@ public class AssetPublisherDisplayContext {
 				"categoryId", String.valueOf(getAssetCategoryId()));
 		}
 
+		if (!isPaginationTypeNone()) {
+			String redirect = ParamUtil.getString(_portletRequest, "redirect");
+
+			if (Validator.isNull(redirect)) {
+				redirect = PortalUtil.getCurrentURL(_portletRequest);
+			}
+
+			if (Validator.isNotNull(redirect)) {
+				portletURL.setParameter("redirect", redirect);
+			}
+		}
+
 		return portletURL;
 	}
 

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -626,9 +626,15 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 				if (Validator.isNotNull(viewURL) &&
 					!Objects.equals(viewURL, noSuchEntryRedirect)) {
 
+					String redirect = ParamUtil.getString(
+						liferayPortletRequest, "redirect");
+
+					if (Validator.isNull(redirect)) {
+						redirect = _portal.getCurrentURL(liferayPortletRequest);
+					}
+
 					viewURL = HttpComponentsUtil.setParameter(
-						viewURL, "redirect",
-						_portal.getCurrentURL(liferayPortletRequest));
+						viewURL, "redirect", redirect);
 				}
 			}
 			catch (Exception exception) {


### PR DESCRIPTION
Hi @liferay-echo!

Previous pull: https://github.com/liferay-echo/liferay-portal/pull/8640

I'm forwarding this pull from @dacousalr to address [LPS-152888](https://issues.liferay.com/browse/LPS-152888). It addresses a specific case where the redirect on an asset publisher can become incorrect/unusable due to using a secondary asset publisher on the same page as a navigational method.

See [PTR-3197](https://issues.liferay.com/browse/PTR-3197) for further context.