### PR TITLE
LPS-165401 Integration Test

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -1923,6 +1923,12 @@ public class PortletDataContextImpl implements PortletDataContext {
 			serviceContext.setModifiedDate(auditedModel.getModifiedDate());
 			serviceContext.setUserId(getUserId(auditedModel));
 		}
+		else if (classedModel instanceof StagedModel) {
+			StagedModel stagedModel = (StagedModel)classedModel;
+
+			serviceContext.setCreateDate(stagedModel.getCreateDate());
+			serviceContext.setModifiedDate(stagedModel.getModifiedDate());
+		}
 
 		// Permissions
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/LayoutClassedModelUsageStagedModelDataHandler.java
@@ -193,9 +193,6 @@ public class LayoutClassedModelUsageStagedModelDataHandler
 
 		importedLayoutClassedModelUsage.setPlid(plid);
 
-		importedLayoutClassedModelUsage.setClassNameId(
-			layoutClassedModelUsage.getClassNameId());
-
 		Map<Long, Long> classPKs =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 				layoutClassedModelUsage.getClassName());

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/staged/model/repository/LayoutClassedModelUsageStagedModelRepository.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/staged/model/repository/LayoutClassedModelUsageStagedModelRepository.java
@@ -21,6 +21,7 @@ import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.portal.kernel.dao.orm.ExportActionableDynamicQuery;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 
 import java.util.List;
 
@@ -126,8 +127,16 @@ public class LayoutClassedModelUsageStagedModelRepository
 			LayoutClassedModelUsage layoutClassedModelUsage)
 		throws PortalException {
 
-		return _layoutClassedModelUsageLocalService.
-			updateLayoutClassedModelUsage(layoutClassedModelUsage);
+		ServiceContextThreadLocal.pushServiceContext(
+			portletDataContext.createServiceContext(layoutClassedModelUsage));
+
+		try {
+			return _layoutClassedModelUsageLocalService.
+				updateLayoutClassedModelUsage(layoutClassedModelUsage);
+		}
+		finally {
+			ServiceContextThreadLocal.popServiceContext();
+		}
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-test/build.gradle
+++ b/modules/apps/layout/layout-test/build.gradle
@@ -8,6 +8,7 @@ dependencies {
 	testIntegrationCompile project(":apps:asset:asset-test-util")
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationCompile project(":apps:dynamic-data-mapping:dynamic-data-mapping-test-util")
+	testIntegrationCompile project(":apps:export-import:export-import-test-util")
 	testIntegrationCompile project(":apps:fragment:fragment-api")
 	testIntegrationCompile project(":apps:fragment:fragment-entry-processor:fragment-entry-processor-api")
 	testIntegrationCompile project(":apps:friendly-url:friendly-url-api")

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/exportimport/data/handler/test/LayoutClassedModelUsageStagedModelDataHandlerTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/exportimport/data/handler/test/LayoutClassedModelUsageStagedModelDataHandlerTest.java
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
+import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Michael Bowerman
+ */
+@RunWith(Arquillian.class)
+public class LayoutClassedModelUsageStagedModelDataHandlerTest
+	extends BaseStagedModelDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	@Override
+	public void setUp() throws Exception {
+		super.setUp();
+
+		_classNameLocalService.addClassName(_CLASS_NAME);
+
+		_classPK = RandomTestUtil.nextLong();
+		_containerKey = String.valueOf(RandomTestUtil.nextLong());
+	}
+
+	@After
+	@Override
+	public void tearDown() throws Exception {
+		super.setUp();
+
+		_classNameLocalService.deleteClassName(
+			_classNameLocalService.getClassName(_CLASS_NAME));
+	}
+
+	@Override
+	protected Map<String, List<StagedModel>> addDependentStagedModelsMap(
+			Group group)
+		throws Exception {
+
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			new HashMap<>();
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(group);
+
+		addDependentStagedModel(dependentStagedModelsMap, Layout.class, layout);
+
+		return dependentStagedModelsMap;
+	}
+
+	@Override
+	protected StagedModel addStagedModel(
+			Group group,
+			Map<String, List<StagedModel>> dependentStagedModelsMap)
+		throws Exception {
+
+		List<StagedModel> layoutDependentStagedModels =
+			dependentStagedModelsMap.get(Layout.class.getSimpleName());
+
+		Layout layout = (Layout)layoutDependentStagedModels.get(0);
+
+		return _layoutClassedModelUsageLocalService.addLayoutClassedModelUsage(
+			group.getGroupId(),
+			_classNameLocalService.getClassNameId(_CLASS_NAME), _classPK,
+			_containerKey,
+			_classNameLocalService.getClassNameId(_CONTAINER_TYPE_CLASS_NAME),
+			layout.getPlid(),
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	@Override
+	protected StagedModel getStagedModel(String uuid, Group group)
+		throws PortalException {
+
+		return _layoutClassedModelUsageLocalService.
+			getLayoutClassedModelUsageByUuidAndGroupId(
+				uuid, group.getGroupId());
+	}
+
+	@Override
+	protected Class<? extends StagedModel> getStagedModelClass() {
+		return Role.class;
+	}
+
+	private static final String _CLASS_NAME = RandomTestUtil.randomString();
+
+	private static final String _CONTAINER_TYPE_CLASS_NAME =
+		RandomTestUtil.randomString();
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	private long _classPK;
+	private String _containerKey;
+
+	@Inject
+	private LayoutClassedModelUsageLocalService
+		_layoutClassedModelUsageLocalService;
+
+}


### PR DESCRIPTION
From the original PR, https://github.com/liferay-staging/liferay-portal/pull/141:

Adds integration test for [LPS-165401](https://issues.liferay.com/browse/LPS-165401)

See added commits: https://github.com/liferay/liferay-portal/compare/dda3e515e3182100e53c1edead56848be01943f1...mbowerman:LPS-165401-test

Note: For https://github.com/liferay/liferay-portal/commit/87511d0bfad5759dfc7870588dcf8989a08bab1e and https://github.com/liferay/liferay-portal/commit/47eb1abfb38f218ead0d176d26cb07569d300dfd, I wasn't sure what the intended behavior was. Should we always set the createDate and modifiedDate in the serviceContext, even for non-AuditedModels? If so, then those commits should be correct, Otherwise, I think we would have to update the validation logic in the test to wrap [these lines](https://github.com/liferay/liferay-portal/blob/dda3e515e3182100e53c1edead56848be01943f1/modules/apps/export-import/export-import-test-util/src/main/java/com/liferay/exportimport/test/util/lar/BaseStagedModelDataHandlerTestCase.java#L1077-L1081) inside of an if (stagedModel instanceof AuditedModel) block.