### PR TITLE
[TS] LPS-169845 | Asset Publisher is not visible in Page Preview

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/AssetPublisherPortlet.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/AssetPublisherPortlet.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
@@ -379,6 +380,18 @@ public class AssetPublisherPortlet extends MVCPortlet {
 			String rootPortletId = PortletIdCodec.decodePortletName(
 				portal.getPortletId(renderRequest));
 
+			PortletPreferences portletPreferences =
+				renderRequest.getPreferences();
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)renderRequest.getAttribute(WebKeys.THEME_DISPLAY);
+
+			PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
+			if (portletDisplay != null) {
+				portletPreferences = portletDisplay.getPortletSetup();
+			}
+
 			AssetPublisherDisplayContext assetPublisherDisplayContext =
 				new AssetPublisherDisplayContext(
 					assetEntryActionRegistry, assetHelper,
@@ -388,7 +401,7 @@ public class AssetPublisherPortlet extends MVCPortlet {
 					assetPublisherHelper, assetPublisherWebConfiguration,
 					assetPublisherWebHelper, infoItemServiceRegistry,
 					itemSelector, renderRequest, renderResponse,
-					renderRequest.getPreferences(), requestContextMapper,
+					portletPreferences, requestContextMapper,
 					segmentsEntryRetriever);
 
 			renderRequest.setAttribute(


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-169845
Thank you!

-------

**Steps to reproduce:**

1. Create a Web Content
2. Create a Page
3. Place an Asset Publisher on the page
4. Configure the Asset Publisher to Dynamic Asset Selection
5. Open "Preview in a New Tab" from the top left kebab menu

**Expected behaviour:** The Asset Publisher is visible on the Preview with the web content
**Actual behaviour:** The Asset Publisher is not visible

The root cause of the issue is that the renderRequest gets the portletPrefrences for the control panel in preview mode, which does not exist. So the configured dynamic selection is not followed. I found that the themeDisplay is properly configured so I try to get the preferences from the themeDisplay -> portletDisplay connection.
