### PR TITLE
[TS] LPS-161073 | using two different site templates can cause name incrementation between public and private pages

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutFriendlyURLStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutFriendlyURLStagedModelDataHandler.java
@@ -192,7 +192,7 @@ public class LayoutFriendlyURLStagedModelDataHandler
 
 		String friendlyURL = layoutFriendlyURL.getFriendlyURL();
 
-		boolean privateLayout = layoutFriendlyURL.isPrivateLayout();
+		boolean privateLayout = portletDataContext.isPrivateLayout();
 
 		if (existingLayoutFriendlyURL != null) {
 			privateLayout = existingLayoutFriendlyURL.isPrivateLayout();


### PR DESCRIPTION
hi Team,
Could you review this?

https://issues.liferay.com/browse/LPS-161073

Best,
Attila

--------
**Steps to reproduce:**
  1. Create two site templates, name them Public and Private
  2. In case of master, enable Private pages in System Settings -> Release Feature Flags
  3. Create a site from Public, leave the checkbox unchecked
  4. In the site configuration -> Pages section, set the Private site template as the source of the Private pages, enable propagation
  5. Create another site from Private, check the checkbox
  6. In the site configuration -> Pages section, set the Public site template as the source of the Public pages, enable propagation
  7. Now trigger the propagation so both sites will have both Public and Private Home pages
  8. Check the Public site's Home pages friendly URLs -> both have it "/home"
  9. Check the Private site's Home pages friendly URLs
 
**Expected behavior:** Both Home pages have the "/home" friendly URL
**Current behavior:** Private Home page has the "/home" friendly URL, Public Home page has the "/home1" url

The root cause of the issue is that the site template handles the pages as private pages and when we propagate the content of the site template to a site as a public page the import process used the isPrivateLayout of the imported layoutFriendlyURL. Which believes it belongs to a private layout because of the original page exists inside of a site template. My solution was to use the import portletDataContext which knows whether or not it is actually a private layout.