### PR TITLE
LPS-167895 Make empty string a valid value

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java
@@ -66,21 +66,21 @@ public class FragmentEntryProcessorHelperImpl
 
 	@Override
 	public String getEditableValue(JSONObject jsonObject, Locale locale) {
-		String value = jsonObject.getString(
-			_language.getLanguageId(locale), null);
+		Object value = jsonObject.get(_language.getLanguageId(locale));
 
 		if (value != null) {
-			return value;
+			return jsonObject.getString(_language.getLanguageId(locale));
 		}
 
-		value = jsonObject.getString(
+		value = jsonObject.get(
 			_language.getLanguageId(LocaleUtil.getSiteDefault()));
 
-		if (Validator.isNull(value)) {
-			value = jsonObject.getString("defaultValue");
+		if (value == null) {
+			return jsonObject.getString("defaultValue");
 		}
 
-		return value;
+		return jsonObject.getString(
+			_language.getLanguageId(LocaleUtil.getSiteDefault()));
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-167895

For fragments, the default value would be displayed if the default locale is an empty string. To resolve this issue, I added a check to make sure the value is acceptable when it is an empty string. 

Mateo said this should be considered a breaking change.
https://issues.liferay.com/browse/PTR-3466?focusedCommentId=2797567&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-2797567

Please let me know if there are any questions or comments about this.
Thank you.