### PR TITLE
[TS] LPS-164273 Remove AssetUtil.filterCategoryIds to prevent filtering out results

### DIFF
--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetSearcherTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/search/test/AssetSearcherTest.java
@@ -16,15 +16,23 @@ package com.liferay.asset.search.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetVocabulary;
+import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetEntryLocalServiceUtil;
+import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.blogs.service.BlogsEntryLocalServiceUtil;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalServiceUtil;
+import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.search.Hits;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -32,8 +40,14 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.SearchContextTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portlet.asset.util.AssetSearcher;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -80,6 +94,58 @@ public class AssetSearcherTest {
 			_internalAssetCategory.getCategoryId(),
 			_publicAssetCategory1.getCategoryId(),
 			_publicAssetCategory2.getCategoryId());
+	}
+
+	@Test
+	public void testGetAssetEntriesFilteredByAllCategoryIds() throws Exception {
+		addAssetVocabulary();
+
+		setGuestUser();
+
+		long[] allAssetCategoryIds = {
+			_assetCategoryIds[0], _assetCategoryIds[1], _assetCategoryIds[2]
+		};
+
+		addAssetEntries(allAssetCategoryIds, new String[0], 3, true);
+
+		AssetSearcher assetSearcher = new AssetSearcher();
+
+		AssetEntryQuery assetEntryQuery = new AssetEntryQuery();
+
+		assetEntryQuery.setAllCategoryIds(allAssetCategoryIds);
+
+		assetSearcher.setAssetEntryQuery(assetEntryQuery);
+
+		Hits hits = assetSearcher.search(
+			SearchContextTestUtil.getSearchContext(_group.getGroupId()));
+
+		Assert.assertEquals(hits.toString(), 3, hits.getLength());
+	}
+
+	@Test
+	public void testGetAssetEntriesFilteredByAnyCategoryIds() throws Exception {
+		addAssetVocabulary();
+
+		setGuestUser();
+
+		long[] anyAssetCategoryIds = {
+			_assetCategoryIds[0], _assetCategoryIds[1], _assetCategoryIds[2]
+		};
+
+		addAssetEntries(anyAssetCategoryIds, new String[0], 3, true);
+
+		AssetSearcher assetSearcher = new AssetSearcher();
+
+		AssetEntryQuery assetEntryQuery = new AssetEntryQuery();
+
+		assetEntryQuery.setAnyCategoryIds(anyAssetCategoryIds);
+
+		assetSearcher.setAssetEntryQuery(assetEntryQuery);
+
+		Hits hits = assetSearcher.search(
+			SearchContextTestUtil.getSearchContext(_group.getGroupId()));
+
+		Assert.assertEquals(hits.toString(), 3, hits.getLength());
 	}
 
 	@Test
@@ -294,6 +360,67 @@ public class AssetSearcherTest {
 		Assert.assertEquals(hits.toString(), 1, hits.getLength());
 	}
 
+	protected void addAssetCategories(long vocabularyId) throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		for (String assetCategoryName : _ASSET_CATEGORY_NAMES) {
+			AssetCategory assetCategory =
+				AssetCategoryLocalServiceUtil.addCategory(
+					TestPropsValues.getUserId(),
+					serviceContext.getScopeGroupId(), assetCategoryName,
+					vocabularyId, serviceContext);
+
+			_assetCategoryIds = ArrayUtil.append(
+				_assetCategoryIds, assetCategory.getCategoryId());
+		}
+	}
+
+	protected List<AssetEntry> addAssetEntries(
+			long[] assetCategoryIds, String[] assetTagNames, int count,
+			boolean manualMode)
+		throws Exception {
+
+		List<AssetEntry> assetEntries = new ArrayList<>();
+
+		for (int i = 0; i < count; i++) {
+			JournalArticle article = JournalTestUtil.addArticle(
+				_group.getGroupId(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(100));
+
+			JournalArticleLocalServiceUtil.updateAsset(
+				TestPropsValues.getUserId(), article, assetCategoryIds,
+				assetTagNames, null, null);
+
+			AssetEntry assetEntry = AssetEntryLocalServiceUtil.getEntry(
+				JournalArticle.class.getName(), article.getResourcePrimKey());
+
+			assetEntries.add(assetEntry);
+		}
+
+		return assetEntries;
+	}
+
+	protected void addAssetVocabulary() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
+
+		serviceContext.setAddGroupPermissions(false);
+		serviceContext.setAddGuestPermissions(false);
+
+		AssetVocabulary assetVocabulary =
+			AssetVocabularyLocalServiceUtil.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), serviceContext);
+
+		addAssetCategories(assetVocabulary.getVocabularyId());
+	}
+
+	protected void setGuestUser() throws Exception {
+		UserTestUtil.setUser(
+			_userLocalService.getDefaultUser(_group.getCompanyId()));
+	}
+
 	private void _addBlogsEntry(long... assetCategoryIds) throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(_group.getGroupId());
@@ -306,6 +433,15 @@ public class AssetSearcherTest {
 			1, 1, 1965, 0, 0, true, true, null, StringPool.BLANK, null, null,
 			serviceContext);
 	}
+
+	private static final String[] _ASSET_CATEGORY_NAMES = {
+		"Athletic", "Olympia", "Sport"
+	};
+
+	@Inject
+	private static UserLocalService _userLocalService;
+
+	private long[] _assetCategoryIds = new long[0];
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetSearcher.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetSearcher.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.search.filter.QueryFilter;
 import com.liferay.portal.kernel.search.filter.TermsFilter;
 import com.liferay.portal.kernel.search.generic.BooleanQueryImpl;
 import com.liferay.portal.kernel.search.generic.StringQuery;
-import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -396,17 +395,8 @@ public class AssetSearcher extends BaseSearcher {
 				continue;
 			}
 
-			long[] filteredAllCategoryIds = AssetUtil.filterCategoryIds(
-				PermissionThreadLocal.getPermissionChecker(), allCategoryIds);
-
-			if (allCategoryIds.length != filteredAllCategoryIds.length) {
-				addImpossibleTerm(queryBooleanFilter, fieldName);
-
-				continue;
-			}
-
 			queryBooleanFilter.add(
-				_getCategoryIdsBooleanFilter(fieldName, filteredAllCategoryIds),
+				_getCategoryIdsBooleanFilter(fieldName, allCategoryIds),
 				BooleanClauseOccur.MUST);
 		}
 	}
@@ -425,20 +415,8 @@ public class AssetSearcher extends BaseSearcher {
 				continue;
 			}
 
-			long[] filteredAnyCategoryIds = AssetUtil.filterCategoryIds(
-				PermissionThreadLocal.getPermissionChecker(), anyCategoryIds);
-
-			filteredAnyCategoryIds = _filterCategoryIdsByVisibilityType(
-				filteredAnyCategoryIds, fieldName);
-
-			if (filteredAnyCategoryIds.length == 0) {
-				addImpossibleTerm(queryBooleanFilter, fieldName);
-
-				continue;
-			}
-
 			categoryIdsQueryBooleanFilter.add(
-				_getCategoryIdsTermsFilter(fieldName, filteredAnyCategoryIds),
+				_getCategoryIdsTermsFilter(fieldName, anyCategoryIds),
 				BooleanClauseOccur.SHOULD);
 		}
 


### PR DESCRIPTION
Hi Team,

https://issues.liferay.com/browse/LPS-164273
THIS TICKET IS MARKED AS BREAKING CHANGE

**Issue:**
Web contents were filtered out in the Asset publisher by their categories, for users who didn't have the role with the permission to see that category. 

**Solution:**
As discussed here: [PTR-3409](https://issues.liferay.com/browse/PTR-3409?focusedCommentId=2781690&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2781690) "Category permissions should not be used to drive the visibility of a given web content with that category assigned."
I implemented the solution suggested on [PTR-3396](https://issues.liferay.com/browse/PTR-3396?focusedCommentId=2777040&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2777040).

I tested this solution in my local environment on master and it worked as expected. Both the admin and the users (with different roles) could see the web contents.

Please review my PR!

Best regards,
Évi