### PR TITLE
LPS-162764 Use the desired languageId to calculate friendlyURL template contextObject

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7843,7 +7843,7 @@ public class JournalArticleLocalServiceImpl
 				themeDisplay, tokens, viewMode, languageId, document,
 				portletRequestModel, script, propagateException,
 				HashMapBuilder.<String, Object>put(
-					"friendlyURL", _getFriendlyURL(friendlyURLMap, themeDisplay)
+					"friendlyURL", _getFriendlyURL(friendlyURLMap, languageId)
 				).put(
 					"friendlyURLs", friendlyURLMap
 				).build());
@@ -8975,10 +8975,9 @@ public class JournalArticleLocalServiceImpl
 	}
 
 	private String _getFriendlyURL(
-			Map<String, String> friendlyURLMap, ThemeDisplay themeDisplay)
-		throws PortalException {
+		Map<String, String> friendlyURLMap, String languageId) {
 
-		String friendlyURL = friendlyURLMap.get(themeDisplay.getLanguageId());
+		String friendlyURL = friendlyURLMap.get(languageId);
 
 		if (Validator.isNotNull(friendlyURL)) {
 			return friendlyURL;


### PR DESCRIPTION
Motivation
=======
[LPS-162764](https://issues.liferay.com/browse/LPS-162764)
ThemeDisplay might not be correctly set up in remote calls of getContent. Using the parameter `languageId` would 100% match the content's languageId.

Proposed Solution
========
Use the input parameter `languageId` to identify the current translation's friendlyURL.

Steps to Verify
========
1. Create a new Web Content Structure with a Text field
2. Create a Template for this structure: add the Text field and ${friendlyURL} to it
3. Create a Display Page Template for this Web Content Structure and set it as default
4. Create a Web Content from the Structure
5. English translation: title: en, content: en, friendlyURL: en
6. French translation: title: fr, content fr, friendlyURL: fr
7. Publish
8. Edit the Web Content again and check the right side menu > Basic Information > ID. Save this value, it will be used in the script as articleId
9. Go Configuration > Site Settings and select Site Configuration
10. Save the value of Site Id, it will be used in the script as groupId
11. Go to Control Panel > Server Administration, Script
12. Set the copied articleId and groupId in the following script and run it:

```
import com.liferay.journal.service.JournalArticleLocalServiceUtil;
import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
import com.liferay.portal.kernel.theme.ThemeDisplay;

long groupId = 20121;
String articleId = "";

article = JournalArticleLocalServiceUtil.fetchArticle(groupId, articleId);
serviceContext = ServiceContextThreadLocal.getServiceContext();
			
ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();

themeDisplay.setLanguageId("en_US");
themeDisplay.setScopeGroupId(groupId);

try {
	out.println(JournalArticleLocalServiceUtil.getArticleContent(
		article, null, null, "fr_FR", null, themeDisplay));
}
catch (Exception e) {
	e.printStackTrace(out);
}
```
**Expected behaviour:** French content is displayed with French friendlyURL (http://localhost:8080/w/fr)
**Actual behaviour:** French content is displayed with English friendlyURL (http://localhost:8080/w/en)