### PR TITLE
[TS] LPS-168004

### DIFF
--- a/modules/apps/wiki/wiki-api/bnd.bnd
+++ b/modules/apps/wiki/wiki-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Wiki API
 Bundle-SymbolicName: com.liferay.wiki.api
-Bundle-Version: 12.0.1
+Bundle-Version: 12.1.0
 Export-Package:\
 	com.liferay.wiki.configuration,\
 	com.liferay.wiki.configuration.definition,\

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPage.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPage.java
@@ -65,6 +65,10 @@ public interface WikiPage extends PersistedModel, WikiPageModel {
 	public WikiPage fetchRedirectPage();
 
 	public java.util.List<com.liferay.portal.kernel.repository.model.FileEntry>
+			getApprovedAttachmentsFileEntries()
+		throws com.liferay.portal.kernel.exception.PortalException;
+
+	public java.util.List<com.liferay.portal.kernel.repository.model.FileEntry>
 			getAttachmentsFileEntries()
 		throws com.liferay.portal.kernel.exception.PortalException;
 

--- a/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageWrapper.java
+++ b/modules/apps/wiki/wiki-api/src/main/java/com/liferay/wiki/model/WikiPageWrapper.java
@@ -258,6 +258,14 @@ public class WikiPageWrapper
 
 	@Override
 	public java.util.List<com.liferay.portal.kernel.repository.model.FileEntry>
+			getApprovedAttachmentsFileEntries()
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return model.getApprovedAttachmentsFileEntries();
+	}
+
+	@Override
+	public java.util.List<com.liferay.portal.kernel.repository.model.FileEntry>
 			getAttachmentsFileEntries()
 		throws com.liferay.portal.kernel.exception.PortalException {
 

--- a/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/model/packageinfo
+++ b/modules/apps/wiki/wiki-api/src/main/resources/com/liferay/wiki/model/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0

--- a/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/model/impl/WikiPageImpl.java
+++ b/modules/apps/wiki/wiki-service/src/main/java/com/liferay/wiki/model/impl/WikiPageImpl.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -94,6 +95,27 @@ public class WikiPageImpl extends WikiPageBaseImpl {
 
 		return WikiPageLocalServiceUtil.fetchPage(
 			getNodeId(), getRedirectTitle());
+	}
+
+	@Override
+	public List<FileEntry> getApprovedAttachmentsFileEntries()
+		throws PortalException {
+
+		List<FileEntry> fileEntries = new ArrayList<>();
+
+		for (FileEntry fileEntry :
+				getAttachmentsFileEntries(
+					QueryUtil.ALL_POS, QueryUtil.ALL_POS)) {
+
+			int value = DateUtil.compareTo(
+				fileEntry.getModifiedDate(), getStatusDate());
+
+			if (value <= 0) {
+				fileEntries.add(fileEntry);
+			}
+		}
+
+		return fileEntries;
 	}
 
 	@Override

--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_attachments.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/view_attachments.jsp
@@ -18,16 +18,18 @@
 
 <%
 final WikiPage wikiPage = (WikiPage)request.getAttribute(WikiWebKeys.WIKI_PAGE);
+
+List<FileEntry> fileEntries = wikiPage.getApprovedAttachmentsFileEntries();
 %>
 
-<c:if test="<%= wikiPage.getAttachmentsFileEntriesCount() > 0 %>">
+<c:if test="<%= !fileEntries.isEmpty() %>">
 	<div class="page-attachments">
 		<h5><liferay-ui:message key="attachments" /></h5>
 
 		<clay:row>
 
 			<%
-			for (FileEntry fileEntry : wikiPage.getAttachmentsFileEntries()) {
+			for (FileEntry fileEntry : fileEntries) {
 			%>
 
 				<clay:col


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-168004

Motivation:
Adding new attachments before the wiki is published results in "draft" attachments appearing on published wiki page.

Proposed Solution:
Only show attachments uploaded at last publish date or earlier.

Steps for reproduction:
1. Navigate to Menu > Configuration > Workflow.
2. Edit Wiki Page > Select Single Approver > Save.
3. Navigate to Home page > Add a Wiki widget to the page > Publish.
4. Edit the Wiki Front Page > Content: "test1" > Open Attachments tab > Select Files > Any file is ideal > Submit for Publication.

Expected results: The Wiki page does not show any changes > you have to approve the changes first.
Actual results: The attachments are already visible, however the changes are not approved yet.