### PR TITLE
LPS-166626 Add item title to JSP preview file for non pop_up states

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content.jsp
@@ -20,10 +20,26 @@
 JournalArticleDisplay articleDisplay = journalDisplayContext.getArticleDisplay();
 %>
 
-<clay:container-fluid
-	cssClass="mt-2"
->
-	<%= articleDisplay.getContent() %>
+<c:if test="<%= renderRequest.getWindowState() != LiferayWindowState.POP_UP %>">
+	<clay:container-fluid
+		cssClass="mt-3"
+	>
+		<clay:row>
+			<clay:col>
+				<h3 class="m-0"><%= articleDisplay.getTitle() %></h3>
+			</clay:col>
+		</clay:row>
+	</clay:container-fluid>
+
+	<hr class="mb-4 separator" />
+</c:if>
+
+<clay:container-fluid>
+	<clay:row>
+		<clay:col>
+			<%= articleDisplay.getContent() %>
+		</clay:col>
+	</clay:row>
 </clay:container-fluid>
 
 <c:if test="<%= articleDisplay.isPaginate() %>">


### PR DESCRIPTION
[Story](https://issues.liferay.com/browse/LPS-161020)
[Figma](https://www.figma.com/file/ZpecwjhViyZGsP8hWxqOSe/LPS-134694-UX-Improvements-in-info-panels-of-content-dashboard?node-id=1080%3A358437)

## Motivation

We are implementing a new preview action for web contents versions in the info panel of the Content Dashboard.
This new preview action opens a new tab instead of a modal.
This new tab need some UI modifications, as showed in the Figma file linked above:
- A title
- A separator

## Solution proposed

Only for **non pop_up window states**, the template will render the title and the separator

## How to verify

- Create a web content, edit it once or twice just to generate versions
- Visit the Content Dashboard
- Open the info panel for the web content by clicking the info icon or using the item kebab menu
- Once in the info panel, click on versions tab
- Use the kebab menu for any version and click on preview action

**Expected**: new browser tab opens with a preview

Current preview implementations should work as before.