### PR TITLE
LPS-169795 Create TagsInfoFilter

### DIFF
--- a/modules/apps/fragment/fragment-collection-filter-tags/bnd.bnd
+++ b/modules/apps/fragment/fragment-collection-filter-tags/bnd.bnd
@@ -1,0 +1,4 @@
+Bundle-Name: Liferay Fragment Collection Filter Tags
+Bundle-SymbolicName: com.liferay.fragment.collection.filter.tags
+Bundle-Version: 1.0.0
+Web-ContextPath: /fragment-collection-filter-tags

--- a/modules/apps/fragment/fragment-collection-filter-tags/build.gradle
+++ b/modules/apps/fragment/fragment-collection-filter-tags/build.gradle
@@ -1,0 +1,13 @@
+dependencies {
+	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
+	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
+	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
+	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:fragment:fragment-api")
+	compileOnly project(":apps:fragment:fragment-collection-filter-api")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-string")
+}

--- a/modules/apps/fragment/fragment-collection-filter-tags/package.json
+++ b/modules/apps/fragment/fragment-collection-filter-tags/package.json
@@ -1,0 +1,12 @@
+{
+	"dependencies": {
+	},
+	"main": "js/SelectTags.tsx",
+	"name": "@liferay/fragment-collection-filter-tags",
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "1.0.0"
+}

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/java/com/liferay/fragment/collection/filter/tags/FragmentCollectionFilterTags.java
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/java/com/liferay/fragment/collection/filter/tags/FragmentCollectionFilterTags.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.fragment.collection.filter.tags;
+
+import com.liferay.asset.kernel.model.AssetTag;
+import com.liferay.asset.kernel.service.AssetTagLocalService;
+import com.liferay.fragment.collection.filter.FragmentCollectionFilter;
+import com.liferay.fragment.collection.filter.tags.display.context.FragmentCollectionFilterTagsDisplayContext;
+import com.liferay.fragment.renderer.FragmentRendererContext;
+import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.ResourceBundleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Locale;
+import java.util.ResourceBundle;
+
+import javax.servlet.RequestDispatcher;
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Pablo Molina
+ */
+@Component(
+	enabled = false, immediate = true, service = FragmentCollectionFilter.class
+)
+public class FragmentCollectionFilterTags implements FragmentCollectionFilter {
+
+	@Override
+	public String getConfiguration() {
+		ResourceBundle resourceBundle = ResourceBundleUtil.getBundle(
+			"content.Language", LocaleUtil.getMostRelevantLocale(), getClass());
+
+		try {
+			String json = StringUtil.read(
+				getClass(),
+				"/com/liferay/fragment/collection/filter/tags/dependencies" +
+					"/configuration.json");
+
+			return _fragmentEntryConfigurationParser.translateConfiguration(
+				_jsonFactory.createJSONObject(json), resourceBundle);
+		}
+		catch (JSONException jsonException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(jsonException);
+			}
+
+			return StringPool.BLANK;
+		}
+	}
+
+	@Override
+	public String getFilterKey() {
+		return "tags";
+	}
+
+	@Override
+	public String getFilterValueLabel(String filterValue, Locale locale) {
+		AssetTag assetTag = _assetTagLocalService.fetchAssetTag(
+			GetterUtil.getLong(filterValue));
+
+		if (assetTag == null) {
+			return filterValue;
+		}
+
+		return assetTag.getName();
+	}
+
+	@Override
+	public String getLabel(Locale locale) {
+		return _language.get(locale, "tags");
+	}
+
+	@Override
+	public void render(
+		FragmentRendererContext fragmentRendererContext,
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
+
+		try {
+			httpServletRequest.setAttribute(
+				FragmentCollectionFilterTagsDisplayContext.class.getName(),
+				new FragmentCollectionFilterTagsDisplayContext(
+					getConfiguration(), _fragmentEntryConfigurationParser,
+					fragmentRendererContext));
+
+			RequestDispatcher requestDispatcher =
+				_servletContext.getRequestDispatcher("/page.jsp");
+
+			requestDispatcher.include(httpServletRequest, httpServletResponse);
+		}
+		catch (Exception exception) {
+			_log.error(
+				"Unable to render collection filter fragment", exception);
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		FragmentCollectionFilterTags.class);
+
+	@Reference
+	private AssetTagLocalService _assetTagLocalService;
+
+	@Reference
+	private FragmentEntryConfigurationParser _fragmentEntryConfigurationParser;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Language _language;
+
+	@Reference(
+		target = "(osgi.web.symbolicname=com.liferay.fragment.collection.filter.tags)"
+	)
+	private ServletContext _servletContext;
+
+}

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/java/com/liferay/fragment/collection/filter/tags/display/context/FragmentCollectionFilterTagsDisplayContext.java
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/java/com/liferay/fragment/collection/filter/tags/display/context/FragmentCollectionFilterTagsDisplayContext.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.fragment.collection.filter.tags.display.context;
+
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.renderer.FragmentRendererContext;
+import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Map;
+
+/**
+ * @author Pablo Molina
+ */
+public class FragmentCollectionFilterTagsDisplayContext {
+
+	public FragmentCollectionFilterTagsDisplayContext(
+		String configuration,
+		FragmentEntryConfigurationParser fragmentEntryConfigurationParser,
+		FragmentRendererContext fragmentRendererContext) {
+
+		_configuration = configuration;
+		_fragmentEntryConfigurationParser = fragmentEntryConfigurationParser;
+		_fragmentRendererContext = fragmentRendererContext;
+
+		_fragmentEntryLink = fragmentRendererContext.getFragmentEntryLink();
+	}
+
+	public String getHelpText() {
+		String helpText = GetterUtil.getString(_getFieldValue("helpText"));
+
+		if (Validator.isNotNull(helpText)) {
+			return helpText;
+		}
+
+		JSONObject defaultValuesJSONObject =
+			_fragmentEntryConfigurationParser.
+				getConfigurationDefaultValuesJSONObject(_configuration);
+
+		return defaultValuesJSONObject.getString("helpText", StringPool.BLANK);
+	}
+
+	public String getHelpTextId() {
+		return "fragment_" +
+			String.valueOf(_fragmentEntryLink.getFragmentEntryLinkId()) +
+				"_helpText";
+	}
+
+	public String getLabel() {
+		String label = GetterUtil.getString(_getFieldValue("label"));
+
+		if (Validator.isNotNull(label)) {
+			return label;
+		}
+
+		return StringPool.BLANK;
+	}
+
+	public String getLabelId() {
+		return "fragment_" +
+			String.valueOf(_fragmentEntryLink.getFragmentEntryLinkId()) +
+				"_label";
+	}
+
+	public Map<String, Object> getProps() {
+		if (_props != null) {
+			return _props;
+		}
+
+		_props = HashMapBuilder.<String, Object>put(
+			"fragmentEntryLinkId",
+			String.valueOf(_fragmentEntryLink.getFragmentEntryLinkId())
+		).put(
+			"label", getLabel()
+		).put(
+			"showHelpText", isShowHelpText()
+		).put(
+			"showLabel", isShowLabel()
+		).build();
+
+		return _props;
+	}
+
+	public boolean isShowHelpText() {
+		return GetterUtil.getBoolean(_getFieldValue("showHelpText"));
+	}
+
+	public boolean isShowLabel() {
+		return GetterUtil.getBoolean(_getFieldValue("showLabel"));
+	}
+
+	private Object _getFieldValue(String fieldName) {
+		return _fragmentEntryConfigurationParser.getFieldValue(
+			_configuration, _fragmentEntryLink.getEditableValues(),
+			_fragmentRendererContext.getLocale(), fieldName);
+	}
+
+	private final String _configuration;
+	private final FragmentEntryConfigurationParser
+		_fragmentEntryConfigurationParser;
+	private final FragmentEntryLink _fragmentEntryLink;
+	private final FragmentRendererContext _fragmentRendererContext;
+	private Map<String, Object> _props;
+
+}

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/init.jsp
@@ -1,0 +1,25 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
+
+<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %>
+
+<%@ page import="com.liferay.fragment.collection.filter.tags.display.context.FragmentCollectionFilterTagsDisplayContext" %>
+
+<%
+FragmentCollectionFilterTagsDisplayContext fragmentCollectionFilterTagsDisplayContext = (FragmentCollectionFilterTagsDisplayContext)request.getAttribute(FragmentCollectionFilterTagsDisplayContext.class.getName());
+%>

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/js/SelectTags.tsx
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/js/SelectTags.tsx
@@ -1,0 +1,67 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayMultiSelect from '@clayui/multi-select';
+import {
+	getCollectionFilterValue,
+	setCollectionFilterValue,
+} from '@liferay/fragment-renderer-collection-filter-impl';
+import React, {useCallback, useMemo} from 'react';
+
+interface IProps {
+	fragmentEntryLinkId: string;
+	label: string;
+	showHelpText: boolean;
+	showLabel: boolean;
+}
+
+export default function SelectTags({
+	fragmentEntryLinkId,
+	showHelpText,
+}: IProps) {
+	const selectedTagIds = useMemo(() => {
+		const value = getCollectionFilterValue('tags', fragmentEntryLinkId);
+
+		if (Array.isArray(value)) {
+			return value.map((tagId) => ({label: tagId, value: tagId}));
+		}
+		else if (value) {
+			return [{label: value, value}];
+		}
+
+		return [];
+	}, [fragmentEntryLinkId]);
+
+	const setSelectedTagIds = useCallback(
+		(nextTags: Array<{label: string; value: string}>) => {
+			setCollectionFilterValue(
+				'tags',
+				fragmentEntryLinkId,
+				nextTags.map((tag) => tag.value)
+			);
+		},
+		[fragmentEntryLinkId]
+	);
+
+	return (
+		<ClayMultiSelect
+			aria-describedby={
+				showHelpText ? `fragment_${fragmentEntryLinkId}_helpText` : null
+			}
+			aria-labelledby={`fragment_${fragmentEntryLinkId}_label`}
+			items={selectedTagIds}
+			onItemsChange={setSelectedTagIds}
+		/>
+	);
+}

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/page.jsp
@@ -1,0 +1,40 @@
+<%--
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<div class="form-group form-group-sm mb-0">
+	<label class="control-label <%= fragmentCollectionFilterTagsDisplayContext.isShowLabel() ? "" : "sr-only" %>" id="<%= fragmentCollectionFilterTagsDisplayContext.getLabelId() %>">
+		<%= fragmentCollectionFilterTagsDisplayContext.getLabel() %>
+	</label>
+
+	<div>
+		<input class="form-control form-control-select form-control-sm w-100" disabled="disabled" type="text" />
+
+		<react:component
+			module="js/SelectTags"
+			props="<%= fragmentCollectionFilterTagsDisplayContext.getProps() %>"
+		/>
+	</div>
+
+	<c:choose>
+		<c:when test="<%= fragmentCollectionFilterTagsDisplayContext.isShowHelpText() %>">
+			<p class="m-0 mt-1 small text-secondary" id="<%= fragmentCollectionFilterTagsDisplayContext.getHelpTextId() %>">
+				<%= fragmentCollectionFilterTagsDisplayContext.getHelpText() %>
+			</p>
+		</c:when>
+	</c:choose>
+</div>

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/com/liferay/fragment/collection/filter/tags/dependencies/configuration.json
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/com/liferay/fragment/collection/filter/tags/dependencies/configuration.json
@@ -1,0 +1,34 @@
+{
+	"fieldSets": [
+		{
+			"fields": [
+				{
+					"defaultValue": false,
+					"label": "show-label",
+					"name": "showLabel",
+					"type": "checkbox"
+				},
+				{
+					"defaultValue": "",
+					"label": "label-text",
+					"localizable": true,
+					"name": "label",
+					"type": "text"
+				},
+				{
+					"defaultValue": false,
+					"label": "show-help-text",
+					"name": "showHelpText",
+					"type": "checkbox"
+				},
+				{
+					"defaultValue": "type-a-comma-or-press-intro-to-enter-a-tag",
+					"label": "help-text",
+					"localizable": true,
+					"name": "helpText",
+					"type": "text"
+				}
+			]
+		}
+	]
+}

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/filter/TagsInfoFilter.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/filter/TagsInfoFilter.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.info.filter;
+
+/**
+ * @author Pablo Molina
+ */
+public class TagsInfoFilter implements InfoFilter {
+
+	public static final String FILTER_TYPE_NAME = "tags";
+
+	@Override
+	public String getFilterTypeName() {
+		return FILTER_TYPE_NAME;
+	}
+
+	public long[][] getTagIds() {
+		return _tagIds;
+	}
+
+	public void setTagIds(long[][] tagIds) {
+		_tagIds = tagIds;
+	}
+
+	private long[][] _tagIds;
+
+}

--- a/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/item/filter/TagsInfoFilterProvider.java
+++ b/modules/apps/info/info-impl/src/main/java/com/liferay/info/internal/item/filter/TagsInfoFilterProvider.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.info.internal.item.filter;
+
+import com.liferay.info.filter.InfoFilterProvider;
+import com.liferay.info.filter.TagsInfoFilter;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Pablo Molina
+ */
+@Component(immediate = true, service = InfoFilterProvider.class)
+public class TagsInfoFilterProvider
+	implements InfoFilterProvider<TagsInfoFilter> {
+
+	@Override
+	public TagsInfoFilter create(Map<String, String[]> values) {
+		TagsInfoFilter tagsInfoFilter = new TagsInfoFilter();
+
+		tagsInfoFilter.setTagIds(_getAssetTagIds(values));
+
+		return tagsInfoFilter;
+	}
+
+	private long[][] _getAssetTagIds(Map<String, String[]> values) {
+		Set<long[]> assetTagIdSet = new HashSet<>();
+
+		for (Map.Entry<String, String[]> entry : values.entrySet()) {
+			if (!StringUtil.startsWith(
+					entry.getKey(),
+					TagsInfoFilter.FILTER_TYPE_NAME + StringPool.UNDERLINE)) {
+
+				continue;
+			}
+
+			assetTagIdSet.add(
+				ArrayUtil.filter(
+					GetterUtil.getLongValues(entry.getValue()),
+					tagId -> tagId != 0));
+		}
+
+		return assetTagIdSet.toArray(new long[assetTagIdSet.size()][]);
+	}
+
+}


### PR DESCRIPTION
This is an initial development for the story, adding a new "Tags" filter fragment. The component is still a dummy fragment that does nothing. In order to test this:

1. Enable FragmentCollectionFilters component.
2. Deploy all modules.
3. Create a manual collection of Web Content Articles (it can be empty).
4. Add a content page with:
   - A collection display fragment targeting the created collection.
   - A collection filter fragment targeting the created collection display.
5. Select "tags" in filter type and publish.

Things to check:
- The page can be published.
- If something is typed into the fragment and enter is pressed, the page reloads and a new URL parameter appears.
- The fragment preserves typed tags into the URL.

In future PRs I will add:
- Autocomplete with existing tags
- Actual filtering of elements