### PR TITLE
LPS-170432 Create unique react component for product menu pages tree

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
@@ -210,94 +210,8 @@ public class LayoutsTreeDisplayContext {
 		return _groupId;
 	}
 
-	public Map<String, Object> getLayoutFinderData() {
-		return HashMapBuilder.<String, Object>put(
-			"administrationPortletNamespace",
-			PortalUtil.getPortletNamespace(LayoutAdminPortletKeys.GROUP_PAGES)
-		).put(
-			"administrationPortletURL", getAdministrationPortletURL()
-		).put(
-			"findLayoutsURL",
-			() -> {
-				LiferayPortletURL findLayoutsURL = PortletURLFactoryUtil.create(
-					_liferayPortletRequest,
-					ProductNavigationProductMenuPortletKeys.
-						PRODUCT_NAVIGATION_PRODUCT_MENU,
-					PortletRequest.RESOURCE_PHASE);
-
-				findLayoutsURL.setResourceID(
-					"/product_navigation_product_menu/find_layouts");
-
-				return findLayoutsURL.toString();
-			}
-		).put(
-			"namespace", getNamespace()
-		).put(
-			"productMenuPortletURL", getProductMenuPortletURL()
-		).put(
-			"spritemap", _themeDisplay.getPathThemeSpritemap()
-		).build();
-	}
-
 	public String getNamespace() {
 		return _namespace;
-	}
-
-	public Map<String, Object> getPagesTreeData() throws Exception {
-		return HashMapBuilder.<String, Object>put(
-			"config",
-			HashMapBuilder.<String, Object>put(
-				"loadMoreItemsURL",
-				() -> {
-					LiferayPortletURL liferayPortletURL =
-						(LiferayPortletURL)ResourceURLBuilder.createResourceURL(
-							_renderResponse
-						).setResourceID(
-							"/product_navigation_product_menu/get_layouts"
-						).buildResourceURL();
-
-					liferayPortletURL.setCopyCurrentRenderParameters(false);
-
-					return liferayPortletURL.toString();
-				}
-			).put(
-				"maxPageSize",
-				GetterUtil.getInteger(
-					PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN)
-			).put(
-				"moveItemURL",
-				() -> {
-					StringBundler sb = new StringBundler(3);
-
-					sb.append(PortalUtil.getPortalURL(_httpServletRequest));
-					sb.append(_themeDisplay.getPathMain());
-					sb.append("/portal/edit_layout?cmd=parent_layout_id");
-
-					return sb.toString();
-				}
-			).put(
-				"namespace", getNamespace()
-			).put(
-				"stagingEnabled",
-				() -> {
-					Group scopeGroup = _themeDisplay.getScopeGroup();
-
-					if (scopeGroup.hasLocalOrRemoteStagingGroup()) {
-						return true;
-					}
-
-					return false;
-				}
-			).build()
-		).put(
-			"isPrivateLayoutsTree", isPrivateLayout()
-		).put(
-			"items", _getLayoutsJSONArray()
-		).put(
-			"selectedLayoutId", getSelPlid()
-		).put(
-			"selectedLayoutPath", _getSelectedLayoutPath()
-		).build();
 	}
 
 	public String getPagesTreeURL() {
@@ -320,35 +234,6 @@ public class LayoutsTreeDisplayContext {
 		).buildString();
 	}
 
-	public Map<String, Object> getPageTypeSelectorData() {
-		return HashMapBuilder.<String, Object>put(
-			"addCollectionLayoutURL", _setSelPlid(getAddCollectionLayoutURL())
-		).put(
-			"addLayoutURL", _setSelPlid(getAddLayoutURL())
-		).put(
-			"configureLayoutSetURL",
-			() -> {
-				if (!isShowConfigureLayout()) {
-					return StringPool.BLANK;
-				}
-
-				return _setSelPlid(getConfigureLayoutSetURL());
-			}
-		).put(
-			"namespace", getNamespace()
-		).put(
-			"pagesTreeURL", getPagesTreeURL()
-		).put(
-			"pageTypeOptions", _getPageTypeOptionsJSONArray()
-		).put(
-			"pageTypeSelectedOption", _getPageTypeSelectedOption()
-		).put(
-			"pageTypeSelectedOptionLabel", _getPageTypeSelectedOptionLabel()
-		).put(
-			"showAddIcon", this::_isShowAddIcon
-		).build();
-	}
-
 	public String getProductMenuPortletURL() {
 		return PortletURLBuilder.create(
 			PortletURLFactoryUtil.create(
@@ -365,6 +250,132 @@ public class LayoutsTreeDisplayContext {
 		).setWindowState(
 			LiferayWindowState.EXCLUSIVE
 		).buildString();
+	}
+
+	public Map<String, Object> getProductMenuTreeData() throws Exception {
+		Map<String, Object> config = HashMapBuilder.<String, Object>put(
+			"addCollectionLayoutURL", _setSelPlid(getAddCollectionLayoutURL())
+		).put(
+			"addLayoutURL", _setSelPlid(getAddLayoutURL())
+		).put(
+			"administrationPortletNamespace",
+			PortalUtil.getPortletNamespace(LayoutAdminPortletKeys.GROUP_PAGES)
+		).put(
+			"administrationPortletURL", getAdministrationPortletURL()
+		).put(
+			"configureLayoutSetURL",
+			() -> {
+				if (!isShowConfigureLayout()) {
+					return StringPool.BLANK;
+				}
+
+				return _setSelPlid(getConfigureLayoutSetURL());
+			}
+		).put(
+			"findLayoutsURL",
+			() -> {
+				LiferayPortletURL findLayoutsURL = PortletURLFactoryUtil.create(
+					_liferayPortletRequest,
+					ProductNavigationProductMenuPortletKeys.
+						PRODUCT_NAVIGATION_PRODUCT_MENU,
+					PortletRequest.RESOURCE_PHASE);
+
+				findLayoutsURL.setResourceID(
+					"/product_navigation_product_menu/find_layouts");
+
+				return findLayoutsURL.toString();
+			}
+		).put(
+			"pagesTreeURL", getPagesTreeURL()
+		).put(
+			"productMenuPortletURL", getProductMenuPortletURL()
+		).build();
+
+		Map<String, Object> treeDate = HashMapBuilder.<String, Object>put(
+			"isSiteNavigationMenu", isSiteNavigationMenu()
+		).put(
+			"pageTypeOptions", _getPageTypeOptionsJSONArray()
+		).put(
+			"pageTypeSelectedOption", _getPageTypeSelectedOption()
+		).put(
+			"pageTypeSelectedOptionLabel", _getPageTypeSelectedOptionLabel()
+		).put(
+			"showAddIcon", this::_isShowAddIcon
+		).put(
+			"spritemap", _themeDisplay.getPathThemeSpritemap()
+		).build();
+
+		if (isSiteNavigationMenu()) {
+			treeDate.putAll(
+				HashMapBuilder.<String, Object>put(
+					"selectedSiteNavigationMenuItemId",
+					String.valueOf(getSelectedSiteNavigationMenuItemId())
+				).put(
+					"siteNavigationMenuItems",
+					_getSiteNavigationMenuItemsJSONArray()
+				).build());
+		}
+		else {
+			config.putAll(
+				HashMapBuilder.<String, Object>put(
+					"loadMoreItemsURL",
+					() -> {
+						LiferayPortletURL liferayPortletURL =
+							(LiferayPortletURL)
+								ResourceURLBuilder.createResourceURL(
+									_renderResponse
+								).setResourceID(
+									"/product_navigation_product_menu" +
+										"/get_layouts"
+								).buildResourceURL();
+
+						liferayPortletURL.setCopyCurrentRenderParameters(false);
+
+						return liferayPortletURL.toString();
+					}
+				).put(
+					"maxPageSize",
+					GetterUtil.getInteger(
+						PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN)
+				).put(
+					"moveItemURL",
+					() -> {
+						StringBundler sb = new StringBundler(3);
+
+						sb.append(PortalUtil.getPortalURL(_httpServletRequest));
+						sb.append(_themeDisplay.getPathMain());
+						sb.append("/portal/edit_layout?cmd=parent_layout_id");
+
+						return sb.toString();
+					}
+				).put(
+					"stagingEnabled",
+					() -> {
+						Group scopeGroup = _themeDisplay.getScopeGroup();
+
+						if (scopeGroup.hasLocalOrRemoteStagingGroup()) {
+							return true;
+						}
+
+						return false;
+					}
+				).build());
+
+			treeDate.putAll(
+				HashMapBuilder.<String, Object>put(
+					"isPrivateLayoutsTree", isPrivateLayout()
+				).put(
+					"items", _getLayoutsJSONArray()
+				).put(
+					"selectedLayoutId", getSelPlid()
+				).put(
+					"selectedLayoutPath", _getSelectedLayoutPath()
+				).build());
+		}
+
+		treeDate.put("config", config);
+
+		return treeDate;
 	}
 
 	public long getSelectedSiteNavigationMenuItemId() {
@@ -393,15 +404,6 @@ public class LayoutsTreeDisplayContext {
 		}
 
 		return layout.getPlid();
-	}
-
-	public Map<String, Object> getSiteNavigationMenuData() {
-		return HashMapBuilder.<String, Object>put(
-			"selectedSiteNavigationMenuItemId",
-			String.valueOf(getSelectedSiteNavigationMenuItemId())
-		).put(
-			"siteNavigationMenuItems", _getSiteNavigationMenuItemsJSONArray()
-		).build();
 	}
 
 	public boolean hasAddLayoutPermission() throws PortalException {

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/display/context/LayoutsTreeDisplayContext.java
@@ -292,6 +292,9 @@ public class LayoutsTreeDisplayContext {
 		).build();
 
 		Map<String, Object> treeDate = HashMapBuilder.<String, Object>put(
+			"hasAdministrationPortletPermission",
+			hasAdministrationPortletPermission()
+		).put(
 			"isSiteNavigationMenu", isSiteNavigationMenu()
 		).put(
 			"pageTypeOptions", _getPageTypeOptionsJSONArray()

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesAdministrationLink.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesAdministrationLink.js
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import ClayLink from '@clayui/link';
+import React from 'react';
+
+export default function PagesAdministrationLink({
+	administrationPortletURL,
+	hasAdministrationPortletPermission,
+}) {
+	return (
+		<>
+			{hasAdministrationPortletPermission && (
+				<div className="pages-administration-link">
+					<ClayLink className="ml-2" href={administrationPortletURL}>
+						{Liferay.Language.get('go-to-pages-administration')}
+					</ClayLink>
+				</div>
+			)}
+		</>
+	);
+}

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/ProductMenuTree.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/ProductMenuTree.js
@@ -1,0 +1,100 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React from 'react';
+
+import LayoutFinder from './LayoutFinder';
+import NavigationMenuItemsTree from './NavigationMenuItemsTree';
+import PageTypeSelector from './PageTypeSelector';
+import PagesAdministrationLink from './PagesAdministrationLink';
+import PagesTree from './PagesTree';
+
+export default function ProductMenuTree({portletNamespace, ...props}) {
+	const {
+		config,
+		hasAdministrationPortletPermission,
+		isPrivateLayoutsTree,
+		isSiteNavigationMenu,
+		items,
+		pageTypeOptions,
+		pageTypeSelectedOption,
+		pageTypeSelectedOptionLabel,
+		selectedLayoutId,
+		selectedLayoutPath,
+		selectedSiteNavigationMenuItemId,
+		showAddIcon,
+		siteNavigationMenuItems,
+	} = props.productMenuTreeData;
+
+	const layoutFinderData = {
+		administrationPortletNamespace: config.administrationPortletNamespace,
+		administrationPortletURL: config.administrationPortletURL,
+		findLayoutsURL: config.findLayoutsURL,
+		namespace: portletNamespace,
+		productMenuPortletURL: config.productMenuPortletURL,
+		viewInPageAdministrationURL: config.viewInPageAdministrationURL,
+	};
+
+	const pagesTreeData = {
+		config: {
+			loadMoreItemsURL: config.loadMoreItemsURL,
+			maxPageSize: config.maxPageSize,
+			moveItemURL: config.moveItemURL,
+			namespace: portletNamespace,
+		},
+		isPrivateLayoutsTree,
+		items,
+		selectedLayoutId,
+		selectedLayoutPath,
+	};
+
+	const pagetypeSelectorData = {
+		addCollectionLayoutURL: config.addCollectionLayoutURL,
+		addLayoutURL: config.addLayoutURL,
+		configureLayoutSetURL: config.configureLayoutSetURL,
+		namespace: portletNamespace,
+		pageTypeOptions,
+		pageTypeSelectedOption,
+		pageTypeSelectedOptionLabel,
+		pagesTreeURL: config.pagesTreeURL,
+		showAddIcon,
+	};
+
+	const siteNavigationMenuData = {
+		portletNamespace,
+		selectedSiteNavigationMenuItemId,
+		siteNavigationMenuItems,
+	};
+
+	const PagesAdministrationData = {
+		administrationPortletURL: config.administrationPortletURL,
+		hasAdministrationPortletPermission,
+	};
+
+	return (
+		<>
+			<LayoutFinder {...layoutFinderData} />
+
+			<PageTypeSelector {...pagetypeSelectorData} />
+
+			{isSiteNavigationMenu ? (
+				<NavigationMenuItemsTree {...siteNavigationMenuData} />
+			) : (
+				<PagesTree {...pagesTreeData} />
+			)}
+
+			<PagesAdministrationLink {...PagesAdministrationData} />
+		</>
+	);
+}

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
@@ -30,6 +30,7 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 <%@ page import="com.liferay.application.list.PanelCategory" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil" %><%@
+page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.SessionClicks" %><%@

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/pages_tree.jsp
@@ -20,49 +20,12 @@
 LayoutsTreeDisplayContext layoutsTreeDisplayContext = (LayoutsTreeDisplayContext)request.getAttribute(ProductNavigationProductMenuWebKeys.LAYOUTS_TREE_DISPLAY_CONTEXT);
 %>
 
-<div id="<%= liferayPortletResponse.getNamespace() %>-layout-finder">
-	<react:component
-		module="js/LayoutFinder"
-		props="<%= layoutsTreeDisplayContext.getLayoutFinderData() %>"
-		servletContext="<%= application %>"
-	/>
-</div>
-
-<div id="<portlet:namespace />layoutsTree">
-	<div id="<%= liferayPortletResponse.getNamespace() %>-page-type">
-		<react:component
-			module="js/PageTypeSelector"
-			props="<%= layoutsTreeDisplayContext.getPageTypeSelectorData() %>"
-			servletContext="<%= application %>"
-		/>
-	</div>
-
-	<c:choose>
-		<c:when test="<%= layoutsTreeDisplayContext.isSiteNavigationMenu() %>">
-			<div>
-				<react:component
-					module="js/NavigationMenuItemsTree"
-					props="<%= layoutsTreeDisplayContext.getSiteNavigationMenuData() %>"
-					servletContext="<%= application %>"
-				/>
-			</div>
-		</c:when>
-		<c:otherwise>
-			<div>
-				<react:component
-					module="js/PagesTree"
-					props="<%= layoutsTreeDisplayContext.getPagesTreeData() %>"
-					servletContext="<%= application %>"
-				/>
-			</div>
-
-			<c:if test="<%= layoutsTreeDisplayContext.hasAdministrationPortletPermission() %>">
-				<div class="pages-administration-link">
-					<aui:a cssClass="ml-2" href="<%= layoutsTreeDisplayContext.getAdministrationPortletURL() %>">
-						<liferay-ui:message key="go-to-pages-administration" />
-					</aui:a>
-				</div>
-			</c:if>
-		</c:otherwise>
-	</c:choose>
-</div>
+<react:component
+	module="js/ProductMenuTree"
+	props='<%=
+		HashMapBuilder.<String, Object>put(
+			"productMenuTreeData", layoutsTreeDisplayContext.getProductMenuTreeData()
+		).build()
+	%>'
+	servletContext="<%= application %>"
+/>


### PR DESCRIPTION
Motivation
=======
Actually, the product menu tree is separated in four react components, we want to unify these component in one to simplify the code.

Steps to Verify
========
1. Go to Product Menu > Page tree

Screenshots 
========
https://user-images.githubusercontent.com/91208451/207571480-e7184f87-5308-4ac2-99f9-b9634c287130.mov

Code
========
- In the first commit, I have unified the React components in one called ProductMenuTree.
- In the second commit, I have unified the part when retrieving the tree's data in only one method called "getProductMenuTreeData()" in order to simplify the code.