### PR TITLE
[TECHNICAL SUPPORT] LPS-165205 Fragment CSS is included multiple times for the same Fragments from U32

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
@@ -251,9 +251,11 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 		sb.append(html);
 		sb.append("</div>");
 
+		FragmentEntryLink fragmentEntryLink =
+			fragmentRendererContext.getFragmentEntryLink();
+
 		if (Validator.isNotNull(css)) {
-			String outputKey =
-				fragmentRendererContext.getFragmentElementId() + "_CSS";
+			String outputKey = fragmentEntryLink.getFragmentEntryId() + "_CSS";
 
 			OutputData outputData = (OutputData)httpServletRequest.getAttribute(
 				WebKeys.OUTPUT_DATA);
@@ -294,9 +296,6 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 					WebKeys.OUTPUT_DATA, outputData);
 			}
 		}
-
-		FragmentEntryLink fragmentEntryLink =
-			fragmentRendererContext.getFragmentEntryLink();
 
 		if (Validator.isNotNull(fragmentEntryLink.getJs())) {
 			sb.append("<script>(function() {");


### PR DESCRIPTION
Hello,

**Motivation**
[LPS-165205](https://issues.liferay.com/browse/LPS-165205),
The CSS is duplicated when we render multiple instances of the same Fragment. This issue was introduced in [LPS-157131](https://issues.liferay.com/browse/LPS-157131)

**Proposed Solution**
In order to not duplicate CSS when we render the same fragment multiple times, we have to create the key for the css from The FragmentEntryLinkId, which is the same across multiple instances of the same fragment.

**Steps to Verify**
Go to Design → Fragments and Create a new Fragment Set
Create a new Fragment with some CSS
Place it to the home page multiple times
Inspect it in DevTools
_**Actual behavior:**_
The styling is present with every fragment.

_**Expected behavior:**_
Prior to update 32 the styling tag was only present with the first fragment.

Please review my changes,

Thanks