### PR TITLE
LPS-165396 | [HR_250] Fixed headings hierarchy in the site builder for Home page

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
+++ b/modules/apps/frontend-theme/frontend-theme-classic/src/templates/portal_normal.ftl
@@ -31,7 +31,7 @@
 								<img alt="${logo_description}" class="mr-2" height="56" src="${site_logo}" />
 
 								<#if show_site_name>
-									<h2 class="font-weight-bold h2 mb-0 text-dark" role="heading" aria-level="1">${site_name}</h2>
+									<h2 class="font-weight-bold h2 mb-0 text-dark">${site_name}</h2>
 								</#if>
 							</a>
 
@@ -69,7 +69,7 @@
 		</#if>
 
 		<section class="${portal_content_css_class} flex-fill" id="content">
-			<h2 class="sr-only" role="heading" aria-level="1">${the_title}</h2>
+			<h2 class="sr-only" role="heading" aria-level="3">${the_title}</h2>
 
 			<#if selectable>
 				<@liferay_util["include"] page=content_include />

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/SidebarPanelHeader.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/SidebarPanelHeader.js
@@ -29,7 +29,7 @@ export default function SidebarPanelHeader({children}) {
 				'align-items-center d-flex justify-content-between my-3 pl-3 pr-2 page-editor__sidebar__panel-header'
 			)}
 		>
-			<h1 className="flex-grow-1 mb-0 mr-1 text-3">{children}</h1>
+			<h2 className="flex-grow-1 mb-0 mr-1 text-3">{children}</h2>
 
 			<ClayButtonWithIcon
 				displayType="unstyled"

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutHeaderProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutHeaderProductNavigationControlMenuEntry.java
@@ -92,8 +92,8 @@ public class LayoutHeaderProductNavigationControlMenuEntry
 		sb.append(_getCssClass(httpServletRequest));
 		sb.append("\"><span class=\"align-items-center ");
 		sb.append("control-menu-level-1-heading d-flex mr-1\" ");
-		sb.append("data-qa-id=\"headerTitle\"><span class=\"");
-		sb.append("lfr-portal-tooltip text-truncate\" title=\"");
+		sb.append("data-qa-id=\"headerTitle\"><h1 class=\"");
+		sb.append("lfr-portal-tooltip text-truncate h4 mb-0\" title=\"");
 
 		String headerTitle = HtmlUtil.escapeAttribute(
 			_getHeaderTitle(httpServletRequest));
@@ -102,7 +102,7 @@ public class LayoutHeaderProductNavigationControlMenuEntry
 
 		sb.append("\">");
 		sb.append(headerTitle);
-		sb.append("</span>");
+		sb.append("</h1>");
 
 		if (_hasDraftLayout(httpServletRequest) &&
 			_hasEditPermission(httpServletRequest)) {


### PR DESCRIPTION
Related Issue: https://issues.liferay.com/browse/LPS-165396

Related HRs:

HR_168 (fix needed to reproduce the expected results, needs https://github.com/ethib137/liferay-portal/pull/67 to be merged)

The solution: Change multiple tags around the page editor to fix the hierarchy.

Reproduction Steps:
Turn on JAWS and navigate to Site Builder > Pages;
Open options for Home page and click on Edit, Home page will appear;
Using JAWS, observe the heading levels on the page.

Expected Results:
There should be only one heading level 1 on the page and the headings should follow the hierarchy.

ATTENTION: The expected result will only fully happen when https://github.com/ethib137/liferay-portal/pull/67 is merged.