### PR TITLE
LPS-156069 Synchronizing vocabulary validation with web content errors

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/categorization.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/categorization.jsp
@@ -78,6 +78,52 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 	ignoreRequestValue="<%= journalEditArticleDisplayContext.isChangeStructure() %>"
 />
 
+<script>
+	var categorationRoot = document.querySelectorAll(
+		'#_com_liferay_journal_web_portlet_JournalPortlet_mvfr___assetCategoriesSelector .form-group'
+	);
+	var vocabularyTitle = categorationRoot[0].textContent.split('Required')[0];
+	var categoriesNotification = document.createElement('div');
+	categoriesNotification.classList.add(
+		'alert',
+		'alert-dismissible',
+		'alert-danger'
+	);
+	categoriesNotification.setAttribute('role', 'alert');
+	categoriesNotification.innerHTML = `
+			<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" data-dismiss="liferay-alert" type="button">
+				<aui:icon image="times" markupView="lexicon" />
+
+				<span class="sr-only"><%= LanguageUtil.get(request, "close") %></span>
+			</button>
+
+			<span class="alert-indicator">
+				<svg aria-hidden="true" class="lexicon-icon lexicon-icon-times">
+					<use xlink:href="<%= themeDisplay.getPathThemeImages() %>/clay/icons.svg#exclamation-full"></use>
+				</svg>
+			</span>
+
+			<strong class="lead">Error:</strong>
+	`;
+	categoriesNotification.innerHTML +=
+		'<liferay-ui:message arguments="' + vocabularyTitle + '" key="please-select-at-least-one-category-for-x" translateArguments="<%= false %>" />';
+
+	document.getElementsByClassName('btn-primary')[0].onclick = function () {
+		if (categorationRoot[0].innerText.includes('Required')) {
+			if (
+				!document.getElementsByClassName('alert-danger').length &&
+				!categorationRoot[0].querySelectorAll(
+					'.input-group .input-group-item .input-group .input-group-item .form-control-inset'
+				)[0].value
+			) {
+				document
+					.querySelector('#categorizationContent')
+					.before(categoriesNotification);
+			}
+		}
+	};
+</script>
+
 <c:if test='<%= GetterUtil.getBoolean(PropsUtil.get("feature.flag.LPS-150762")) && (article != null) %>'>
 
 	<%


### PR DESCRIPTION
Please see this discussion: https://issues.liferay.com/browse/PTR-3101

Related ticket: https://issues.liferay.com/browse/LPS-156069

==============



```
Steps to reproduce:

   1. Create a structure with at least one required field.
    2. Create a vocabulary in Categorization > Categories
    3. In Associated Asset Types chose Web Content Article and the created structure and set it to required
    4. Create a new web content with the structure, try to publish it without filling out the structure's required field
    5. Inspect that there is no warning message for the Vocabulary, and it is not highlighted
    6. Fill out the structure's required field and try to publish
    7. The warning message for the Vocabulary is there.
```

Expected behavior:
**The vocabulary field should be validated at step 4 as well.** (Example in Image 1)
![Image 1](https://user-images.githubusercontent.com/41641596/180217477-ad2bb2e2-a156-42a6-9df0-2cb706e1c462.png)

