### PR TITLE
LPS-163499 Add missing attributes from ImagePicker.es

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/ImageImportDDMFormFieldValueTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/ImageImportDDMFormFieldValueTransformer.java
@@ -103,7 +103,8 @@ public class ImageImportDDMFormFieldValueTransformer
 
 			String fileEntryJSON = _toJSON(
 				importedFileEntry, jsonObject.getString("type"),
-				jsonObject.getString("alt"));
+				jsonObject.getString("alt"), jsonObject.getString("url"),
+				jsonObject.getString("height"), jsonObject.getString("width"));
 
 			value.addString(locale, fileEntryJSON);
 
@@ -167,13 +168,20 @@ public class ImageImportDDMFormFieldValueTransformer
 		}
 	}
 
-	private String _toJSON(FileEntry fileEntry, String type, String alt) {
+	private String _toJSON(
+		FileEntry fileEntry, String type, String alt, String url, String height,
+		String width) {
+
 		return JSONUtil.put(
 			"alt", alt
+		).put(
+			"description", alt
 		).put(
 			"fileEntryId", fileEntry.getFileEntryId()
 		).put(
 			"groupId", fileEntry.getGroupId()
+		).put(
+			"height", height
 		).put(
 			"name", fileEntry.getFileName()
 		).put(
@@ -188,7 +196,11 @@ public class ImageImportDDMFormFieldValueTransformer
 		).put(
 			"type", type
 		).put(
+			"url", url
+		).put(
 			"uuid", fileEntry.getUuid()
+		).put(
+			"width", width
 		).toString();
 	}
 


### PR DESCRIPTION
## Motivation

https://issues.liferay.com/browse/LPS-163499

## Proposed Solution

Add the missing attributes listed in https://github.com/liferay/liferay-portal-ee/blob/7.4.13-u42/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/ImagePicker/ImagePicker.es.js#L69-L78 so that they are accounted for during the LAR import.

## Steps to Verify

Starts from a clean bundle.

1. Create a web content structure "My Image" with an image field and set the field reference to "myimage"
1. Create a web content template "My Image" for the structure we added in step 1, and use the following template code:
```ftl
<#if (myimage.getData())?? && myimage.getData() != "">
	<img alt="${myimage.getAttribute("alt")}" data-fileentryid="${myimage.getAttribute("fileEntryId")}" src="${myimage.getAttribute("url")}" />
</#if>
```
3. Add a "My Image" web content titled "My Image WC", and point the image field to tree.png that gets included by default in a clean bundle
3. Add a web content display portlet to the home page and select the "My Image WC" content, but do not publish the changes
3. Enable local live staging
3. Navigate to the home page in staging and attempt to edit the page

**Expected behavior**:
The page shows the web content display portlet with our image

**Actual behavior**:
The page shows an error:

```
The following has evaluated to null or missing:
==> myimage.getAttribute("url") 
```

7. Edit the web content "My Image WC" and publish
7. Navigate back to the home page and confirm the image now shows up
7. Publish the page to live
7. Navigate to the live page

**Expected behavior**:
The page shows the web content display portlet with our image

**Actual behavior**:
The page shows an error:

```
The following has evaluated to null or missing:
==> myimage.getAttribute("url") 
```