### PR TITLE
LPS-163347 Add terms as a MUST clause to filter hits

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/query/contributor/JournalArticleModelPreFilterContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/query/contributor/JournalArticleModelPreFilterContributor.java
@@ -163,8 +163,13 @@ public class JournalArticleModelPreFilterContributor
 			booleanFilter.addRequiredTerm("headListable", Boolean.TRUE);
 		}
 		else if (headOrShowNonindexable && !relatedClassName) {
-			booleanFilter.addTerm("head", Boolean.TRUE);
-			booleanFilter.addTerm("headListable", Boolean.TRUE);
+			BooleanFilter headOrShowNonindexableFilter = new BooleanFilter();
+
+			headOrShowNonindexableFilter.addTerm("head", Boolean.TRUE);
+			headOrShowNonindexableFilter.addTerm("headListable", Boolean.TRUE);
+
+			booleanFilter.add(
+				headOrShowNonindexableFilter, BooleanClauseOccur.MUST);
 		}
 
 		boolean filterExpired = GetterUtil.getBoolean(


### PR DESCRIPTION
Sending this to fix https://issues.liferay.com/browse/LPS-163347 which is a regression of https://issues.liferay.com/browse/LPS-163003

 **Step to reproduce:**

- Add an Asset Publisher to a widget page
- Navigate to the configuration modal of Asset Publisher
- Change the asset selection to dynamic
- Add a web content based on Basic Web Content via Asset Publisher
- Edit the web content via Asset Publisher then publish

 **Expected Results:**

- There should be only one web content shown on Asset Publisher.

 **Actual Results:**

- There is a duplicated web content shown on Asset Publisher.

Instead of adding the terms in a SHOULD clause as I did in the LPS-163003 pr, I included them as a MUST clause in order to filter hits.
In the last pull I included them both as a SHOULD and it did not filter documents which had fields: head=false and headListable=false. After including them as a MUST, these documents won't be included as hits and the duplication of contents shown in the asset publisher will be avoided.
Thanks.