### PR TITLE
[TS] LPS-162351 |  Page configuration does not save after the default language of the site was changed

### DIFF
--- a/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
+++ b/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java
@@ -615,21 +615,6 @@ public class LayoutImpl extends LayoutBaseImpl {
 				layoutFriendlyURL.getFriendlyURL());
 		}
 
-		// If the site/portal default language changes, there may not exist a
-		// value for the new default language. In this situation, we will use
-		// the value from the previous default language.
-
-		Locale defaultSiteLocale = LocaleUtil.getSiteDefault();
-
-		if (Validator.isNull(friendlyURLMap.get(defaultSiteLocale))) {
-			Locale defaultLocale = LocaleUtil.fromLanguageId(
-				getDefaultLanguageId());
-
-			String defaultFriendlyURL = friendlyURLMap.get(defaultLocale);
-
-			friendlyURLMap.put(defaultSiteLocale, defaultFriendlyURL);
-		}
-
 		return friendlyURLMap;
 	}
 


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?

https://issues.liferay.com/browse/LPS-162351

Best,
Attila

----------------------------------------------------------------------

**Reproduction steps:**

1. Go to Control Panel > Sites and create a new site and name it test
2. Within the site create a new content page called home
3. Go to Site settings > Localization and change the default language
4. Go back to the above created page and enter configuration 
5. With or Without changing any of the configuration try to Save

**Actual result:** Configuration page does not save with the following error.
**Expected behaviour:** Configuration save without error

After LPS-141974 If the user changes the default langue of a Site or instance, the content pages will not be editable in the page settings.
The reason for this is that when the _layoutSerivce.updateLayout is called in the [EditLayoutMVCActionCommand.java](https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java#L185-L193) for the draft version. The draft version will use the getFriendlyURLMap for the update call and the [getFrendlyURLMap](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/model/impl/LayoutImpl.java#L606-L634) will return the previous default firendlyURL if there is no translation for the language. I removed this part of the code because it contradicts LPS-141974 and the unique index on the friendlyURL.
