### PR TITLE
[TS] LPS-167839 | Can't add assets to collections after upgrade from 7.2

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java
@@ -710,8 +710,11 @@ public class EditAssetListDisplayContext {
 
 		long[] classNameIds = GetterUtil.getLongValues(
 			StringUtil.split(
-				unicodeProperties.getProperty("classNameIds", null)),
-			_getDefaultClassNameIds());
+				unicodeProperties.getProperty("classNameIds", null)));
+
+		if (classNameIds.length == 0) {
+			classNameIds = _getDefaultClassNameIds();
+		}
 
 		for (long classNameId : classNameIds) {
 			AssetRendererFactory<?> assetRendererFactory =


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-167839
Thank you!

-------

**Steps to reproduce:**

1. Start a 7.2 bundle
2. Create a manual collection in Site administration -> Content and data -> Content sets
3. You will see a 'Select' button where you can add assets to the collection
4. Shut down the server and upgrade it to 7.4 or master
5. Check the collection in Site builder -> Collections

**Expected behavior:** Select button should still be there
**Current behavior:** Select button is not available

Note:

To upgrade to master, just use the upgrade.database.auto.run=true property in your master bundle

The root cause of the issue is that on the older version we did not force the user to decide the type of the collection. As a result, the typesettings related to the asset list are empty for the migrated asset lists.
There is a fallback logic for the empty typesettings but because of the StringUtil.split in the code, we will never receive a null. I changed the code to see whether or not we got an empty string array as a result of the StringUtil.split and if we did I fallback to the _getDefaultClassNameIds.