### PR TITLE
[TS] LPS-165413 File structure naming persists though the Master Template is renamed

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionLocalServiceImpl.java
@@ -226,6 +226,9 @@ public class LayoutPageTemplateCollectionLocalServiceImpl
 		}
 
 		layoutPageTemplateCollection.setModifiedDate(new Date());
+		layoutPageTemplateCollection.setLayoutPageTemplateCollectionKey(
+			_generateLayoutPageTemplateCollectionKey(
+				layoutPageTemplateCollection.getGroupId(), name));
 		layoutPageTemplateCollection.setName(name);
 		layoutPageTemplateCollection.setDescription(description);
 

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
@@ -622,6 +622,9 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 		}
 
 		layoutPageTemplateEntry.setModifiedDate(new Date());
+		layoutPageTemplateEntry.setLayoutPageTemplateEntryKey(
+			_generateLayoutPageTemplateEntryKey(
+				layoutPageTemplateEntry.getGroupId(), name));
 		layoutPageTemplateEntry.setName(name);
 		layoutPageTemplateEntry.setStatus(status);
 		layoutPageTemplateEntry.setStatusByUserId(userId);
@@ -650,6 +653,9 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 			layoutPageTemplateEntry.getType());
 
 		layoutPageTemplateEntry.setModifiedDate(new Date());
+		layoutPageTemplateEntry.setLayoutPageTemplateEntryKey(
+			_generateLayoutPageTemplateEntryKey(
+				layoutPageTemplateEntry.getGroupId(), name));
 		layoutPageTemplateEntry.setName(name);
 
 		layoutPageTemplateEntry =

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateCollectionServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateCollectionServiceTest.java
@@ -488,7 +488,9 @@ public class LayoutPageTemplateCollectionServiceTest {
 		Assert.assertEquals(
 			"Layout Page Template Collection New",
 			layoutPageTemplateCollection.getName());
-
+		Assert.assertEquals(
+			"layout-page-template-collection-new",
+			layoutPageTemplateCollection.getLayoutPageTemplateCollectionKey());
 		Assert.assertEquals(
 			"Description New", layoutPageTemplateCollection.getDescription());
 	}

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryServiceTest.java
@@ -328,20 +328,27 @@ public class LayoutPageTemplateEntryServiceTest {
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			LayoutPageTemplateTestUtil.addLayoutPageTemplateEntry(
 				_layoutPageTemplateCollection.
-					getLayoutPageTemplateCollectionId());
-
-		String updatedName = RandomTestUtil.randomString();
-
-		_layoutPageTemplateEntryService.updateLayoutPageTemplateEntry(
-			layoutPageTemplateEntry.getLayoutPageTemplateEntryId(),
-			updatedName);
+					getLayoutPageTemplateCollectionId(),
+				"tiger");
 
 		LayoutPageTemplateEntry persistedLayoutPageTemplateEntry =
 			_layoutPageTemplateEntryPersistence.fetchByPrimaryKey(
 				layoutPageTemplateEntry.getLayoutPageTemplateEntryId());
 
 		Assert.assertEquals(
-			updatedName, persistedLayoutPageTemplateEntry.getName());
+			"tiger", persistedLayoutPageTemplateEntry.getName());
+		Assert.assertEquals(
+			"tiger",
+			persistedLayoutPageTemplateEntry.getLayoutPageTemplateEntryKey());
+
+		_layoutPageTemplateEntryService.updateLayoutPageTemplateEntry(
+			layoutPageTemplateEntry.getLayoutPageTemplateEntryId(), "leopard");
+
+		Assert.assertEquals(
+			"leopard", persistedLayoutPageTemplateEntry.getName());
+		Assert.assertEquals(
+			"leopard",
+			persistedLayoutPageTemplateEntry.getLayoutPageTemplateEntryKey());
 	}
 
 	@Test


### PR DESCRIPTION
Hi guys,
Please help review this PR and leave your comments. Thanks.
Ticket: https://issues.liferay.com/browse/LPS-165413
Chi's Solution:
Exported file structure uses the template entry key as the subfolder name, however, when changing the name for an existing template, it is not updated accordingly, we should update the template entry key when changing the name as it is in the add new template function. Therefore the exported structure file will base on the latest name.
cc @chileces