### PR TITLE
LPS-168190 Simplify

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
@@ -451,6 +451,14 @@ public class JournalArticleItemSelectorViewDisplayContext {
 		return _articleSearchContainer;
 	}
 
+	public boolean isRefererArticle(JournalArticle journalArticle) {
+		if (_getRefererClassPK() == journalArticle.getResourcePrimKey()) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public boolean isSearch() {
 		if (_isEverywhereScopeFilter()) {
 			return true;
@@ -633,6 +641,17 @@ public class JournalArticleItemSelectorViewDisplayContext {
 		return _orderByType;
 	}
 
+	private long _getRefererClassPK() {
+		if (_refererClassPK != null) {
+			return _refererClassPK;
+		}
+
+		_refererClassPK = ParamUtil.getLong(
+			_httpServletRequest, "refererClassPK");
+
+		return _refererClassPK;
+	}
+
 	private BreadcrumbEntry _getSiteBreadcrumb() throws Exception {
 		BreadcrumbEntry breadcrumbEntry = new BreadcrumbEntry();
 
@@ -702,6 +721,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 	private final PortletRequest _portletRequest;
 	private final PortletResponse _portletResponse;
 	private final PortletURL _portletURL;
+	private Long _refererClassPK;
 	private final boolean _search;
 	private Boolean _searchEverywhere;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/item/selector/select_articles.jsp
@@ -60,7 +60,11 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 				<c:when test="<%= curArticle != null %>">
 
 					<%
-					row.setCssClass("articles selector-button" + row.getCssClass());
+					row.setCssClass("articles " + row.getCssClass());
+
+					if (!journalArticleItemSelectorViewDisplayContext.isRefererArticle(curArticle)) {
+						row.setCssClass("selector-button " + row.getCssClass());
+					}
 
 					row.setData(journalArticleItemSelectorViewDisplayContext.getJournalArticleContext(curArticle));
 					%>
@@ -69,7 +73,9 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 						<c:when test='<%= Objects.equals(journalArticleItemSelectorViewDisplayContext.getDisplayStyle(), "descriptive") %>'>
 
 							<%
-							row.setCssClass("item-preview " + row.getCssClass());
+							if (!journalArticleItemSelectorViewDisplayContext.isRefererArticle(curArticle)) {
+								row.setCssClass("item-preview " + row.getCssClass());
+							}
 							%>
 
 							<liferay-ui:search-container-column-text>
@@ -118,6 +124,7 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 
 							<liferay-ui:search-container-column-text>
 								<clay:vertical-card
+									disabled="<%= journalArticleItemSelectorViewDisplayContext.isRefererArticle(curArticle) %>"
 									verticalCard="<%= new JournalArticleItemSelectorVerticalCard(curArticle, renderRequest) %>"
 								/>
 							</liferay-ui:search-container-column-text>
@@ -125,7 +132,9 @@ JournalArticleItemSelectorViewDisplayContext journalArticleItemSelectorViewDispl
 						<c:otherwise>
 
 							<%
-							row.setCssClass("item-preview " + row.getCssClass());
+							if (!journalArticleItemSelectorViewDisplayContext.isRefererArticle(curArticle)) {
+								row.setCssClass("item-preview " + row.getCssClass());
+							}
 							%>
 
 							<c:if test="<%= journalArticleItemSelectorViewDisplayContext.showArticleId() %>">


### PR DESCRIPTION
From: https://github.com/liferay-echo/liferay-portal/pull/10314

Hi Team,

Motivation
=======
[LPS-168190](https://issues.liferay.com/browse/LPS-168190)
Having a Web Content refer itself could cause infinite recursion in ddm templates.

Proposed Solution
========
By forwarding the referring article's resourcePrimKey to the Item Selector, we can disable selectablility for the referer article
I'm unsure if any extra CSS to differentiate this referer article would be needed or what would be suitable for it.

Steps to Verify
========
1. Create a Web Content Structure with a Web Content field
2. Create a Web Content from this Structure and save it
3. Edit this Web Content and press Select for the Web Content field

**Expected behaviour:** The current Web Content should not be selectable to eliminate the change of infinite loops
**Actual behaviour:** The current Web Content is selectable

References to existing code (if applies)
========
A similar solution was used for Related Assets in https://github.com/liferay/liferay-portal/blob/master/modules/apps/asset/asset-browser-web/src/main/java/com/liferay/asset/browser/web/internal/display/context/AssetBrowserDisplayContext.java#L327

Alternative Solutions that were discarded
========
I've discarded filtering the results in the 
- business logic layer: because of performance reasons and manipulating the results would make the result list less maintainable.
- service layer: While Search could be filtered with the correct search context having an exclusion term added, The DisplayContext uses multiple Service calls, that would need an extra parameter to work. I've opted to avoid creating new service methods.

Cheers,
Balázs