### PR TITLE
[TS] LPP-46181 > LPS 160071 HTML injection in Liferay URL parameter p_p_id vulnerable to content spoofing

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutHeaderProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutHeaderProductNavigationControlMenuEntry.java
@@ -81,6 +81,9 @@ public class LayoutHeaderProductNavigationControlMenuEntry
 
 		Writer writer = httpServletResponse.getWriter();
 
+		String headerTitle = HtmlUtil.escapeAttribute(
+			_getHeaderTitle(httpServletRequest));
+
 		StringBundler sb = new StringBundler(17);
 
 		sb.append("<li class=\"");
@@ -89,10 +92,9 @@ public class LayoutHeaderProductNavigationControlMenuEntry
 		sb.append("control-menu-level-1-heading d-flex mr-1\" ");
 		sb.append("data-qa-id=\"headerTitle\"><span class=\"");
 		sb.append("lfr-portal-tooltip text-truncate\" title=\"");
-		sb.append(
-			HtmlUtil.escapeAttribute(_getHeaderTitle(httpServletRequest)));
+		sb.append(headerTitle);
 		sb.append("\">");
-		sb.append(_getHeaderTitle(httpServletRequest));
+		sb.append(headerTitle);
 		sb.append("</span>");
 
 		if (_hasDraftLayout(httpServletRequest) &&


### PR DESCRIPTION
Motivation
=======
Dear Team,
Our customer finds out an issue that HTML injection in Liferay URL parameter p_p_id vulnerable to content spoofing.
This PR is to fix it. Please help to review this solution and give me feedback.

Proposed Solution
========

Escape the header title attribute from the httpServletRequest before append to the writer

Steps to Verify
========
see Ticket https://issues.liferay.com/browse/LPP-46181 > https://issues.liferay.com/browse/LPS-160071

References to existing code (if applies)
========
similar to the title field, span content also need to be escaped

modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutHeaderProductNavigationControlMenuEntry.java line 93

Thank you very much,
@chileces