### PR TITLE
[TS] LPS-159309

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentDropZoneRendererImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentDropZoneRendererImpl.java
@@ -14,6 +14,7 @@
 
 package com.liferay.fragment.internal.renderer;
 
+import com.liferay.fragment.constants.FragmentEntryLinkConstants;
 import com.liferay.fragment.exception.FragmentEntryContentException;
 import com.liferay.fragment.renderer.FragmentDropZoneRenderer;
 import com.liferay.layout.taglib.servlet.taglib.RenderFragmentLayoutTag;
@@ -21,6 +22,8 @@ import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
 import com.liferay.portal.kernel.util.WebKeys;
+
+import java.util.Objects;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -60,8 +63,10 @@ public class FragmentDropZoneRendererImpl implements FragmentDropZoneRenderer {
 			throw new FragmentEntryContentException(exception);
 		}
 		finally {
-			httpServletRequest.setAttribute(
-				WebKeys.SHOW_PORTLET_TOPPER, Boolean.TRUE);
+			if (Objects.equals(mode, FragmentEntryLinkConstants.VIEW)) {
+				httpServletRequest.setAttribute(
+					WebKeys.SHOW_PORTLET_TOPPER, Boolean.TRUE);
+			}
 		}
 
 		return unsyncStringWriter.toString();

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentDropZoneRendererImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentDropZoneRendererImpl.java
@@ -20,6 +20,7 @@ import com.liferay.layout.taglib.servlet.taglib.RenderFragmentLayoutTag;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -57,6 +58,10 @@ public class FragmentDropZoneRendererImpl implements FragmentDropZoneRenderer {
 		}
 		catch (Exception exception) {
 			throw new FragmentEntryContentException(exception);
+		}
+		finally {
+			httpServletRequest.setAttribute(
+				WebKeys.SHOW_PORTLET_TOPPER, Boolean.TRUE);
 		}
 
 		return unsyncStringWriter.toString();


### PR DESCRIPTION
Motivation
=======
Widgets will show portlet configuration on content page if they are placed below a drop zone fragment

https://issues.liferay.com/browse/LPS-159309



Proposed Solution
========
@NemethNorbert originally wrote:

> When we start rendering the fragments under the masterLayout with a fragmentLayoutTag, it will set the showPortletTropper attribute to true in the request, and will remove it, once it finished rendering.
> The root cause is that the dropZone fragment renders a FragmentLayoutTag as well, that will end up removing the showPortletTopper attribute from the request when finished rendering. When it is set to true, we won't render the portlet configuration, which is the expected behaviour on a content page. However the remaining widgets that we might render under a drop zone on a content page still needs this attribute in the request to not show their configuration.
> My fix restores this attribute once we finished rendering a dropZoneFragment.

Steps to Verify
========

1. Set up DXP 7.4 U23 (it is reproducible with the latest update and master as well).
2. Go to Content & Data --> Web Content and add basic web content.
3. Go to Site Builder --> Pages and add a content page and to it the following fragments:
a. Drop zone fragment (should be added on top).
b. Asset Publisher widget and configure it to display the web content
c. A footer
4. Publish the page then view it and hover over the widgets.

Actual Result: The configuration of the widgets appears as if the page is on edit mode.
Expected Result: The widgets configuration should not appear.



Alternative Solutions that were discarded
========
Other solutions you considered or tried, and why you decided to discard them
Proposed alternative solution in https://github.com/dacousalr/liferay-portal/pull/351#issuecomment-1199189113, but discarded due to https://github.com/dacousalr/liferay-portal/pull/351#issuecomment-1199199264