### PR TITLE
LPS 161452

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleCacheModel.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleCacheModel.java
@@ -315,15 +315,11 @@ public class JournalArticleCacheModel
 
 		journalArticleImpl.resetOriginalValues();
 
-		journalArticleImpl.setDocument(_document);
-
 		return journalArticleImpl;
 	}
 
 	@Override
-	public void readExternal(ObjectInput objectInput)
-		throws ClassNotFoundException, IOException {
-
+	public void readExternal(ObjectInput objectInput) throws IOException {
 		mvccVersion = objectInput.readLong();
 
 		ctCollectionId = objectInput.readLong();
@@ -374,9 +370,6 @@ public class JournalArticleCacheModel
 		statusByUserId = objectInput.readLong();
 		statusByUserName = objectInput.readUTF();
 		statusDate = objectInput.readLong();
-
-		_document =
-			(com.liferay.portal.kernel.xml.Document)objectInput.readObject();
 	}
 
 	@Override
@@ -507,8 +500,6 @@ public class JournalArticleCacheModel
 		}
 
 		objectOutput.writeLong(statusDate);
-
-		objectOutput.writeObject(_document);
 	}
 
 	public long mvccVersion;
@@ -546,6 +537,5 @@ public class JournalArticleCacheModel
 	public long statusByUserId;
 	public String statusByUserName;
 	public long statusDate;
-	public com.liferay.portal.kernel.xml.Document _document;
 
 }

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -732,7 +732,6 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 
 	private Map<Locale, String> _descriptionMap;
 
-	@CacheField(propagateToInterface = true)
 	private Document _document;
 
 	private long _imagesFolderId;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -50,7 +50,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Image;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.Repository;
-import com.liferay.portal.kernel.model.cache.CacheField;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
@@ -203,13 +202,19 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 			JournalArticleLocalServiceUtil.getArticleLocalizationLanguageIds(
 				getId()));
 
-		Document document = getDocument();
+		DDMStructure ddmStructure = getDDMStructure();
 
-		if (document != null) {
-			for (String availableLanguageId :
-					LocalizationUtil.getAvailableLanguageIds(document)) {
+		if (ddmStructure == null) {
+			return availableLanguageIds.toArray(new String[0]);
+		}
 
-				availableLanguageIds.add(availableLanguageId);
+		DDMFormValues ddmFormValues = DDMFieldLocalServiceUtil.getDDMFormValues(
+			ddmStructure.getDDMForm(), getId());
+
+		if (ddmFormValues != null) {
+			for (Locale availableLocale : ddmFormValues.getAvailableLocales()) {
+				availableLanguageIds.add(
+					LocaleUtil.toLanguageId(availableLocale));
 			}
 		}
 
@@ -731,9 +736,7 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 	private static volatile JournalConverter _journalConverter;
 
 	private Map<Locale, String> _descriptionMap;
-
 	private Document _document;
-
 	private long _imagesFolderId;
 	private String _smallImageType;
 	private Map<Locale, String> _titleMap;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -384,7 +384,7 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 
 			if (content != null) {
 				try {
-					_document = SAXReaderUtil.read(getContent());
+					_document = SAXReaderUtil.read(content);
 				}
 				catch (DocumentException documentException) {
 					if (_log.isWarnEnabled()) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleModelImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleModelImpl.java
@@ -1397,13 +1397,6 @@ public class JournalArticleModelImpl
 		_statusDate = statusDate;
 	}
 
-	public com.liferay.portal.kernel.xml.Document getDocument() {
-		return null;
-	}
-
-	public void setDocument(com.liferay.portal.kernel.xml.Document document) {
-	}
-
 	@Override
 	public StagedModelType getStagedModelType() {
 		return new StagedModelType(
@@ -1882,8 +1875,6 @@ public class JournalArticleModelImpl
 
 		_setModifiedDate = false;
 
-		setDocument(null);
-
 		_columnBitmask = 0;
 	}
 
@@ -2087,10 +2078,6 @@ public class JournalArticleModelImpl
 		else {
 			journalArticleCacheModel.statusDate = Long.MIN_VALUE;
 		}
-
-		setDocument(null);
-
-		journalArticleCacheModel._document = getDocument();
 
 		return journalArticleCacheModel;
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticlePersistenceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticlePersistenceImpl.java
@@ -34033,21 +34033,11 @@ public class JournalArticlePersistenceImpl
 				continue;
 			}
 
-			JournalArticle cachedJournalArticle =
-				(JournalArticle)entityCache.getResult(
-					JournalArticleImpl.class, journalArticle.getPrimaryKey());
+			if (entityCache.getResult(
+					JournalArticleImpl.class, journalArticle.getPrimaryKey()) ==
+						null) {
 
-			if (cachedJournalArticle == null) {
 				cacheResult(journalArticle);
-			}
-			else {
-				JournalArticleModelImpl journalArticleModelImpl =
-					(JournalArticleModelImpl)journalArticle;
-				JournalArticleModelImpl cachedJournalArticleModelImpl =
-					(JournalArticleModelImpl)cachedJournalArticle;
-
-				journalArticleModelImpl.setDocument(
-					cachedJournalArticleModelImpl.getDocument());
 			}
 		}
 	}


### PR DESCRIPTION
Hi, 

The main reason to open this PR is fix some performance issues we've detected when rendering articles.

In the past the content xml was stored in the database, but now this column has been removed.

Anyway some uses of the XML remain in the product, and, for example it is been used to calculate the language ids of the content.

Another problem is that is been cached. In the past it was almost free because we didn't had to parse or calculate it, but now we force the system calculate it every time we retrieve the article from the database.

Since that I've:

- Remove the document field cache 
- Remove some uses of the xml (that assume that this xml is cached)

If you have any question, do not hesitate in contact me.