### PR TITLE
LPS-165401 LayoutClassedModelUsage's containerType field not set correctly on impor

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
@@ -94,9 +94,6 @@ public class LayoutClassedModelUsageStagedModelDataHandler
 			layoutClassedModelUsage);
 
 		element.addAttribute(
-			"layout-classed-model-class-name",
-			_portal.getClassName(layoutClassedModelUsage.getClassNameId()));
-		element.addAttribute(
 			"layout-classed-model-container-class-name",
 			_portal.getClassName(layoutClassedModelUsage.getContainerType()));
 
@@ -240,9 +237,8 @@ public class LayoutClassedModelUsageStagedModelDataHandler
 
 		LayoutClassedModelUsage existingLayoutClassedModelUsage =
 			_layoutClassedModelUsageLocalService.fetchLayoutClassedModelUsage(
-				_portal.getClassNameId(
-					element.attributeValue("layout-classed-model-class-name")),
-				classPK, importedLayoutClassedModelUsage.getContainerKey(),
+				importedLayoutClassedModelUsage.getClassNameId(), classPK,
+				importedLayoutClassedModelUsage.getContainerKey(),
 				containerTypeClassNameId, plid);
 
 		if (existingLayoutClassedModelUsage == null) {

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
@@ -194,7 +194,7 @@ public class LayoutClassedModelUsageStagedModelDataHandler
 		importedLayoutClassedModelUsage.setPlid(plid);
 
 		importedLayoutClassedModelUsage.setClassNameId(
-			_portal.getClassNameId(layoutClassedModelUsage.getClassName()));
+			layoutClassedModelUsage.getClassNameId());
 
 		Map<Long, Long> classPKs =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
@@ -216,6 +216,9 @@ public class LayoutClassedModelUsageStagedModelDataHandler
 			element.attributeValue(
 				"layout-classed-model-container-class-name"));
 
+		importedLayoutClassedModelUsage.setContainerType(
+			containerTypeClassNameId);
+
 		if (containerTypeClassNameId == _portal.getClassNameId(
 				FragmentEntryLink.class)) {
 
@@ -232,9 +235,6 @@ public class LayoutClassedModelUsageStagedModelDataHandler
 
 				importedLayoutClassedModelUsage.setContainerKey(
 					String.valueOf(containerKey));
-
-				importedLayoutClassedModelUsage.setContainerType(
-					_portal.getClassNameId(FragmentEntryLink.class));
 			}
 		}
 


### PR DESCRIPTION
Forwarding from: https://github.com/liferay-staging/liferay-portal/pull/136

* Note about commit https://github.com/liferay-echo/liferay-portal/commit/fb025ce3398894ea2922946f9fede3818f3c76cb : `classNameIds` can be different between instances, so conversion during import might still be necessary.

cc: @mbowerman