### PR TITLE
LPS-169365 Don't persist fallback to default layout if redeployment might be in progress

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/GuardedLayoutResetter.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/GuardedLayoutResetter.java
@@ -1,0 +1,215 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.taglib.internal.servlet.taglib;
+
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutTemplate;
+import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.LayoutTemplateLocalService;
+import com.liferay.portal.kernel.util.LayoutTypePortletFactoryUtil;
+import com.liferay.portal.util.PropsValues;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.BundleEvent;
+import org.osgi.framework.SynchronousBundleListener;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Matthias Bläsing
+ */
+@Component(immediate = true, service = GuardedLayoutResetter.class)
+public class GuardedLayoutResetter implements SynchronousBundleListener {
+
+	@Override
+	public void bundleChanged(BundleEvent be) {
+		if (_log.isDebugEnabled()) {
+			Bundle bundle = be.getBundle();
+
+			String bundleSymbolicName = bundle.getSymbolicName();
+
+			_log.debug(
+				String.format(
+					"bundleChanged: %s: %d", bundleSymbolicName, be.getType()));
+		}
+
+		synchronized (_updater) {
+			for (Map.Entry<Long, LayoutTemplateUpdater> entry :
+					_updater.entrySet()) {
+
+				ScheduledFuture<?> updateRequest = _updatesScheduled.get(
+					entry.getKey());
+
+				if (!updateRequest.cancel(false)) {
+					continue;
+				}
+
+				_updatesScheduled.remove(entry.getKey());
+				_updatesScheduled.put(
+					entry.getKey(),
+					_scheduledExecutorService.schedule(
+						entry.getValue(), _REDEPLOYMENT_GRACE_PERIOD,
+						TimeUnit.MILLISECONDS));
+			}
+		}
+	}
+
+	public void checkAndResetTemplatteId(long plid) {
+		synchronized (_updater) {
+			if (!_updater.containsKey(plid)) {
+				LayoutTemplateUpdater layoutTemplateUpdater =
+					new LayoutTemplateUpdater(plid);
+
+				_updater.put(plid, layoutTemplateUpdater);
+				_updatesScheduled.put(
+					plid,
+					_scheduledExecutorService.schedule(
+						layoutTemplateUpdater, _REDEPLOYMENT_GRACE_PERIOD,
+						TimeUnit.MILLISECONDS));
+			}
+		}
+	}
+
+	@Activate
+	protected void activate(BundleContext bundleContext) {
+		_bundleContext = bundleContext;
+
+		bundleContext.addBundleListener(this);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_bundleContext.removeBundleListener(this);
+
+		synchronized (_updater) {
+			for (Long plid : new ArrayList<>(_updater.keySet())) {
+				ScheduledFuture<?> updateRequest = _updatesScheduled.get(plid);
+
+				updateRequest.cancel(false);
+			}
+
+			_updater.clear();
+			_updatesScheduled.clear();
+		}
+	}
+
+	private static final long _REDEPLOYMENT_GRACE_PERIOD = 1L * 60L * 1000L;
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GuardedLayoutResetter.class);
+
+	private BundleContext _bundleContext;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutTemplateLocalService _layoutTemplateLocalService;
+
+	private final ScheduledExecutorService _scheduledExecutorService =
+		Executors.newScheduledThreadPool(0);
+	private final Map<Long, LayoutTemplateUpdater> _updater = new HashMap<>();
+	private final Map<Long, ScheduledFuture<?>> _updatesScheduled =
+		new HashMap<>();
+
+	private class LayoutTemplateUpdater implements Runnable {
+
+		public LayoutTemplateUpdater(long plid) {
+			_plid = plid;
+		}
+
+		public void run() {
+			try {
+				Layout layout = _layoutLocalService.getLayout(_plid);
+
+				LayoutTypePortlet layoutTypePortlet =
+					LayoutTypePortletFactoryUtil.create(layout);
+
+				if (layoutTypePortlet.getLayoutTemplateId() == null) {
+					return;
+				}
+
+				LayoutTemplate layoutTemplate =
+					_layoutTemplateLocalService.getLayoutTemplate(
+						layoutTypePortlet.getLayoutTemplateId(), false,
+						layout.getThemeId());
+
+				if (layoutTemplate != null) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(
+							String.format(
+								_LAYOUT_FOUND_LOG_MSG, _plid,
+								layout.getThemeId(),
+								layoutTypePortlet.getLayoutTemplateId()));
+					}
+
+					return;
+				}
+
+				layoutTypePortlet.setLayoutTemplateId(
+					layout.getUserId(), PropsValues.DEFAULT_LAYOUT_TEMPLATE_ID);
+
+				_layoutLocalService.updateLayout(
+					layout.getGroupId(), layout.isPrivateLayout(),
+					layout.getLayoutId(), layout.getTypeSettings());
+
+				if (_log.isInfoEnabled()) {
+					String logInfo = String.format(
+						_RESET_LAYOUT_LOG_MSG, _plid, layout.getGroupId(),
+						layout.isPrivateLayout(), layout.getLayoutId());
+
+					_log.info(logInfo);
+				}
+			}
+			catch (Throwable throwable) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(throwable);
+				}
+			}
+			finally {
+				synchronized (_updater) {
+					_updater.remove(_plid);
+					_updatesScheduled.remove(_plid);
+				}
+			}
+		}
+
+		private static final String _LAYOUT_FOUND_LOG_MSG =
+			"Layout template found (plid: %d, themeId: %s, layoutTemplateId: " +
+				"%s)";
+
+		private static final String _RESET_LAYOUT_LOG_MSG =
+			"Resetting layout to default (plid: %d, groupId: %d, " +
+				"privateLayout: %b, layoutId: %d)";
+
+		private final long _plid;
+
+	}
+
+}

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -62,8 +62,6 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringWriter;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.layoutconfiguration.util.RuntimePageUtil;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTemplate;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java
@@ -44,6 +44,7 @@ import com.liferay.layout.taglib.internal.display.context.RenderCollectionLayout
 import com.liferay.layout.taglib.internal.display.context.RenderLayoutStructureDisplayContext;
 import com.liferay.layout.taglib.internal.info.search.InfoSearchClassMapperRegistryUtil;
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.layout.taglib.internal.servlet.taglib.GuardedLayoutResetter;
 import com.liferay.layout.taglib.internal.util.SegmentsExperienceUtil;
 import com.liferay.layout.util.constants.LayoutStructureConstants;
 import com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem;
@@ -61,12 +62,13 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.io.unsync.UnsyncStringWriter;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.layoutconfiguration.util.RuntimePageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTemplate;
 import com.liferay.portal.kernel.model.LayoutTemplateConstants;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
-import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutTemplateLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -91,6 +93,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.jsp.JspWriter;
 import javax.servlet.jsp.PageContext;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
 
 /**
  * @author Eudaldo Alonso
@@ -1248,14 +1255,39 @@ public class RenderLayoutStructureTag extends IncludeTag {
 			return layoutTypePortlet;
 		}
 
-		layoutTypePortlet.setLayoutTemplateId(
-			layout.getUserId(), PropsValues.DEFAULT_LAYOUT_TEMPLATE_ID);
+		Bundle bundle = FrameworkUtil.getBundle(RenderLayoutStructureTag.class);
 
-		layout = LayoutLocalServiceUtil.updateLayout(
-			layout.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),
-			layout.getTypeSettings());
+		BundleContext bundleContext = bundle.getBundleContext();
 
-		return (LayoutTypePortlet)layout.getLayoutType();
+		ServiceReference<GuardedLayoutResetter>
+			guardedLayoutResetterServiceReference =
+				bundleContext.getServiceReference(GuardedLayoutResetter.class);
+
+		GuardedLayoutResetter guardedLayoutResetter = null;
+
+		if (guardedLayoutResetterServiceReference != null) {
+			guardedLayoutResetter = bundleContext.getService(
+				guardedLayoutResetterServiceReference);
+		}
+
+		try {
+			if (guardedLayoutResetter != null) {
+				guardedLayoutResetter.checkAndResetTemplatteId(
+					layout.getPlid());
+
+				return layoutTypePortlet;
+			}
+		}
+		finally {
+			if ((guardedLayoutResetterServiceReference != null) &&
+				(guardedLayoutResetter != null)) {
+
+				bundleContext.ungetService(
+					guardedLayoutResetterServiceReference);
+			}
+		}
+
+		return layoutTypePortlet;
 	}
 
 	private void _write(


### PR DESCRIPTION
With LPS-66138 a mechanism was introduced, that switches the layout for a page to the default layout if the selected layout does not exist and persists that change.

Before the change associated with that issue the switch was only transient.

This causes a regression if the following sequence happens:

1. layout template plugin is being redeployed - as one of the first steps the layout is made unavailable
2. user accesses a page configured with one of the layouts in the plugin
3. LPS-66138 change _permanently_ switches layout to default layout
4. Redeployment completes

The fix is to only apply the fix from step three if no redeployment is in flight.

The obvious way would be to listen for BundleEvents and block the fix when a STOPPING event is seen and reenable it once STARTED (redeployment) or UNINSTALLED (undeployment) is observed.

For layouts this does not work because the themes are (un-)installed by deploylisteners, that are invoked before the OSGI integration. So there is a gap between the layout template not being available and the STOPPING BundleEvent.

The fix idea is to use a ScheduledExecutor, that delays application of the layout reset (fix in step 3) for a grace period of one minute. In case a BundleEvent is received in between, all pending layout resets are rescheduled. It is assumed, that one minute is enough time, that a redeployment will run completely through.

In the referenced issue steps to reproduce are provided. This change can be tested by enabling logging on level `TRACE` for  `com.liferay.layout.taglib.internal.servlet.taglib.GuardedLayoutResetter`.

**Redeployment**

1.  Run the setup from the issue description is done (steps 1-6)
2. Remove the layout plugin by deleting it from the `osgi/war` folder and wait until it is fully undeployed (you'll find `STOPPED testlayout-layouttpl_1.0.0 [????]`  in the log
3. Open the test page in browser again (layout from plugin is not visible anymore)
4. Reinstall the layout plugin again by copying it to the `deploy` folder and wait until it is deployed again (you'll find `STARTED testlayout-layouttpl_1.0.0 [????]` in the log) (this must have happened in less than 60 seconds after step 3!)
5. Open the test page in browser again (layout is now visible again)
6. Wait for one minute - you'll find `Resetting layout to default (plid: ??, groupId: ???, privateLayout: false, layoutId: ??)` in the log. Indicating, that the layout template was found and thus no reset happened.
7. Open the test page again and you'll find, that the layout from the plugin is still configured

**Uninstalling**

1.  Run the setup from the issue description is done (steps 1-6)
2. Remove the layout plugin by deleting it from the `osgi/war` folder and wait until it is fully undeployed (you'll find `STOPPED testlayout-layouttpl_1.0.0 [????]`  in the log
3. Open the test page in browser again (layout from plugin is not visible anymore, in the page settings no layout is selected)
4. Wait for one minute - you'll find `Resetting layout to default (plid: ??, groupId: ???, privateLayout: false, layoutId: ??)` in the log. Indicating, that the layout template was found and thus no reset happened.
5. Open the test page again - layout is still the default layout, but in the page settings the default layout is now selected

So both cases work now.