### PR TITLE
LPS-159106 If layoutStructureItem is null this assetListEntryUsage is not present in the current layoutStructure

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/AssetListEntryUsagesUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/AssetListEntryUsagesUtil.java
@@ -607,7 +607,8 @@ public class AssetListEntryUsagesUtil {
 			layoutStructure.getLayoutStructureItemByFragmentEntryLinkId(
 				fragmentEntryLink.getFragmentEntryLinkId());
 
-		if (layoutStructure.isItemMarkedForDeletion(
+		if ((layoutStructureItem == null) ||
+			layoutStructure.isItemMarkedForDeletion(
 				layoutStructureItem.getItemId())) {
 
 			return true;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/AssetListEntryUsagesUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/AssetListEntryUsagesUtil.java
@@ -60,7 +60,6 @@ import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
-import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -84,13 +83,14 @@ public class AssetListEntryUsagesUtil {
 
 	public static JSONArray getPageContentsJSONArray(
 			HttpServletRequest httpServletRequest,
-			HttpServletResponse httpServletResponse, long plid)
+			HttpServletResponse httpServletResponse, long plid,
+			long segmentsExperienceId)
 		throws PortalException {
 
 		JSONArray mappedContentsJSONArray = JSONFactoryUtil.createJSONArray();
 
 		LayoutStructure layoutStructure = _getLayoutStructure(
-			httpServletRequest, plid);
+			httpServletRequest, plid, segmentsExperienceId);
 		Set<String> uniqueAssetListEntryUsagesKeys = new HashSet<>();
 
 		List<AssetListEntryUsage> assetListEntryUsages =
@@ -425,7 +425,8 @@ public class AssetListEntryUsagesUtil {
 	}
 
 	private static LayoutStructure _getLayoutStructure(
-			HttpServletRequest httpServletRequest, long plid)
+			HttpServletRequest httpServletRequest, long plid,
+			long segmentsExperienceId)
 		throws PortalException {
 
 		ThemeDisplay themeDisplay =
@@ -433,8 +434,7 @@ public class AssetListEntryUsagesUtil {
 				WebKeys.THEME_DISPLAY);
 
 		return LayoutStructureUtil.getLayoutStructure(
-			themeDisplay.getScopeGroupId(), plid,
-			ParamUtil.getLong(httpServletRequest, "segmentsExperienceId"));
+			themeDisplay.getScopeGroupId(), plid, segmentsExperienceId);
 	}
 
 	private static JSONObject _getPageContentJSONObject(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/ContentUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/ContentUtil.java
@@ -133,7 +133,8 @@ public class ContentUtil {
 			_getLayoutClassedModelPageContentsJSONArray(
 				httpServletRequest, plid, segmentsExperienceId),
 			AssetListEntryUsagesUtil.getPageContentsJSONArray(
-				httpServletRequest, httpServletResponse, plid));
+				httpServletRequest, httpServletResponse, plid,
+				segmentsExperienceId));
 	}
 
 	private static String _generateUniqueLayoutClassedModelUsageKey(


### PR DESCRIPTION
Motivation
=======
Collection selector fragments are generating NPE in the Page Editor

Proposed Solution
========
The issue relates LPS-149434, which change 0 being the default experienceId. The editor in this case is not using the correct experience and returns a layoutStructure that is wrong. So firstly, I'm fixing layoutStructure generation based on logics from LPS-149434. Secondly, the assetListEntryUsages were not limited to the current experience either, so if there are multiple experiences, an NPE could be avoided by checking the layoutStructureItem.

Steps to Verify
========
1. Go to Design > Fragments
2. Click on the kebab menu of "FRAGMENT SETS" and import the attached file: collections-20220720135554025.zip
3. Go to Site Builder > Collections and add a dynamic collection:
4. Web Content Article as the "Item Type"
5. And "Basic web Content" as the Item Subtype
6. Go to Site Builder > Pages and add a blank (content) page
7. Add the fragment "Example" > "CollectionSelector" to the page
8. Click on the fragment and select the created collection
9. Publish the page
10. Go to Site Builder > Pages and click on the 3 dot menu beside the page and select "Edit"

Expected behaviour: Page editor appears with no errors
Actual behaviour: An error appears in the UI: "Content Page Editor Temporarily Unavailable"