### PR TITLE
[TS] LPS-161719 | Links to inactive sites in the Breadcrumb Portlet direct to 404 Not Found error

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/BreadcrumbUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/servlet/taglib/ui/BreadcrumbUtil.java
@@ -296,7 +296,10 @@ public class BreadcrumbUtil {
 
 			breadcrumbEntry.setTitle(
 				group.getDescriptiveName(themeDisplay.getLocale()));
-			breadcrumbEntry.setURL(layoutSetFriendlyURL);
+
+			if (group.isActive()) {
+				breadcrumbEntry.setURL(layoutSetFriendlyURL);
+			}
 
 			breadcrumbEntries.add(breadcrumbEntry);
 		}


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?

https://issues.liferay.com/browse/LPS-161719

Best,
Attila

------


**Reproduction Steps:**

1. Open the menu on the top right --> Control Panel --> Sites --> Sites and add a blank Site, then add a page to it.
2. Go to Control Panel --> Sites and add a child Site to the created Site by clicking the 3 dot menu beside the parent Site and selecting "Add Child Site".
3. Add a widget page to the child site and add to it Breadcrumb Portlet by clicking on "+" from the top right panel.
4. Go to Control Panel --> Sites and click on the 3 dot menu beside the parent Site and select "Deactivate" to deactivate the parent Site.
5. Go to the Child Site and click on the inactive parent Site link in the Breadcrumb Portlet.

**Actual Result:** A 404 Not Found is displayed because the parent Site is inactive.
**Expected Result:** Inactive Sites should be displayed in the Breadcrumb portlet but not as links.

 Based on https://issues.liferay.com/browse/PTR-3297 I consider it as a bug and fixed it by only adding the URL to the breadcrumb entries if the group is active.