### PR TITLE
[TS] LPS-161717

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/layout/listener/AssetPublisherPortletLayoutListener.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/layout/listener/AssetPublisherPortletLayoutListener.java
@@ -53,6 +53,7 @@ import com.liferay.subscription.service.SubscriptionLocalService;
 import java.util.List;
 import java.util.Objects;
 
+import javax.portlet.PortletPreferences;
 import javax.portlet.PortletRequest;
 
 import org.osgi.service.component.annotations.Component;
@@ -113,7 +114,7 @@ public class AssetPublisherPortletLayoutListener
 			return;
 		}
 
-		javax.portlet.PortletPreferences portletPreferences =
+		PortletPreferences portletPreferences =
 			PortletPreferencesFactoryUtil.getLayoutPortletSetup(
 				layout, portletId);
 
@@ -224,8 +225,7 @@ public class AssetPublisherPortletLayoutListener
 	}
 
 	private void _addLayoutClassedModelUsages(
-			long plid, String portletId,
-			javax.portlet.PortletPreferences portletPreferences)
+			long plid, String portletId, PortletPreferences portletPreferences)
 		throws PortletLayoutListenerException {
 
 		try {

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/layout/listener/AssetPublisherPortletLayoutListener.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/layout/listener/AssetPublisherPortletLayoutListener.java
@@ -34,20 +34,18 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
 import com.liferay.portal.kernel.model.Portlet;
-import com.liferay.portal.kernel.model.PortletPreferences;
-import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.portlet.PortletLayoutListener;
 import com.liferay.portal.kernel.portlet.PortletLayoutListenerException;
 import com.liferay.portal.kernel.portlet.PortletPreferencesFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.subscription.service.SubscriptionLocalService;
@@ -97,19 +95,6 @@ public class AssetPublisherPortletLayoutListener
 				_journalArticleLocalService.deleteLayoutArticleReferences(
 					layout.getGroupId(), layout.getUuid());
 			}
-
-			long ownerId = PortletKeys.PREFS_OWNER_ID_DEFAULT;
-			int ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
-
-			if (PortletIdCodec.hasUserId(portletId)) {
-				ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
-				ownerId = PortletIdCodec.decodeUserId(portletId);
-			}
-
-			_subscriptionLocalService.deleteSubscriptions(
-				layout.getCompanyId(), PortletPreferences.class.getName(),
-				_assetPublisherWebHelper.getSubscriptionClassPK(
-					ownerId, ownerType, plid, portletId));
 
 			_deleteLayoutClassedModelUsages(layout, portletId);
 
@@ -320,6 +305,9 @@ public class AssetPublisherPortletLayoutListener
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
 	@Reference
 	private SubscriptionLocalService _subscriptionLocalService;

--- a/modules/apps/subscription/subscription-service/src/main/java/com/liferay/subscription/internal/model/listener/SubscriptionPortletPreferencesModelListener.java
+++ b/modules/apps/subscription/subscription-service/src/main/java/com/liferay/subscription/internal/model/listener/SubscriptionPortletPreferencesModelListener.java
@@ -14,11 +14,18 @@
 
 package com.liferay.subscription.internal.model.listener;
 
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.PortletPreferences;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
+import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
+import com.liferay.portal.kernel.util.CopyLayoutThreadLocal;
+import com.liferay.subscription.model.Subscription;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
 import org.osgi.service.component.annotations.Component;
@@ -42,10 +49,80 @@ public class SubscriptionPortletPreferencesModelListener
 		}
 
 		try {
-			_subscriptionLocalService.deleteSubscriptions(
-				portletPreferences.getCompanyId(),
-				portletPreferences.getModelClassName(),
-				portletPreferences.getPortletPreferencesId());
+			if (!CopyLayoutThreadLocal.isCopyLayout()) {
+				_subscriptionLocalService.deleteSubscriptions(
+					portletPreferences.getCompanyId(),
+					portletPreferences.getModelClassName(),
+					portletPreferences.getPortletPreferencesId());
+			}
+			else {
+				TransactionCommitCallbackUtil.registerCallback(
+					() -> {
+						PortletPreferences remainingPortletPreferences =
+							_portletPreferencesLocalService.
+								fetchPortletPreferences(
+									portletPreferences.getOwnerId(),
+									portletPreferences.getOwnerType(),
+									portletPreferences.getPlid(),
+									portletPreferences.getPortletId());
+
+						if (remainingPortletPreferences == null) {
+							_subscriptionLocalService.deleteSubscriptions(
+								portletPreferences.getCompanyId(),
+								portletPreferences.getModelClassName(),
+								portletPreferences.getPortletPreferencesId());
+						}
+						else {
+							ActionableDynamicQuery actionableDynamicQuery =
+								_subscriptionLocalService.
+									getActionableDynamicQuery();
+
+							actionableDynamicQuery.setAddCriteriaMethod(
+								dynamicQuery -> {
+									dynamicQuery.add(
+										RestrictionsFactoryUtil.eq(
+											"companyId",
+											remainingPortletPreferences.
+												getCompanyId()));
+
+									dynamicQuery.add(
+										RestrictionsFactoryUtil.eq(
+											"classNameId",
+											_classNameLocalService.
+												getClassNameId(
+													remainingPortletPreferences.
+														getModelClassName())));
+
+									dynamicQuery.add(
+										RestrictionsFactoryUtil.eq(
+											"classPK",
+											portletPreferences.
+												getPortletPreferencesId()));
+								});
+
+							actionableDynamicQuery.setPerformActionMethod(
+								(Subscription subscription) -> {
+									subscription.setClassPK(
+										remainingPortletPreferences.
+											getPortletPreferencesId());
+
+									_subscriptionLocalService.
+										updateSubscription(subscription);
+								});
+
+							try {
+								actionableDynamicQuery.performActions();
+							}
+							catch (Exception exception) {
+								_log.error(
+									"Unable to restore subscriptions",
+									exception);
+							}
+						}
+
+						return null;
+					});
+			}
 		}
 		catch (Exception exception) {
 			_log.error("Unable to delete subscriptions", exception);
@@ -54,6 +131,12 @@ public class SubscriptionPortletPreferencesModelListener
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SubscriptionPortletPreferencesModelListener.class);
+
+	@Reference
+	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
 	@Reference
 	private SubscriptionLocalService _subscriptionLocalService;


### PR DESCRIPTION
Hi team, could you please review this PR if you are ok with the chosen approach?

Thanks in advance!

* * *

Motivation
=======
[LPS-161717](https://issues.liferay.com/browse/LPS-161717) Asset Publisher's Subscriptions are not preserved after editing a Content page

When a content page is published, a copy from the draft is made to overwrite the previously published version. This is made mainly by deleting the existing fragments and create some new ones. This is done for all the fragments, even some of them have remained unchanged.

However, the deletion of fragments which contain portlets, leads to the deletion of their portlet preferences, and, consequently, this finally leads to the deletion of the subscriptions.

There is additional information in [PTR-3318](https://issues.liferay.com/browse/PTR-3318)

Proposed Solution
========
The proposed solution is to defer the deletion of the subscriptions to the end of the transaction. If, at that time, there are some portlet preferences linked to the portlet, then the former subscriptions are updated to the recreated portlet preferences. If there are no portlet preferences linked to the portlet, then the former subscriptions are effectively deleted.

Steps to Verify
========

1. Create a Content Page
2. Add an Asset Publisher
3. From the Asset Publisher's configuration, enable the subscribe button
4. Publish the Page
5. Click on subscribe
6. Edit the Page
7. Publish the Page

- Actual behaviour: You are not subscribed to the Asset Publisher
- Expected behaviour: You are subscribed to the Asset Publisher
