### PR TITLE
LPS-171051 Clean all accessibility warnings in page editor

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/jest-setup.config.js
+++ b/modules/apps/layout/layout-content-page-editor-web/jest-setup.config.js
@@ -83,7 +83,9 @@ jest.mock(
 			panels: [['browser']],
 			portletNamespace: 'page-editor-portlet-namespace',
 			selectedViewportSize: 'desktop',
-			sidebarPanels: {browser: {sidebarPanelId: 'browser'}},
+			sidebarPanels: {
+				browser: {label: 'Browser', sidebarPanelId: 'browser'},
+			},
 		},
 	})
 );

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/HTMLEditorModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/HTMLEditorModal.js
@@ -52,6 +52,9 @@ const HTMLEditorModal = ({
 					<div className="d-flex justify-content-end pr-2 w-100">
 						<ClayButton.Group>
 							<ClayButtonWithIcon
+								aria-label={Liferay.Language.get(
+									'display-vertically'
+								)}
 								displayType="secondary"
 								onClick={() => setViewType(VIEW_TYPES.columns)}
 								small
@@ -62,6 +65,9 @@ const HTMLEditorModal = ({
 							/>
 
 							<ClayButtonWithIcon
+								aria-label={Liferay.Language.get(
+									'display-horizontally'
+								)}
 								displayType="secondary"
 								onClick={() => setViewType(VIEW_TYPES.rows)}
 								small
@@ -72,6 +78,7 @@ const HTMLEditorModal = ({
 							/>
 
 							<ClayButtonWithIcon
+								aria-label={Liferay.Language.get('full-screen')}
 								displayType="secondary"
 								onClick={() =>
 									setViewType(VIEW_TYPES.fullscreen)

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ReorderSetsModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/ReorderSetsModal.js
@@ -21,6 +21,7 @@ import ClayLoadingIndicator from '@clayui/loading-indicator';
 import ClayModal, {useModal} from '@clayui/modal';
 import ClayTabs from '@clayui/tabs';
 import classNames from 'classnames';
+import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useMemo, useState} from 'react';
 import {useDrag, useDrop} from 'react-dnd';
@@ -267,7 +268,7 @@ function Items({items: initialItems, listId, updateLists}) {
 
 Items.propTypes = {
 	items: PropTypes.array,
-	listId: PropTypes.string.isRequired,
+	listId: PropTypes.number.isRequired,
 	updateLists: PropTypes.func.isRequired,
 };
 
@@ -346,6 +347,7 @@ function ReorderDropdown({index, item, numberOfItems, onChangeItemPosition}) {
 			items={items}
 			trigger={
 				<ClayButtonWithIcon
+					aria-label={sub(Liferay.Language.get('move-x'), item.name)}
 					className="text-secondary"
 					displayType="unstyled"
 					small

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/AdvancedSelectField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/AdvancedSelectField.js
@@ -135,6 +135,11 @@ export function AdvancedSelectField({
 		);
 	}, [activeItemId, field.cssProperty, globalContext, value]);
 
+	const resetButtonLabel = useMemo(
+		() => getResetLabelByViewport(selectedViewportSize),
+		[selectedViewportSize]
+	);
+
 	return (
 		<div
 			className={classNames('page-editor__select-field d-flex', {
@@ -174,6 +179,7 @@ export function AdvancedSelectField({
 			{canDetachTokenValues ? (
 				isTokenValueOrInherited ? (
 					<ClayButtonWithIcon
+						aria-label={Liferay.Language.get('detach-style')}
 						className="border-0 flex-shrink-0 mb-0 ml-2 page-editor__select-field__action-button"
 						displayType="secondary"
 						onClick={() => {
@@ -201,6 +207,9 @@ export function AdvancedSelectField({
 						onActiveChange={setActive}
 						trigger={
 							<ClayButtonWithIcon
+								aria-label={Liferay.Language.get(
+									'value-from-stylebook'
+								)}
 								className="border-0"
 								displayType="secondary"
 								id={triggerId}
@@ -240,6 +249,7 @@ export function AdvancedSelectField({
 
 			{value && value !== field.defaultValue ? (
 				<ClayButtonWithIcon
+					aria-label={resetButtonLabel}
 					className="border-0 flex-shrink-0 mb-0 ml-2 page-editor__select-field__action-button"
 					displayType="secondary"
 					onClick={() =>
@@ -247,7 +257,7 @@ export function AdvancedSelectField({
 					}
 					small
 					symbol="restore"
-					title={getResetLabelByViewport(selectedViewportSize)}
+					title={resetButtonLabel}
 				/>
 			) : null}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/ButtonGroupField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/ButtonGroupField.js
@@ -39,6 +39,7 @@ export function ButtonGroupField({field, onValueSelect, value}) {
 
 			{field.typeOptions?.validValues.map((validValue) => (
 				<ClayButtonWithIcon
+					aria-label={validValue.label}
 					aria-pressed={nextValue === validValue.value}
 					className={
 						nextValue === validValue.value

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/CheckboxField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/CheckboxField.js
@@ -92,6 +92,7 @@ export function CheckboxField({
 				{field.responsive &&
 					selectedViewportSize !== VIEWPORT_SIZES.desktop && (
 						<ClayButtonWithIcon
+							aria-label={Liferay.Language.get('restore-default')}
 							data-tooltip-align="bottom"
 							displayType="secondary"
 							onClick={() => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/CustomCSSField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/CustomCSSField.js
@@ -73,6 +73,7 @@ export default function CustomCSSField({field, onValueSelect, value}) {
 					</label>
 
 					<ClayButtonWithIcon
+						aria-label={Liferay.Language.get('expand')}
 						className="mb-2 p-0 page-editor__custom-css-field__expand-button text-secondary"
 						displayType="unstyled"
 						monospaced

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/HideFragmentField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment-configuration-fields/HideFragmentField.js
@@ -123,6 +123,9 @@ export function HideFragmentField({
 					{field.responsive &&
 						selectedViewportSize !== VIEWPORT_SIZES.desktop && (
 							<ClayButtonWithIcon
+								aria-label={Liferay.Language.get(
+									'restore-default'
+								)}
 								data-tooltip-align="bottom"
 								displayType="secondary"
 								onClick={() => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/Topper.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/Topper.js
@@ -276,6 +276,9 @@ function TopperContent({
 						{item.type === LAYOUT_DATA_ITEM_TYPES.fragment && (
 							<li className="page-editor__topper__item tbar-item">
 								<ClayButton
+									aria-label={Liferay.Language.get(
+										'comments'
+									)}
 									displayType="unstyled"
 									small
 									title={Liferay.Language.get('comments')}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/TopperItemActions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/TopperItemActions.js
@@ -164,6 +164,7 @@ export default function TopperItemActions({item}) {
 				onActiveChange={setActive}
 				trigger={
 					<ClayButton
+						aria-label={Liferay.Language.get('options')}
 						displayType="unstyled"
 						small
 						title={Liferay.Language.get('options')}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ColorPicker/ColorPicker.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ColorPicker/ColorPicker.js
@@ -19,7 +19,7 @@ import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
 import {debounce} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useRef, useState} from 'react';
+import React, {useMemo, useRef, useState} from 'react';
 
 import {useActiveItemId} from '../../../app/contexts/ControlsContext';
 import {
@@ -214,6 +214,14 @@ export function ColorPicker({
 		}
 	};
 
+	const resetButtonLabel = useMemo(
+		() =>
+			selectedViewportSize
+				? getResetLabelByViewport(selectedViewportSize)
+				: Liferay.Language.get('clear-selection'),
+		[selectedViewportSize]
+	);
+
 	return (
 		<ClayForm.Group small>
 			<label className={classNames({'sr-only': !showLabel})} id={labelId}>
@@ -306,6 +314,7 @@ export function ColorPicker({
 				{tokenLabel ? (
 					canDetachTokenValues && (
 						<ClayButtonWithIcon
+							aria-label={Liferay.Language.get('detach-style')}
 							className="border-0 flex-shrink-0 mb-0 ml-2 page-editor__color-picker__action-button"
 							displayType="secondary"
 							onClick={() => {
@@ -355,6 +364,7 @@ export function ColorPicker({
 
 				{value ? (
 					<ClayButtonWithIcon
+						aria-label={resetButtonLabel}
 						className="border-0 flex-shrink-0 ml-2 page-editor__color-picker__action-button"
 						displayType="secondary"
 						onClick={() => {
@@ -375,11 +385,7 @@ export function ColorPicker({
 						}}
 						small
 						symbol="restore"
-						title={
-							selectedViewportSize
-								? getResetLabelByViewport(selectedViewportSize)
-								: Liferay.Language.get('clear-selection')
-						}
+						title={resetButtonLabel}
 					/>
 				) : null}
 			</div>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ColorPicker/DropdownColorPicker.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ColorPicker/DropdownColorPicker.js
@@ -160,6 +160,7 @@ export function DropdownColorPicker({
 				</ClayButton>
 			) : (
 				<ClayButtonWithIcon
+					aria-label={Liferay.Language.get('value-from-stylebook')}
 					className="border-0 flex-shrink-0"
 					displayType="secondary"
 					onClick={() => onSetActive(!active)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ImageSelector.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/ImageSelector.js
@@ -45,6 +45,13 @@ export function ImageSelector({
 
 	const hasImageTitle = !!imageTitle.length;
 
+	const selectButtonLabel = sub(
+		hasImageTitle
+			? Liferay.Language.get('change-x')
+			: Liferay.Language.get('select-x'),
+		Liferay.Language.get('image')
+	);
+
 	return selectedViewportSize === VIEWPORT_SIZES.desktop ? (
 		<>
 			<ClayForm.Group>
@@ -69,6 +76,7 @@ export function ImageSelector({
 
 					<ClayInput.GroupItem shrink>
 						<ClayButtonWithIcon
+							aria-label={selectButtonLabel}
 							displayType="secondary"
 							onClick={() =>
 								openImageSelector((image) => {
@@ -77,12 +85,7 @@ export function ImageSelector({
 							}
 							small
 							symbol={hasImageTitle ? 'change' : 'plus'}
-							title={sub(
-								hasImageTitle
-									? Liferay.Language.get('change-x')
-									: Liferay.Language.get('select-x'),
-								Liferay.Language.get('image')
-							)}
+							title={selectButtonLabel}
 						/>
 					</ClayInput.GroupItem>
 
@@ -90,6 +93,9 @@ export function ImageSelector({
 						<>
 							<ClayInput.GroupItem shrink>
 								<ClayButtonWithIcon
+									aria-label={Liferay.Language.get(
+										'clear-selection'
+									)}
 									displayType="secondary"
 									onClick={onClearButtonPressed}
 									small

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/LengthField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/LengthField.js
@@ -75,6 +75,11 @@ export function LengthField({field, onEnter, onValueSelect, value}) {
 		RESTORABLE_FIELDS.has(field.name) && value !== field.defaultValue
 	);
 
+	const resetButtonLabel = useMemo(
+		() => getResetLabelByViewport(selectedViewportSize),
+		[selectedViewportSize]
+	);
+
 	return (
 		<div className="align-items-center d-flex page-editor__length-field">
 			<LengthInput
@@ -95,6 +100,7 @@ export function LengthField({field, onEnter, onValueSelect, value}) {
 
 			{showRestoreButton ? (
 				<ClayButtonWithIcon
+					aria-label={resetButtonLabel}
 					className="border-0 flex-shrink-0 mb-0 ml-2"
 					displayType="secondary"
 					onClick={() => {
@@ -105,7 +111,7 @@ export function LengthField({field, onEnter, onValueSelect, value}) {
 					}}
 					small
 					symbol="restore"
-					title={getResetLabelByViewport(selectedViewportSize)}
+					title={resetButtonLabel}
 				/>
 			) : null}
 		</div>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/SearchForm.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/SearchForm.js
@@ -52,6 +52,9 @@ export default function SearchForm({className, label, onChange}) {
 					<ClayInput.GroupInsetItem after tag="span">
 						{searchValue ? (
 							<ClayButtonWithIcon
+								aria-label={Liferay.Language.get(
+									'clear-search'
+								)}
 								borderless
 								displayType="secondary"
 								monospaced={false}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/SidebarPanelHeader.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/SidebarPanelHeader.js
@@ -41,6 +41,7 @@ export default function SidebarPanelHeader({
 			{iconRight}
 
 			<ClayButtonWithIcon
+				aria-label={Liferay.Language.get('close')}
 				displayType="unstyled"
 				onClick={() => {
 					dispatch(switchSidebarPanel({sidebarOpen: false}));

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/SpacingBox.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/SpacingBox.js
@@ -18,7 +18,7 @@ import ClayTooltip from '@clayui/tooltip';
 import {ReactPortal} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
 import {sub} from 'frontend-js-web';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 import {useGlobalContext} from '../../app/contexts/GlobalContext';
 import {useSelector} from '../../app/contexts/StoreContext';
@@ -186,6 +186,11 @@ function SpacingSelectorButton({
 		(state) => state.selectedViewportSize
 	);
 
+	const resetButtonLabel = useMemo(
+		() => getResetLabelByViewport(selectedViewportSize),
+		[selectedViewportSize]
+	);
+
 	useEffect(() => {
 		if (active && itemListRef.current) {
 			setTimeout(
@@ -273,6 +278,7 @@ function SpacingSelectorButton({
 
 								{value && (
 									<ClayButtonWithIcon
+										aria-label={resetButtonLabel}
 										borderless
 										className="lfr-portal-tooltip text-3"
 										displayType="secondary"
@@ -285,9 +291,7 @@ function SpacingSelectorButton({
 										}}
 										small
 										symbol="restore"
-										title={getResetLabelByViewport(
-											selectedViewportSize
-										)}
+										title={resetButtonLabel}
 									/>
 								)}
 							</li>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTreeNodeActions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTreeNodeActions.js
@@ -73,6 +73,7 @@ export default function StructureTreeNodeActions({
 			<ClayButton
 				aria-expanded={active}
 				aria-haspopup="true"
+				aria-label={Liferay.Language.get('options')}
 				className={classNames(
 					'page-editor__page-structure__tree-node__actions-button',
 					{

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTreeNodeActions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page-structure/components/StructureTreeNodeActions.js
@@ -252,6 +252,9 @@ const ActionList = ({item, setActive, setEditingName, setOpenSaveModal}) => {
 						) : (
 							<React.Fragment key={index}>
 								<ClayDropDown.Item
+									aria-label={Liferay.Language.get(
+										dropdownItem.label
+									)}
 									onClick={() => {
 										setActive(false);
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/FragmentComment.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/comments/components/FragmentComment.js
@@ -184,6 +184,7 @@ export default function FragmentComment({
 						onActiveChange={setDropDownActive}
 						trigger={
 							<ClayButton
+								aria-label={Liferay.Language.get('options')}
 								borderless
 								disabled={editing}
 								displayType="secondary"

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments-widgets/components/FragmentsSidebar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments-widgets/components/FragmentsSidebar.js
@@ -226,6 +226,13 @@ export default function FragmentsSidebar() {
 		}
 	}, [dispatch, searchValue, widgetFragmentEntryLinksRef, widgets]);
 
+	const viewButtonLabel = sub(
+		Liferay.Language.get('switch-to-x-view'),
+		displayStyle === FRAGMENTS_DISPLAY_STYLES.LIST
+			? Liferay.Language.get('card')
+			: Liferay.Language.get('list')
+	);
+
 	return (
 		<>
 			<SidebarPanelHeader>
@@ -245,6 +252,7 @@ export default function FragmentsSidebar() {
 					/>
 
 					<ClayButtonWithIcon
+						aria-label={Liferay.Language.get('reorder-sets')}
 						borderless
 						className="lfr-portal-tooltip ml-2 mt-0"
 						data-tooltip-align="bottom-right"
@@ -256,6 +264,7 @@ export default function FragmentsSidebar() {
 					/>
 
 					<ClayButtonWithIcon
+						aria-label={viewButtonLabel}
 						borderless
 						className="lfr-portal-tooltip ml-2 mt-0"
 						data-tooltip-align="bottom-right"
@@ -275,12 +284,7 @@ export default function FragmentsSidebar() {
 								? 'cards2'
 								: 'list'
 						}
-						title={sub(
-							Liferay.Language.get('switch-to-x-view'),
-							displayStyle === FRAGMENTS_DISPLAY_STYLES.LIST
-								? Liferay.Language.get('card')
-								: Liferay.Language.get('list')
-						)}
+						title={viewButtonLabel}
 					/>
 				</div>
 


### PR DESCRIPTION
There is one warning pending in HideSidebarButton.js because the button has an `aria-labelledby` instead of an `aria-label`. Yesterday I made [this request](https://github.com/liferay/clay/issues/5249) to Clay and they will include it as soon as they can.