### PR TITLE
LPS-159247

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/display/context/AssetCategoriesDisplayContext.java
@@ -750,7 +750,13 @@ public class AssetCategoriesDisplayContext {
 	}
 
 	public boolean isItemSelector() {
-		return Validator.isNotNull(getItemSelectorEventName());
+		if (Validator.isNotNull(getItemSelectorEventName()) ||
+			LiferayWindowState.isPopUp(_httpServletRequest)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	public boolean isSaveAndAddNewButtonDisabled() throws Exception {

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ItemSelectorAddCategory.js
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/js/ItemSelectorAddCategory.js
@@ -92,6 +92,12 @@ export default function ({currentURL, namespace, redirect}) {
 		buttons.forEach((button) => footer.appendChild(button));
 	}
 
+	const hideAddCategoryButtons = () => {
+		footer
+			.querySelectorAll('.add-category-toolbar-button')
+			.forEach((button) => button.parentElement.classList.add('hide'));
+	};
+
 	const delegateHandler = delegate(
 		footer,
 		'click',
@@ -99,25 +105,9 @@ export default function ({currentURL, namespace, redirect}) {
 		(event) => {
 			const delegateTarget = event.delegateTarget;
 
-			modalTitle.textContent = initialModalTitle;
-
-			initialModalFooterButtons.forEach((item) => {
-				item.classList.remove('hide');
-			});
-
-			const hideAddCategoryButtons = () => {
-				footer
-					.querySelectorAll('.add-category-toolbar-button')
-					.forEach((button) =>
-						button.parentElement.classList.add('hide')
-					);
-			};
-
 			const action = delegateTarget.dataset.action;
 
 			if (action === 'cancel') {
-				hideAddCategoryButtons();
-
 				navigate(redirect);
 			}
 			else if (action === 'saveAndAddNew') {
@@ -128,14 +118,22 @@ export default function ({currentURL, namespace, redirect}) {
 				submitForm(document.getElementById(`${namespace}fm`));
 			}
 			else if (action === 'save') {
-				hideAddCategoryButtons();
-
 				submitForm(document.getElementById(`${namespace}fm`));
 			}
 		}
 	);
 
 	return {
-		dispose: () => delegateHandler.dispose(),
+		dispose: () => {
+			initialModalFooterButtons.forEach((item) => {
+				item.classList.remove('hide');
+			});
+
+			hideAddCategoryButtons();
+
+			modalTitle.textContent = initialModalTitle;
+
+			delegateHandler.dispose();
+		},
 	};
 }


### PR DESCRIPTION
## Motivation:
Adding on the fly an existing category causes buttons to be duplicated
https://issues.liferay.com/browse/LPS-159247

## Steps to verify: 
 1. Create a new vocabulary voc1, and create a category cat1 in it.
 2. Put a Wiki widget on a page.
 3. Click on the Edit icon (pen) in the upper right part (so as if you would edit any given wiki page)
 4. In the Categorization section click on Select next to voc1.
 5. In the resulting popup, click the + button (to add on the fly a new category to that vocabulary)

 - Type in cat1 and click 'Save and Add New One' button. (so by accident you entered here the name of an already existing category)
 *Result*: The footer buttons are duplicated and initial modal buttons are displayed again
 
- Click 'Save and Add New One' or 'Save' button without filling the required input 
 *Result*: The footer buttons are duplicated and Modal Title is also reset

### Proposed Solution:
- Check if the SessionErrors object is empty so the edit/add page buttons are not displayed if an exception occurs 
- Reorganize the function that removes the "hide" attribute on the initial modal buttons so it can be triggered after the action is called
- Validation on ItemSelectorAddCategory to check if a required input is empty so the form can not be submitted

## Commits included:
- LPS-159247 Fixes initial modal buttons appearing when a footer button is clicked before the action is finished
- LPS-159247 Insert validation method on ItemSelectorAddCategory to check when a required field is empty so the form is not submitted
-  LPS-159247 Add another condition so the buttons from the edit category form do not appear in add category form modal
- LPS-159247 SF
