### PR TITLE
LPS-169776 Two select buttons appear in AP widget configuration after asset library scope is added

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
@@ -97,30 +97,41 @@ List<AssetEntry> assetEntries = assetPublisherHelper.getAssetEntries(renderReque
 
 <%
 long[] groupIds = assetPublisherDisplayContext.getGroupIds();
+%>
 
+<c:if test="<%= ArrayUtil.isNotEmpty(groupIds) %>">
+
+<div class="d-flex">
+
+<%
 for (long groupId : groupIds) {
 	Group group = GroupLocalServiceUtil.getGroup(groupId);
 
 	String title = LanguageUtil.format(request, (groupIds.length == 1) ? "select" : "select-in-x", HtmlUtil.escape(group.getDescriptiveName(locale)), false);
 %>
 
-	<clay:dropdown-menu
-		additionalProps='<%=
-			HashMapBuilder.<String, Object>put(
-				"currentURL", currentURL
-			).build()
-		%>'
-		aria-label="<%= title %>"
-		displayType="secondary"
-		dropdownItems="<%= assetPublisherDisplayContext.getDropdownItems(group) %>"
-		label="select"
-		propsTransformer="js/AssetEntrySelectionDropdownPropsTransformer"
-		title="<%= title %>"
-	/>
+		<clay:dropdown-menu
+			additionalProps='<%=
+				HashMapBuilder.<String, Object>put(
+					"currentURL", currentURL
+				).build()
+			%>'
+			aria-label="<%= title %>"
+			cssClass="mr-2"
+			displayType="secondary"
+			dropdownItems="<%= assetPublisherDisplayContext.getDropdownItems(group) %>"
+			label="select"
+			propsTransformer="js/AssetEntrySelectionDropdownPropsTransformer"
+			title="<%= title %>"
+		/>
 
 <%
 }
 %>
+
+</div>
+
+</c:if>
 
 <script>
 	function <portlet:namespace />moveSelectionDown(assetEntryOrder) {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
@@ -120,7 +120,7 @@ for (long groupId : groupIds) {
 			cssClass="mr-2"
 			displayType="secondary"
 			dropdownItems="<%= assetPublisherDisplayContext.getDropdownItems(group) %>"
-			label="select"
+			label="<%= title %>"
 			propsTransformer="js/AssetEntrySelectionDropdownPropsTransformer"
 			title="<%= title %>"
 		/>


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-169776)

Recently Echo Team has been working in migrating icon-menus to dropdown-items. Which leads to certain issues...


## Change summary:

* Change so that the buttons to select assets are shown horizontaly, just like with the icon-menu
* Label the buttons correctly


## Test Scenario

* Add a new site
* Add an asset library and connect it to the site
* Add an Asset Publisher to the site
* Configure it and select manual selection
* Two buttons should be shown horizontally and with the correct label


![Screenshot 2022-11-28 at 12 06 32](https://user-images.githubusercontent.com/4267448/204262839-4cdea355-0948-4ecd-a337-3268158866ad.png)
