### PR TITLE
LPS-159591 Revert "LPS-159515 Inline"

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
@@ -410,6 +410,11 @@ public class UpdateFormItemConfigMVCActionCommand extends BaseMVCActionCommand {
 					(FormStyledLayoutStructureItem)
 						layoutStructure.getLayoutStructureItem(formItemId);
 
+			long previousClassNameId =
+				previousFormStyledLayoutStructureItem.getClassNameId();
+			long previousClassTypeId =
+				previousFormStyledLayoutStructureItem.getClassTypeId();
+
 			FormStyledLayoutStructureItem formStyledLayoutStructureItem =
 				(FormStyledLayoutStructureItem)layoutStructure.updateItemConfig(
 					JSONFactoryUtil.createJSONObject(itemConfig), formItemId);
@@ -426,10 +431,10 @@ public class UpdateFormItemConfigMVCActionCommand extends BaseMVCActionCommand {
 					PropsUtil.get("feature.flag.LPS-157738")) &&
 				(!Objects.equals(
 					formStyledLayoutStructureItem.getClassNameId(),
-					previousFormStyledLayoutStructureItem.getClassNameId()) ||
+					previousClassNameId) ||
 				 !Objects.equals(
 					 formStyledLayoutStructureItem.getClassTypeId(),
-					 previousFormStyledLayoutStructureItem.getClassTypeId()))) {
+					 previousClassTypeId))) {
 
 				removedLayoutStructureItemsJSONArray =
 					_removeLayoutStructureItemsJSONArray(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-159591

Why should we revert this commit?

previousFormStyledLayoutStructureItem and formStyledLayoutStructureItem point to the same object, so when updating the item configuration, previousFormStyledLayoutStructureItem changes its values ​​always having the same as formStyledLayoutStructureItem so the condition of the bellow if clause is never met because we are comparing the same objects. The consequence of it is that the form content is never automatically updated.