### PR TITLE
[TS] LPP-46108 > LPS-159985 JavaScript set in the site template is not properly propagated

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -2887,7 +2887,9 @@ public class LayoutStagedModelDataHandler
 				layoutTypePortlet.getTypeSettingsProperties();
 
 			UnicodeProperties newTypeSettingsUnicodeProperties =
-				UnicodePropertiesBuilder.fastLoad(
+				UnicodePropertiesBuilder.create(
+					prototypeTypeSettingsUnicodeProperties.isSafe()
+				).fastLoad(
 					prototypeTypeSettingsUnicodeProperties.toString()
 				).build();
 


### PR DESCRIPTION
Dear Team,
Could you review this?

https://issues.liferay.com/browse/LPS-159985

Thanks,
Loc
====================================================
**Steps to reproduce**
 1. Navigate to Control Panel > Site > Site Template
 2.  Add a site template
 3. Open site template created in step 2
 4. Navigate to Site Builder > Pages
 5. Choose + > Add Site Template Page > Full Page Application
 6. Paste the following code on the Advanced tab > JAVASCRIPT field and save
`$(function(){
    $(document).on('contextmenu',function(e){
        return false;
    });
    $document.on('dragover',function(e){
      return false ;
    });
    $document.on('drop',function(e){
      return false ;
    });
});`
 7. Navigate to Control Pane > Sites > Sites
 8. Create a site using the site template added in step 2
 9. Navigate to created site
 10. Open "Configure" on the default（Home）page

**Actual result**
 Some contents of JAVASCRIPT have been deleted.
**Expected result**
 The contents of JAVASCRIPT will be properly propagated.
 
 This is reviewed in https://github.com/liferay-staging/liferay-portal/pull/101
 cc:@chileces