### PR TITLE
HR_247/LPS-165264 - add aria-required to form fields

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/create-layout-page-template-entry-modal/components/CreateLayoutPageTemplateEntryModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/create-layout-page-template-entry-modal/components/CreateLayoutPageTemplateEntryModal.js
@@ -169,6 +169,7 @@ const CreateLayoutPageTemplateEntryModal = ({observer, onClose}) => {
 						name={Liferay.Language.get('name')}
 					>
 						<input
+							aria-required="true"
 							className="form-control"
 							id={`${config.portletNamespace}name`}
 							onChange={() => setError({...error, name: null})}
@@ -185,6 +186,7 @@ const CreateLayoutPageTemplateEntryModal = ({observer, onClose}) => {
 							name={Liferay.Language.get('page-template-set')}
 						>
 							<select
+								aria-required="true"
 								className="form-control"
 								id={`${config.portletNamespace}layoutPageTemplateCollectionId`}
 								ref={layoutPageTemplateCollectionInputRef}


### PR DESCRIPTION
Forwarded from https://github.com/ethib137/liferay-portal/pull/66

Hi @ethib137!

https://issues.liferay.com/browse/LPS-165264

This one is pretty straightforward. We have two required form fields in this modal that the screen reader does not identify as 'required'. Adding aria-required fixes this.