### PR TITLE
LPS-163005 Do not send notifications for comments if the layout is being copied.

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.service.PortletPreferenceValueLocalServiceUtil;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.CopyLayoutThreadLocal;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -80,10 +81,22 @@ public class SegmentsExperienceUtil {
 			long userId)
 		throws PortalException {
 
-		_copyLayoutData(
-			plid, commentManager, groupId, portletRegistry,
-			sourceSegmentsExperienceId, targetSegmentsExperienceId,
-			serviceContextFunction, userId);
+		boolean copyLayout = CopyLayoutThreadLocal.isCopyLayout();
+
+		try {
+			CopyLayoutThreadLocal.setCopyLayout(true);
+
+			_copyLayoutData(
+				plid, commentManager, groupId, portletRegistry,
+				sourceSegmentsExperienceId, targetSegmentsExperienceId,
+				serviceContextFunction, userId);
+		}
+		catch (Throwable throwable) {
+			throw new PortalException(throwable);
+		}
+		finally {
+			CopyLayoutThreadLocal.setCopyLayout(copyLayout);
+		}
 	}
 
 	public static Map<String, Object> getAvailableSegmentsExperiences(

--- a/modules/apps/message-boards/message-boards-service/build.gradle
+++ b/modules/apps/message-boards/message-boards-service/build.gradle
@@ -22,6 +22,7 @@ dependencies {
 	compileOnly project(":apps:comment:comment-api")
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:friendly-url:friendly-url-api")
+	compileOnly project(":apps:layout:layout-api")
 	compileOnly project(":apps:message-boards:message-boards-api")
 	compileOnly project(":apps:petra:petra-portlet-url-builder")
 	compileOnly project(":apps:portal-search:portal-search-api")

--- a/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
+++ b/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java
@@ -116,6 +116,7 @@ import com.liferay.portal.kernel.systemevent.SystemEvent;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.CopyLayoutThreadLocal;
 import com.liferay.portal.kernel.util.EscapableLocalizableFunction;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -2225,6 +2226,10 @@ public class MBMessageLocalServiceImpl extends MBMessageLocalServiceBaseImpl {
 		}
 
 		if (message.isDiscussion()) {
+			if (CopyLayoutThreadLocal.isCopyLayout()) {
+				return;
+			}
+
 			try {
 				notifyDiscussionSubscribers(userId, message, serviceContext);
 			}


### PR DESCRIPTION
Hi Echo Team,

Can you help review this PR?

As mentioned in [PTR-3327](https://issues.liferay.com/browse/PTR-3327), this PR is solution 1.

**Notes from @noornajj:**

> https://issues.liferay.com/browse/LPS-163005
> 
> The issue here is that notifications for content page comments were be sent every time the page was published or a new experience was created. This was due to the layout being copied and therefore the comments being copied as well.
> 
> To fix the issue, I added a check in the notifySubscribers method to check whether the layout is being copied using the CopyLayoutThreadLocal variable.

I'll also leave a few observations I had, in case it helps.

Please let us know if you have any questions.
Thanks!

----

**Additional Observations**
The `_copyLayoutData` method may eventually call the method: `_copyPortletPreferences`. Not sure if this would eventually land here: [PortletPreferencesLocalServiceImpl.java#L1035-L1054](https://github.com/liferay/liferay-portal/blob/7.4.3.41-ga41/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java#L1035-L1054), which has logic involving: `CopyLayoutThreadLocal`
```
if (CopyLayoutThreadLocal.isCopyLayout()) {
```

Not entirely related, but I noticed in the same `notifySubscribers` method, a threadlocal is used: `MailingListThreadLocal`, in [MBMessageLocalServiceImpl.java#L2384](https://github.com/liferay/liferay-portal/blob/7.4.3.41-ga41/modules/apps/message-boards/message-boards-service/src/main/java/com/liferay/message/boards/service/impl/MBMessageLocalServiceImpl.java#L2384)