### PR TITLE
LPS-166370 Add paragraph tag to paragraph fragment

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/paragraph/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/paragraph/index.html
@@ -1,5 +1,7 @@
 <div class="clearfix component-paragraph text-break" data-lfr-editable-id="element-text" data-lfr-editable-type="rich-text">
-	A paragraph is a self-contained unit of a discourse in writing dealing with
-	a particular point or idea. Paragraphs are usually an expected part of
-	formal writing, used to organize longer prose.
+	<p>
+		A paragraph is a self-contained unit of a discourse in writing dealing with
+		a particular point or idea. Paragraphs are usually an expected part of
+		formal writing, used to organize longer prose.
+	</p>
 </div>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-166370

When adding a paragraph tag to a page, the text is not in a paragraph tag by default. I added the paragraph tag to fix this.

Please let me know if there are any questions or comments about this.
Thank you!