### PR TITLE
LPS-169798 Page Template import fails after several attempts

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -412,11 +412,18 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 					groupId, layoutPageTemplateCollectionKey);
 
 		if (layoutPageTemplateCollection == null) {
-			return _layoutPageTemplateCollectionService.
-				addLayoutPageTemplateCollection(
-					groupId, pageTemplateCollection.getName(),
-					pageTemplateCollection.getDescription(),
-					ServiceContextThreadLocal.getServiceContext());
+			layoutPageTemplateCollection =
+				_layoutPageTemplateCollectionLocalService.
+					fetchLayoutPageTemplateCollectionByName(
+						groupId, pageTemplateCollection.getName());
+
+			if (layoutPageTemplateCollection == null) {
+				return _layoutPageTemplateCollectionService.
+					addLayoutPageTemplateCollection(
+						groupId, pageTemplateCollection.getName(),
+						pageTemplateCollection.getDescription(),
+						ServiceContextThreadLocal.getServiceContext());
+			}
 		}
 
 		if (overwrite) {

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -435,6 +435,12 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 					pageTemplateCollection.getDescription());
 		}
 
+		if (layoutPageTemplateCollection == null) {
+			throw new PortalException(
+				"Invalid layout page template collection ID: " +
+					layoutPageTemplateCollectionId);
+		}
+
 		return layoutPageTemplateCollection;
 	}
 

--- a/modules/apps/layout/layout-page-template-api/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Page Template API
 Bundle-SymbolicName: com.liferay.layout.page.template.api
-Bundle-Version: 14.0.1
+Bundle-Version: 14.1.0
 Export-Package:\
 	com.liferay.layout.page.template.constants,\
 	com.liferay.layout.page.template.exception,\

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalService.java
@@ -228,6 +228,10 @@ public interface LayoutPageTemplateCollectionLocalService
 	public LayoutPageTemplateCollection fetchLayoutPageTemplateCollection(
 		long groupId, String layoutPageTemplateCollectionKey);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public LayoutPageTemplateCollection fetchLayoutPageTemplateCollectionByName(
+		long groupId, String name);
+
 	/**
 	 * Returns the layout page template collection matching the UUID and group.
 	 *

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalServiceUtil.java
@@ -245,6 +245,13 @@ public class LayoutPageTemplateCollectionLocalServiceUtil {
 			groupId, layoutPageTemplateCollectionKey);
 	}
 
+	public static LayoutPageTemplateCollection
+		fetchLayoutPageTemplateCollectionByName(long groupId, String name) {
+
+		return getService().fetchLayoutPageTemplateCollectionByName(
+			groupId, name);
+	}
+
 	/**
 	 * Returns the layout page template collection matching the UUID and group.
 	 *

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalServiceWrapper.java
@@ -272,6 +272,14 @@ public class LayoutPageTemplateCollectionLocalServiceWrapper
 				groupId, layoutPageTemplateCollectionKey);
 	}
 
+	@Override
+	public LayoutPageTemplateCollection fetchLayoutPageTemplateCollectionByName(
+		long groupId, String name) {
+
+		return _layoutPageTemplateCollectionLocalService.
+			fetchLayoutPageTemplateCollectionByName(groupId, name);
+	}
+
 	/**
 	 * Returns the layout page template collection matching the UUID and group.
 	 *

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionLocalServiceImpl.java
@@ -161,6 +161,14 @@ public class LayoutPageTemplateCollectionLocalServiceImpl
 	}
 
 	@Override
+	public LayoutPageTemplateCollection fetchLayoutPageTemplateCollectionByName(
+		long groupId, String name) {
+
+		return layoutPageTemplateCollectionPersistence.fetchByG_N(
+			groupId, name);
+	}
+
+	@Override
 	public List<LayoutPageTemplateCollection> getLayoutPageTemplateCollections(
 		long groupId, int start, int end) {
 


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-169798)

There's an issue where an exported page template entry cannot be re-imported in a collection. This is because we don't store the page template collection key in the definition, but we take the name of the path and autogenerate the key. This will make it fail

## Proposed solution

Fallback to the name of the collection that is unique if the page template collection is not found. In case it's still null, throw an exception


## Change summary:

* Adds a new method to retrieve a page template collection by name
* If the page template collection is not found by key, fallback to name
* Adds integration tests


## Test Scenario

* Create a new page template collection
* Add a page template entry to it and export it
* Delete the page template entry
* Import it
* Repeat last steps several times
* the page template should always be imported

![page templates](https://user-images.githubusercontent.com/4267448/204237912-1af7132b-2f96-4c8f-8eae-dcc6747601ba.gif)

