### PR TITLE
LPS-168734 Add role=alert to announce required fields when press enter

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/convert-to-page-template-modal/components/FormField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/convert-to-page-template-modal/components/FormField.js
@@ -23,6 +23,7 @@ const FormField = ({children, error, id, name}) => {
 	return (
 		<div
 			className={classNames({'form-group': true, 'has-error': hasError})}
+			role="alert"
 		>
 			<label htmlFor={id}>
 				{name}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168734

The Screen Reader does not read the required messages when we try to submit the form by pressing `Enter`. I found that adding `role="alert"` made the screen reader read this out.

Please let me know if you have any questions or comments about this.
Thank you!