### PR TITLE
LPS-84862 use the service object to call copyStructure instead of calling the post

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/service/impl/DDMStructureLocalServiceImpl.java
@@ -41,6 +41,9 @@ import com.liferay.dynamic.data.mapping.model.DDMDataProviderInstanceLink;
 import com.liferay.dynamic.data.mapping.model.DDMForm;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
 import com.liferay.dynamic.data.mapping.model.DDMFormLayout;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayoutColumn;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayoutPage;
+import com.liferay.dynamic.data.mapping.model.DDMFormLayoutRow;
 import com.liferay.dynamic.data.mapping.model.DDMFormRule;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMStructureLayout;
@@ -106,6 +109,7 @@ import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashSet;
@@ -422,8 +426,8 @@ public class DDMStructureLocalServiceImpl
 		DDMStructure newStructure = _addStructure(
 			user, structure.getGroupId(), structure.getParentStructureId(),
 			structure.getClassNameId(), structureKey, nameMap, descriptionMap,
-			structure.getDDMForm(), structure.getStorageType(),
-			structure.getType(), serviceContext);
+			_uniquifyDDMFormFields(structure.getDDMForm()),
+			structure.getStorageType(), structure.getType(), serviceContext);
 
 		// Resources
 
@@ -446,7 +450,8 @@ public class DDMStructureLocalServiceImpl
 				userId, structure.getGroupId(), newStructure.getClassNameId(),
 				newStructure.getStructureKey(),
 				structureVersion.getStructureVersionId(),
-				structure.getDDMFormLayout(), serviceContext);
+				_uniquifyDDMFormLayoutFields(structure.getDDMFormLayout()),
+				serviceContext);
 		}
 
 		// Data provider instance links
@@ -1908,6 +1913,54 @@ public class DDMStructureLocalServiceImpl
 
 				return null;
 			});
+	}
+
+	private void _uniquifyDDMFormField(DDMFormField ddmFormField) {
+		ddmFormField.setFieldReference(
+			"CopyOf" + ddmFormField.getFieldReference());
+
+		ddmFormField.setName("CopyOf" + ddmFormField.getName());
+
+		Collection<DDMFormField> nestedDDMFormFields =
+			ddmFormField.getNestedDDMFormFields();
+
+		nestedDDMFormFields.forEach(
+			nestedDDMFormField -> _uniquifyDDMFormField(nestedDDMFormField));
+	}
+
+	private DDMForm _uniquifyDDMFormFields(DDMForm ddmForm) {
+		Collection<DDMFormField> ddmFormFields = ddmForm.getDDMFormFields();
+
+		ddmFormFields.forEach(
+			ddmFormField -> _uniquifyDDMFormField(ddmFormField));
+
+		return ddmForm;
+	}
+
+	private DDMFormLayout _uniquifyDDMFormLayoutFields(
+		DDMFormLayout ddmFormLayout) {
+
+		for (DDMFormLayoutPage ddmFormLayoutPage :
+				ddmFormLayout.getDDMFormLayoutPages()) {
+
+			for (DDMFormLayoutRow ddmFormLayoutRow :
+					ddmFormLayoutPage.getDDMFormLayoutRows()) {
+
+				for (DDMFormLayoutColumn ddmFormLayoutColumn :
+						ddmFormLayoutRow.getDDMFormLayoutColumns()) {
+
+					List<String> ddmFormFieldNames =
+						ddmFormLayoutColumn.getDDMFormFieldNames();
+
+					for (int i = 0; i < ddmFormFieldNames.size(); i++) {
+						ddmFormFieldNames.set(
+							i, "CopyOf" + ddmFormFieldNames.get(i));
+					}
+				}
+			}
+		}
+
+		return ddmFormLayout;
 	}
 
 	private void _updateDataProviderInstanceLinks(

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/CopyDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/CopyDataDefinitionMVCActionCommand.java
@@ -14,7 +14,6 @@
 
 package com.liferay.journal.web.internal.portlet.action;
 
-import com.liferay.data.engine.field.type.util.LocalizedValueUtil;
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
 import com.liferay.data.engine.rest.dto.v2_0.DataDefinitionField;
 import com.liferay.data.engine.rest.dto.v2_0.DataLayout;
@@ -29,18 +28,15 @@ import com.liferay.dynamic.data.mapping.service.DDMStructureService;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateService;
 import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.model.JournalArticle;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.transaction.Transactional;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
-import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Locale;
 import java.util.Map;
@@ -81,9 +77,6 @@ public class CopyDataDefinitionMVCActionCommand
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
 		long ddmStructureId = ParamUtil.getLong(
 			actionRequest, "ddmStructureId");
 
@@ -92,40 +85,16 @@ public class CopyDataDefinitionMVCActionCommand
 		Map<Locale, String> nameMap = _localization.getLocalizationMap(
 			actionRequest, "name");
 
-		DataDefinitionResource.Builder dataDefinitionResourcedBuilder =
-			_dataDefinitionResourceFactory.create();
+		ServiceContext serviceContext = ServiceContextFactory.getInstance(
+			DDMStructure.class.getName(), actionRequest);
 
-		DataDefinitionResource dataDefinitionResource =
-			dataDefinitionResourcedBuilder.user(
-				themeDisplay.getUser()
-			).build();
-
-		DataDefinition dataDefinition =
-			dataDefinitionResource.getDataDefinition(ddmStructureId);
-
-		_uniquifyDataDefinitionFields(dataDefinition);
-
-		dataDefinition.setDataDefinitionKey(StringPool.BLANK);
-		dataDefinition.setDescription(
-			LocalizedValueUtil.toStringObjectMap(descriptionMap));
-		dataDefinition.setName(LocalizedValueUtil.toStringObjectMap(nameMap));
-
-		dataDefinition =
-			dataDefinitionResource.postSiteDataDefinitionByContentType(
-				themeDisplay.getScopeGroupId(), "journal", dataDefinition);
+		DDMStructure ddmStructure = _ddmStructureService.copyStructure(
+			ddmStructureId, nameMap, descriptionMap, serviceContext);
 
 		boolean copyTemplates = ParamUtil.getBoolean(
 			actionRequest, "copyTemplates");
 
 		if (copyTemplates) {
-			DDMStructure ddmStructure = _ddmStructureService.getStructure(
-				themeDisplay.getScopeGroupId(),
-				_portal.getClassNameId(JournalArticle.class),
-				dataDefinition.getDataDefinitionKey());
-
-			ServiceContext serviceContext = ServiceContextFactory.getInstance(
-				DDMStructure.class.getName(), actionRequest);
-
 			_ddmTemplateService.copyTemplates(
 				_portal.getClassNameId(DDMStructure.class), ddmStructureId,
 				_portal.getClassNameId(JournalArticle.class),


### PR DESCRIPTION
[LPS-84862](https://issues.liferay.com/browse/LPS-84862) The copying of the structure in the CopyDataDefinitionMVCActionCommand class was being done through the ‘post’ method of the dataDefinitionResource without copying the permissions. The solution was to, instead of this, use the “copyStructure” method of the “ddmStructureService”, which adequately copies the permissions.