### PR TITLE
LPS-164130 Fix: Canonical URLs contain duplicate locales on Display page when using locale.prepend.friendly.url.style=2

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8320,9 +8320,12 @@ public class PortalImpl implements Portal {
 				alternateURL = canonicalURLPrefix.concat(alternateURLSuffix);
 			}
 
-			if (siteDefaultLocale.equals(locale) &&
-				(PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE != 2)) {
+			if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
+				alternateURL = canonicalURLPrefix + alternateURLSuffix;
 
+				alternateURLs.put(locale, alternateURL);
+			}
+			else if (siteDefaultLocale.equals(locale)) {
 				alternateURLs.put(locale, alternateURL);
 			}
 			else {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8323,6 +8323,15 @@ public class PortalImpl implements Portal {
 			if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
 				alternateURL = canonicalURLPrefix + alternateURLSuffix;
 
+				if (siteDefaultLocale.equals(locale)) {
+					String i18nPath = _buildI18NPath(
+						siteDefaultLocale, layout.getGroup());
+
+					alternateURL =
+						canonicalURLPrefix + i18nPath +
+							alternateURLSuffix;
+				}
+
 				alternateURLs.put(locale, alternateURL);
 			}
 			else if (siteDefaultLocale.equals(locale)) {

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8223,11 +8223,11 @@ public class PortalImpl implements Portal {
 		String siteDefaultLocaleI18nPath = _buildI18NPath(
 			siteDefaultLocale, layout.getGroup());
 
-		if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
-			if (canonicalURLSuffix.startsWith(siteDefaultLocaleI18nPath)) {
-				canonicalURLSuffix = canonicalURLSuffix.substring(
-					siteDefaultLocaleI18nPath.length());
-			}
+		if ((PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) &&
+			canonicalURLSuffix.startsWith(siteDefaultLocaleI18nPath)) {
+
+			canonicalURLSuffix = canonicalURLSuffix.substring(
+				siteDefaultLocaleI18nPath.length());
 		}
 
 		String groupFriendlyURL = StringPool.BLANK;

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -8220,13 +8220,13 @@ public class PortalImpl implements Portal {
 
 		String canonicalURLSuffix = canonicalURL.substring(pos);
 
-		if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
-			String i18nPath = _buildI18NPath(
-				siteDefaultLocale, layout.getGroup());
+		String siteDefaultLocaleI18nPath = _buildI18NPath(
+			siteDefaultLocale, layout.getGroup());
 
-			if (canonicalURLSuffix.startsWith(i18nPath)) {
+		if (PropsValues.LOCALE_PREPEND_FRIENDLY_URL_STYLE == 2) {
+			if (canonicalURLSuffix.startsWith(siteDefaultLocaleI18nPath)) {
 				canonicalURLSuffix = canonicalURLSuffix.substring(
-					i18nPath.length());
+					siteDefaultLocaleI18nPath.length());
 			}
 		}
 
@@ -8324,11 +8324,8 @@ public class PortalImpl implements Portal {
 				alternateURL = canonicalURLPrefix + alternateURLSuffix;
 
 				if (siteDefaultLocale.equals(locale)) {
-					String i18nPath = _buildI18NPath(
-						siteDefaultLocale, layout.getGroup());
-
 					alternateURL =
-						canonicalURLPrefix + i18nPath +
+						canonicalURLPrefix + siteDefaultLocaleI18nPath +
 							alternateURLSuffix;
 				}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-164130

cc: @bakayattila