### PR TITLE
LPS-167139 Web content display selection removed when scope is set to default on upgrade

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
@@ -90,9 +90,7 @@ public class UpgradePortletPreferences
 				return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 			}
 
-			if (!group.isCompany() && !group.isLayout() &&
-				Validator.isNull(lfrScopeType)) {
-
+			if (!group.isCompany() && !group.isLayout()) {
 				return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 			}
 

--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/upgrade/v1_1_0/UpgradePortletPreferences.java
@@ -79,7 +79,10 @@ public class UpgradePortletPreferences
 			String lfrScopeType = portletPreferences.getValue(
 				"lfrScopeType", StringPool.BLANK);
 
-			if (group.isCompany() && Objects.equals("company", lfrScopeType)) {
+			if (Validator.isBlank(lfrScopeType) ||
+				(group.isCompany() &&
+				 Objects.equals("company", lfrScopeType))) {
+
 				return PortletPreferencesFactoryUtil.toXML(portletPreferences);
 			}
 


### PR DESCRIPTION
Original comment:

Hi @jkappler, sure thing! In 7.3 dxp-2 and lower web content could be selected from the global site. (I am not sure when this changed, but at least 7.3 dxp-2 and before it was possible) In LPS-96195 this upgrade process was added, but it did not take into account web content displays that did not set a scope, so there is nothing returned with the lfrScopeType portlet preference. The upgrade process took that to mean that an invalid web content was selected, but that is not the case when a global web content is selected without changing the scope.