### PR TITLE
LPS-159386 - properties "*.friendly.url.page.not.found" can cause StackoverFlowErrors if the target is a layout that redirects to another layout

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletFragmentEntryProcessor.java
@@ -418,7 +418,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 
 		String instanceId = jsonObject.getString("instanceId");
 
-		String encodePortletId = PortletIdCodec.encode(portletId, instanceId);
+		String encodedPortletId = PortletIdCodec.encode(portletId, instanceId);
 
 		String html = _fragmentPortletRenderer.renderPortlet(
 			fragmentEntryProcessorContext.getHttpServletRequest(),
@@ -427,7 +427,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 			PortletPreferencesFactoryUtil.toXML(
 				PortletPreferencesFactoryUtil.getPortletPreferences(
 					fragmentEntryProcessorContext.getHttpServletRequest(),
-					encodePortletId)));
+					encodedPortletId)));
 
 		HttpServletRequest httpServletRequest =
 			fragmentEntryProcessorContext.getHttpServletRequest();
@@ -443,7 +443,7 @@ public class PortletFragmentEntryProcessor implements FragmentEntryProcessor {
 				ParamUtil.getLong(
 					fragmentEntryProcessorContext.getHttpServletRequest(),
 					"p_l_id"),
-				"#", encodePortletId);
+				"#", encodedPortletId);
 
 			httpServletRequest.setAttribute(
 				FragmentWebKeys.ACCESS_ALLOWED_TO_FRAGMENT_ENTRY_LINK_ID +

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -973,6 +973,8 @@ public class RenderLayoutStructureTag extends IncludeTag {
 				HttpServletResponse httpServletResponse =
 					(HttpServletResponse)pageContext.getResponse();
 
+				// LPS-164462 Call render before getting attribute value
+
 				String html = fragmentRendererController.render(
 					defaultFragmentRendererContext, httpServletRequest,
 					httpServletResponse);

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -973,6 +973,10 @@ public class RenderLayoutStructureTag extends IncludeTag {
 				HttpServletResponse httpServletResponse =
 					(HttpServletResponse)pageContext.getResponse();
 
+				String html = fragmentRendererController.render(
+					defaultFragmentRendererContext, httpServletRequest,
+					httpServletResponse);
+
 				if (GetterUtil.getBoolean(
 						httpServletRequest.getAttribute(
 							FragmentWebKeys.
@@ -988,10 +992,7 @@ public class RenderLayoutStructureTag extends IncludeTag {
 					jspWriter.write("<div>");
 				}
 
-				jspWriter.write(
-					fragmentRendererController.render(
-						defaultFragmentRendererContext, httpServletRequest,
-						httpServletResponse));
+				jspWriter.write(html);
 				jspWriter.write("</div>");
 			}
 		}


### PR DESCRIPTION
//cc @ealonso @lfbesada