### PR TITLE
LPS-161694 master

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java
@@ -480,7 +480,8 @@ public class AssetCategoriesSelectorTag extends IncludeTag {
 		List<AssetVocabulary> vocabularies = new ArrayList<>();
 
 		vocabularies.addAll(
-			AssetVocabularyServiceUtil.getGroupVocabularies(getGroupIds()));
+			AssetVocabularyServiceUtil.getGroupVocabularies(
+				getGroupIds(), _visibilityTypes));
 
 		HttpServletRequest httpServletRequest = getRequest();
 

--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries_resources.jsp
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/upload_multiple_file_entries_resources.jsp
@@ -333,7 +333,6 @@ else {
 						className="<%= DLFileEntry.class.getName() %>"
 						classPK="<%= assetClassPK %>"
 						classTypePK="<%= fileEntryTypeId %>"
-						visibilityTypes="<%= AssetVocabularyConstants.VISIBILITY_TYPES %>"
 					/>
 
 					<liferay-asset:asset-tags-selector


### PR DESCRIPTION
Hi @liferay-echo 

could you please review my fix?
https://issues.liferay.com/browse/LPS-161694

**Steps to reproduce:**

As admin:

1.) Add a Organization Role "testrole" and define permissions as follows:
Categorization => Categories: Set all Permissions
Content & Data => Documents and Media: Set all permissions

2.) Add a second Organization Role "testaddon", set no permissions for this role

3.) Add a new user to the portal called "testuser"

4.) Add a new organization called "testorg" and create an organization site in this organization.

5.) Add "testuser" to "testorg" and assign "testrole" and "testaddon" at organization roles.

6.) Go to the settings of the organization site => Categorization => Categories and add 2 vocabularies, visible for site-members only, one called "viewable" and one "limited".

7.) Open the permissions-setting for the vocabulary "limited" and uncheck the checkbox in the viewable-column for the role "Site Member". 

8.) Save the settings and add a category to each vocabulary, viewable again by site-members only. You can name them "category1" and "category2".

9.) Finally, add a blank page to the site, so the user can navigate to it.

10.) Now impersonate the user "testuser" and navigate to the organization site (/web/testorg).

11.) Open the Categorization Menu and make sure you see both vocabularies (viewable and limited) with the corresponding categories in them.

12.) Then go to Content & Data => Documents and Media and add a new document via file upload. Scroll down and open the "Categorization" tab. You will only see the "viewable" vocabulary along with "Topic" and "Tags", although the user should see both vocabularies according to the role permissions set in "testrole".

**Result**: The user will now be able to see the vocabulary "limited" in the upload-screen.

This beahviour is not limited to uploads only. It also occurs when trying to edit existing assets.

**Expected behaviour:** the "View" Setting inherited from the role-settings should also allow users to see the vocabulary in asset-editing, especially as the users are able to see and edit the vocabularies at the Categorization menu.


**Fix**
I added the _visibilityTypes filter parameter to the getGroupVocabularies method 
and in the upload_multiple_file_entries_resources.jsp page i removed visibilityTypes attrib from the liferay-asset:asset-categories-selector to use the default AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC visibilityType

Thanks, Roland