### PR TITLE
LPS-168644 Folder capabilities should be supported by staging process

### DIFF
--- a/modules/apps/fragment/fragment-service/bnd.bnd
+++ b/modules/apps/fragment/fragment-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.fragment.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 2.10.0
+Liferay-Require-SchemaVersion: 2.10.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentCollectionStagedModelDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentCollectionStagedModelDataHandler.java
@@ -14,28 +14,16 @@
 
 package com.liferay.fragment.internal.exportimport.data.handler;
 
-import com.liferay.document.library.kernel.exception.NoSuchFileException;
-import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
-import com.liferay.fragment.constants.FragmentPortletKeys;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Element;
-import com.liferay.portlet.documentlibrary.lar.FileEntryUtil;
-
-import java.io.InputStream;
-
-import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -132,55 +120,6 @@ public class FragmentCollectionStagedModelDataHandler
 					portletDataContext, importedFragmentCollection);
 		}
 
-		if (existingFragmentCollection != null) {
-			for (FileEntry fileEntry :
-					existingFragmentCollection.getResources()) {
-
-				PortletFileRepositoryUtil.deletePortletFileEntry(
-					fileEntry.getFileEntryId());
-			}
-		}
-
-		long userId = portletDataContext.getUserId(
-			fragmentCollection.getUserUuid());
-
-		List<Element> resourceElements =
-			portletDataContext.getReferenceDataElements(
-				fragmentCollection, DLFileEntry.class,
-				PortletDataContext.REFERENCE_TYPE_WEAK);
-
-		for (Element resourceElement : resourceElements) {
-			String path = resourceElement.attributeValue("path");
-
-			FileEntry fileEntry =
-				(FileEntry)portletDataContext.getZipEntryAsObject(path);
-
-			String binPath = resourceElement.attributeValue("bin-path");
-
-			try (InputStream inputStream = _getResourceInputStream(
-					binPath, portletDataContext, fileEntry)) {
-
-				if (inputStream == null) {
-					if (_log.isWarnEnabled()) {
-						_log.warn(
-							"Unable to import resource for file entry " +
-								fileEntry.getFileEntryId());
-					}
-
-					continue;
-				}
-
-				PortletFileRepositoryUtil.addPortletFileEntry(
-					null, importedFragmentCollection.getGroupId(), userId,
-					FragmentCollection.class.getName(),
-					importedFragmentCollection.getFragmentCollectionId(),
-					FragmentPortletKeys.FRAGMENT,
-					importedFragmentCollection.getResourcesFolderId(),
-					inputStream, fileEntry.getFileName(),
-					fileEntry.getMimeType(), false);
-			}
-		}
-
 		portletDataContext.importClassedModel(
 			fragmentCollection, importedFragmentCollection);
 	}
@@ -191,32 +130,6 @@ public class FragmentCollectionStagedModelDataHandler
 
 		return _stagedModelRepository;
 	}
-
-	private InputStream _getResourceInputStream(
-			String binPath, PortletDataContext portletDataContext,
-			FileEntry fileEntry)
-		throws Exception {
-
-		if (Validator.isNull(binPath) &&
-			portletDataContext.isPerformDirectBinaryImport()) {
-
-			try {
-				return FileEntryUtil.getContentStream(fileEntry);
-			}
-			catch (NoSuchFileException noSuchFileException) {
-				if (_log.isDebugEnabled()) {
-					_log.debug(noSuchFileException);
-				}
-
-				return null;
-			}
-		}
-
-		return portletDataContext.getZipEntryAsInputStream(binPath);
-	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		FragmentCollectionStagedModelDataHandler.class);
 
 	@Reference(
 		target = "(model.class.name=com.liferay.fragment.model.FragmentCollection)",

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
@@ -14,6 +14,7 @@
 
 package com.liferay.fragment.internal.upgrade.registry;
 
+import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.fragment.internal.upgrade.v1_1_0.PortletPreferencesUpgradeProcess;
 import com.liferay.fragment.internal.upgrade.v2_0_0.util.FragmentCollectionTable;
 import com.liferay.fragment.internal.upgrade.v2_0_0.util.FragmentEntryLinkTable;
@@ -21,6 +22,7 @@ import com.liferay.fragment.internal.upgrade.v2_0_0.util.FragmentEntryTable;
 import com.liferay.fragment.internal.upgrade.v2_1_0.SchemaUpgradeProcess;
 import com.liferay.fragment.internal.upgrade.v2_4_0.FragmentEntryLinkUpgradeProcess;
 import com.liferay.fragment.internal.upgrade.v2_6_0.util.FragmentEntryVersionTable;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.upgrade.BaseSQLServerDatetimeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
@@ -183,7 +185,19 @@ public class FragmentServiceUpgradeStepRegistrator
 			"2.9.4", "2.10.0",
 			new com.liferay.fragment.internal.upgrade.v2_10_0.
 				FragmentEntryLinkUpgradeProcess());
+
+		registry.register(
+			"2.10.0", "2.10.1",
+			new com.liferay.fragment.internal.upgrade.v2_10_1.
+				FragmentCollectionUpgradeProcess(
+					_dlFolderLocalService, _groupLocalService));
 	}
+
+	@Reference
+	private DLFolderLocalService _dlFolderLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
@@ -22,7 +22,6 @@ import com.liferay.fragment.internal.upgrade.v2_0_0.util.FragmentEntryTable;
 import com.liferay.fragment.internal.upgrade.v2_1_0.SchemaUpgradeProcess;
 import com.liferay.fragment.internal.upgrade.v2_4_0.FragmentEntryLinkUpgradeProcess;
 import com.liferay.fragment.internal.upgrade.v2_6_0.util.FragmentEntryVersionTable;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.upgrade.BaseSQLServerDatetimeUpgradeProcess;
 import com.liferay.portal.kernel.upgrade.CTModelUpgradeProcess;
@@ -189,15 +188,11 @@ public class FragmentServiceUpgradeStepRegistrator
 		registry.register(
 			"2.10.0", "2.10.1",
 			new com.liferay.fragment.internal.upgrade.v2_10_1.
-				FragmentCollectionUpgradeProcess(
-					_dlFolderLocalService, _groupLocalService));
+				FragmentCollectionUpgradeProcess(_dlFolderLocalService));
 	}
 
 	@Reference
 	private DLFolderLocalService _dlFolderLocalService;
-
-	@Reference
-	private GroupLocalService _groupLocalService;
 
 	@Reference
 	private LayoutLocalService _layoutLocalService;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v2_10_1/FragmentCollectionUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v2_10_1/FragmentCollectionUpgradeProcess.java
@@ -17,20 +17,15 @@ package com.liferay.fragment.internal.upgrade.v2_10_1;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.fragment.constants.FragmentPortletKeys;
-import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.Folder;
-import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-
-import java.util.List;
 
 /**
  * @author Jürgen Kappler
@@ -38,11 +33,9 @@ import java.util.List;
 public class FragmentCollectionUpgradeProcess extends UpgradeProcess {
 
 	public FragmentCollectionUpgradeProcess(
-		DLFolderLocalService dlFolderLocalService,
-		GroupLocalService groupLocalService) {
+		DLFolderLocalService dlFolderLocalService) {
 
 		_dlFolderLocalService = dlFolderLocalService;
-		_groupLocalService = groupLocalService;
 	}
 
 	@Override
@@ -51,55 +44,46 @@ public class FragmentCollectionUpgradeProcess extends UpgradeProcess {
 	}
 
 	private void _upgradeFragmentCollectionResourceFolder() throws Exception {
-		List<Group> groups = _groupLocalService.getGroups(
-			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select groupId, fragmentCollectionId, fragmentCollectionKey " +
+					"from FragmentCollection")) {
 
-		for (Group group : groups) {
-			Repository repository =
-				PortletFileRepositoryUtil.fetchPortletRepository(
-					group.getGroupId(), FragmentPortletKeys.FRAGMENT);
+			ResultSet resultSet = preparedStatement1.executeQuery();
 
-			if (repository == null) {
-				continue;
-			}
+			while (resultSet.next()) {
+				long groupId = resultSet.getLong("groupId");
 
-			try (PreparedStatement preparedStatement1 =
-					connection.prepareStatement(
-						"select fragmentCollectionId, fragmentCollectionKey " +
-							"from FragmentCollection where groupId = ?")) {
+				Repository repository =
+					PortletFileRepositoryUtil.fetchPortletRepository(
+						groupId, FragmentPortletKeys.FRAGMENT);
 
-				preparedStatement1.setLong(1, group.getGroupId());
+				if (repository == null) {
+					continue;
+				}
 
-				ResultSet resultSet = preparedStatement1.executeQuery();
+				long fragmentCollectionId = resultSet.getLong(
+					"fragmentCollectionId");
+				String fragmentCollectionKey = resultSet.getString(
+					"fragmentCollectionKey");
 
-				while (resultSet.next()) {
-					long fragmentCollectionId = resultSet.getLong(
-						"fragmentCollectionId");
+				try {
+					Folder portletFolder =
+						PortletFileRepositoryUtil.getPortletFolder(
+							repository.getRepositoryId(),
+							repository.getDlFolderId(),
+							String.valueOf(fragmentCollectionId));
 
-					String fragmentCollectionKey = resultSet.getString(
-						"fragmentCollectionKey");
+					if (portletFolder.getModel() instanceof DLFolder) {
+						DLFolder dlFolder = (DLFolder)portletFolder.getModel();
 
-					try {
-						Folder portletFolder =
-							PortletFileRepositoryUtil.getPortletFolder(
-								repository.getRepositoryId(),
-								repository.getDlFolderId(),
-								String.valueOf(fragmentCollectionId));
+						dlFolder.setName(fragmentCollectionKey);
 
-						if (portletFolder.getModel() instanceof DLFolder) {
-							DLFolder dlFolder =
-								(DLFolder)portletFolder.getModel();
-
-							dlFolder.setName(fragmentCollectionKey);
-
-							_dlFolderLocalService.updateDLFolder(dlFolder);
-						}
+						_dlFolderLocalService.updateDLFolder(dlFolder);
 					}
-					catch (Exception exception) {
-						if (_log.isWarnEnabled()) {
-							_log.warn(
-								"Unable to get portlet folder", exception);
-						}
+				}
+				catch (Exception exception) {
+					if (_log.isWarnEnabled()) {
+						_log.warn("Unable to get portlet folder", exception);
 					}
 				}
 			}
@@ -110,6 +94,5 @@ public class FragmentCollectionUpgradeProcess extends UpgradeProcess {
 		FragmentCollectionUpgradeProcess.class);
 
 	private final DLFolderLocalService _dlFolderLocalService;
-	private final GroupLocalService _groupLocalService;
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v2_10_1/FragmentCollectionUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v2_10_1/FragmentCollectionUpgradeProcess.java
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.fragment.internal.upgrade.v2_10_1;
+
+import com.liferay.document.library.kernel.model.DLFolder;
+import com.liferay.document.library.kernel.service.DLFolderLocalService;
+import com.liferay.fragment.constants.FragmentPortletKeys;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Repository;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import java.util.List;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class FragmentCollectionUpgradeProcess extends UpgradeProcess {
+
+	public FragmentCollectionUpgradeProcess(
+		DLFolderLocalService dlFolderLocalService,
+		GroupLocalService groupLocalService) {
+
+		_dlFolderLocalService = dlFolderLocalService;
+		_groupLocalService = groupLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_upgradeFragmentCollectionResourceFolder();
+	}
+
+	private void _upgradeFragmentCollectionResourceFolder() throws Exception {
+		List<Group> groups = _groupLocalService.getGroups(
+			QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+
+		for (Group group : groups) {
+			Repository repository =
+				PortletFileRepositoryUtil.fetchPortletRepository(
+					group.getGroupId(), FragmentPortletKeys.FRAGMENT);
+
+			if (repository == null) {
+				continue;
+			}
+
+			try (PreparedStatement preparedStatement1 =
+					connection.prepareStatement(
+						"select fragmentCollectionId, fragmentCollectionKey " +
+							"from FragmentCollection where groupId = ?")) {
+
+				preparedStatement1.setLong(1, group.getGroupId());
+
+				ResultSet resultSet = preparedStatement1.executeQuery();
+
+				while (resultSet.next()) {
+					long fragmentCollectionId = resultSet.getLong(
+						"fragmentCollectionId");
+
+					String fragmentCollectionKey = resultSet.getString(
+						"fragmentCollectionKey");
+
+					try {
+						Folder portletFolder =
+							PortletFileRepositoryUtil.getPortletFolder(
+								repository.getRepositoryId(),
+								repository.getDlFolderId(),
+								String.valueOf(fragmentCollectionId));
+
+						if (portletFolder.getModel() instanceof DLFolder) {
+							DLFolder dlFolder =
+								(DLFolder)portletFolder.getModel();
+
+							dlFolder.setName(fragmentCollectionKey);
+
+							_dlFolderLocalService.updateDLFolder(dlFolder);
+						}
+					}
+					catch (Exception exception) {
+						if (_log.isWarnEnabled()) {
+							_log.warn(
+								"Unable to get portlet folder", exception);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FragmentCollectionUpgradeProcess.class);
+
+	private final DLFolderLocalService _dlFolderLocalService;
+	private final GroupLocalService _groupLocalService;
+
+}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
@@ -99,7 +99,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 		try {
 			folder = PortletFileRepositoryUtil.getPortletFolder(
 				repository.getRepositoryId(), repository.getDlFolderId(),
-				String.valueOf(getFragmentCollectionKey()));
+				getFragmentCollectionKey());
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -114,8 +114,8 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 
 				folder = PortletFileRepositoryUtil.addPortletFolder(
 					getUserId(), repository.getRepositoryId(),
-					repository.getDlFolderId(),
-					String.valueOf(getFragmentCollectionKey()), serviceContext);
+					repository.getDlFolderId(), getFragmentCollectionKey(),
+					serviceContext);
 			}
 			else {
 				return 0;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionImpl.java
@@ -99,7 +99,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 		try {
 			folder = PortletFileRepositoryUtil.getPortletFolder(
 				repository.getRepositoryId(), repository.getDlFolderId(),
-				String.valueOf(getFragmentCollectionId()));
+				String.valueOf(getFragmentCollectionKey()));
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -115,7 +115,7 @@ public class FragmentCollectionImpl extends FragmentCollectionBaseImpl {
 				folder = PortletFileRepositoryUtil.addPortletFolder(
 					getUserId(), repository.getRepositoryId(),
 					repository.getDlFolderId(),
-					String.valueOf(getFragmentCollectionId()), serviceContext);
+					String.valueOf(getFragmentCollectionKey()), serviceContext);
 			}
 			else {
 				return 0;

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/staging/test/FragmentCollectionStagingTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/staging/test/FragmentCollectionStagingTest.java
@@ -1,0 +1,191 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.fragment.staging.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.constants.FragmentPortletKeys;
+import com.liferay.fragment.model.FragmentCollection;
+import com.liferay.fragment.service.FragmentCollectionLocalService;
+import com.liferay.fragment.util.FragmentEntryTestUtil;
+import com.liferay.fragment.util.FragmentStagingTestUtil;
+import com.liferay.fragment.util.FragmentTestUtil;
+import com.liferay.portal.kernel.io.unsync.UnsyncByteArrayInputStream;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
+import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.repository.model.Folder;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.util.PropsUtil;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class FragmentCollectionStagingTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		UserTestUtil.setUser(TestPropsValues.getUser());
+
+		_liveGroup = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testFragmentResourcesWithFoldersCopiedWhenLocalStagingActivated()
+		throws Exception {
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-158675", "true"
+			).build());
+
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(_liveGroup.getGroupId());
+
+		FragmentEntryTestUtil.addFragmentEntry(
+			fragmentCollection.getFragmentCollectionId());
+
+		_addPortletFileEntry(
+			fragmentCollection.getResourcesFolderId(), fragmentCollection,
+			"Image1");
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_liveGroup.getGroupId(), TestPropsValues.getUserId());
+
+		Folder folder1 = _addPortletFolder(
+			fragmentCollection.getResourcesFolderId(), _liveGroup.getGroupId(),
+			"Folder1", serviceContext);
+
+		_addPortletFileEntry(
+			folder1.getFolderId(), fragmentCollection, "Image2");
+
+		Folder folder2 = _addPortletFolder(
+			folder1.getFolderId(), _liveGroup.getGroupId(), "Folder2",
+			serviceContext);
+
+		_addPortletFileEntry(
+			folder2.getFolderId(), fragmentCollection, "Image3");
+
+		_stagingGroup = FragmentStagingTestUtil.enableLocalStaging(_liveGroup);
+
+		FragmentCollection stagingFragmentCollection =
+			_fragmentCollectionLocalService.
+				fetchFragmentCollectionByUuidAndGroupId(
+					fragmentCollection.getUuid(), _stagingGroup.getGroupId());
+
+		Assert.assertNotNull(stagingFragmentCollection);
+
+		Map<String, FileEntry> resourcesMap =
+			stagingFragmentCollection.getResourcesMap();
+
+		Assert.assertTrue(resourcesMap.containsKey("Image1"));
+		Assert.assertTrue(resourcesMap.containsKey("Folder1/Image2"));
+		Assert.assertTrue(resourcesMap.containsKey("Folder1/Folder2/Image3"));
+
+		PropsUtil.addProperties(
+			UnicodePropertiesBuilder.setProperty(
+				"feature.flag.LPS-158675", "false"
+			).build());
+	}
+
+	@Test
+	public void testSingleFragmentResourceCopiedWhenLocalStagingActivated()
+		throws Exception {
+
+		FragmentCollection fragmentCollection =
+			FragmentTestUtil.addFragmentCollection(_liveGroup.getGroupId());
+
+		FragmentEntryTestUtil.addFragmentEntry(
+			fragmentCollection.getFragmentCollectionId());
+
+		_addPortletFileEntry(
+			fragmentCollection.getResourcesFolderId(), fragmentCollection,
+			"Image");
+
+		_stagingGroup = FragmentStagingTestUtil.enableLocalStaging(_liveGroup);
+
+		FragmentCollection stagingFragmentCollection =
+			_fragmentCollectionLocalService.
+				fetchFragmentCollectionByUuidAndGroupId(
+					fragmentCollection.getUuid(), _stagingGroup.getGroupId());
+
+		Assert.assertNotNull(stagingFragmentCollection);
+
+		Map<String, FileEntry> resourcesMap =
+			stagingFragmentCollection.getResourcesMap();
+
+		Assert.assertTrue(resourcesMap.containsKey("Image"));
+	}
+
+	private FileEntry _addPortletFileEntry(
+			long folderId, FragmentCollection fragmentCollection, String name)
+		throws Exception {
+
+		return PortletFileRepositoryUtil.addPortletFileEntry(
+			null, fragmentCollection.getGroupId(), TestPropsValues.getUserId(),
+			FragmentCollection.class.getName(),
+			fragmentCollection.getFragmentCollectionId(),
+			FragmentPortletKeys.FRAGMENT, folderId,
+			new UnsyncByteArrayInputStream(new byte[0]), name,
+			ContentTypes.IMAGE_PNG, false);
+	}
+
+	private Folder _addPortletFolder(
+			long folderId, long groupId, String name,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		return PortletFileRepositoryUtil.addPortletFolder(
+			groupId, TestPropsValues.getUserId(), FragmentPortletKeys.FRAGMENT,
+			folderId, name, serviceContext);
+	}
+
+	@Inject
+	private FragmentCollectionLocalService _fragmentCollectionLocalService;
+
+	@DeleteAfterTestRun
+	private Group _liveGroup;
+
+	private Group _stagingGroup;
+
+}


### PR DESCRIPTION
## Motivation

[Link to task](https://issues.liferay.com/browse/LPS-168644)

Through [Use simple repository browser tag for fragment resources](https://issues.liferay.com/browse/LPS-167491), we now allow users to add folders to fragment collections, thus we need to adapt existing code so that it matches the new feature.

## Change summary:

* Change how we create the folder for the fragment collection (use unique key instead of ID)
* Upgrade process
* Adds integration tests for existing and new features


## Test Scenario No. 1

* Enable feature flag: feature.flag.LPS-158675
* Go to fragments admin
* Create a new fragment collection
* Go to resources tab
* Add a new folder
* Inside the folder, add a new image
* Create a new fragment and use the resource (i.e. [resource:folderName/imageName])
* Add the fragment to a page and publish
* Enable staging and visit the page
* The fragment should be shown

![staging](https://user-images.githubusercontent.com/4267448/202167644-2a722dc6-20d6-450b-92be-5c6e6f553107.gif)

## Test Scenario No. 2

* Enable feature flag: feature.flag.LPS-158675
* Go to fragments admin
* Create a new fragment collection
* Go to resources tab
* Add a new folder
* Inside the folder, add a new image
* Create a new fragment and use the resource (i.e. [resource:folderName/imageName])
* Go to Export and publish the LAR
* Stop the portal and delete the database
* Start the portal and import the LAR
* Go to the resources tab in the fragment collection
* The folder structure should be shown

![export](https://user-images.githubusercontent.com/4267448/202168266-8c7e8bf8-54d7-46ca-8e34-c5414f3788c6.gif)


## Test Scenario No. 3

* Start a Liferay Portal 7.3
* Create a fragment collection and add resources
* Stop the portal and upgrade to 7.4
* Check that the resources are available for the collection





