### PR TITLE
LPS-160715 Add status parameter to JSON call addDisplayPageTemplateEntry

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplate.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplate.macro
@@ -102,7 +102,8 @@ definition {
 			displayPageTemplateEntryName = "${displayPageTemplateEntryName}",
 			groupId = "${groupId}",
 			masterLayoutPlid = "${masterLayoutPlid}",
-			serviceContext = "${serviceContext}");
+			serviceContext = "${serviceContext}",
+			status = "${status}");
 	}
 
 	@summary = "Add a PageTemplateEntry to the Global site"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplate.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplate.macro
@@ -89,6 +89,13 @@ definition {
 			var masterLayoutPlid = "0";
 		}
 
+		if (isSet(status)) {
+			var status = "0";
+		}
+		else {
+			var status = "2";
+		}
+
 		var serviceContext = JSONLayoutpagetemplateSetter.setServiceContext(
 			addGuestPermissions = "true",
 			assetCategoryIds = "${assetCategoryIds}",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplateAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplateAPI.macro
@@ -15,7 +15,7 @@ definition {
 			  -d classTypeId=${classTypeId} \
 			  -d name=${displayPageTemplateEntryName} \
 			  -d masterLayoutPlid=${masterLayoutPlid} \
-			  -d status=2 \
+			  -d status=${status} \
 			  -d serviceContext=${serviceContext}
 		''';
 


### PR DESCRIPTION
**Ticket**:
[LPS-160715](https://issues.liferay.com/browse/LPS-160715)

**Motivation**:
When we create a Display Page Template using JSON, by default it's set to be created as a DRAFT, to usually Publish it manually. In some cases, some test (in Tango, for example) don't need to any information to the page, but we still have to use the UI to Publish it.

**Proposed Solution**:
Use the _status_ parameter to set the status of the DPT. If the tester do not set the parameter, it will be the same as today (DRAFT). But if the tester set it, it will be publisher (APPROVED),
```
if (isSet(status)) {
	var status = "0";
}
else {
	var status = "2";
}
```

The usage of the macro would look like this:

```
JSONLayoutpagetemplate.addDisplayPageTemplateEntry(
	contentType = "Web Content Article",
	displayPageTemplateEntryName = "Display Page Name",
	groupName = "Test Site Name",
	status = "Approved",
	subType = "Basic Web Content");
```