### PR TITLE
LPS-165485 - Selecting an option from the "Page Design" Select should keep focus on the button that opens the dropdown.

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/EditModeSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/EditModeSelector.js
@@ -29,7 +29,6 @@ export default function EditModeSelector() {
 	const canSwitchEditMode = useSelector(selectCanSwitchEditMode);
 	const dispatch = useDispatch();
 
-	const [active, setActive] = useState(false);
 	const [editMode, setEditMode] = useState(
 		canSwitchEditMode ? EDIT_MODES.pageDesign : EDIT_MODES.contentEditing
 	);
@@ -54,15 +53,14 @@ export default function EditModeSelector() {
 
 	return (
 		<ClayDropDown
-			active={active}
 			alignmentPosition={Align.BottomLeft}
+			closeOnClick
 			menuElementAttrs={{
 				className: 'page-editor__edit-mode-dropdown-menu',
 				containerProps: {
 					className: 'cadmin',
 				},
 			}}
-			onActiveChange={setActive}
 			trigger={
 				<ClayButton
 					className="form-control-select page-editor__edit-mode-selector text-left"
@@ -78,7 +76,6 @@ export default function EditModeSelector() {
 			<ClayDropDown.ItemList>
 				<ClayDropDown.Item
 					onClick={() => {
-						setActive(false);
 						setEditMode(EDIT_MODES.pageDesign);
 
 						dispatch(
@@ -94,7 +91,6 @@ export default function EditModeSelector() {
 
 				<ClayDropDown.Item
 					onClick={() => {
-						setActive(false);
 						setEditMode(EDIT_MODES.contentEditing);
 
 						dispatch(


### PR DESCRIPTION
Motivation
=======
Selecting an option from the "Page Design" Select causes the focus to move the end of the page instead of staying.

https://issues.liferay.com/browse/LPS-165485

Proposed Solution
========
This dropdown's active state was being controlled by the page editor, but it doesn't need to be. The ClayDropdown can control it's own active state, and when it does it properly handles which element should be focused when an item is clicked.

Steps to Verify
========
1. Navigate to the page editor.
2. Press tab until the "Page Design" select is focused. 
3. Press 'Enter' or 'Space' to open the select.
4. Use the down arrow keys to move to an item.
5. Press 'Enter' to select an item.

Expected Result:
Focus stays on the Button that opens the select.

Actual Result:
Focus moves to the bottom of the page.
