### PR TITLE
LPS-168249 - revert behavior introduced by LPS-139624, so the users can edit the friendlyUrl of a web content even in the Global site.

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/BaseJournalFormNavigatorEntry.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/BaseJournalFormNavigatorEntry.java
@@ -21,12 +21,13 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanParamUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.model.Group;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+
 
 import java.util.Locale;
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/BaseJournalFormNavigatorEntry.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/BaseJournalFormNavigatorEntry.java
@@ -21,13 +21,12 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanParamUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
-import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
-import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-
+import com.liferay.portal.kernel.util.JavaConstants;
 
 import java.util.Locale;
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/JournalDisplayPageFormNavigatorEntry.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/JournalDisplayPageFormNavigatorEntry.java
@@ -14,25 +14,19 @@
 
 package com.liferay.journal.web.internal.frontend.taglib.form.navigator;
 
-import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.frontend.taglib.form.navigator.FormNavigatorEntry;
 import com.liferay.item.selector.ItemSelectorView;
 import com.liferay.journal.model.JournalArticle;
-import com.liferay.portal.kernel.bean.BeanParamUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.Portal;
 
-import javax.portlet.PortletRequest;
-
 import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletRequest;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -59,9 +53,21 @@ public class JournalDisplayPageFormNavigatorEntry
 
 	@Override
 	public boolean isVisible(User user, JournalArticle article) {
-		if (_isDepotArticle(article) || isGlobalScopeArticle(article) ||
-			_isGlobalStructure(article)) {
+		Group group = null;
 
+		if ((article != null) && (article.getId() > 0)) {
+			group = _groupLocalService.fetchGroup(article.getGroupId());
+		}
+		else {
+			ServiceContext serviceContext =
+				ServiceContextThreadLocal.getServiceContext();
+
+			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+			group = themeDisplay.getScopeGroup();
+		}
+
+		if ((group != null) && group.isCompany()) {
 			return false;
 		}
 
@@ -81,85 +87,6 @@ public class JournalDisplayPageFormNavigatorEntry
 	@Override
 	protected String getJspPath() {
 		return "/article/asset_display_page.jsp";
-	}
-
-	private Group _getGroup(JournalArticle article) {
-		if ((article != null) && (article.getId() > 0)) {
-			return _groupLocalService.fetchGroup(article.getGroupId());
-		}
-
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
-
-		return themeDisplay.getScopeGroup();
-	}
-
-	private boolean _isDepotArticle(JournalArticle article) {
-		Group group = _getGroup(article);
-
-		if ((group != null) && group.isDepot()) {
-			return true;
-		}
-
-		return false;
-	}
-
-	private boolean _isGlobalStructure(JournalArticle article) {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		HttpServletRequest httpServletRequest = serviceContext.getRequest();
-
-		PortletRequest portletRequest =
-			(PortletRequest)httpServletRequest.getAttribute(
-				JavaConstants.JAVAX_PORTLET_REQUEST);
-
-		long classNameId = BeanParamUtil.getLong(
-			article, portletRequest, "classNameId");
-
-		if (classNameId != _portal.getClassNameId(DDMStructure.class)) {
-			return false;
-		}
-
-		long classPK = BeanParamUtil.getLong(
-			article, portletRequest, "classPK");
-
-		if (classPK == 0) {
-			return false;
-		}
-
-		DDMStructure ddmStructure = _ddmStructureLocalService.fetchDDMStructure(
-			classPK);
-
-		if (ddmStructure == null) {
-			long groupId = BeanParamUtil.getLong(
-				article, portletRequest, "groupId");
-
-			String ddmStructureKey = BeanParamUtil.getString(
-				article, portletRequest, "ddmStructureKey");
-
-			ddmStructure = _ddmStructureLocalService.fetchStructure(
-				groupId, _portal.getClassNameId(JournalArticle.class),
-				ddmStructureKey);
-		}
-
-		if (ddmStructure == null) {
-			return false;
-		}
-
-		Group group = _groupLocalService.fetchGroup(ddmStructure.getGroupId());
-
-		if (group == null) {
-			return false;
-		}
-
-		if (group.isCompany()) {
-			return true;
-		}
-
-		return false;
 	}
 
 	@Reference

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/JournalFriendlyURLFormNavigatorEntry.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/form/navigator/JournalFriendlyURLFormNavigatorEntry.java
@@ -45,7 +45,7 @@ public class JournalFriendlyURLFormNavigatorEntry
 
 	@Override
 	public boolean isVisible(User user, JournalArticle article) {
-		if (isEditDefaultValues(article) || isGlobalScopeArticle(article)) {
+		if (isEditDefaultValues(article)) {
 			return false;
 		}
 


### PR DESCRIPTION
Motivation
=======
Customers are not able to change the friendly url of a web content in the global site, using the UI. [PTR-3438](https://issues.liferay.com/browse/PTR-3438) was opened and the product team reported that the users should be able to change the friendly url as it was before the implementation of [LPS-139624](https://issues.liferay.com/browse/LPS-139624).

Proposed Solution
========
Revert the changes introduced by [LPS-139624](https://issues.liferay.com/browse/LPS-139624)

Steps to Verify
========
1. A setup step / beginning state -> use a bundle from the master branch (latest)
1. What to do next -> apply the proposed changes in this PR
1. Expected behavior -> user should be able to see the friendly url property and be able to change it on the liferay's global site
1. Suggestions for testing -> first, check on liferay's default site if the user can change the friendly url of a web content. Then, go to the global website, and after applying the proposed solution, check if the user also can change the friendly url of a web content.