### PR TITLE
[TS] LPS-171043 Increase max title length for JournalArticle

### DIFF
--- a/modules/apps/journal/journal-service/bnd.bnd
+++ b/modules/apps/journal/journal-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal Service
 Bundle-SymbolicName: com.liferay.journal.service
 Bundle-Version: 7.0.102
-Liferay-Require-SchemaVersion: 4.4.0
+Liferay-Require-SchemaVersion: 4.4.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/registry/JournalServiceUpgradeStepRegistrator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/registry/JournalServiceUpgradeStepRegistrator.java
@@ -337,6 +337,11 @@ public class JournalServiceUpgradeStepRegistrator
 			new GlobalJournalArticleUrlTitleUpgradeProcess(
 				_classNameLocalService, _companyLocalService,
 				_groupLocalService));
+
+		registry.register(
+			"4.4.0", "4.4.1",
+			UpgradeProcessFactory.alterColumnType(
+				"JournalArticleLocalization", "title", "VARCHAR(800) null"));
 	}
 
 	private void _deleteTempImages() throws Exception {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/JournalArticleLocalizedValuesUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v1_1_0/JournalArticleLocalizedValuesUpgradeProcess.java
@@ -283,7 +283,7 @@ public class JournalArticleLocalizedValuesUpgradeProcess
 
 	private static final int _MAX_LENGTH_DESCRIPTION = 4000;
 
-	private static final int _MAX_LENGTH_TITLE = 400;
+	private static final int _MAX_LENGTH_TITLE = 800;
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		JournalArticleLocalizedValuesUpgradeProcess.class);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleLocalizationModelImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleLocalizationModelImpl.java
@@ -88,7 +88,7 @@ public class JournalArticleLocalizationModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table JournalArticleLocalization (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,articleLocalizationId LONG not null,companyId LONG,articlePK LONG,title VARCHAR(400) null,description STRING null,languageId VARCHAR(75) null,primary key (articleLocalizationId, ctCollectionId))";
+		"create table JournalArticleLocalization (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,articleLocalizationId LONG not null,companyId LONG,articlePK LONG,title VARCHAR(800) null,description STRING null,languageId VARCHAR(75) null,primary key (articleLocalizationId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP =
 		"drop table JournalArticleLocalization";

--- a/modules/apps/journal/journal-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/journal/journal-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -59,7 +59,7 @@
 		<field name="companyId" type="long" />
 		<field name="articlePK" type="long" />
 		<field name="title" type="String">
-			<hint name="max-length">400</hint>
+			<hint name="max-length">800</hint>
 		</field>
 		<field name="description" type="String">
 			<hint name="max-length">4000</hint>

--- a/modules/apps/journal/journal-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/journal/journal-service/src/main/resources/META-INF/sql/tables.sql
@@ -43,7 +43,7 @@ create table JournalArticleLocalization (
 	articleLocalizationId LONG not null,
 	companyId LONG,
 	articlePK LONG,
-	title VARCHAR(400) null,
+	title VARCHAR(800) null,
 	description STRING null,
 	languageId VARCHAR(75) null,
 	primary key (articleLocalizationId, ctCollectionId)

--- a/modules/apps/journal/journal-service/src/main/resources/com/liferay/journal/internal/upgrade/v1_1_0/dependencies/update.sql
+++ b/modules/apps/journal/journal-service/src/main/resources/com/liferay/journal/internal/upgrade/v1_1_0/dependencies/update.sql
@@ -2,7 +2,7 @@ create table JournalArticleLocalization (
 	articleLocalizationId LONG not null primary key,
 	companyId LONG,
 	articlePK LONG,
-	title VARCHAR(400) null,
+	title VARCHAR(800) null,
 	description STRING null,
 	languageId VARCHAR(75) null
 );


### PR DESCRIPTION
[LPS-171043](https://issues.liferay.com/browse/LPS-171043)

---

Hi @liferay-echo!

According to our discussion in [PTR-3494](https://issues.liferay.com/browse/PTR-3494), I have increased the length for `JournalArticleLocalization.title` column. The customer agreed to use 700, but I have used 800 because is `currentValue * 2` exactly.

In [LPS-67685](https://issues.liferay.com/browse/LPS-67685) an increment was already done (75 -> 400). You can check the pr: https://github.com/brianchandotcom/liferay-portal/pull/42589

I have checked the auto-generated Friendly URLs in case this change could cause issues, but their current limit is 255 characters. See [FriendlyURLEntryLocalization.urlTitle](https://github.com/liferay/liferay-portal/blob/c095d83e59e09f7f1e439efaba10a01a7b2e8785/modules/apps/friendly-url/friendly-url-service/src/main/resources/META-INF/portlet-model-hints.xml#L24-L25) and [JournalArticle.urlTitle](https://github.com/liferay/liferay-portal/blob/931c3b0f61d92af605d104d8cab972a9f42e715d/modules/apps/journal/journal-service/src/main/resources/META-INF/portlet-model-hints.xml#L27-L28) model hints. Those URLs are generated in [FriendlyURLEntryLocalServiceImpl#getUniqueUrlTitle](https://github.com/liferay/liferay-portal/blob/ec090e286e700f505ca88be021aefcf0786c98b0/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java#L425-L463) (note the use of `maxLength` value).

Could you review these chagnes?

Thanks!