### PR TITLE
LPS-162783 Use a fallback value in case languageId is missing from the typeSettings

### DIFF
--- a/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_0_0/UpgradeGroup.java
@@ -124,7 +124,9 @@ public class UpgradeGroup extends UpgradeProcess {
 					).build();
 
 				String defaultLanguageId =
-					typeSettingsUnicodeProperties.getProperty("languageId");
+					typeSettingsUnicodeProperties.getProperty(
+						"languageId",
+						LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()));
 
 				Locale currentDefaultLocale =
 					LocaleThreadLocal.getSiteDefaultLocale();


### PR DESCRIPTION
Motivation
=======
[LPS-162783](https://issues.liferay.com/browse/LPS-162783)
It might be possible that `languageId` is missing from typeSettings, but locales are present. In that case [LocalizationImpl#getXML](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/util/LocalizationImpl.java#L876) would throw a NullPointerException because of the `!defaultLanguageId.equals(languageId)` comparison.

Proposed Solution
========
By providing a fallback value for languageId we can prevent the NullPointerException

Steps to Verify
========

1. Start a 6.2 Portal
2. Go to Admin > Site Administration > Configuration
3. Open Display Settings from the right side menu
4. Select "Define a custom default language and additional available languages for this site."
5. Change the default language to French
6. Press Save
7. Open your DB admin tool (some older behaviour might have produced data like this)
8. Run select * from group_ where typeSettings like "%fr_FR%";
9. Edit the result group's typeSettings: remove the "languageId=fr_FR" line
10. Update the database record
11. Upgrade the database to master

**Expected behaviour:** Upgrade is successful
**Actual behaviour:** Upgrade fails with
```
java.lang.NullPointerException: null
 at com.liferay.portal.util.LocalizationImpl.getXml(LocalizationImpl.java:868) ~[portal-impl.jar:?]
 at com.liferay.portal.util.LocalizationImpl.updateLocalization(LocalizationImpl.java:1141) ~[portal-impl.jar:?]
 at com.liferay.portal.kernel.util.LocalizationUtil.updateLocalization(LocalizationUtil.java:384) ~[portal-kernel.jar:?]
 at com.liferay.portal.upgrade.v7_0_0.UpgradeGroup.updateGroupsNames(UpgradeGroup.java:149) ~[portal-impl.jar:?]
```