### PR TITLE
LPS-171160 Fix the delete for the Utility Pages

### DIFF
--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -187,6 +187,19 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 	}
 
 	@Override
+	public LayoutUtilityPageEntry deleteLayoutUtilityPageEntry(
+			long layoutUtilityPageEntryId)
+		throws PortalException {
+
+		LayoutUtilityPageEntry layoutUtilityPageEntry =
+			layoutUtilityPageEntryLocalService.fetchLayoutUtilityPageEntry(
+				layoutUtilityPageEntryId);
+
+		return layoutUtilityPageEntryLocalService.deleteLayoutUtilityPageEntry(
+			layoutUtilityPageEntry);
+	}
+
+	@Override
 	public LayoutUtilityPageEntry fetchDefaultLayoutUtilityPageEntry(
 		long groupId, String type) {
 


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-171160)

When deleting a utility page, the layout associated with that utility page must also be deleted.

## Proposed solution

Modify the service to use the deleteLayoutUtilityPageEntry with the Layout Utility Page Entry instead of layoutUtilityPageEntryId.

## Test Scenario

1. Go to Design > Fragments and create a new set of fragments.
2. Select any fragment of the default ones and copy it to the New set created before.
3. Go to Site Builder > Pages and go to the Utility Pages tab.
4. Create a new Utility Page and add to it the fragment copied.
5. Publish it, and then delete the utility Page.
6. Go again to Design > Fragments.
7. Open the three dot menu of the fragment you copied and click on "View usages".

## Notes
Step by step video (before the fix):

https://user-images.githubusercontent.com/93203423/207637616-87d15ae6-d710-4089-a9dd-893df8dcbdcd.mov

Test after the fix:

https://user-images.githubusercontent.com/93203423/207637848-f7dd2ec4-b300-49cf-a4ae-c26250a227ba.mov

