### PR TITLE
[TECHNICAL SUPPORT] LPS-168575 Error message does not specifies the reason why the import of JSON web content structure fails

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportDataDefinitionMVCActionCommand.java
@@ -111,6 +111,11 @@ public class ImportDataDefinitionMVCActionCommand extends BaseMVCActionCommand {
 			SessionErrors.add(
 				actionRequest, "importDataDefinitionErrorMessage");
 
+			if (Validator.isNotNull(exception.getMessage())) {
+				SessionErrors.add(
+					actionRequest, "importDataDefinitionException", exception);
+			}
+
 			hideDefaultErrorMessage(actionRequest);
 		}
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_structures.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_ddm_structures.jsp
@@ -48,6 +48,16 @@ JournalDDMStructuresManagementToolbarDisplayContext journalDDMStructuresManageme
 	<liferay-ui:success key="importDataDefinitionSuccessMessage" message="the-structure-was-successfully-imported" />
 
 	<liferay-ui:error embed="<%= false %>" key="importDataDefinitionErrorMessage" message="the-structure-was-not-successfully-imported" />
+
+	<liferay-ui:error embed="<%= false %>" key="importDataDefinitionException">
+
+		<%
+		Exception exception = (Exception)errorException;
+		%>
+
+		<liferay-ui:message key="<%= exception.getMessage() %>" />
+	</liferay-ui:error>
+
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureReferencedByStructureLinks.class %>" message="the-structure-cannot-be-deleted-because-it-is-required-by-one-or-more-structure-links" />
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureReferencedByTemplates.class %>" message="the-structure-cannot-be-deleted-because-it-is-required-by-one-or-more-templates" />
 	<liferay-ui:error exception="<%= RequiredStructureException.MustNotDeleteStructureThatHasChild.class %>" message="the-structure-cannot-be-deleted-because-it-has-one-or-more-substructures" />


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
If importing a Web Content Structure fails, the error message "Error: The structure was not successfully imported." isn't descriptive enough, as the failure could have many reasons. If information about the root cause can be extracted from the exception, at least some of it should be part of the error message presented to the user. 
https://issues.liferay.com/browse/LPS-168575

Proposed Solution
========
If the exception has a message, it is forwarded to the UI to be displayed.

Steps to Verify
========
Please consult the linked LPS for reproduction steps.

Thank you and best regards,
István