### PR TITLE
LPS-167535 Add combobox role to trigger, listbox role to item list, and option role to items

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PageTypeSelector.js
@@ -100,14 +100,14 @@ function PageTypeSelector({
 					<ClayButton
 						className="form-control-select text-left"
 						displayType="secondary"
+						role="combobox"
 						small
-						type="button"
 					>
 						{pageTypeSelectedOptionLabel}
 					</ClayButton>
 				}
 			>
-				<ClayDropDown.ItemList>
+				<ClayDropDown.ItemList role="listbox">
 					{pageTypeOptions
 						.filter((option) => option.items.length)
 						.map((option, index) => (
@@ -121,6 +121,7 @@ function PageTypeSelector({
 										className="page-type-selector-option"
 										key={item.value}
 										onClick={() => handleSelect(item.value)}
+										roleItem="option"
 										symbolRight={
 											item.value ===
 											pageTypeSelectedOption


### PR DESCRIPTION
Motivation
=======
This is the LPS ticket: https://issues.liferay.com/browse/LPS-167535.
We had this issue flagged because Lexicon and Clay are working on adding a new component for this kind of drodpowns that is more accesible (https://github.com/liferay/clay/issues/5181). But in the meantime, I think we can give proper roles to our dropdown so it's accesiblely more correct.

Steps to Verify
========
1. Enable the screen readeer
2. Open product menu tree
3. Focus the tree type selector

Proposed Solution
========
Giving `combobox` role to the dropdown trigger, `listbox` to the list of items and `option` to each item on the list.

Reference
========
An example of a similar dropdown: https://www.w3.org/WAI/ARIA/apg/example-index/combobox/combobox-select-only.html