### PR TITLE
LPS-166624 Not able to search page with workflow in new site

### DIFF
--- a/modules/apps/layout/layout-api/bnd.bnd
+++ b/modules/apps/layout/layout-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout API
 Bundle-SymbolicName: com.liferay.layout.api
-Bundle-Version: 22.1.1
+Bundle-Version: 23.0.0
 Export-Package:\
 	com.liferay.layout.adaptive.media,\
 	com.liferay.layout.configuration,\

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/service/LayoutLocalizationLocalService.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/service/LayoutLocalizationLocalService.java
@@ -353,7 +353,8 @@ public interface LayoutLocalizationLocalService
 		LayoutLocalization layoutLocalization);
 
 	public LayoutLocalization updateLayoutLocalization(
-		String content, String languageId, long plid);
+		String content, String languageId, long plid,
+		ServiceContext serviceContext);
 
 	@Override
 	@Transactional(enabled = false)

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/service/LayoutLocalizationLocalServiceUtil.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/service/LayoutLocalizationLocalServiceUtil.java
@@ -402,9 +402,11 @@ public class LayoutLocalizationLocalServiceUtil {
 	}
 
 	public static LayoutLocalization updateLayoutLocalization(
-		String content, String languageId, long plid) {
+		String content, String languageId, long plid,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext) {
 
-		return getService().updateLayoutLocalization(content, languageId, plid);
+		return getService().updateLayoutLocalization(
+			content, languageId, plid, serviceContext);
 	}
 
 	public static LayoutLocalizationLocalService getService() {

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/service/LayoutLocalizationLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/service/LayoutLocalizationLocalServiceWrapper.java
@@ -457,10 +457,11 @@ public class LayoutLocalizationLocalServiceWrapper
 
 	@Override
 	public LayoutLocalization updateLayoutLocalization(
-		String content, String languageId, long plid) {
+		String content, String languageId, long plid,
+		com.liferay.portal.kernel.service.ServiceContext serviceContext) {
 
 		return _layoutLocalizationLocalService.updateLayoutLocalization(
-			content, languageId, plid);
+			content, languageId, plid, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/service/packageinfo
+++ b/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.5.0
+version 2.0.0

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutMVCActionCommand.java
@@ -154,7 +154,8 @@ public class PublishLayoutMVCActionCommand
 
 			layout = _layoutLocalService.getLayout(layout.getPlid());
 
-			_updateLayoutContent(actionRequest, actionResponse, layout);
+			_updateLayoutContent(
+				actionRequest, actionResponse, layout, serviceContext);
 
 			draftLayout = _layoutLocalService.getLayout(draftLayout.getPlid());
 
@@ -212,7 +213,7 @@ public class PublishLayoutMVCActionCommand
 
 	private void _updateLayoutContent(
 		ActionRequest actionRequest, ActionResponse actionResponse,
-		Layout layout) {
+		Layout layout, ServiceContext serviceContext) {
 
 		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
 			actionRequest);
@@ -225,7 +226,8 @@ public class PublishLayoutMVCActionCommand
 			_layoutLocalizationLocalService.updateLayoutLocalization(
 				_layoutContentProvider.getLayoutContent(
 					httpServletRequest, httpServletResponse, layout, locale),
-				LocaleUtil.toLanguageId(locale), layout.getPlid());
+				LocaleUtil.toLanguageId(locale), layout.getPlid(),
+				serviceContext);
 		}
 	}
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/workflow/LayoutWorkflowHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/workflow/LayoutWorkflowHandler.java
@@ -138,7 +138,7 @@ public class LayoutWorkflowHandler extends BaseWorkflowHandler<Layout> {
 
 			_updateLayoutContent(
 				serviceContext.getRequest(), serviceContext.getResponse(),
-				layout);
+				layout, serviceContext);
 		}
 
 		return _layoutLocalService.updateStatus(
@@ -154,7 +154,8 @@ public class LayoutWorkflowHandler extends BaseWorkflowHandler<Layout> {
 
 	private void _updateLayoutContent(
 		HttpServletRequest httpServletRequest,
-		HttpServletResponse httpServletResponse, Layout layout) {
+		HttpServletResponse httpServletResponse, Layout layout,
+		ServiceContext serviceContext) {
 
 		for (Locale locale :
 				_language.getAvailableLocales(layout.getGroupId())) {
@@ -162,7 +163,8 @@ public class LayoutWorkflowHandler extends BaseWorkflowHandler<Layout> {
 			_layoutLocalizationLocalService.updateLayoutLocalization(
 				_layoutContentProvider.getLayoutContent(
 					httpServletRequest, httpServletResponse, layout, locale),
-				LocaleUtil.toLanguageId(locale), layout.getPlid());
+				LocaleUtil.toLanguageId(locale), layout.getPlid(),
+				serviceContext);
 		}
 	}
 

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/service/impl/LayoutLocalizationLocalServiceImpl.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/service/impl/LayoutLocalizationLocalServiceImpl.java
@@ -23,7 +23,6 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 
 import java.util.List;
 
@@ -93,7 +92,8 @@ public class LayoutLocalizationLocalServiceImpl
 
 	@Override
 	public LayoutLocalization updateLayoutLocalization(
-		String content, String languageId, long plid) {
+		String content, String languageId, long plid,
+		ServiceContext serviceContext) {
 
 		Layout layout = _layoutLocalService.fetchLayout(plid);
 
@@ -103,8 +103,7 @@ public class LayoutLocalizationLocalServiceImpl
 
 		if (layoutLocalization == null) {
 			return addLayoutLocalization(
-				layout.getGroupId(), content, languageId, plid,
-				ServiceContextThreadLocal.getServiceContext());
+				layout.getGroupId(), content, languageId, plid, serviceContext);
 		}
 
 		layoutLocalization.setContent(content);

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
@@ -36,6 +36,8 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
 import com.liferay.portal.kernel.servlet.TransferHeadersHelper;
@@ -348,8 +350,10 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 	}
 
 	private void _updateLayoutContent(
-		HttpServletRequest httpServletRequest,
-		HttpServletResponse httpServletResponse, Layout layout, Locale locale) {
+			HttpServletRequest httpServletRequest,
+			HttpServletResponse httpServletResponse, Layout layout,
+			Locale locale)
+		throws Exception {
 
 		LayoutLocalization layoutLocalization =
 			_layoutLocalizationLocalService.fetchLayoutLocalization(
@@ -360,13 +364,17 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 			return;
 		}
 
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			httpServletRequest);
+
 		for (Locale curLocale :
 				_language.getAvailableLocales(layout.getGroupId())) {
 
 			_layoutLocalizationLocalService.updateLayoutLocalization(
 				_layoutContentProvider.getLayoutContent(
 					httpServletRequest, httpServletResponse, layout, curLocale),
-				LocaleUtil.toLanguageId(curLocale), layout.getPlid());
+				LocaleUtil.toLanguageId(curLocale), layout.getPlid(),
+				serviceContext);
 		}
 	}
 

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommand.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommand.java
@@ -17,6 +17,7 @@ package com.liferay.portal.workflow.task.web.internal.portlet.action;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortletKeys;
@@ -33,6 +34,9 @@ import java.util.Map;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
+import javax.portlet.PortletResponse;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -71,7 +75,20 @@ public class CompleteTaskMVCActionCommand
 		ServiceContext serviceContext = (ServiceContext)workflowContext.get(
 			"serviceContext");
 
-		serviceContext.setRequest(_portal.getHttpServletRequest(actionRequest));
+		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
+			actionRequest);
+
+		PortletResponse portletResponse =
+			(PortletResponse)httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_RESPONSE);
+
+		if (portletResponse == null) {
+			httpServletRequest.setAttribute(
+				JavaConstants.JAVAX_PORTLET_RESPONSE,
+				_portal.getLiferayPortletResponse(actionResponse));
+		}
+
+		serviceContext.setRequest(httpServletRequest);
 
 		workflowContext.put(
 			WorkflowConstants.CONTEXT_USER_ID,

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommand.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommand.java
@@ -75,6 +75,24 @@ public class CompleteTaskMVCActionCommand
 		ServiceContext serviceContext = (ServiceContext)workflowContext.get(
 			"serviceContext");
 
+		serviceContext.setRequest(
+			_getHttpServletRequest(actionRequest, actionResponse));
+
+		workflowContext.put(
+			WorkflowConstants.CONTEXT_USER_ID,
+			String.valueOf(themeDisplay.getUserId()));
+
+		workflowTaskManager.completeWorkflowTask(
+			themeDisplay.getCompanyId(), themeDisplay.getUserId(),
+			workflowTaskId, transitionName, comment, workflowContext);
+	}
+
+	@Reference
+	protected WorkflowTaskManager workflowTaskManager;
+
+	private HttpServletRequest _getHttpServletRequest(
+		ActionRequest actionRequest, ActionResponse actionResponse) {
+
 		HttpServletRequest httpServletRequest = _portal.getHttpServletRequest(
 			actionRequest);
 
@@ -88,19 +106,8 @@ public class CompleteTaskMVCActionCommand
 				_portal.getLiferayPortletResponse(actionResponse));
 		}
 
-		serviceContext.setRequest(httpServletRequest);
-
-		workflowContext.put(
-			WorkflowConstants.CONTEXT_USER_ID,
-			String.valueOf(themeDisplay.getUserId()));
-
-		workflowTaskManager.completeWorkflowTask(
-			themeDisplay.getCompanyId(), themeDisplay.getUserId(),
-			workflowTaskId, transitionName, comment, workflowContext);
+		return httpServletRequest;
 	}
-
-	@Reference
-	protected WorkflowTaskManager workflowTaskManager;
 
 	private Map<String, Serializable> _getWorkflowContext(
 			long companyId, long workflowTaskId)

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommandTest.java
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/test/java/com/liferay/portal/workflow/task/web/internal/portlet/action/CompleteTaskMVCActionCommandTest.java
@@ -1,0 +1,125 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portal.workflow.task.web.internal.portlet.action;
+
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.portletmvc4spring.test.mock.web.portlet.MockActionRequest;
+import com.liferay.portletmvc4spring.test.mock.web.portlet.MockActionResponse;
+import com.liferay.portletmvc4spring.test.mock.web.portlet.MockPortletResponse;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class CompleteTaskMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Before
+	public void setUp() {
+		_completeTaskMVCActionCommand = new CompleteTaskMVCActionCommand();
+	}
+
+	@Test
+	public void testGetHttpServletRequest() {
+		ActionRequest mockActionRequest = new MockActionRequest();
+
+		HttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_RESPONSE, new MockPortletResponse());
+
+		Portal portal = Mockito.mock(Portal.class);
+
+		Mockito.when(
+			portal.getHttpServletRequest(mockActionRequest)
+		).thenReturn(
+			mockHttpServletRequest
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_completeTaskMVCActionCommand, "_portal", portal);
+
+		HttpServletRequest httpServletRequest = ReflectionTestUtil.invoke(
+			_completeTaskMVCActionCommand, "_getHttpServletRequest",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			mockActionRequest, new MockActionResponse());
+
+		Assert.assertNotNull(httpServletRequest);
+
+		Assert.assertNotNull(
+			httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_RESPONSE));
+	}
+
+	@Test
+	public void testGetHttpServletRequestWithNoPortletResponse() {
+		ActionRequest mockActionRequest = new MockActionRequest();
+		ActionResponse mockActionResponse = new MockActionResponse();
+
+		Portal portal = Mockito.mock(Portal.class);
+
+		Mockito.when(
+			portal.getHttpServletRequest(mockActionRequest)
+		).thenReturn(
+			new MockHttpServletRequest()
+		);
+
+		Mockito.when(
+			portal.getLiferayPortletResponse(mockActionResponse)
+		).thenReturn(
+			new MockLiferayPortletActionResponse()
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			_completeTaskMVCActionCommand, "_portal", portal);
+
+		HttpServletRequest httpServletRequest = ReflectionTestUtil.invoke(
+			_completeTaskMVCActionCommand, "_getHttpServletRequest",
+			new Class<?>[] {ActionRequest.class, ActionResponse.class},
+			mockActionRequest, mockActionResponse);
+
+		Assert.assertNotNull(httpServletRequest);
+
+		Assert.assertNotNull(
+			httpServletRequest.getAttribute(
+				JavaConstants.JAVAX_PORTLET_RESPONSE));
+	}
+
+	private CompleteTaskMVCActionCommand _completeTaskMVCActionCommand;
+
+}


### PR DESCRIPTION
## Motivation

[Link to bug](https://issues.liferay.com/browse/LPS-166624)

There's a bug when after approving a content page, when searching for text in it, no results are found. This is because we check that the request and the response are present when generating the content


## Proposed solution

Always add the response to the request, this is done when completing the task


## Change summary:

* Check if the response is present in the httpServletRequest, if not, retrieve it from actionResponse and add it
* Add unit tests for the changes in action command
* Change methods for localisation so that we pass the service context instead of retrieving it from the ThreadLocal
* Adapt integration test for workflow handler


## How to test the changes

* Create a new site
* Enable workflow for content pages
* Create a new widget page called "Search" and add a "Search Result" widget to it
* Create a new content page, add something with text on it and submit for publication
* In publication tasks assign the page to you
* Approve the page
* Go to any page and search for text that was added to the content page

![workflow](https://user-images.githubusercontent.com/4267448/198309317-8b67eb7d-bd68-4ccb-88df-65383d374a96.gif)


