### PR TITLE
[TS] LPS-168164 HTTP 414 error for a valid Friendly URL after using an invalid long value in Page Admin

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/general.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/general.jsp
@@ -63,6 +63,8 @@ if (Validator.isNotNull(backURL)) {
 }
 
 renderResponse.setTitle(layoutsAdminDisplayContext.getConfigurationTitle(selLayout, locale));
+
+String screenNavigationPortletURL = String.valueOf(layoutsAdminDisplayContext.getScreenNavigationPortletURL());
 %>
 
 <c:choose>
@@ -83,7 +85,7 @@ renderResponse.setTitle(layoutsAdminDisplayContext.getConfigurationTitle(selLayo
 					if (enableLayoutButton) {
 						enableLayoutButton.addEventListener('click', (event) => {
 							<portlet:actionURL name="/layout_admin/enable_layout" var="enableLayoutURL">
-								<portlet:param name="redirect" value="<%= currentURL %>" />
+								<portlet:param name="redirect" value="<%= screenNavigationPortletURL %>" />
 								<portlet:param name="incompleteLayoutRevisionId" value="<%= String.valueOf(layoutRevision.getLayoutRevisionId()) %>" />
 							</portlet:actionURL>
 
@@ -98,7 +100,7 @@ renderResponse.setTitle(layoutsAdminDisplayContext.getConfigurationTitle(selLayo
 					if (deleteLayoutButton) {
 						deleteLayoutButton.addEventListener('click', (event) => {
 							<portlet:actionURL name="/layout_admin/delete_layout" var="deleteLayoutURL">
-								<portlet:param name="redirect" value="<%= currentURL %>" />
+								<portlet:param name="redirect" value="<%= screenNavigationPortletURL %>" />
 								<portlet:param name="selPlid" value="<%= String.valueOf(layoutsAdminDisplayContext.getSelPlid()) %>" />
 								<portlet:param name="layoutSetBranchId" value="0" />
 							</portlet:actionURL>
@@ -116,7 +118,7 @@ renderResponse.setTitle(layoutsAdminDisplayContext.getConfigurationTitle(selLayo
 		</portlet:actionURL>
 
 		<aui:form action='<%= HttpComponentsUtil.addParameter(editLayoutURL, "refererPlid", plid) %>' enctype="multipart/form-data" method="post" name="editLayoutFm" onSubmit="event.preventDefault();">
-			<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+			<aui:input name="redirect" type="hidden" value="<%= screenNavigationPortletURL %>" />
 			<aui:input name="backURL" type="hidden" value="<%= backURL %>" />
 			<aui:input name="portletResource" type="hidden" value="<%= portletResource %>" />
 			<aui:input name="groupId" type="hidden" value="<%= layoutsAdminDisplayContext.getGroupId() %>" />


### PR DESCRIPTION
Relevant issues: [LPS-168164](https://issues.liferay.com/browse/LPS-168164)

---

Hi @liferay-echo

In page admin, when you use a long friendly url (+255 characters) you get an error. After that, you will get a 414 Error if you try to save again with a valid friendly url. See reproduction steps in [LPS-168164](https://issues.liferay.com/browse/LPS-168164)

To avoid that, I have used the approach implemented by Pavel Savinov in https://github.com/brianchandotcom/liferay-portal/pull/83000/commits/89f72a238f4329d7a4cba84e6c252be7f1503f9b ([LPS-106606](https://issues.liferay.com/browse/LPS-106606)).

Could you review this pr?

Thanks!



