### PR TITLE
[TS] LPS-164405 Site page Export/Import with a JournalArticle configured in multiple pages with references to DM and WC, in some situations they end with wrong references after import

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java
@@ -208,8 +208,6 @@ public class JournalArticleExportImportContentProcessor
 		if (GetterUtil.getBoolean(entityElement.attributeValue("cached"))) {
 			portletDataContext.removePrimaryKey(
 				ExportImportPathUtil.getModelPath(stagedModel));
-
-			return content;
 		}
 
 		content = _replaceImportJournalArticleReferences(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-164405

This was reproduced by a customer in a Remote Staging publication from Staging to Live, but after some investigations, I was able to isolate the issue and reproduce it with a simple export/import operation.

The issue is caused by [LPS-128533](https://issues.liferay.com/browse/LPS-128533) and it is produced with following preconditions:

- You have a JournalArticle created from a structure with links to DM and WC
- The JournalArticle is included in two pages
- When you export the LAR file, you are only exporting the pages, you are not exporting the contents

The exact steps to reproduce the issue are in the [LPS-164405](https://issues.liferay.com/browse/LPS-164405) description

After my change, we leave the logic similar to this https://github.com/liferay-echo/liferay-portal/blob/73aea653d5007ff6c2e46fb81c625161b92dcd2e/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/content/processor/JournalArticleExportImportContentProcessor.java#L563-L564 that was included in LPS-88743, see commit: https://github.com/liferay-echo/liferay-portal/commit/d765c5c5106c5981e57fb2eaeaa12dfdf64dc3fd

------

This PR was originally sent to the Staging Team here https://github.com/liferay-staging/liferay-portal/pull/131 but they said this change should be reviewed by the Echo Team, see this comment: https://github.com/liferay-staging/liferay-portal/pull/131#issuecomment-1266587074

Regards,
Jorge