### PR TITLE
LPS-167430 Set min-height for editable content

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/_FragmentContent.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-content/_FragmentContent.scss
@@ -58,6 +58,10 @@ html#{$cadmin-selector} {
 					}
 				}
 			}
+
+			.portlet-content.portlet-content-editable {
+				min-height: 54px;
+			}
 		}
 
 		.portlet-msg-info {


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-167430

The issue is that editable content do not have a `min-height` and so it can be difficult to get the menu kebab to display.
Here is an example of the difficultly.
https://user-images.githubusercontent.com/31672551/199601594-b1fd8ec6-e55e-4e72-afd8-cb2ff9cf707f.mp4


To fix this, I added `min-height: 40px` so that it can be more reasonable to get the menu kebab. 
Please let me know if there are any questions or comments about this.

Thank you!