### PR TITLE
LPS-165478 master

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type-api/bnd.bnd
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Dynamic Data Mapping Form Field Type API
 Bundle-SymbolicName: com.liferay.dynamic.data.mapping.form.field.type.api
-Bundle-Version: 1.6.1
+Bundle-Version: 1.7.0
 Export-Package: com.liferay.dynamic.data.mapping.form.field.type.constants

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type-api/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/constants/DDMFormFieldTypeConstants.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type-api/src/main/java/com/liferay/dynamic/data/mapping/form/field/type/constants/DDMFormFieldTypeConstants.java
@@ -33,6 +33,8 @@ public class DDMFormFieldTypeConstants {
 
 	public static final String DDM_IMAGE = "ddm-image";
 
+	public static final String DECIMAL = "ddm-decimal";
+
 	public static final String DOCUMENT_LIBRARY = "document_library";
 
 	public static final String FIELDSET = "fieldset";

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type-api/src/main/resources/com/liferay/dynamic/data/mapping/form/field/type/constants/packageinfo
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type-api/src/main/resources/com/liferay/dynamic/data/mapping/form/field/type/constants/packageinfo
@@ -1,1 +1,1 @@
-version 1.6.0
+version 1.7.0

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
@@ -25,7 +25,6 @@ import com.liferay.dynamic.data.mapping.kernel.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.kernel.DDMFormValues;
 import com.liferay.dynamic.data.mapping.kernel.LocalizedValue;
 import com.liferay.dynamic.data.mapping.kernel.Value;
-import com.liferay.dynamic.data.mapping.model.DDMFormFieldType;
 import com.liferay.dynamic.data.mapping.storage.constants.FieldConstants;
 import com.liferay.dynamic.data.mapping.util.DDMBeanTranslator;
 import com.liferay.info.field.InfoFieldValue;
@@ -38,7 +37,6 @@ import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
@@ -49,6 +47,7 @@ import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.text.DateFormat;
@@ -211,13 +210,15 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 
 		try {
 			if (Objects.equals(
-					ddmFormFieldValue.getType(), DDMFormFieldType.CHECKBOX) ||
+					ddmFormFieldValue.getType(),
+					DDMFormFieldTypeConstants.CHECKBOX) ||
 				Objects.equals(ddmFormFieldValue.getType(), "boolean")) {
 
 				return GetterUtil.getBoolean(valueString);
 			}
 			else if (Objects.equals(
-						ddmFormFieldValue.getType(), DDMFormFieldType.DATE) ||
+						ddmFormFieldValue.getType(),
+						DDMFormFieldTypeConstants.DATE) ||
 					 Objects.equals(ddmFormFieldValue.getType(), "date")) {
 
 				if (Validator.isNull(valueString)) {
@@ -238,10 +239,10 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 			}
 			else if (Objects.equals(
 						ddmFormFieldValue.getType(),
-						DDMFormFieldType.DECIMAL) ||
+						DDMFormFieldTypeConstants.DECIMAL) ||
 					 Objects.equals(
 						 ddmFormFieldValue.getType(),
-						 DDMFormFieldType.NUMERIC)) {
+						 DDMFormFieldTypeConstants.NUMERIC)) {
 
 				if (Validator.isNull(valueString)) {
 					return null;
@@ -263,7 +264,8 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 				return numberFormat.format(numberFormat.parse(valueString));
 			}
 			else if (Objects.equals(
-						ddmFormFieldValue.getType(), DDMFormFieldType.IMAGE) ||
+						ddmFormFieldValue.getType(),
+						DDMFormFieldTypeConstants.IMAGE) ||
 					 Objects.equals(ddmFormFieldValue.getType(), "image")) {
 
 				return _getWebImage(
@@ -271,7 +273,28 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 			}
 			else if (Objects.equals(
 						ddmFormFieldValue.getType(),
-						DDMFormFieldTypeConstants.SELECT)) {
+						DDMFormFieldTypeConstants.RADIO)) {
+
+				if (Validator.isNull(valueString)) {
+					return null;
+				}
+
+				DDMFormField ddmFormField = ddmFormFieldValue.getDDMFormField();
+
+				DDMFormFieldOptions ddmFormFieldOptions =
+					ddmFormField.getDDMFormFieldOptions();
+
+				LocalizedValue localizedValue =
+					ddmFormFieldOptions.getOptionLabels(valueString);
+
+				return localizedValue.getString(locale);
+			}
+			else if (Objects.equals(
+						ddmFormFieldValue.getType(),
+						DDMFormFieldTypeConstants.CHECKBOX_MULTIPLE) ||
+					 Objects.equals(
+						 ddmFormFieldValue.getType(),
+						 DDMFormFieldTypeConstants.SELECT)) {
 
 				if (Validator.isNull(valueString)) {
 					return null;
@@ -298,18 +321,18 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 				DDMFormFieldOptions ddmFormFieldOptions =
 					ddmFormField.getDDMFormFieldOptions();
 
-				JSONArray optionLabelsJSONArray =
-					JSONFactoryUtil.createJSONArray();
+				String[] optionLabelsArray =
+					new String[optionReferencesJSONArray.length()];
 
 				for (int i = 0; i < optionReferencesJSONArray.length(); i++) {
 					LocalizedValue localizedValue =
 						ddmFormFieldOptions.getOptionLabels(
 							optionReferencesJSONArray.getString(i));
 
-					optionLabelsJSONArray.put(localizedValue.getString(locale));
+					optionLabelsArray[i] = localizedValue.getString(locale);
 				}
 
-				return JSONUtil.toString(optionLabelsJSONArray);
+				return StringUtil.merge(optionLabelsArray, StringPool.COMMA);
 			}
 
 			return SanitizerUtil.sanitize(

--- a/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java
@@ -20,6 +20,7 @@ import com.liferay.asset.kernel.model.AssetRendererFactory;
 import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
 import com.liferay.document.library.kernel.util.DLUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -34,6 +35,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.text.DecimalFormat;
@@ -161,7 +163,10 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 	public String getData() {
 		String type = getType();
 
-		if (type.equals("color") || type.equals("ddm-color")) {
+		if (type.equals("checkbox_multiple")) {
+			return _getMultipleOptionData();
+		}
+		else if (type.equals("color") || type.equals("ddm-color")) {
 			return _getColorData();
 		}
 		else if (type.equals("ddm-decimal") || type.equals("ddm-number") ||
@@ -179,6 +184,9 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 		}
 		else if (type.equals("geolocation")) {
 			return _getGeolocationData();
+		}
+		else if (type.equals("radio") || type.equals("select")) {
+			return _getOptionData();
 		}
 
 		return (String)get("data");
@@ -455,6 +463,39 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 		return (String)get("data");
 	}
 
+	private String _getMultipleOptionData() {
+		String data = (String)get("data");
+
+		if (Validator.isNull(data)) {
+			return StringPool.BLANK;
+		}
+
+		JSONArray dataJSONArray = null;
+
+		try {
+			dataJSONArray = JSONFactoryUtil.createJSONArray(data);
+		}
+		catch (JSONException jsonException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(jsonException);
+			}
+		}
+
+		if (dataJSONArray == null) {
+			return StringPool.BLANK;
+		}
+
+		Map<String, String> optionsMap = getOptionsMap();
+
+		String[] optionsDataArray = new String[dataJSONArray.length()];
+
+		for (int i = 0; i < dataJSONArray.length(); i++) {
+			optionsDataArray[i] = optionsMap.get(dataJSONArray.getString(i));
+		}
+
+		return StringUtil.merge(optionsDataArray, StringPool.COMMA);
+	}
+
 	private String _getNumericData() {
 		String data = (String)get("data");
 
@@ -466,6 +507,22 @@ public class TemplateNode extends LinkedHashMap<String, Object> {
 		decimalFormat.setParseBigDecimal(true);
 
 		return decimalFormat.format(GetterUtil.getDouble(data));
+	}
+
+	private String _getOptionData() {
+		String data = (String)get("data");
+
+		if (Validator.isNull(data)) {
+			return StringPool.BLANK;
+		}
+
+		Map<String, String> optionsMap = getOptionsMap();
+
+		if (optionsMap != null) {
+			data = optionsMap.get(data);
+		}
+
+		return data;
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(TemplateNode.class);


### PR DESCRIPTION
Hi Team.

could you please review my fix?

Thanks, Roland

**Reproduction Steps:**

1. Set up the master bundle
2. Go to Content and Data --> Web Content --> Structures and create a structure with a "Select from list" field.
3. Go to web content and create web content from the structure and in the content select "Option" then publish.
4. Go to Design --> Page Templates --> Display Page Templates and add a DPT and add to it a Heading fragment.
5. Doubleclick on the fragment and from the right panel at the "Mapping" --> "Source" select "Specific Content" and select the web content under "Item" and at the "Field" find the content structure and select "Select from list".
6. Check the fragment heading.

**Actual Result:** The Option appears incorrectly rendered with characters like [" Option "]. There are no errors in the log and browser console.
**Expected Result:** The Option appears normally as it is.

In case creating a Template for the structure and mapping this template to the Fragment

<#if (SelectFromList54473153.getData())??>
    ${SelectFromList54473153.getData()}
</#if>
the rendering shows the Field reference (Option65398360) instead of the field value (Option)

**Fix**
The SELECT, RADIO and CHECKBOX_MULTIPLE types cases are implemented

https://issues.liferay.com/browse/LPS-165478