### PR TITLE
[TS] LPS-161738 Have the Private Page tab always be visible whether private pages exists or not

### DIFF
--- a/modules/apps/layout/layout-item-selector-web/src/main/java/com/liferay/layout/item/selector/web/internal/PrivateLayoutsItemSelectorView.java
+++ b/modules/apps/layout/layout-item-selector-web/src/main/java/com/liferay/layout/item/selector/web/internal/PrivateLayoutsItemSelectorView.java
@@ -79,7 +79,7 @@ public class PrivateLayoutsItemSelectorView
 
 		Group group = themeDisplay.getScopeGroup();
 
-		if (group.getPrivateLayoutsPageCount() <= 0) {
+		if (!group.isPrivateLayoutsEnabled() && !group.isLayoutSetPrototype()) {
 			return false;
 		}
 


### PR DESCRIPTION
Hi Echo Team,

Can you help review this PR?

**Notes from @noornajj**

> https://issues.liferay.com/browse/LPS-161738
> 
> The issue here is that the Private Pages tab was being set to visible based on whether the SCOPED group had private pages created. However, the Portlet URL for the tab was being generated off of the REFERRER group. This caused a null pointer error to occur and the portlet to become unavailable when the Private Pages tab is clicked. This is because the URL is trying to navigate to the private pages of a group that does have any private pages.
> 
> To fix the issue, I had the Private Pages tab work similar to the Public Pages so that it will always be visible but will show "No pages available" if the group doesn't have any pages.
> Based on how the [PortletURL](https://github.com/noornajj/liferay-portal/blob/2173b7690c4205ef30cabbadc4c7fecdd599f193/modules/apps/item-selector/item-selector-web/src/main/java/com/liferay/item/selector/web/internal/ItemSelectorImpl.java#L335) gets generated, it intentionally sets the group of all tabs, other than the selected tab, to the referrer group. Therefore, it would make sense that the visibility of the Private Pages tab should not be dependent on the SCOPED group.

Please let us know if you have any questions.
Thanks!