### PR TITLE
LPS-160143 Add simpler API for getURLViewInContext

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/asset/model/BlogsEntryAssetRenderer.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/asset/model/BlogsEntryAssetRenderer.java
@@ -225,7 +225,7 @@ public class BlogsEntryAssetRenderer
 			LiferayPortletRequest liferayPortletRequest,
 			LiferayPortletResponse liferayPortletResponse,
 			String noSuchEntryRedirect)
-		throws Exception {
+		throws PortalException {
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)liferayPortletRequest.getAttribute(
@@ -236,7 +236,7 @@ public class BlogsEntryAssetRenderer
 
 	public String getURLViewInContext(
 			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
-		throws Exception {
+		throws PortalException {
 
 		if (_assetDisplayPageFriendlyURLProvider != null) {
 			String friendlyURL =

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/asset/model/BlogsEntryAssetRenderer.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/asset/model/BlogsEntryAssetRenderer.java
@@ -225,13 +225,20 @@ public class BlogsEntryAssetRenderer
 			LiferayPortletRequest liferayPortletRequest,
 			LiferayPortletResponse liferayPortletResponse,
 			String noSuchEntryRedirect)
-		throws PortalException {
+		throws Exception {
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)liferayPortletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return getURLViewInContext(themeDisplay, noSuchEntryRedirect);
+	}
+
+	public String getURLViewInContext(
+			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
+		throws Exception {
 
 		if (_assetDisplayPageFriendlyURLProvider != null) {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)liferayPortletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
-
 			String friendlyURL =
 				_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 					getClassName(), getClassPK(), themeDisplay);
@@ -241,17 +248,13 @@ public class BlogsEntryAssetRenderer
 			}
 		}
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)liferayPortletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		if (!_hasViewInContextGroupLayout(_entry.getGroupId(), themeDisplay)) {
 			return null;
 		}
 
 		return getURLViewInContext(
-			liferayPortletRequest, noSuchEntryRedirect, "/blogs/find_entry",
-			"entryId", _entry.getEntryId());
+			themeDisplay, noSuchEntryRedirect, "/blogs/find_entry", "entryId",
+			_entry.getEntryId());
 	}
 
 	@Override

--- a/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/asset/model/BookmarksEntryAssetRenderer.java
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/asset/model/BookmarksEntryAssetRenderer.java
@@ -176,6 +176,15 @@ public class BookmarksEntryAssetRenderer
 	}
 
 	@Override
+	public String getURLViewInContext(
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
+
+		return getURLViewInContext(
+			themeDisplay, noSuchEntryRedirect, "/bookmarks/find_entry",
+			"entryId", _entry.getEntryId());
+	}
+
+	@Override
 	public long getUserId() {
 		return _entry.getUserId();
 	}

--- a/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/asset/model/BookmarksFolderAssetRenderer.java
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/asset/model/BookmarksFolderAssetRenderer.java
@@ -188,6 +188,15 @@ public class BookmarksFolderAssetRenderer
 	}
 
 	@Override
+	public String getURLViewInContext(
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
+
+		return getURLViewInContext(
+			themeDisplay, noSuchEntryRedirect, "/bookmarks/find_folder",
+			"folderId", _folder.getFolderId());
+	}
+
+	@Override
 	public long getUserId() {
 		return _folder.getUserId();
 	}

--- a/modules/apps/comment/comment-web/src/main/java/com/liferay/comment/web/internal/asset/model/CommentAssetRenderer.java
+++ b/modules/apps/comment/comment-web/src/main/java/com/liferay/comment/web/internal/asset/model/CommentAssetRenderer.java
@@ -210,6 +210,26 @@ public class CommentAssetRenderer
 	}
 
 	@Override
+	public String getURLViewInContext(
+			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
+		throws Exception {
+
+		AssetRendererFactory<?> assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClassName(
+				_workflowableComment.getClassName());
+
+		if (assetRendererFactory == null) {
+			return null;
+		}
+
+		AssetRenderer<?> assetRenderer = assetRendererFactory.getAssetRenderer(
+			_workflowableComment.getClassPK());
+
+		return assetRenderer.getURLViewInContext(
+			themeDisplay, noSuchEntryRedirect);
+	}
+
+	@Override
 	public long getUserId() {
 		return _workflowableComment.getUserId();
 	}

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/asset/CPDefinitionAssetRenderer.java
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/java/com/liferay/commerce/product/definitions/web/internal/asset/CPDefinitionAssetRenderer.java
@@ -177,14 +177,21 @@ public class CPDefinitionAssetRenderer
 		LiferayPortletResponse liferayPortletResponse,
 		String noSuchEntryRedirect) {
 
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)liferayPortletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		return getURLViewInContext(themeDisplay, noSuchEntryRedirect);
+	}
+
+	@Override
+	public String getURLViewInContext(
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
+
 		try {
 			if (!_cpDefinition.isApproved() || !_cpDefinition.isPublished()) {
 				return null;
 			}
-
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)liferayPortletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
 
 			return _cpDefinitionHelper.getFriendlyURL(
 				_cpDefinition.getCPDefinitionId(), themeDisplay);

--- a/modules/apps/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/asset/model/UserAssetRenderer.java
+++ b/modules/apps/contacts/contacts-web/src/main/java/com/liferay/contacts/web/internal/asset/model/UserAssetRenderer.java
@@ -137,6 +137,13 @@ public class UserAssetRenderer extends BaseJSPAssetRenderer<User> {
 			(ThemeDisplay)liferayPortletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		return getURLViewInContext(themeDisplay, noSuchEntryRedirect);
+	}
+
+	@Override
+	public String getURLViewInContext(
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
+
 		try {
 			return _user.getDisplayURL(themeDisplay);
 		}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/asset/model/DLFileEntryAssetRenderer.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/asset/model/DLFileEntryAssetRenderer.java
@@ -302,11 +302,19 @@ public class DLFileEntryAssetRenderer
 			String noSuchEntryRedirect)
 		throws PortalException {
 
-		if (_assetDisplayPageFriendlyURLProvider != null) {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)liferayPortletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)liferayPortletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
+		return getURLViewInContext(themeDisplay, noSuchEntryRedirect);
+	}
+
+	@Override
+	public String getURLViewInContext(
+			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
+		throws PortalException {
+
+		if (_assetDisplayPageFriendlyURLProvider != null) {
 			String friendlyURL =
 				_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 					FileEntry.class.getName(), getClassPK(), themeDisplay);
@@ -316,10 +324,6 @@ public class DLFileEntryAssetRenderer
 			}
 		}
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)liferayPortletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		if (!_hasViewInContextGroupLayout(
 				themeDisplay, _fileEntry.getGroupId())) {
 
@@ -327,7 +331,7 @@ public class DLFileEntryAssetRenderer
 		}
 
 		return getURLViewInContext(
-			liferayPortletRequest, noSuchEntryRedirect,
+			themeDisplay, noSuchEntryRedirect,
 			"/document_library/find_file_entry", "fileEntryId",
 			_fileEntry.getFileEntryId());
 	}

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/asset/model/DLFolderAssetRenderer.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/asset/model/DLFolderAssetRenderer.java
@@ -174,6 +174,15 @@ public class DLFolderAssetRenderer
 	}
 
 	@Override
+	public String getURLViewInContext(
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
+
+		return getURLViewInContext(
+			themeDisplay, noSuchEntryRedirect, "/document_library/find_folder",
+			"folderId", _folder.getFolderId());
+	}
+
+	@Override
 	public long getUserId() {
 		return _folder.getUserId();
 	}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/asset/model/DDLRecordAssetRenderer.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/asset/model/DDLRecordAssetRenderer.java
@@ -186,6 +186,14 @@ public class DDLRecordAssetRenderer extends BaseJSPAssetRenderer<DDLRecord> {
 	}
 
 	@Override
+	public String getURLViewInContext(
+			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
+		throws Exception {
+
+		return noSuchEntryRedirect;
+	}
+
+	@Override
 	public long getUserId() {
 		return _recordVersion.getUserId();
 	}

--- a/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/asset/model/DDLRecordAssetRenderer.java
+++ b/modules/apps/dynamic-data-lists/dynamic-data-lists-web/src/main/java/com/liferay/dynamic/data/lists/web/internal/asset/model/DDLRecordAssetRenderer.java
@@ -177,18 +177,16 @@ public class DDLRecordAssetRenderer extends BaseJSPAssetRenderer<DDLRecord> {
 
 	@Override
 	public String getURLViewInContext(
-			LiferayPortletRequest liferayPortletRequest,
-			LiferayPortletResponse liferayPortletResponse,
-			String noSuchEntryRedirect)
-		throws Exception {
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse,
+		String noSuchEntryRedirect) {
 
 		return noSuchEntryRedirect;
 	}
 
 	@Override
 	public String getURLViewInContext(
-			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
-		throws Exception {
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
 
 		return noSuchEntryRedirect;
 	}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/asset/model/DDMFormAssetRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/asset/model/DDMFormAssetRenderer.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -201,6 +202,14 @@ public class DDMFormAssetRenderer
 			LiferayPortletRequest liferayPortletRequest,
 			LiferayPortletResponse liferayPortletResponse,
 			String noSuchEntryRedirect)
+		throws Exception {
+
+		return noSuchEntryRedirect;
+	}
+
+	@Override
+	public String getURLViewInContext(
+			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
 		throws Exception {
 
 		return noSuchEntryRedirect;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/asset/model/DDMFormAssetRenderer.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/java/com/liferay/dynamic/data/mapping/form/web/internal/asset/model/DDMFormAssetRenderer.java
@@ -199,18 +199,16 @@ public class DDMFormAssetRenderer
 
 	@Override
 	public String getURLViewInContext(
-			LiferayPortletRequest liferayPortletRequest,
-			LiferayPortletResponse liferayPortletResponse,
-			String noSuchEntryRedirect)
-		throws Exception {
+		LiferayPortletRequest liferayPortletRequest,
+		LiferayPortletResponse liferayPortletResponse,
+		String noSuchEntryRedirect) {
 
 		return noSuchEntryRedirect;
 	}
 
 	@Override
 	public String getURLViewInContext(
-			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
-		throws Exception {
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
 
 		return noSuchEntryRedirect;
 	}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java
@@ -363,7 +363,7 @@ public class JournalArticleAssetRenderer
 			LiferayPortletRequest liferayPortletRequest,
 			LiferayPortletResponse liferayPortletResponse,
 			String noSuchEntryRedirect)
-		throws Exception {
+		throws PortalException {
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)liferayPortletRequest.getAttribute(
@@ -375,7 +375,7 @@ public class JournalArticleAssetRenderer
 	@Override
 	public String getURLViewInContext(
 			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
-		throws Exception {
+		throws PortalException {
 
 		if (!_isShowDisplayPage(themeDisplay.getScopeGroupId(), _article)) {
 			return _getHitLayoutURL(noSuchEntryRedirect, themeDisplay);
@@ -601,7 +601,7 @@ public class JournalArticleAssetRenderer
 
 	private String _getHitLayoutURL(
 			String noSuchEntryRedirect, ThemeDisplay themeDisplay)
-		throws Exception {
+		throws PortalException {
 
 		List<LayoutClassedModelUsage> layoutClassedModelUsages =
 			LayoutClassedModelUsageLocalServiceUtil.getLayoutClassedModelUsages(
@@ -644,7 +644,7 @@ public class JournalArticleAssetRenderer
 	}
 
 	private boolean _isShowDisplayPage(long groupId, JournalArticle article)
-		throws Exception {
+		throws PortalException {
 
 		AssetRendererFactory<JournalArticle> assetRendererFactory =
 			getAssetRendererFactory();

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java
@@ -369,6 +369,14 @@ public class JournalArticleAssetRenderer
 			(ThemeDisplay)liferayPortletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		return getURLViewInContext(themeDisplay, noSuchEntryRedirect);
+	}
+
+	@Override
+	public String getURLViewInContext(
+			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
+		throws Exception {
+
 		if (!_isShowDisplayPage(themeDisplay.getScopeGroupId(), _article)) {
 			return _getHitLayoutURL(noSuchEntryRedirect, themeDisplay);
 		}

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/model/KBArticleAssetRenderer.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/asset/model/KBArticleAssetRenderer.java
@@ -144,6 +144,15 @@ public class KBArticleAssetRenderer extends BaseJSPAssetRenderer<KBArticle> {
 	}
 
 	@Override
+	public String getURLViewInContext(
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
+
+		return KnowledgeBaseUtil.getKBArticleURL(
+			themeDisplay.getPlid(), _kbArticle.getResourcePrimKey(),
+			_kbArticle.getStatus(), themeDisplay.getPortalURL(), false);
+	}
+
+	@Override
 	public long getUserId() {
 		return _kbArticle.getUserId();
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRenderer.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutAssetRenderer.java
@@ -111,6 +111,13 @@ public class LayoutAssetRenderer extends BaseJSPAssetRenderer<Layout> {
 			(ThemeDisplay)liferayPortletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		return getURLViewInContext(themeDisplay, noSuchEntryRedirect);
+	}
+
+	@Override
+	public String getURLViewInContext(
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
+
 		try {
 			if (!_layout.isDenied() && !_layout.isPending()) {
 				return PortalUtil.getLayoutFriendlyURL(_layout, themeDisplay);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutRevisionAssetRenderer.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/asset/model/LayoutRevisionAssetRenderer.java
@@ -125,11 +125,18 @@ public class LayoutRevisionAssetRenderer
 		LiferayPortletResponse liferayPortletResponse,
 		String noSuchEntryRedirect) {
 
-		try {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)liferayPortletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)liferayPortletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
+		return getURLViewInContext(themeDisplay, noSuchEntryRedirect);
+	}
+
+	@Override
+	public String getURLViewInContext(
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
+
+		try {
 			String layoutURL = PortalUtil.getLayoutURL(
 				LayoutLocalServiceUtil.getLayout(_layoutRevision.getPlid()),
 				themeDisplay);

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/asset/model/MBCategoryAssetRenderer.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/asset/model/MBCategoryAssetRenderer.java
@@ -167,6 +167,15 @@ public class MBCategoryAssetRenderer extends BaseJSPAssetRenderer<MBCategory> {
 	}
 
 	@Override
+	public String getURLViewInContext(
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
+
+		return getURLViewInContext(
+			themeDisplay, noSuchEntryRedirect, "/message_boards/find_category",
+			"mbCategoryId", _category.getCategoryId());
+	}
+
+	@Override
 	public long getUserId() {
 		return _category.getUserId();
 	}

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/asset/model/MBMessageAssetRenderer.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/asset/model/MBMessageAssetRenderer.java
@@ -196,7 +196,7 @@ public class MBMessageAssetRenderer
 			LiferayPortletRequest liferayPortletRequest,
 			LiferayPortletResponse liferayPortletResponse,
 			String noSuchEntryRedirect)
-		throws Exception {
+		throws PortalException {
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)liferayPortletRequest.getAttribute(
@@ -208,7 +208,7 @@ public class MBMessageAssetRenderer
 	@Override
 	public String getURLViewInContext(
 			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
-		throws Exception {
+		throws PortalException {
 
 		if (_assetDisplayPageFriendlyURLProvider != null) {
 			String friendlyURL =

--- a/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/asset/model/MBMessageAssetRenderer.java
+++ b/modules/apps/message-boards/message-boards-web/src/main/java/com/liferay/message/boards/web/internal/asset/model/MBMessageAssetRenderer.java
@@ -198,11 +198,19 @@ public class MBMessageAssetRenderer
 			String noSuchEntryRedirect)
 		throws Exception {
 
-		if (_assetDisplayPageFriendlyURLProvider != null) {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)liferayPortletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)liferayPortletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
+		return getURLViewInContext(themeDisplay, noSuchEntryRedirect);
+	}
+
+	@Override
+	public String getURLViewInContext(
+			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
+		throws Exception {
+
+		if (_assetDisplayPageFriendlyURLProvider != null) {
 			String friendlyURL =
 				_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 					getClassName(), getClassPK(), themeDisplay);
@@ -212,10 +220,6 @@ public class MBMessageAssetRenderer
 			}
 		}
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)liferayPortletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		if (!_hasViewInContextGroupLayout(
 				_message.getGroupId(), themeDisplay)) {
 
@@ -223,9 +227,8 @@ public class MBMessageAssetRenderer
 		}
 
 		return getURLViewInContext(
-			liferayPortletRequest, noSuchEntryRedirect,
-			"/message_boards/find_message", "messageId",
-			_message.getMessageId());
+			themeDisplay, noSuchEntryRedirect, "/message_boards/find_message",
+			"messageId", _message.getMessageId());
 	}
 
 	@Override

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBCategoryAssetRenderer.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBCategoryAssetRenderer.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Locale;
@@ -125,6 +126,13 @@ public class MBCategoryAssetRenderer extends BaseJSPAssetRenderer<MBCategory> {
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse,
 		String noSuchEntryRedirect) {
+
+		return null;
+	}
+
+	@Override
+	public String getURLViewInContext(
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
 
 		return null;
 	}

--- a/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBMessageAssetRenderer.java
+++ b/modules/apps/questions/questions-web/src/main/java/com/liferay/questions/web/internal/asset/model/MBMessageAssetRenderer.java
@@ -153,6 +153,13 @@ public class MBMessageAssetRenderer
 			(ThemeDisplay)liferayPortletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		return getURLViewInContext(themeDisplay, noSuchEntryRedirect);
+	}
+
+	@Override
+	public String getURLViewInContext(
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect) {
+
 		return _getQuestionsURL(themeDisplay.getPortalURL());
 	}
 

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/asset/model/WikiPageAssetRenderer.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/asset/model/WikiPageAssetRenderer.java
@@ -299,11 +299,19 @@ public class WikiPageAssetRenderer
 			String noSuchEntryRedirect)
 		throws Exception {
 
-		if (_assetDisplayPageFriendlyURLProvider != null) {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)liferayPortletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)liferayPortletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
 
+		return getURLViewInContext(themeDisplay, noSuchEntryRedirect);
+	}
+
+	@Override
+	public String getURLViewInContext(
+			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
+		throws Exception {
+
+		if (_assetDisplayPageFriendlyURLProvider != null) {
 			String friendlyURL =
 				_assetDisplayPageFriendlyURLProvider.getFriendlyURL(
 					getClassName(), getClassPK(), themeDisplay);
@@ -313,16 +321,12 @@ public class WikiPageAssetRenderer
 			}
 		}
 
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)liferayPortletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		if (!_hasViewInContextGroupLayout(_page.getGroupId(), themeDisplay)) {
 			return null;
 		}
 
 		return getURLViewInContext(
-			liferayPortletRequest, noSuchEntryRedirect, "/wiki/find_page",
+			themeDisplay, noSuchEntryRedirect, "/wiki/find_page",
 			"pageResourcePrimKey", _page.getResourcePrimKey());
 	}
 

--- a/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/asset/model/WikiPageAssetRenderer.java
+++ b/modules/apps/wiki/wiki-web/src/main/java/com/liferay/wiki/web/internal/asset/model/WikiPageAssetRenderer.java
@@ -297,7 +297,7 @@ public class WikiPageAssetRenderer
 			LiferayPortletRequest liferayPortletRequest,
 			LiferayPortletResponse liferayPortletResponse,
 			String noSuchEntryRedirect)
-		throws Exception {
+		throws PortalException {
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)liferayPortletRequest.getAttribute(
@@ -309,7 +309,7 @@ public class WikiPageAssetRenderer
 	@Override
 	public String getURLViewInContext(
 			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
-		throws Exception {
+		throws PortalException {
 
 		if (_assetDisplayPageFriendlyURLProvider != null) {
 			String friendlyURL =

--- a/portal-kernel/bnd.bnd
+++ b/portal-kernel/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 74.0.0
+Bundle-Version: 74.1.0
 Export-Package:\
 	!com.liferay.portal.kernel.internal.*,\
 	!com.liferay.portal.kernel.module.util,\

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetRenderer.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetRenderer.java
@@ -164,13 +164,9 @@ public interface AssetRenderer<T> extends Renderer {
 			String noSuchEntryRedirect)
 		throws Exception;
 
-	public default String getURLViewInContext(
+	public String getURLViewInContext(
 			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
-		throws Exception {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
-	}
+		throws Exception;
 
 	public default String getURLViewUsages(
 			HttpServletRequest httpServletRequest)

--- a/portal-kernel/src/com/liferay/asset/kernel/model/AssetRenderer.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/AssetRenderer.java
@@ -164,6 +164,14 @@ public interface AssetRenderer<T> extends Renderer {
 			String noSuchEntryRedirect)
 		throws Exception;
 
+	public default String getURLViewInContext(
+			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
 	public default String getURLViewUsages(
 			HttpServletRequest httpServletRequest)
 		throws Exception {

--- a/portal-kernel/src/com/liferay/asset/kernel/model/BaseAssetRenderer.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/BaseAssetRenderer.java
@@ -358,6 +358,15 @@ public abstract class BaseAssetRenderer<T> implements AssetRenderer<T> {
 			(ThemeDisplay)liferayPortletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		return getURLViewInContext(
+			themeDisplay, noSuchEntryRedirect, path, primaryKeyParameterName,
+			primaryKeyParameterValue);
+	}
+
+	protected String getURLViewInContext(
+		ThemeDisplay themeDisplay, String noSuchEntryRedirect, String path,
+		String primaryKeyParameterName, long primaryKeyParameterValue) {
+
 		return PortalUtil.addPreservedParameters(
 			themeDisplay,
 			StringBundler.concat(

--- a/portal-kernel/src/com/liferay/asset/kernel/model/BaseAssetRenderer.java
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/BaseAssetRenderer.java
@@ -267,6 +267,14 @@ public abstract class BaseAssetRenderer<T> implements AssetRenderer<T> {
 	}
 
 	@Override
+	public String getURLViewInContext(
+			ThemeDisplay themeDisplay, String noSuchEntryRedirect)
+		throws Exception {
+
+		throw null;
+	}
+
+	@Override
 	public String getViewInContextMessage() {
 		return "view-in-context";
 	}

--- a/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
+++ b/portal-kernel/src/com/liferay/asset/kernel/model/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0


### PR DESCRIPTION
Hi Team,
This is an updated version of https://github.com/liferay-echo/liferay-portal/pull/9464 based on Brian's feedback on https://github.com/brianchandotcom/liferay-portal/pull/122897

Motivation
=======
[LPS-160143](https://issues.liferay.com/browse/LPS-160143)
GetURLViewInContext relies on `liferayPortletRequest` and `liferayPortletResponse`, which are not available in fragments. In the majority of cases `themeDisplay` is the only data extracted from these parameters, thus providing a `themeDisplay` based implementation would speed up template migration from widget pages to content pages.

Proposed Solution
========
As discussed in [PTR-3216](https://issues.liferay.com/browse/PTR-3216), adding a new method that instead of `liferayPortletRequest` and `liferayPortletResponse` relies on `themeDisplay` could be a solution to migrate templates with minimal changes on the user's side.
I've created the new method as a default method so that backporting it would not be a breaking change
I've added 
```
throw new UnsupportedOperationException(
			"This method needs to be implemented");
```
to the default implementation because I couldn't find a way to make the logic work without a liferayPortletResponse for Base, CommerceOrder, Microblogs, JournalFolder and CalendarBooking. Please bare this in mind and share any concerns about this or ideas that might improve it.

Steps to Verify
========
1. Create a new Web Content Structure with a text field
1. Create a Template for it
```
<#assign
    journalArticleLocalService = serviceLocator.findService("com.liferay.journal.service.JournalArticleLocalService")
    assetEntryLocalService = serviceLocator.findService("com.liferay.asset.kernel.service.AssetEntryLocalService")
/>

<#assign
    article = journalArticleLocalService.getArticle(getterUtil.getLong(articleGroupId), .vars['reserved-article-id'].data) />
<#assign
    asset = assetEntryLocalService.getEntry('com.liferay.journal.model.JournalArticle', article.resourcePrimKey) />

<#if renderRequest??>
    <#assign
        urlViewInContext = asset.getAssetRenderer().getURLViewInContext(renderRequest, renderResponse, currentURL) />
<#else>
    <#assign
        urlViewInContext = asset.getAssetRenderer().getURLViewInContext(themeDisplay, currentURL) />
</#if>
<pre>${urlViewInContext}</pre>
```
1. Create a Widget Page with a Default Asset Publisher
2. Create a Web Content based on the new Structure and set the Widget Page as Display Page
1. Create a Content Page with an Asset Publisher and Publish it

*Expected behaviour:* urlViewInContext is available in both edit and view mode of the page.

Alternative Solutions that were discarded
========
Alternate solution [LPS-156378](https://issues.liferay.com/browse/LPS-156378) was discarded on https://github.com/liferay-echo/liferay-portal/pull/8549.