### PR TITLE
LPS-165966 HR_73

### DIFF
--- a/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/init.jsp
@@ -29,7 +29,6 @@ page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletProvider" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletProviderUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletURLUtil" %><%@
-page import="com.liferay.portal.kernel.servlet.SessionMessages" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@

--- a/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/undo/page.jsp
+++ b/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/undo/page.jsp
@@ -102,4 +102,10 @@ int trashedEntriesCount = GetterUtil.getInteger(request.getAttribute("liferay-tr
 	</aui:form>
 </liferay-util:buffer>
 
-<liferay-ui:success key="<%= portletDisplay.getId() + SessionMessages.KEY_SUFFIX_DELETE_SUCCESS_DATA %>" message="<%= alertMessage %>" />
+<clay:alert
+	autoClose="<%= false %>"
+	cssClass="alert-notifications-fixed"
+	dismissible="<%= true %>"
+	displayType="success"
+	message="<%= alertMessage %>"
+/>


### PR DESCRIPTION
### [LPS-165966](https://issues.liferay.com/browse/LPS-165966) HR_73 
**Solution**
Added clay alert to utilize autoClose feature. This solves the issue of not having enough time to navigate to this alert while using a screen reader. 

**Description**
Screen Reader (SR) user is not getting enough time to move to the links "The recycle Bin" and "Undo" on the success message alert

**Steps to reproduce**

1. From the menu, Navigate to Content and Data > Web content
2. Navigate to More options (three dots) menu and expand it
3. Press enter on move to recycle bin option
4. Press enter on ok button. Alert message opens

**Results of Testing**
_Expected Result:_
Message stays open until the user uses any of the links/buttons to navigate to the recycle bin, undo the deletion, or close the alert. 