### PR TITLE
LPS-171455 Display Page Preview does not display changes

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetPagePreviewMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetPagePreviewMVCResourceCommand.java
@@ -216,7 +216,7 @@ public class GetPagePreviewMVCResourceCommand extends BaseMVCResourceCommand {
 
 		String version = ParamUtil.getString(httpServletRequest, "version");
 
-		if (Validator.isNull(version)) {
+		if (Validator.isNotNull(version)) {
 			infoItemIdentifier.setVersion(version);
 		}
 


### PR DESCRIPTION
Motivation
=======
Draft versions of Web Contents can't accurately be displayed in Display Page Template Previews if an approved version exists.
[LPS-171455](https://issues.liferay.com/browse/LPS-171455)

Proposed Solution
========
Adding NOT to the isNull check will make sure the version is forwarded if it exists.

Steps to Verify
========
1. Create a Display Page Template for Web Content > Basic Web Content
2. Add a Display Page Content fragment to it and Publish
3. Create an Asset Library
4. Add a Web Content to the Asset Library and Publish it
5. Edit the Web Content; add "draft version" to its content field, but **do not** Publish
6. Select the Display Page Template under Display Page Preview
7. Press Preview

**Expected behaviour:** "draft version" **is** displayed in the Display Page Content fragment
**Actual behaviour:** "draft version" **is not** displayed in the Display Page Content fragment

Thanks,
Balázs