### PR TITLE
LPS-164942 User without permission should not see form container

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -682,11 +682,8 @@ public class ContentPageEditorDisplayContext {
 				LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale())
 			).put(
 				"layoutData",
-				() -> {
-					LayoutStructure layoutStructure = _getLayoutStructure();
-
-					return layoutStructure.toJSONObject();
-				}
+				LayoutStructureUtil.getLayoutDataJSONObject(
+					_getLayoutStructure())
 			).put(
 				"mappingFields", _getMappingFieldsJSONObject()
 			).put(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinkMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinkMVCActionCommand.java
@@ -204,7 +204,8 @@ public class AddFragmentEntryLinkMVCActionCommand
 				fragmentEntryLink, _portal.getHttpServletRequest(actionRequest),
 				_portal.getHttpServletResponse(actionResponse), layoutStructure)
 		).put(
-			"layoutData", layoutStructure.toJSONObject()
+			"layoutData",
+			LayoutStructureUtil.getLayoutDataJSONObject(layoutStructure)
 		);
 	}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinksMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentEntryLinksMVCActionCommand.java
@@ -175,7 +175,8 @@ public class AddFragmentEntryLinksMVCActionCommand
 		).put(
 			"fragmentEntryLinks", fragmentEntryLinksJSONObject
 		).put(
-			"layoutData", layoutStructure.toJSONObject()
+			"layoutData",
+			LayoutStructureUtil.getLayoutDataJSONObject(layoutStructure)
 		);
 	}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddSegmentsExperienceMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddSegmentsExperienceMVCActionCommand.java
@@ -21,7 +21,6 @@ import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortlet
 import com.liferay.layout.content.page.editor.web.internal.segments.SegmentsExperienceUtil;
 import com.liferay.layout.content.page.editor.web.internal.util.FragmentEntryLinkManager;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
-import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.portal.kernel.comment.CommentManager;
@@ -104,8 +103,8 @@ public class AddSegmentsExperienceMVCActionCommand
 				segmentsExperience.getSegmentsExperienceId())
 		).put(
 			"layoutData",
-			_getLayoutDataJSONObject(
-				plid, groupId, segmentsExperience.getSegmentsExperienceId())
+			LayoutStructureUtil.getLayoutDataJSONObject(
+				groupId, plid, segmentsExperience.getSegmentsExperienceId())
 		).put(
 			"segmentsExperience",
 			SegmentsExperienceUtil.getSegmentsExperienceJSONObject(
@@ -220,18 +219,6 @@ public class AddSegmentsExperienceMVCActionCommand
 		}
 
 		return fragmentEntryLinksJSONObject;
-	}
-
-	private JSONObject _getLayoutDataJSONObject(
-			long classPK, long groupId, long segmentsExperienceId)
-		throws PortalException {
-
-		LayoutPageTemplateStructure layoutPageTemplateStructure =
-			_layoutPageTemplateStructureLocalService.
-				fetchLayoutPageTemplateStructure(groupId, classPK, true);
-
-		return _jsonFactory.createJSONObject(
-			layoutPageTemplateStructure.getData(segmentsExperienceId));
 	}
 
 	private SegmentsExperiment _getSegmentsExperiment(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/DuplicateSegmentsExperienceMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/DuplicateSegmentsExperienceMVCActionCommand.java
@@ -21,7 +21,6 @@ import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortlet
 import com.liferay.layout.content.page.editor.web.internal.segments.SegmentsExperienceUtil;
 import com.liferay.layout.content.page.editor.web.internal.util.FragmentEntryLinkManager;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
-import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.portal.kernel.comment.CommentManager;
@@ -112,8 +111,8 @@ public class DuplicateSegmentsExperienceMVCActionCommand
 				duplicatedSegmentsExperience.getSegmentsExperienceId())
 		).put(
 			"layoutData",
-			_getLayoutDataJSONObject(
-				themeDisplay.getPlid(), themeDisplay.getScopeGroupId(),
+			LayoutStructureUtil.getLayoutDataJSONObject(
+				themeDisplay.getScopeGroupId(), themeDisplay.getPlid(),
 				duplicatedSegmentsExperience.getSegmentsExperienceId())
 		).put(
 			"segmentsExperience",
@@ -150,18 +149,6 @@ public class DuplicateSegmentsExperienceMVCActionCommand
 		}
 
 		return fragmentEntryLinksJSONObject;
-	}
-
-	private JSONObject _getLayoutDataJSONObject(
-			long classPK, long groupId, long segmentsExperienceId)
-		throws Exception {
-
-		LayoutPageTemplateStructure layoutPageTemplateStructure =
-			_layoutPageTemplateStructureLocalService.
-				fetchLayoutPageTemplateStructure(groupId, classPK, true);
-
-		return _jsonFactory.createJSONObject(
-			layoutPageTemplateStructure.getData(segmentsExperienceId));
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateConfigurationValuesMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateConfigurationValuesMVCActionCommand.java
@@ -178,7 +178,8 @@ public class UpdateConfigurationValuesMVCActionCommand
 				fragmentEntryLink, _portal.getHttpServletRequest(actionRequest),
 				_portal.getHttpServletResponse(actionResponse), layoutStructure)
 		).put(
-			"layoutData", layoutStructure.toJSONObject()
+			"layoutData",
+			LayoutStructureUtil.getLayoutDataJSONObject(layoutStructure)
 		).put(
 			"pageContents",
 			ContentUtil.getPageContentsJSONArray(

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateFormItemConfigMVCActionCommand.java
@@ -529,7 +529,9 @@ public class UpdateFormItemConfigMVCActionCommand extends BaseMVCActionCommand {
 			jsonObject.put(
 				"addedFragmentEntryLinks", addedFragmentEntryLinksJSONObject
 			).put(
-				"layoutData", updatedLayoutStructure.toJSONObject()
+				"layoutData",
+				LayoutStructureUtil.getLayoutDataJSONObject(
+					updatedLayoutStructure)
 			).put(
 				"removedFragmentEntryLinkIds",
 				removedLayoutStructureItemsJSONArray

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateRowColumnsMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateRowColumnsMVCActionCommand.java
@@ -19,7 +19,6 @@ import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.web.internal.util.ContentUtil;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
-import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -100,14 +99,9 @@ public class UpdateRowColumnsMVCActionCommand
 			"deletedFragmentEntryLinkIds", deletedFragmentEntryLinkIds.toArray()
 		).put(
 			"layoutData",
-			() -> {
-				LayoutStructure layoutStructure =
-					LayoutStructureUtil.getLayoutStructure(
-						themeDisplay.getScopeGroupId(), themeDisplay.getPlid(),
-						segmentsExperienceId);
-
-				return layoutStructure.toJSONObject();
-			}
+			LayoutStructureUtil.getLayoutDataJSONObject(
+				themeDisplay.getScopeGroupId(), themeDisplay.getPlid(),
+				segmentsExperienceId)
 		).put(
 			"pageContents",
 			ContentUtil.getPageContentsJSONArray(


### PR DESCRIPTION
@ealonso  
Here is the PR for fixing https://issues.liferay.com/browse/LPS-164942. The original PR was passed my review. Please help to review and leave your comments.

The solution is as below:
The LayoutData contains the items to be displayed on the Content Page Editor. So I filter the data layout to make sure the Form Containers that the user doesn't have permission to view and its children wouldn't be included.
I also have a change on getFragmentEntryLinkJSONObject to not show submit button in [ContentsSidebar](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page-content/components/ContentsSidebar.js)

cc: @tototrinh

Thanks