### PR TITLE
LPS-159046

### DIFF
--- a/modules/apps/asset/asset-tags-selector-web/src/main/java/com/liferay/asset/tags/selector/web/internal/display/context/AssetTagsSelectorDisplayContext.java
+++ b/modules/apps/asset/asset-tags-selector-web/src/main/java/com/liferay/asset/tags/selector/web/internal/display/context/AssetTagsSelectorDisplayContext.java
@@ -162,16 +162,28 @@ public class AssetTagsSelectorDisplayContext {
 			return _groupIds;
 		}
 
-		_groupIds = StringUtil.split(
+		long[] groupIds = StringUtil.split(
 			ParamUtil.getString(_httpServletRequest, "groupIds"), 0L);
 
-		if (ArrayUtil.isEmpty(_groupIds)) {
+		if (ArrayUtil.isEmpty(groupIds)) {
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)_httpServletRequest.getAttribute(
 					WebKeys.THEME_DISPLAY);
 
-			_groupIds = new long[] {themeDisplay.getScopeGroupId()};
+			groupIds = new long[] {themeDisplay.getScopeGroupId()};
 		}
+
+		for (long groupId : groupIds) {
+			Group group = GroupLocalServiceUtil.fetchGroup(groupId);
+
+			if ((group != null) && group.isLayout() &&
+				!ArrayUtil.contains(groupIds, group.getParentGroupId())) {
+
+				groupIds = ArrayUtil.append(groupIds, group.getParentGroupId());
+			}
+		}
+
+		_groupIds = groupIds;
 
 		return _groupIds;
 	}


### PR DESCRIPTION
This is very similar to the pull request that I sent for [LPS-155947](https://issues.liferay.com/browse/LPS-155947) originally at https://github.com/liferay-echo/liferay-portal/pull/8452. That pull request was originally rejected and a new solution was offered in its place at https://github.com/liferay-echo/liferay-portal/pull/8505.

The reason the original pull request was rejected and a new solution offered is because the original solution was seen as too "risky" since it modifies the behavior at the Tags Selector level, and the new solution only modifies the behavior at the "Caller of the Tags Selector" level. (Please correct me if I misunderstood the reasoning).

However, this new solution doesn't solve all cases because there are other Callers of the Tags Selector that were not modified by that solution.

I don't really agree that the Tags Selector-level solution (which I am re-sending here) is risky because it only modifies the groupIds that are Layout-scoped. As far as I can tell, it is not possible for a Layout-scoped Group to have any Tags anyway, so if a Caller passed a Layout-scoped groupId to the Tags Selector, then this was a mistake which the Tags Selector should rectify for them.

I don't want to modify the Caller in this case because the Caller is using [AssetPublisherDisplayContext.getGroupIds](https://github.com/liferay/liferay-portal/blob/76decce50c5addd31992686cf43a6c3b41157738/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java#L891). This is used in all sorts of places throughout the Asset Publisher portlet, and seems likely to have negative consequences if we modify it to include the ancestor groupIds there.

https://issues.liferay.com/browse/LPS-159046