### PR TITLE
LPS-169146 The fragment inside fragment composition is not counted

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/frontend/taglib/clay/servlet/taglib/BasicFragmentEntryVerticalCard.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/frontend/taglib/clay/servlet/taglib/BasicFragmentEntryVerticalCard.java
@@ -16,6 +16,7 @@ package com.liferay.fragment.web.internal.frontend.taglib.clay.servlet.taglib;
 
 import com.liferay.fragment.constants.FragmentActionKeys;
 import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
 import com.liferay.fragment.web.internal.security.permission.resource.FragmentPermission;
 import com.liferay.fragment.web.internal.servlet.taglib.util.BasicFragmentEntryActionDropdownItemsProvider;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
@@ -118,13 +119,11 @@ public class BasicFragmentEntryVerticalCard
 
 	@Override
 	public String getSubtitle() {
-		long usageCount = fragmentEntry.getUsageCount();
-
-		if (fragmentEntry.getGroupId() == themeDisplay.getCompanyGroupId()) {
-			usageCount = fragmentEntry.getGlobalUsageCount();
-		}
-
-		return LanguageUtil.format(_httpServletRequest, "x-usages", usageCount);
+		return LanguageUtil.format(
+			_httpServletRequest, "x-usages",
+			FragmentEntryLinkLocalServiceUtil.
+				getFragmentEntryLinksCountByFragmentEntryId(
+					fragmentEntry.getFragmentEntryId()));
 	}
 
 	@Override


### PR DESCRIPTION
## Motivation

[Link to task](https://issues.liferay.com/browse/LPS-169146)

Usage count for the fragment is not correctly reflected in the card. It shows the usage per layout, not the individual usage


## Change summary:

* Use method to retrieve individual usage count for the fragment, not by layout


## Test Scenario

* Create a fragment
* Add it several times to a page, and then to another page
* The label for usages should reflect the individual usages

## Additional notes

* Tests are not included in the PR, will be added most probably through poshi tests
* Changes also apply to global fragments, not site fragments

![usages](https://user-images.githubusercontent.com/4267448/203779571-85c0dad9-a754-441f-ab77-4dbead35a394.gif)
