### PR TITLE
LPS-163003 Asset publisher with dynamic selection won't display contents that have their latest version in scheduled status

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherHelperImpl.java
@@ -402,7 +402,7 @@ public class AssetPublisherHelperImpl implements AssetPublisherHelper {
 			overrideAllAssetCategoryIds, overrideAllAssetTagNames,
 			overrideAllKeywords);
 
-		assetEntryQuery.setAttribute("showNonindexable", Boolean.TRUE);
+		assetEntryQuery.setAttribute("headOrShowNonIndexable", Boolean.TRUE);
 		assetEntryQuery.setGroupIds(groupIds);
 
 		boolean anyAssetType = GetterUtil.getBoolean(

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
@@ -762,6 +762,12 @@ public class AssetHelperImpl implements AssetHelper {
 			searchContext.setAttribute("showNonindexable", Boolean.TRUE);
 		}
 
+		if (GetterUtil.getBoolean(
+				assetEntryQuery.getAttribute("headOrShowNonIndexable"))) {
+
+			searchContext.setAttribute("headOrShowNonIndexable", Boolean.TRUE);
+		}
+
 		searchContext.setClassTypeIds(assetEntryQuery.getClassTypeIds());
 		searchContext.setEnd(end);
 		searchContext.setGroupIds(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/query/contributor/JournalArticleModelPreFilterContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/query/contributor/JournalArticleModelPreFilterContributor.java
@@ -138,6 +138,8 @@ public class JournalArticleModelPreFilterContributor
 
 		boolean head = GetterUtil.getBoolean(
 			searchContext.getAttribute("head"), Boolean.TRUE);
+		boolean headOrShowNonIndexable = GetterUtil.getBoolean(
+			searchContext.getAttribute("headOrShowNonIndexable"));
 		boolean latest = GetterUtil.getBoolean(
 			searchContext.getAttribute("latest"));
 		boolean relatedClassName = GetterUtil.getBoolean(
@@ -148,7 +150,9 @@ public class JournalArticleModelPreFilterContributor
 		if (latest && !relatedClassName && !showNonindexable) {
 			booleanFilter.addRequiredTerm("latest", Boolean.TRUE);
 		}
-		else if (head && !relatedClassName && !showNonindexable) {
+		else if (head && !headOrShowNonIndexable && !relatedClassName &&
+				 !showNonindexable) {
+
 			booleanFilter.addRequiredTerm("head", Boolean.TRUE);
 		}
 
@@ -157,6 +161,10 @@ public class JournalArticleModelPreFilterContributor
 		}
 		else if (!relatedClassName && showNonindexable) {
 			booleanFilter.addRequiredTerm("headListable", Boolean.TRUE);
+		}
+		else if (headOrShowNonIndexable && !relatedClassName) {
+			booleanFilter.addTerm("head", Boolean.TRUE);
+			booleanFilter.addTerm("headListable", Boolean.TRUE);
 		}
 
 		boolean filterExpired = GetterUtil.getBoolean(


### PR DESCRIPTION
Hi,
I send this pull in order to fix [LPS-163003](https://issues.liferay.com/browse/LPS-163003).
**Reproduction steps:**

- Add an asset publisher widget to a page and configure it with dynamic selection of assets.
- Create a basic web content and publish it.
- Edit this basic web content and set a display date set in the future.
- Publish this new version of the content that should remain in SCHEDULED status.
- In this point the web content should have two versions: 1.0 in APPROVED status and 1.1 in SCHEDULED status.

**Expected behavior:**

- When rendering the asset publisher, it shows the content.

**Actual behavior:**

- When rendering the asset publisher, it does not show the content created in the reproduction steps.

After the changes made in [LPS-141570](https://issues.liferay.com/browse/LPS-141570), asset publisher shows non-searchable contents. The boolean query used to get these results from the search indices queries documents which have field `headListable=true AND status=0`.
When a new version with SCHEDULED status is added to an existing content, it is indexed with the following field values in the search index: `head=false, headListable=true, status=7`.
This means that the asset publisher query will not get this last version because its status is not zero (APPROVED).
I changed JournalArticleModelPreFilterContributor to get documents that have `(headListable=true OR head=true) AND status=0`. This way if a content have a latest version in SCHEDULED status, it will get its last APPROVED version and it will be shown in asset publisher results.

In JournalArticleModelPreFilterContributor class I'm using a new attribute called "headOrShowNonIndexable". I could have used the existing head and headListable attributes both with value="true" to represent this use case but I thought that it could imply that an AND operation was being made like in `(headListable=true AND head=true)` when actually is an OR.
Thanks.