### PR TITLE
[TS] LPS-163085 adding assetcategories from page template

### DIFF
--- a/modules/apps/layout/layout-admin-web/build.gradle
+++ b/modules/apps/layout/layout-admin-web/build.gradle
@@ -10,6 +10,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
 	compileOnly project(":apps:asset:asset-display-page-api")
+	compileOnly project(":apps:asset:asset-entry-rel-api")
 	compileOnly project(":apps:asset:asset-list-api")
 	compileOnly project(":apps:asset:asset-taglib")
 	compileOnly project(":apps:change-tracking:change-tracking-spi")

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/AddContentLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/AddContentLayoutMVCActionCommand.java
@@ -14,6 +14,10 @@
 
 package com.liferay.layout.admin.web.internal.portlet.action;
 
+import com.liferay.asset.entry.rel.model.AssetEntryAssetCategoryRel;
+import com.liferay.asset.entry.rel.service.AssetEntryAssetCategoryRelLocalService;
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.admin.web.internal.handler.LayoutExceptionRequestHandler;
 import com.liferay.layout.admin.web.internal.security.permission.resource.LayoutPageTemplateEntryPermission;
@@ -36,6 +40,7 @@ import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.MultiSessionMessages;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -44,7 +49,9 @@ import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.sites.kernel.util.Sites;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
@@ -141,6 +148,31 @@ public class AddContentLayoutMVCActionCommand
 						masterLayoutPlid =
 							layoutPageTemplateEntryLayout.getMasterLayoutPlid();
 					}
+
+					AssetEntry assetEntry = _assetEntryLocalService.fetchEntry(
+						portal.getClassNameId(Layout.class),
+						layoutPageTemplateEntry.getPlid());
+
+					List<AssetEntryAssetCategoryRel>
+						assetEntryAssetCategoryRels =
+							_assetEntryAssetCategoryRelLocalService.
+								getAssetEntryAssetCategoryRelsByAssetEntryId(
+									assetEntry.getEntryId());
+
+					List<Long> assetCategoryIds = new ArrayList<>();
+
+					for (AssetEntryAssetCategoryRel assetEntryAssetCategoryRel :
+							assetEntryAssetCategoryRels) {
+
+						assetCategoryIds.add(
+							assetEntryAssetCategoryRel.getAssetCategoryId());
+					}
+
+					if (assetCategoryIds != null) {
+						serviceContext.setAssetCategoryIds(
+							ArrayUtil.toArray(
+								assetCategoryIds.toArray(new Long[0])));
+					}
 				}
 
 				layout = _layoutService.addLayout(
@@ -188,6 +220,13 @@ public class AddContentLayoutMVCActionCommand
 				actionRequest, actionResponse, exception);
 		}
 	}
+
+	@Reference
+	private AssetEntryAssetCategoryRelLocalService
+		_assetEntryAssetCategoryRelLocalService;
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
 
 	@Reference
 	private LayoutExceptionRequestHandler _layoutExceptionRequestHandler;


### PR DESCRIPTION
Hi Team,
Could you review this PR?
https://issues.liferay.com/browse/LPS-163085

Thank you and best regards,
Gábor

------------------------------------

**Reproduction Steps:**

1. Go to Categorization --> Categories --> create a vocabulary and add a category to it.
2. Go to Design --> Page Templates and add a template collection, then add a content page Template and publish it.
3. Go back to the page Templates and on the created Template click on configure and add the Category to it, then save it.
4. Go to Site Builder --> Pages and create a content Page based on the template and publish it.
5. Go to Site Builder --> Pages and click on the 3 dot menu beside the Page and select Configure, then check the category.

**Actual Result:** The category is not set on the Page.
**Expected Result:** The category is set on the page.

The category from the page template was not in the servicecontext when the page was created from a page template. I got the categoryId from the page template and passed it through the servicecontext. [AddContentLayoutMVCActionCommand](https://github.com/liferay/liferay-portal/blob/f2471ae7850b6937f6e662b274f0901413151dc8/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/AddContentLayoutMVCActionCommand.java) 