### PR TITLE
[TS] LPS-164130 | Canonical URLs contain duplicate locales on Display page when using locale.prepend.friendly.url.style=2

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8326,13 +8326,25 @@ public class PortalImpl implements Portal {
 				alternateURLs.put(locale, alternateURL);
 			}
 			else {
-				alternateURLs.put(
-					locale,
-					StringBundler.concat(
-						canonicalURLPrefix,
-						_buildI18NPath(
-							languageId, locale, themeDisplay.getSiteGroup()),
-						alternateURLSuffix));
+				String i18Npath = _buildI18NPath(
+					languageId, locale, themeDisplay.getSiteGroup());
+
+				if (alternateURLSuffix.contains(
+						i18Npath + StringPool.FORWARD_SLASH)) {
+
+					alternateURLs.put(
+						locale, canonicalURLPrefix + alternateURLSuffix);
+				}
+				else {
+					alternateURLs.put(
+						locale,
+						StringBundler.concat(
+							canonicalURLPrefix,
+							_buildI18NPath(
+								languageId, locale,
+								themeDisplay.getSiteGroup()),
+							alternateURLSuffix));
+				}
 			}
 		}
 


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-164130
Thank you!

------
**Steps to reproduce:**

1. Put locale.prepend.friendly.url.style=2 in the portal-ext
2. Create a Display page template for basic web content, mark it as default
3. Create a basic web content, publish it
4. Open the web content in incognito mode, check the page source

**Current behavior:** Locales are duplicated in the canonical URLs
**Expected behavior:** Locales shouldn't be duplicated 


Based on my tests the root cause of the issue is that the alternateURL generator adds the language path without checking if it's there. At that point, the display page already added the language path to the web content friendlyURL path.