### PR TITLE
LPS-159512 Copy the LayoutClassedUsages to the draftLayout

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
@@ -931,10 +931,6 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 
 				_consumer.accept(_targetLayout);
 
-				// Copy classedModelUsages after copying the structure
-
-				_copyLayoutClassedModelUsages(_sourceLayout, _targetLayout);
-
 				List<String> portletIds = _getLayoutPortletIds(
 					_sourceLayout, _sourceSegmentsExperiencesIds);
 
@@ -944,6 +940,10 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 				_copyPortletPreferences(
 					portletIds, _sourceLayout, _targetLayout);
 			}
+
+			// Copy classedModelUsages after copying the structure
+
+			_copyLayoutClassedModelUsages(_sourceLayout, _targetLayout);
 
 			_sites.copyExpandoBridgeAttributes(_sourceLayout, _targetLayout);
 			_sites.copyPortletSetups(_sourceLayout, _targetLayout);


### PR DESCRIPTION
Motivation
=======
[LPS-159512](https://issues.liferay.com/browse/LPS-159512)
When a Widget Page is converted into a Content Page, its LayoutClassedUsages are not copied to the draftLayout, so by publishing the draft, the original Page loses the LayoutClassedUsages.

Proposed Solution
========
Copy the LayoutClassedUsages to the draftLayout during conversion

Steps to Verify
========
1. Go to Site menu > Content & Data > Web content and create a web content
2. Name it "my web content" and add the text "usages" to it
3. Go to Site menu > Builder > Pages, create a new Widget page (named p1)
4. Place a Web Content Display on the widget page which displays the web content
5. Go to Home page and search for "usages"
6. Verify that when clicking on the result, it will open the web content on p1
7. Go to Site menu > Builder > Pages
8. From the kebab menu of p1, click "Convert to content page..."
9. Publish the page
10. Go to Home page and search for "usages"
11. Click on the Web Content search result (not the page)

*Expected behaviour:* Navigation happens to p1 where the web content is displayed in context
*Actual behaviour:* Navigation happens to the search page where the web content is displayed out of context