### PR TITLE
LPS-167504 - Select buttons in the Category and Tag Selectors are being announced with the same name.

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetVocabularyCategoriesSelector.es.js
@@ -46,6 +46,7 @@ function AssetVocabulariesCategoriesSelector({
 
 	const [invalidItems, setInvalidItems] = useState([]);
 	const [resource, setResource] = useState([]);
+	const [selectionModalIsOpen, setSelectionModalIsOpen] = useState(false);
 	const selectButtonRef = useRef();
 
 	const previousInputValue = usePrevious(inputValue);
@@ -134,7 +135,11 @@ function AssetVocabulariesCategoriesSelector({
 		onSelectedItemsChange(current);
 	};
 
+	const selectionModalId = inputName + '_SelectionModal';
+
 	const handleSelectButtonClick = () => {
+		setSelectionModalIsOpen(true);
+
 		const url = createPortletURL(portletURL, {
 			selectedCategories: selectedItems.map((item) => item.value).join(),
 			singleSelect,
@@ -144,9 +149,12 @@ function AssetVocabulariesCategoriesSelector({
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
 			height: '70vh',
+			id: selectionModalId,
 			iframeBodyCssClass: '',
 			multiple: true,
 			onClose: () => {
+				setSelectionModalIsOpen(false);
+
 				selectButtonRef.current?.focus();
 			},
 			onSelect: (selectedItems) => {
@@ -271,6 +279,13 @@ function AssetVocabulariesCategoriesSelector({
 
 					<ClayInput.GroupItem shrink>
 						<ClayButton
+							aria-controls={selectionModalId}
+							aria-expanded={selectionModalIsOpen}
+							aria-haspopup="dialog"
+							aria-label={sub(
+								Liferay.Language.get('select-x'),
+								label
+							)}
 							displayType="secondary"
 							onClick={handleSelectButtonClick}
 							ref={selectButtonRef}

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
@@ -19,7 +19,7 @@ import ClayMultiSelect, {itemLabelFilter} from '@clayui/multi-select';
 import {usePrevious} from '@liferay/frontend-js-react-web';
 import {objectToFormData, openSelectionModal, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 const noop = () => {};
 
@@ -38,6 +38,7 @@ function AssetTagsSelector({
 	showSelectButton,
 }) {
 	const [selectionModalIsOpen, setSelectionModalIsOpen] = useState(false);
+	const selectButtonRef = useRef();
 
 	const {refetch, resource} = useResource({
 		fetchOptions: {
@@ -141,6 +142,8 @@ function AssetTagsSelector({
 			multiple: true,
 			onClose: () => {
 				setSelectionModalIsOpen(false);
+
+				selectButtonRef.current?.focus();
 			},
 			onSelect: (dialogSelectedItems) => {
 				if (!dialogSelectedItems?.length) {
@@ -254,6 +257,7 @@ function AssetTagsSelector({
 								)}
 								displayType="secondary"
 								onClick={handleSelectButtonClick}
+								ref={selectButtonRef}
 							>
 								{Liferay.Language.get('select')}
 							</ClayButton>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_selector/AssetTagsSelector.es.js
@@ -17,9 +17,9 @@ import {useResource} from '@clayui/data-provider';
 import ClayForm, {ClayInput} from '@clayui/form';
 import ClayMultiSelect, {itemLabelFilter} from '@clayui/multi-select';
 import {usePrevious} from '@liferay/frontend-js-react-web';
-import {objectToFormData, openSelectionModal} from 'frontend-js-web';
+import {objectToFormData, openSelectionModal, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useEffect} from 'react';
+import React, {useEffect, useState} from 'react';
 
 const noop = () => {};
 
@@ -29,7 +29,7 @@ function AssetTagsSelector({
 	id,
 	inputName,
 	inputValue,
-	label,
+	label = Liferay.Language.get('tags'),
 	onInputValueChange = noop,
 	onSelectedItemsChange = noop,
 	portletURL,
@@ -37,6 +37,8 @@ function AssetTagsSelector({
 	selectedItems = [],
 	showSelectButton,
 }) {
+	const [selectionModalIsOpen, setSelectionModalIsOpen] = useState(false);
+
 	const {refetch, resource} = useResource({
 		fetchOptions: {
 			'body': objectToFormData({
@@ -120,7 +122,11 @@ function AssetTagsSelector({
 		);
 	};
 
+	const selectionModalId = inputName + '_SelectionModal';
+
 	const handleSelectButtonClick = () => {
+		setSelectionModalIsOpen(true);
+
 		const sub = (str, object) =>
 			str.replace(/\{([^}]+)\}/g, (_, m) => object[m]);
 
@@ -131,7 +137,11 @@ function AssetTagsSelector({
 		openSelectionModal({
 			buttonAddLabel: Liferay.Language.get('done'),
 			getSelectedItemsOnly: false,
+			id: {selectionModalId},
 			multiple: true,
+			onClose: () => {
+				setSelectionModalIsOpen(false);
+			},
 			onSelect: (dialogSelectedItems) => {
 				if (!dialogSelectedItems?.length) {
 					return;
@@ -204,9 +214,7 @@ function AssetTagsSelector({
 	return (
 		<div className="lfr-tags-selector-content" id={id}>
 			<ClayForm.Group>
-				<label htmlFor={inputName + '_MultiSelect'}>
-					{label || Liferay.Language.get('tags')}
-				</label>
+				<label htmlFor={inputName + '_MultiSelect'}>{label}</label>
 
 				<ClayInput.Group>
 					<ClayInput.GroupItem>
@@ -237,6 +245,13 @@ function AssetTagsSelector({
 					{showSelectButton && (
 						<ClayInput.GroupItem shrink>
 							<ClayButton
+								aria-controls={selectionModalId}
+								aria-expanded={selectionModalIsOpen}
+								aria-haspopup="dialog"
+								aria-label={sub(
+									Liferay.Language.get('select-x'),
+									label
+								)}
 								displayType="secondary"
 								onClick={handleSelectButtonClick}
 							>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-167504

 **Steps to Reproduce:**
1. Turn on JAWS > Open the URL.
2. Navigate to the Site Menu > Content & Data > Web Content.
3. Click the "+" to add a new Basic Web Content.
4. Press tab until you reach the Categories section of the sidebar.
5. Tab through each Select button.
6. Observe the JAWS.

 **Expected Result:**
Each select button should have a unique descriptive name.
For example:
"Select topic button
Opens a dialog
To activate press enter".

 **Actual Result:**
There are multiple select buttons on the page with same announcement by SR: ("select button").
This will confuse the SR users.

 

**How to fix, recommendation:**

Add additional aria properties:
aria-controls={selectionModalId}
aria-expanded={selectionModalOpen}
aria-haspopup="dialog"
aria-label="select-x"