### PR TITLE
LPS-163433 Unnecessary calls to JournalArticle.getContent, when we really need DDMFormValues objects

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormValuesConverterUtil.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/DDMFormValuesConverterUtil.java
@@ -16,6 +16,8 @@ package com.liferay.dynamic.data.mapping.util;
 
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
+import com.liferay.dynamic.data.mapping.model.LocalizedValue;
+import com.liferay.dynamic.data.mapping.model.UnlocalizedValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -53,6 +55,13 @@ public class DDMFormValuesConverterUtil {
 						{
 							setInstanceId(StringUtil.randomString());
 							setName(ddmFormFieldName);
+
+							if (ddmFormField.isLocalizable()) {
+								setValue(new LocalizedValue());
+							}
+							else {
+								setValue(new UnlocalizedValue((String)null));
+							}
 						}
 					});
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/StructuredContentDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/StructuredContentDTOConverter.java
@@ -25,8 +25,6 @@ import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
-import com.liferay.dynamic.data.mapping.storage.Fields;
-import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
 import com.liferay.headless.delivery.dto.v1_0.ContentField;
 import com.liferay.headless.delivery.dto.v1_0.RenderedContent;
 import com.liferay.headless.delivery.dto.v1_0.StructuredContent;
@@ -44,7 +42,6 @@ import com.liferay.info.item.InfoItemServiceTracker;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleService;
 import com.liferay.journal.util.JournalContent;
-import com.liferay.journal.util.JournalConverter;
 import com.liferay.layout.display.page.LayoutDisplayPageProviderTracker;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
 import com.liferay.petra.string.StringPool;
@@ -138,8 +135,7 @@ public class StructuredContentDTOConverter
 					journalArticle.getAvailableLanguageIds());
 				contentFields = _toContentFields(
 					_dlAppService, _dlURLHelper, dtoConverterContext,
-					_fieldsToDDMFormValuesConverter, journalArticle,
-					_journalArticleService, _journalConverter,
+					journalArticle, _journalArticleService,
 					_layoutLocalService);
 				contentStructureId = ddmStructure.getStructureId();
 				creator = CreatorUtil.toCreator(
@@ -239,20 +235,12 @@ public class StructuredContentDTOConverter
 	private ContentField[] _toContentFields(
 			DLAppService dlAppService, DLURLHelper dlURLHelper,
 			DTOConverterContext dtoConverterContext,
-			FieldsToDDMFormValuesConverter fieldsToDDMFormValuesConverter,
 			JournalArticle journalArticle,
 			JournalArticleService journalArticleService,
-			JournalConverter journalConverter,
 			LayoutLocalService layoutLocalService)
 		throws Exception {
 
-		DDMStructure ddmStructure = journalArticle.getDDMStructure();
-
-		Fields fields = journalConverter.getDDMFields(
-			ddmStructure, journalArticle.getContent());
-
-		DDMFormValues ddmFormValues = fieldsToDDMFormValuesConverter.convert(
-			ddmStructure, fields);
+		DDMFormValues ddmFormValues = journalArticle.getDDMFormValues();
 
 		return TransformUtil.transformToArray(
 			ddmFormValues.getDDMFormFieldValues(),
@@ -377,9 +365,6 @@ public class StructuredContentDTOConverter
 	private DLURLHelper _dlURLHelper;
 
 	@Reference
-	private FieldsToDDMFormValuesConverter _fieldsToDDMFormValuesConverter;
-
-	@Reference
 	private GroupLocalService _groupLocalService;
 
 	@Reference
@@ -390,9 +375,6 @@ public class StructuredContentDTOConverter
 
 	@Reference
 	private JournalContent _journalContent;
-
-	@Reference
-	private JournalConverter _journalConverter;
 
 	@Reference
 	private LayoutDisplayPageProviderTracker _layoutDisplayPageProviderTracker;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.Field;
 import com.liferay.dynamic.data.mapping.storage.Fields;
 import com.liferay.dynamic.data.mapping.util.DDM;
+import com.liferay.dynamic.data.mapping.util.DDMFormValuesToFieldsConverter;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
 import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
 import com.liferay.dynamic.data.mapping.validator.DDMFormValuesValidator;
@@ -947,8 +948,8 @@ public class StructuredContentResourceImpl
 
 		DDMStructure ddmStructure = journalArticle.getDDMStructure();
 
-		Fields fields = _journalConverter.getDDMFields(
-			ddmStructure, journalArticle.getContent());
+		Fields fields = _ddmFormValuesToFieldsConverter.convert(
+			ddmStructure, journalArticle.getDDMFormValues());
 
 		if (ArrayUtil.isEmpty(contentFields)) {
 			return fields;
@@ -1219,6 +1220,9 @@ public class StructuredContentResourceImpl
 
 	@Reference
 	private DDM _ddm;
+
+	@Reference
+	private DDMFormValuesToFieldsConverter _ddmFormValuesToFieldsConverter;
 
 	@Reference
 	private DDMFormValuesValidator _ddmFormValuesValidator;

--- a/modules/apps/journal/journal-api/bnd.bnd
+++ b/modules/apps/journal/journal-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal API
 Bundle-SymbolicName: com.liferay.journal.api
-Bundle-Version: 18.2.1
+Bundle-Version: 18.3.0
 Export-Package:\
 	com.liferay.journal.configuration,\
 	com.liferay.journal.constants,\

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticle.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticle.java
@@ -102,6 +102,9 @@ public interface JournalArticle
 
 	public String getContentByLocale(String languageId);
 
+	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
+		getDDMFormValues();
+
 	public com.liferay.dynamic.data.mapping.model.DDMStructure
 		getDDMStructure();
 

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleWrapper.java
@@ -429,6 +429,13 @@ public class JournalArticleWrapper
 	}
 
 	@Override
+	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
+		getDDMFormValues() {
+
+		return model.getDDMFormValues();
+	}
+
+	@Override
 	public com.liferay.dynamic.data.mapping.model.DDMStructure
 		getDDMStructure() {
 

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/model/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/model/packageinfo
@@ -1,1 +1,1 @@
-version 9.1.0
+version 9.2.0

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/asset/auto/tagger/text/extractor/JournalArticleTextExtractor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/asset/auto/tagger/text/extractor/JournalArticleTextExtractor.java
@@ -15,18 +15,12 @@
 package com.liferay.journal.internal.asset.auto.tagger.text.extractor;
 
 import com.liferay.asset.auto.tagger.text.extractor.TextExtractor;
-import com.liferay.dynamic.data.mapping.model.DDMStructure;
-import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
-import com.liferay.dynamic.data.mapping.storage.Fields;
 import com.liferay.dynamic.data.mapping.util.DDMIndexer;
-import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
 import com.liferay.journal.model.JournalArticle;
-import com.liferay.journal.util.JournalConverter;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.Portal;
 
 import java.util.Locale;
 
@@ -44,23 +38,10 @@ public class JournalArticleTextExtractor
 
 	@Override
 	public String extract(JournalArticle journalArticle, Locale locale) {
-		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
-			_portal.getSiteGroupId(journalArticle.getGroupId()),
-			_portal.getClassNameId(JournalArticle.class),
-			journalArticle.getDDMStructureKey(), true);
-
-		if (ddmStructure == null) {
-			return StringPool.BLANK;
-		}
-
 		DDMFormValues ddmFormValues = null;
 
 		try {
-			Fields fields = _journalConverter.getDDMFields(
-				ddmStructure, journalArticle.getDocument());
-
-			ddmFormValues = _fieldsToDDMFormValuesConverter.convert(
-				ddmStructure, fields);
+			ddmFormValues = journalArticle.getDDMFormValues();
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -75,7 +56,7 @@ public class JournalArticleTextExtractor
 		}
 
 		return _ddmIndexer.extractIndexableAttributes(
-			ddmStructure, ddmFormValues, locale);
+			journalArticle.getDDMStructure(), ddmFormValues, locale);
 	}
 
 	@Override
@@ -88,17 +69,5 @@ public class JournalArticleTextExtractor
 
 	@Reference
 	private DDMIndexer _ddmIndexer;
-
-	@Reference
-	private DDMStructureLocalService _ddmStructureLocalService;
-
-	@Reference
-	private FieldsToDDMFormValuesConverter _fieldsToDDMFormValuesConverter;
-
-	@Reference
-	private JournalConverter _journalConverter;
-
-	@Reference
-	private Portal _portal;
 
 }

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelDocumentContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelDocumentContributor.java
@@ -86,8 +86,7 @@ public class JournalArticleModelDocumentContributor
 			document.addKeyword(
 				Field.CLASS_TYPE_ID, ddmStructure.getStructureId());
 
-			ddmFormValues = _ddmFieldLocalService.getDDMFormValues(
-				ddmStructure.getDDMForm(), journalArticle.getId());
+			ddmFormValues = journalArticle.getDDMFormValues();
 
 			if (ddmFormValues != null) {
 				for (Locale contentAvailableLocale :

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -477,11 +477,13 @@ public class JournalConverterImpl implements JournalConverter {
 			return _getSelectValue(dynamicContentElement);
 		}
 
+		String value = dynamicContentElement.getText();
+
 		return FieldConstants.getSerializable(
 			LocaleUtil.ROOT,
 			LocaleUtil.fromLanguageId(
 				dynamicContentElement.attributeValue("language-id")),
-			ddmFormField.getDataType(), dynamicContentElement.getText());
+			ddmFormField.getDataType(), value.trim());
 	}
 
 	private String _getSelectValue(Element dynamicContentElement) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -15,6 +15,7 @@
 package com.liferay.journal.model.impl;
 
 import com.liferay.document.library.kernel.model.DLFolderConstants;
+import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.service.DDMFieldLocalServiceUtil;
@@ -22,6 +23,7 @@ import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalServiceUtil;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.storage.Fields;
+import com.liferay.dynamic.data.mapping.util.DDMFormValuesConverterUtil;
 import com.liferay.dynamic.data.mapping.util.DDMFormValuesToFieldsConverter;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
@@ -266,6 +268,27 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 		}
 
 		return getContentByLocale(getDocument(), languageId, tokens);
+	}
+
+	@Override
+	public DDMFormValues getDDMFormValues() {
+		DDMStructure ddmStructure = getDDMStructure();
+
+		if (ddmStructure == null) {
+			return null;
+		}
+
+		DDMForm ddmForm = ddmStructure.getDDMForm();
+
+		DDMFormValues ddmFormValues = DDMFieldLocalServiceUtil.getDDMFormValues(
+			ddmForm, getId());
+
+		ddmFormValues.setDDMFormFieldValues(
+			DDMFormValuesConverterUtil.addMissingDDMFormFieldValues(
+				ddmForm.getDDMFormFields(),
+				ddmFormValues.getDDMFormFieldValuesMap(true)));
+
+		return ddmFormValues;
 	}
 
 	@Override

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -283,10 +283,12 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 		DDMFormValues ddmFormValues = DDMFieldLocalServiceUtil.getDDMFormValues(
 			ddmForm, getId());
 
-		ddmFormValues.setDDMFormFieldValues(
-			DDMFormValuesConverterUtil.addMissingDDMFormFieldValues(
-				ddmForm.getDDMFormFields(),
-				ddmFormValues.getDDMFormFieldValuesMap(true)));
+		if (ddmFormValues != null) {
+			ddmFormValues.setDDMFormFieldValues(
+				DDMFormValuesConverterUtil.addMissingDDMFormFieldValues(
+					ddmForm.getDDMFormFields(),
+					ddmFormValues.getDDMFormFieldValuesMap(true)));
+		}
 
 		return ddmFormValues;
 	}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1147,7 +1147,9 @@ public class JournalArticleLocalServiceImpl
 				locale, getUniqueUrlTitle(id, groupId, newArticleId, urlTitle));
 		}
 
-		Locale locale = getArticleDefaultLocale(oldArticle.getContent());
+		DDMFormValues ddmFormValues = oldArticle.getDDMFormValues();
+
+		Locale locale = ddmFormValues.getDefaultLocale();
 
 		String newURLTitle = newUniqueURLTitleMap.get(locale);
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/JournalArticleDDMFormValuesReader.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/JournalArticleDDMFormValuesReader.java
@@ -16,15 +16,9 @@ package com.liferay.journal.web.internal.asset;
 
 import com.liferay.asset.kernel.model.BaseDDMFormValuesReader;
 import com.liferay.dynamic.data.mapping.kernel.DDMFormValues;
-import com.liferay.dynamic.data.mapping.model.DDMStructure;
-import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
-import com.liferay.dynamic.data.mapping.storage.Fields;
 import com.liferay.dynamic.data.mapping.util.DDMBeanTranslatorUtil;
-import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
 import com.liferay.journal.model.JournalArticle;
-import com.liferay.journal.util.JournalConverter;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.util.PortalUtil;
 
 /**
  * @author Adolfo Pérez
@@ -39,17 +33,7 @@ public final class JournalArticleDDMFormValuesReader
 	@Override
 	public DDMFormValues getDDMFormValues() throws PortalException {
 		try {
-			DDMStructure ddmStructure =
-				DDMStructureLocalServiceUtil.getStructure(
-					PortalUtil.getSiteGroupId(_article.getGroupId()),
-					PortalUtil.getClassNameId(JournalArticle.class),
-					_article.getDDMStructureKey(), true);
-
-			Fields fields = _journalConverter.getDDMFields(
-				ddmStructure, _article.getContent());
-
-			return DDMBeanTranslatorUtil.translate(
-				_fieldsToDDMFormValuesConverter.convert(ddmStructure, fields));
+			return DDMBeanTranslatorUtil.translate(_article.getDDMFormValues());
 		}
 		catch (Exception exception) {
 			throw new PortalException(
@@ -58,18 +42,6 @@ public final class JournalArticleDDMFormValuesReader
 		}
 	}
 
-	public void setFieldsToDDMFormValuesConverter(
-		FieldsToDDMFormValuesConverter fieldsToDDMFormValuesConverter) {
-
-		_fieldsToDDMFormValuesConverter = fieldsToDDMFormValuesConverter;
-	}
-
-	public void setJournalConverter(JournalConverter journalConverter) {
-		_journalConverter = journalConverter;
-	}
-
 	private final JournalArticle _article;
-	private FieldsToDDMFormValuesConverter _fieldsToDDMFormValuesConverter;
-	private JournalConverter _journalConverter;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java
@@ -20,7 +20,6 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.asset.kernel.model.BaseJSPAssetRenderer;
 import com.liferay.asset.kernel.model.DDMFormValuesReader;
-import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.constants.JournalPortletKeys;
@@ -28,7 +27,6 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleDisplay;
 import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.journal.util.JournalContent;
-import com.liferay.journal.util.JournalConverter;
 import com.liferay.journal.web.internal.asset.JournalArticleDDMFormValuesReader;
 import com.liferay.journal.web.internal.security.permission.resource.JournalArticlePermission;
 import com.liferay.journal.web.internal.util.JournalHelperUtil;
@@ -135,15 +133,7 @@ public class JournalArticleAssetRenderer
 
 	@Override
 	public DDMFormValuesReader getDDMFormValuesReader() {
-		JournalArticleDDMFormValuesReader journalArticleDDMFormValuesReader =
-			new JournalArticleDDMFormValuesReader(_article);
-
-		journalArticleDDMFormValuesReader.setFieldsToDDMFormValuesConverter(
-			_fieldsToDDMFormValuesConverter);
-		journalArticleDDMFormValuesReader.setJournalConverter(
-			_journalConverter);
-
-		return journalArticleDDMFormValuesReader;
+		return new JournalArticleDDMFormValuesReader(_article);
 	}
 
 	@Override
@@ -519,18 +509,8 @@ public class JournalArticleAssetRenderer
 			assetDisplayPageFriendlyURLProvider;
 	}
 
-	public void setFieldsToDDMFormValuesConverter(
-		FieldsToDDMFormValuesConverter fieldsToDDMFormValuesConverter) {
-
-		_fieldsToDDMFormValuesConverter = fieldsToDDMFormValuesConverter;
-	}
-
 	public void setJournalContent(JournalContent journalContent) {
 		_journalContent = journalContent;
-	}
-
-	public void setJournalConverter(JournalConverter journalConverter) {
-		_journalConverter = journalConverter;
 	}
 
 	private JournalArticleDisplay _getArticleDisplay(
@@ -672,10 +652,8 @@ public class JournalArticleAssetRenderer
 	private final JournalArticle _article;
 	private AssetDisplayPageFriendlyURLProvider
 		_assetDisplayPageFriendlyURLProvider;
-	private FieldsToDDMFormValuesConverter _fieldsToDDMFormValuesConverter;
 	private final HtmlParser _htmlParser;
 	private JournalContent _journalContent;
-	private JournalConverter _journalConverter;
 	private JournalServiceConfiguration _journalServiceConfiguration;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRendererFactory.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRendererFactory.java
@@ -21,7 +21,6 @@ import com.liferay.asset.kernel.model.BaseAssetRendererFactory;
 import com.liferay.asset.kernel.model.ClassTypeReader;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
-import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
 import com.liferay.journal.constants.JournalConstants;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.exception.NoSuchArticleException;
@@ -274,10 +273,7 @@ public class JournalArticleAssetRendererFactory
 
 		journalArticleAssetRenderer.setAssetDisplayPageFriendlyURLProvider(
 			_assetDisplayPageFriendlyURLProvider);
-		journalArticleAssetRenderer.setFieldsToDDMFormValuesConverter(
-			_fieldsToDDMFormValuesConverter);
 		journalArticleAssetRenderer.setJournalContent(_journalContent);
-		journalArticleAssetRenderer.setJournalConverter(_journalConverter);
 		journalArticleAssetRenderer.setServletContext(_servletContext);
 
 		return journalArticleAssetRenderer;
@@ -298,9 +294,6 @@ public class JournalArticleAssetRendererFactory
 	)
 	private ModelResourcePermission<DDMStructure>
 		_ddmStructureModelResourcePermission;
-
-	@Reference
-	private FieldsToDDMFormValuesConverter _fieldsToDDMFormValuesConverter;
 
 	@Reference
 	private HtmlParser _htmlParser;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFieldValuesProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemFieldValuesProvider.java
@@ -19,6 +19,7 @@ import com.liferay.asset.info.item.provider.AssetEntryInfoItemFieldSetProvider;
 import com.liferay.dynamic.data.mapping.info.item.provider.DDMFormValuesInfoFieldValuesProvider;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.service.DDMFieldLocalService;
 import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
 import com.liferay.expando.info.item.provider.ExpandoInfoItemFieldSetProvider;
 import com.liferay.info.constants.InfoDisplayWebKeys;
@@ -40,7 +41,6 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleDisplay;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.util.JournalContent;
-import com.liferay.journal.util.JournalConverter;
 import com.liferay.journal.util.JournalHelper;
 import com.liferay.journal.web.internal.asset.JournalArticleDDMFormValuesReader;
 import com.liferay.journal.web.internal.info.item.JournalArticleInfoItemFields;
@@ -130,11 +130,6 @@ public class JournalArticleInfoItemFieldValuesProvider
 
 		JournalArticleDDMFormValuesReader journalArticleDDMFormValuesReader =
 			new JournalArticleDDMFormValuesReader(article);
-
-		journalArticleDDMFormValuesReader.setFieldsToDDMFormValuesConverter(
-			_fieldsToDDMFormValuesConverter);
-		journalArticleDDMFormValuesReader.setJournalConverter(
-			_journalConverter);
 
 		try {
 			return _ddmFormValuesInfoFieldValuesProvider.getInfoFieldValues(
@@ -434,6 +429,9 @@ public class JournalArticleInfoItemFieldValuesProvider
 		_assetEntryInfoItemFieldSetProvider;
 
 	@Reference
+	private DDMFieldLocalService _ddmFieldLocalService;
+
+	@Reference
 	private DDMFormValuesInfoFieldValuesProvider
 		_ddmFormValuesInfoFieldValuesProvider;
 
@@ -459,9 +457,6 @@ public class JournalArticleInfoItemFieldValuesProvider
 
 	@Reference
 	private JournalContent _journalContent;
-
-	@Reference
-	private JournalConverter _journalConverter;
 
 	@Reference
 	private JournalHelper _journalHelper;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-163433

In [LPS-129058](https://issues.liferay.com/browse/LPS-129058) the JournalArticle xml was extracted to the DDM* database tables.

After that LPS changes, the JournalArticle.getContent now calls the DDM API to get the DDMFormValues object and generate the XML, see:
https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java#L226-L254

But we have several calls to JournalArticle.getContent that parses the content XML to generate the DDMFormValues so in the end we are doing unnecessary transformations:

- getContent: gets the DDMFormValues => Fields => and generates the XML calling journalConverter.getContent
- the method that calls getContent, needs the DDMFormValues or the Fields, so it parses the XML to generate them

To avoid this:

1. In https://github.com/liferay-echo/liferay-portal/commit/529ce6ea5cbb10c577ebb164d432b264bb63c467 I have created a new `JournalArticleImpl.getDDMFormValues()` method that calls the **DDMFieldLocalServiceUtil.getDDMFormValues** method
2. In https://github.com/liferay-echo/liferay-portal/commit/25f69a79da1462a5ad6df724154f22a60fba1d81 I have applied this method in all getContent calls where we really need the DDMFormValues object
3. I have added two commits to fix some test problems, see https://github.com/liferay-echo/liferay-portal/commit/a9331d7a8253a7ff55ec87f4f776fa16d264df2d and https://github.com/liferay-echo/liferay-portal/commit/f157d26c24bf87da1129a0798c9a3d48ea92b18d

Let me know if you have any question.