### PR TITLE
LPS-169519 Persist active tab id

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-web/package.json
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"@liferay/layout-content-page-editor-web": "*",
 		"frontend-js-web": "*",
 		"react": "16.12.0",
 		"react-dnd": "11.1.1",

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabsPanel.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabsPanel.js
@@ -13,8 +13,9 @@
  */
 
 import ClayTabs from '@clayui/tabs';
+import {useSessionState} from '@liferay/layout-content-page-editor-web';
 import PropTypes from 'prop-types';
-import React, {useContext, useState} from 'react';
+import React, {useContext} from 'react';
 
 import {AddPanelContext} from './AddPanel';
 import TabsContent from './TabsContent';
@@ -22,7 +23,10 @@ import TabsContent from './TabsContent';
 const TabsPanel = ({tabs}) => {
 	const {portletNamespace} = useContext(AddPanelContext);
 
-	const [activeTabId, setActiveTabId] = useState(0);
+	const [activeTabId, setActiveTabId] = useSessionState(
+		`${portletNamespace}_active-tab-id`,
+		0
+	);
 
 	const getTabId = (tabId) => `${portletNamespace}_tab_${tabId}`;
 	const getTabPanelId = (tabId) => `${portletNamespace}_tabPanel_${tabId}`;


### PR DESCRIPTION
Motivation
=======
Users want to remember which tab was selected when using a widget page. Described in ticket https://issues.liferay.com/browse/LPS-169310

Proposed Solution
========
Apply existing useSessionState hook from Page Editor.

Steps to Verify
========
1. Deploy product-navigation-control-menu-web
2. Create a widget page
3. Open add panel, and select "content" tab
4. Reload the page
5. See that "content" tab is selected by default