### PR TITLE
LPS-164576 Use "Private Page Index" if LayoutCrawler can't retrieve content

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -61,6 +61,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PropsKeys;
 import com.liferay.portal.kernel.util.PropsUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -77,6 +78,7 @@ import java.security.Principal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
@@ -168,8 +170,11 @@ public class LayoutModelDocumentContributor
 			layout.getGroupId());
 
 		if (_isUseLayoutCrawler(layout)) {
-			for (Locale locale : locales) {
+			Iterator<Locale> iterator = locales.iterator();
+
+			while (iterator.hasNext()) {
 				String content = StringPool.BLANK;
+				Locale locale = iterator.next();
 
 				try {
 					content = _layoutCrawler.getLayoutContent(layout, locale);
@@ -180,10 +185,16 @@ public class LayoutModelDocumentContributor
 					}
 				}
 
-				_addLocalizedContentField(content, document, locale);
+				if (Validator.isNotNull(content)) {
+					iterator.remove();
+
+					_addLocalizedContentField(content, document, locale);
+				}
 			}
 
-			return;
+			if (SetUtil.isEmpty(locales)) {
+				return;
+			}
 		}
 
 		HttpServletRequest httpServletRequest = null;

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -157,6 +157,13 @@ public class LayoutModelDocumentContributor
 			return;
 		}
 
+		_addContent(document, layout, layoutPageTemplateStructure);
+	}
+
+	private void _addContent(
+		Document document, Layout layout,
+		LayoutPageTemplateStructure layoutPageTemplateStructure) {
+
 		Set<Locale> locales = _language.getAvailableLocales(
 			layout.getGroupId());
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -78,6 +78,7 @@ import java.security.Principal;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Enumeration;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
@@ -166,8 +167,8 @@ public class LayoutModelDocumentContributor
 		Document document, Layout layout,
 		LayoutPageTemplateStructure layoutPageTemplateStructure) {
 
-		Set<Locale> locales = _language.getAvailableLocales(
-			layout.getGroupId());
+		Set<Locale> locales = new HashSet<>(
+			_language.getAvailableLocales(layout.getGroupId()));
 
 		if (_isUseLayoutCrawler(layout)) {
 			Iterator<Locale> iterator = locales.iterator();


### PR DESCRIPTION
Motivation
=======
[LPS-164576](https://issues.liferay.com/browse/LPS-164576)
Ideally LayoutCrawler should be able to handle Public Page indexing, but should it fail because of any reasons (proxy settings, Crawler override settings being bad) the Private Page Indexing logic is not used as a fallback

Proposed Solution
========
Should the Crawler return an empty String for any locale, try the Private Page logic for that locale

Steps to Verify
========
1. Go to Instance Settings
2. Search for Crawler
3. Open Layout Crawler Client Configuration
4. Set Enabled=true and "Hostname or IP Address" = "invalid"
5. Press Save
6. Create a Page with a paragraph with the text "help"
7. Publish the page
8. Search for "help"

Expected behaviour: Page is found
Actual behaviour: Page is not found