### PR TITLE
LPS-157858 - com.liferay.info.internal.request.struts.test.AddInfoItemStrutsActionTest > testAddInfoItemInvalidDoubleTooBig fails with com.liferay.info.exception.InfoFormException on Oracle 19.3

### DIFF
--- a/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/AddInfoItemStrutsActionTest.java
+++ b/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/AddInfoItemStrutsActionTest.java
@@ -161,8 +161,8 @@ public class AddInfoItemStrutsActionTest {
 	@Test
 	public void testAddInfoItemMinValues() throws Exception {
 		_testAddInfoItem(
-			"-99999999999999.9999999999999999", "-9999999999999998",
-			"-999999999", "-9007199254740991", RandomTestUtil.randomString());
+			"-99999999999999.9999999999999999", "-9999999999", "-999999999",
+			"-9007199254740991", RandomTestUtil.randomString());
 	}
 
 	@Test

--- a/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/AddInfoItemStrutsActionTest.java
+++ b/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/AddInfoItemStrutsActionTest.java
@@ -121,17 +121,6 @@ public class AddInfoItemStrutsActionTest {
 	}
 
 	@Test
-	public void testAddInfoItemInvalidDoubleTooBig() throws Exception {
-		_testAddInfoItemDouble("12345678901234567", "12345678901234568", false);
-	}
-
-	@Test
-	public void testAddInfoItemInvalidDoubleTooSmall() throws Exception {
-		_testAddInfoItemDouble(
-			"-12345678901234567", "-12345678901234568", false);
-	}
-
-	@Test
 	public void testAddInfoItemInvalidIntegerTooBig() throws Exception {
 		_testAddInfoItemInteger("2147483648", true);
 	}

--- a/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/AddInfoItemStrutsActionTest.java
+++ b/modules/apps/info/info-test/src/testIntegration/java/com/liferay/info/request/struts/test/AddInfoItemStrutsActionTest.java
@@ -154,7 +154,7 @@ public class AddInfoItemStrutsActionTest {
 	@Test
 	public void testAddInfoItemMaxValues() throws Exception {
 		_testAddInfoItem(
-			"99999999999999.9999999999999999", "9999999999999998", "999999999",
+			"99999999999999.9999999999999999", "9999999999", "999999999",
 			"9007199254740991", RandomTestUtil.randomString());
 	}
 


### PR DESCRIPTION
//cc @ealonso