### PR TITLE
LPS-167552 Check the url when the attribute tabindex is added

### DIFF
--- a/portal-web/docroot/html/taglib/ui/icon/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/icon/page.jsp
@@ -65,7 +65,7 @@ if (useDialog || (urlIsNotNull && url.startsWith("javascript:"))) {
 		<span
 			class="<%= cssClass %>"
 
-			<c:if test="<%= toolTip %>">
+			<c:if test="<%= toolTip && !urlIsNotNull %>">
 				tabindex="0"
 			</c:if>
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-167552

cc @marcoscv-work, @edalgrin

This issue is related to this https://issues.liferay.com/browse/LPS-165642. I have added to the condition to add the `tabindex` attribute the url check. So when the element has a url, it will not be necessary to add the `tabindex` attribute.

