### PR TITLE
[TECHNICAL-SUPPPORT] LPS-170488 Always log the error

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportAndOverrideDataDefinitionMVCActionCommand.java
@@ -87,9 +87,7 @@ public class ImportAndOverrideDataDefinitionMVCActionCommand
 			hideDefaultSuccessMessage(actionRequest);
 		}
 		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
+			_log.error(exception);
 
 			SessionErrors.add(
 				actionRequest, "importDataDefinitionErrorMessage");

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/ImportDataDefinitionMVCActionCommand.java
@@ -104,9 +104,7 @@ public class ImportDataDefinitionMVCActionCommand extends BaseMVCActionCommand {
 			hideDefaultSuccessMessage(actionRequest);
 		}
 		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
+			_log.error(exception);
 
 			SessionErrors.add(
 				actionRequest, "importDataDefinitionErrorMessage", exception);


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
If importing a web content structure fails for some reason, the error message on the UI may not be specific enough to derive the reason. By default, the exception and the stack trace do not appear on the console, and it takes additional effort to set the log levels for `ImportDataDefinitionMVCActionCommand` and `ImportAndOverrideDataDefinitionMVCActionCommand`. 
https://issues.liferay.com/browse/LPS-170488

Proposed Solution
========
I have switched the debug to error statements so that the expectation and stack trace appears on the console.

Steps to Verify
========
Please consult the linked LPS.

Thank you and best regards,
István