### PR TITLE
LPS-162207 - When empty message is configured by the user it should be used in view mode instead of the default message

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -716,7 +716,7 @@ public class RenderLayoutStructureTag extends IncludeTag {
 				String customMessage = messageMap.get(
 					String.valueOf(themeDisplay.getLocale()));
 
-				if (Validator.isNotNull(customMessage)) {
+				if (customMessage != null) {
 					message = customMessage;
 				}
 			}


### PR DESCRIPTION
//cc @ealonso @victorg1991