### PR TITLE
[TS] LPS-170287 Documents and Media - Wrong name is set when creating a folder with a lowercase

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java
@@ -72,16 +72,14 @@ public class HorizontalCardTag extends BaseCardTag {
 	}
 
 	public String getTitle() {
-		String title = _title;
-
 		HorizontalCard horizontalCard = getHorizontalCard();
 
 		if ((_title == null) && (horizontalCard != null)) {
-			title = horizontalCard.getTitle();
+			return horizontalCard.getTitle();
 		}
 
 		return LanguageUtil.get(
-			TagResourceBundleUtil.getResourceBundle(pageContext), title);
+			TagResourceBundleUtil.getResourceBundle(pageContext), _title);
 	}
 
 	public void setHorizontalCard(HorizontalCard horizontalCard) {
@@ -205,6 +203,7 @@ public class HorizontalCardTag extends BaseCardTag {
 		if ((href != null) && !disabled) {
 			LinkTag linkTag = new LinkTag();
 
+			linkTag.setLocalizeTitle(true);
 			linkTag.setCssClass("text-truncate");
 			linkTag.setHref(href);
 

--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/LinkTag.java
@@ -91,6 +91,10 @@ public class LinkTag extends BaseContainerTag {
 		return _label;
 	}
 
+	public boolean getLocalizeTitle() {
+		return _localizeTitle;
+	}
+
 	public boolean getMonospaced() {
 		return _monospaced;
 	}
@@ -135,6 +139,10 @@ public class LinkTag extends BaseContainerTag {
 		_label = label;
 	}
 
+	public void setLocalizeTitle(boolean localizeTitle) {
+		_localizeTitle = localizeTitle;
+	}
+
 	public void setMonospaced(boolean monospaced) {
 		_monospaced = monospaced;
 	}
@@ -162,6 +170,7 @@ public class LinkTag extends BaseContainerTag {
 		_href = null;
 		_icon = null;
 		_label = null;
+		_localizeTitle = false;
 		_monospaced = false;
 		_outline = false;
 		_small = false;
@@ -258,9 +267,13 @@ public class LinkTag extends BaseContainerTag {
 			}
 
 			if (Validator.isNotNull(_label)) {
-				String label = LanguageUtil.get(
-					TagResourceBundleUtil.getResourceBundle(pageContext),
-					_label);
+				String label = getLabel();
+
+				if (!_localizeTitle) {
+					label = LanguageUtil.get(
+						TagResourceBundleUtil.getResourceBundle(pageContext),
+						_label);
+				}
 
 				jspWriter.write(HtmlUtil.escape(label));
 			}
@@ -280,6 +293,7 @@ public class LinkTag extends BaseContainerTag {
 	private String _href;
 	private String _icon;
 	private String _label;
+	private boolean _localizeTitle;
 	private boolean _monospaced;
 	private boolean _outline;
 	private boolean _small;


### PR DESCRIPTION
Hi Team,

 Here is the PR for fixing https://issues.liferay.com/browse/LPS-170287. 
Please help to review and leave your comments.
This issue is because [LanguageUtil.get](https://github.com/liferay/liferay-portal/blob/master/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/HorizontalCardTag.java#L83-L84) function. 
In some cases, the title of HorizontalCardTag is one of keys in the resources of portal-language-lang, so the return value gotten from portal-language-lang is not right. 
Solution: Add condition to avoid using LanguageUtil.get() functoin in needed.

Thank you!