### PR TITLE
LPS-161955 Test - that Layouts using a Master Page are propagating from a Site Template correctly

### DIFF
--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/test/LayoutSetPrototypePropagationTest.java
@@ -322,6 +322,55 @@ public class LayoutSetPrototypePropagationTest
 	}
 
 	@Test
+	public void testLayoutPropagationWithMasterLayout() throws Exception {
+		Layout masterLayoutOfLayoutSetPrototype =
+			LayoutTestUtil.addTypeContentLayout(
+				_layoutSetPrototypeGroup, true, false);
+
+		Layout layoutOfLayoutSetPrototype1 =
+			LayoutTestUtil.addTypeContentLayout(
+				_layoutSetPrototypeGroup, true, false);
+
+		layoutOfLayoutSetPrototype1.setMasterLayoutPlid(
+			masterLayoutOfLayoutSetPrototype.getPlid());
+
+		LayoutLocalServiceUtil.updateLayout(layoutOfLayoutSetPrototype1);
+
+		propagateChanges(group);
+
+		Layout layoutOfLayoutSetPrototype2 =
+			LayoutTestUtil.addTypeContentLayout(
+				_layoutSetPrototypeGroup, true, false);
+
+		layoutOfLayoutSetPrototype2.setMasterLayoutPlid(
+			masterLayoutOfLayoutSetPrototype.getPlid());
+
+		LayoutLocalServiceUtil.updateLayout(layoutOfLayoutSetPrototype2);
+
+		propagateChanges(group);
+
+		List<Layout> siteLayoutsWithTemplateMasters =
+			LayoutLocalServiceUtil.getMasterLayouts(
+				group.getGroupId(), masterLayoutOfLayoutSetPrototype.getPlid());
+
+		Assert.assertEquals(
+			siteLayoutsWithTemplateMasters.toString(), 0,
+			siteLayoutsWithTemplateMasters.size());
+
+		Layout layoutMasterOfSite = LayoutLocalServiceUtil.getFriendlyURLLayout(
+			group.getGroupId(), false,
+			masterLayoutOfLayoutSetPrototype.getFriendlyURL());
+
+		List<Layout> siteLayoutsWithSiteMasters =
+			LayoutLocalServiceUtil.getMasterLayouts(
+				group.getGroupId(), layoutMasterOfSite.getPlid());
+
+		Assert.assertEquals(
+			siteLayoutsWithSiteMasters.toString(), 2,
+			siteLayoutsWithSiteMasters.size());
+	}
+
+	@Test
 	public void testPortletDataPropagationWithLinkDisabled() throws Exception {
 		doTestPortletDataPropagation(false);
 	}


### PR DESCRIPTION
Resending [previous pull](https://github.com/liferay-echo/liferay-portal/pull/9942) with modifications based on https://github.com/brianchandotcom/liferay-portal/pull/124721#issuecomment-1281378693





Motivation
=======
[LPS-161955](https://issues.liferay.com/browse/LPS-161955)
Only Pages that were present in a Site Template during Site creation use the Site's Master Page Templates. Pages added later to the Site Template will propagate to the Site retaining the Site Template's Master Page Template.

Proposed Solution
=======
Move the solution of LPS-159751 and change it to be ran during the Master Page import instead of the implementing Pages' import.

Steps to Verify
=======
1. Create a Site Template
2. Create a Master Page
3. Create a Page based on the Master Page
4. Create a Site from the Site Template
5. Go back to the Site Template
6. Create a new Page from based on the Master Page
7. Go back to the Site
8. Go to Design > Page Template, Masters tab
9. Edit the Master Page
10. Add a new heading (this is the Site's local Master Page, not the Site Template's)
11. Publish the changes
12. Visit both pages in the Site

**Expected behaviour:** Both pages are displaying the changes made to the Site's Master Page
**Actual behaviour:** Only the first page (from the initial propagation of the Site creation) uses the Site's Master Page, the second page shows the Site Template's
















