### PR TITLE
LPS-160858 Implement update-layout-page-template-entry endpoint to poshi

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplate.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplate.macro
@@ -247,4 +247,20 @@ definition {
 		JSONLayoutpagetemplateAPI._deleteLayoutPageTemplateEntry(layoutPageTemplateEntryId = "${layoutPageTemplateEntryId}");
 	}
 
+	@summary = "Set a layoutPageTemplateEntry as default"
+	macro setLayoutPageTemplateEntryAsDefault {
+		Variables.assertDefined(parameterList = "${groupName},${layoutPageTemplateEntryName},${type}");
+
+		var groupId = JSONLayoutpagetemplateSetter.setGroupId(
+			groupKey = "${groupName}",
+			site = "${site}");
+
+		var layoutPageTemplateEntryId = JSONLayoutpagetemplateSetter.setLayoutPageTemplateEntryId(
+			groupId = "${groupId}",
+			layoutPageTemplateEntryName = "${layoutPageTemplateEntryName}",
+			type = "${type}");
+
+		JSONLayoutpagetemplateAPI._setDisplayPageTemplateEntryAsDefault(layoutPageTemplateEntryId = "${layoutPageTemplateEntryId}");
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplateAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplateAPI.macro
@@ -186,4 +186,20 @@ definition {
 		return "${masterLayoutPlid}";
 	}
 
+	@summary = "Set the layoutPageTemplateEntry as default by using layoutPageTemplateEntryId"
+	macro _setDisplayPageTemplateEntryAsDefault {
+		Variables.assertDefined(parameterList = "${layoutPageTemplateEntryId}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/api/jsonws/layout.layoutpagetemplateentry/update-layout-page-template-entry \
+				-u test@liferay.com:test \
+				-d layoutPageTemplateEntryId=${layoutPageTemplateEntryId} \
+				-d defaultTemplate=true
+		''';
+
+		com.liferay.poshi.runner.util.JSONCurlUtil.post("${curl}");
+	}
+
 }

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplateSetter.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/layoutpagetemplate/JSONLayoutpagetemplateSetter.macro
@@ -132,7 +132,7 @@ definition {
 	macro setStatus {
 		Variables.assertDefined(parameterList = "${statusKey}");
 
-		if ("${statusKey}" == "APPROVE") {
+		if ("${statusKey}" == "APPROVED") {
 			var status = "0";
 		}
 


### PR DESCRIPTION
**Ticket**: [LPS-160858](https://issues.liferay.com/browse/LPS-160858)

Motivation
=======
Implement update-layout-page-template-entry endpoint to poshi

Proposed Solution
========
Implement this endpoint to poshi, allowing to set the Display Page Template as default using the JSON API. The usage would  like like this:
```
JSONLayoutpagetemplate.setLayoutPageTemplateEntryAsDefault(
	groupName = "Test Site Name",
	layoutPageTemplateEntryName = "Display Page Name",
	type = "Display Page Template");
```
