### PR TITLE
LPS-160185 Add type declaration to Collapse component in layout-content-page-editor-web module

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/Collapse.tsx
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/Collapse.tsx
@@ -14,16 +14,19 @@
 
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
-import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import React, {ReactNode, useState} from 'react';
 
 import './Collapse.scss';
 
-export default function Collapse({children, label, onOpen, open}) {
+export default function Collapse({
+	children,
+	label,
+	onOpen,
+	open,
+}: ICollapseProps) {
 	const [internalIsOpen, setInternalIsOpen] = useState(open);
 	const isOpen = onOpen ? open : internalIsOpen;
 	const setIsOpen = onOpen || setInternalIsOpen;
-
 	const collapseIcon = isOpen ? 'angle-down' : 'angle-right';
 	const collapseIconClassName = isOpen ? 'open' : 'closed';
 
@@ -51,7 +54,7 @@ export default function Collapse({children, label, onOpen, open}) {
 				onClick={handleClick}
 				type="button"
 			>
-				<span className="c-inner text-truncate" tabIndex="-1">
+				<span className="c-inner text-truncate" tabIndex={-1}>
 					{label}
 
 					<span className={`collapse-icon-${collapseIconClassName}`}>
@@ -67,9 +70,9 @@ export default function Collapse({children, label, onOpen, open}) {
 	);
 }
 
-Collapse.propTypes = {
-	children: PropTypes.node.isRequired,
-	label: PropTypes.string,
-	onOpen: PropTypes.func,
-	open: PropTypes.bool,
-};
+interface ICollapseProps {
+	children: ReactNode;
+	label: string;
+	onOpen?: (value: boolean) => void;
+	open: boolean;
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/index.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/index.ts
@@ -13,5 +13,3 @@
  */
 
 export {default as Collapse} from '../common/components/Collapse';
-export {default as SearchForm} from './components/SearchForm';
-export {default as SidebarPanelHeader} from './components/SidebarPanelHeader';

--- a/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/ts_modules/layout-content-page-editor-web.d.ts
+++ b/modules/apps/notification/notification-web/src/main/resources/META-INF/resources/ts_modules/layout-content-page-editor-web.d.ts
@@ -12,6 +12,6 @@
  * details.
  */
 
-export {default as Collapse} from '../common/components/Collapse';
-export {default as SearchForm} from './components/SearchForm';
-export {default as SidebarPanelHeader} from './components/SidebarPanelHeader';
+declare module '@liferay/layout-content-page-editor-web' {
+	export * from '@liferay/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/index';
+}

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/CodeEditor/Collapsible.tsx
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/components/CodeEditor/Collapsible.tsx
@@ -12,8 +12,6 @@
  * details.
  */
 
-// @ts-ignore
-
 import {Collapse} from '@liferay/layout-content-page-editor-web';
 import React from 'react';
 

--- a/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/ts_modules/layout-content-page-editor-web.d.ts
+++ b/modules/apps/object/object-js-components-web/src/main/resources/META-INF/resources/ts_modules/layout-content-page-editor-web.d.ts
@@ -12,6 +12,6 @@
  * details.
  */
 
-export {default as Collapse} from '../common/components/Collapse';
-export {default as SearchForm} from './components/SearchForm';
-export {default as SidebarPanelHeader} from './components/SidebarPanelHeader';
+declare module '@liferay/layout-content-page-editor-web' {
+	export * from '@liferay/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/index';
+}

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/ts_modules/layout-content-page-editor-web.d.ts
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/ts_modules/layout-content-page-editor-web.d.ts
@@ -12,6 +12,6 @@
  * details.
  */
 
-export {default as Collapse} from '../common/components/Collapse';
-export {default as SearchForm} from './components/SearchForm';
-export {default as SidebarPanelHeader} from './components/SidebarPanelHeader';
+declare module '@liferay/layout-content-page-editor-web' {
+	export * from '@liferay/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/index';
+}


### PR DESCRIPTION
Related issue: https://issues.liferay.com/browse/LPS-160185

### Motivation

Hello Reviewer, I'm working on a technical debt to remove some `@ts-ignore` annotations from the Objects code. For this I have to create some type declarations for components that were not developed in `typescript`, I can declare these types in the `object-js-components-web` module, but I think it will be restricted just for our case, so I decided to declare the types in the `layout-content-page-editor-web` which is the root of the `Collapse` component I had to remove the `@ts-ignore`, so anyone who wants to use this component with `typescript` in the future doesn't need to declare the same types in their own module, avoiding code repetition. What do you think?