### PR TITLE
LPS-159386 properties "*.friendly.url.page.not.found" can cause StackoverFlowErrors if the target is a layout that redirects to another layout

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/java/com/liferay/layout/type/controller/link/to/page/internal/layout/type/controller/LinkToPageLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/java/com/liferay/layout/type/controller/link/to/page/internal/layout/type/controller/LinkToPageLayoutTypeController.java
@@ -122,7 +122,7 @@ public class LinkToPageLayoutTypeController
 	private static final String _URL =
 		"${liferay:mainPath}/portal/layout?p_v_l_s_g_id=${liferay:pvlsgid}&" +
 			"groupId=${liferay:groupId}&privateLayout=${privateLayout}&" +
-				"layoutId=${linkToLayoutId}";
+				"layoutId=${linkToLayoutId}&p_l_id=0";
 
 	@Reference
 	private ItemSelector _itemSelector;


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-159386

cc @ealonso