### PR TITLE
LPP-45812 | LPS-157509: Element placement on drop zones are not retained after fragment modification

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -564,11 +564,6 @@ public class FragmentEntryLinkLocalServiceImpl
 		fragmentEntryLink.setType(fragmentEntry.getType());
 		fragmentEntryLink.setLastPropagationDate(new Date());
 
-		fragmentEntryLink = fragmentEntryLinkPersistence.update(
-			fragmentEntryLink);
-
-		_updateFragmentEntryLinkLayout(fragmentEntryLink);
-
 		List<FragmentEntryLinkListener> fragmentEntryLinkListeners =
 			_fragmentEntryLinkListenerTracker.getFragmentEntryLinkListeners();
 
@@ -578,6 +573,11 @@ public class FragmentEntryLinkLocalServiceImpl
 			fragmentEntryLinkListener.
 				onUpdateFragmentEntryLinkConfigurationValues(fragmentEntryLink);
 		}
+
+		fragmentEntryLink = fragmentEntryLinkPersistence.update(
+			fragmentEntryLink);
+
+		_updateFragmentEntryLinkLayout(fragmentEntryLink);
 	}
 
 	private String _getProcessedHTML(


### PR DESCRIPTION
@liferay-echo,
I have updated source to fix this issue relating to drop zones. 
Currently, it works well with these simple cases. However, we have an issue with the workflow that is used to restore these deletedLayoutStructureItems. There is a condition used to check a deletedLayoutStructureItem whether restored or not. But this condition is not correct for all cases. I think we can try to verify by tagId(for example: <lfr-drop-zone id="drop-zone-1"></lfr-drop-zone> =>tagId is "drop-zone01", and each tagId is required an unique value) instead of the current condition, or remove restoring layout flow.

Refer to [condition code](https://github.com/liferay/liferay-portal/blob/master/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-drop-zone/src/main/java/com/liferay/fragment/entry/processor/drop/zone/listener/DropZoneFragmentEntryLinkListener.java#L106-L108)