### PR TITLE
LPS-171084 The same Utility Page cannot be copied more than once if it has a thumbnail

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutUtilityPageEntryPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutUtilityPageEntryPreviewMVCActionCommand.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.model.Repository;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
-import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -70,10 +69,8 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 
 		FileEntry fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
 
-		Repository repository =
-			PortletFileRepositoryUtil.fetchPortletRepository(
-				themeDisplay.getScopeGroupId(),
-				LayoutAdminPortletKeys.GROUP_PAGES);
+		Repository repository = _portletFileRepository.fetchPortletRepository(
+			themeDisplay.getScopeGroupId(), LayoutAdminPortletKeys.GROUP_PAGES);
 
 		if (repository == null) {
 			ServiceContext serviceContext = new ServiceContext();
@@ -81,7 +78,7 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 			serviceContext.setAddGroupPermissions(true);
 			serviceContext.setAddGuestPermissions(true);
 
-			repository = PortletFileRepositoryUtil.addPortletRepository(
+			repository = _portletFileRepository.addPortletRepository(
 				themeDisplay.getScopeGroupId(),
 				LayoutAdminPortletKeys.GROUP_PAGES, serviceContext);
 		}
@@ -89,16 +86,16 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 		String fileName =
 			layoutUtilityPageEntryId + "_preview." + fileEntry.getExtension();
 
-		FileEntry oldFileEntry =
-			PortletFileRepositoryUtil.fetchPortletFileEntry(
-				themeDisplay.getScopeGroupId(), repository.getDlFolderId(),
-				fileName);
+		FileEntry oldFileEntry = _portletFileRepository.fetchPortletFileEntry(
+			themeDisplay.getScopeGroupId(), repository.getDlFolderId(),
+			fileName);
 
 		long folderId = 0;
 
 		if (oldFileEntry != null) {
 			folderId = oldFileEntry.getFolderId();
-			PortletFileRepositoryUtil.deletePortletFileEntry(
+
+			_portletFileRepository.deletePortletFileEntry(
 				oldFileEntry.getFileEntryId());
 		}
 
@@ -124,7 +121,7 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 			folderId = folder.getFolderId();
 		}
 
-		fileEntry = PortletFileRepositoryUtil.addPortletFileEntry(
+		fileEntry = _portletFileRepository.addPortletFileEntry(
 			null, themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
 			LayoutUtilityPageEntry.class.getName(), layoutUtilityPageEntryId,
 			LayoutAdminPortletKeys.GROUP_PAGES, folderId,

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutUtilityPageEntryPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutUtilityPageEntryPreviewMVCActionCommand.java
@@ -14,9 +14,11 @@
 
 package com.liferay.layout.admin.web.internal.portlet.action;
 
+import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.document.library.kernel.model.DLFolderConstants;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.kernel.service.DLFolderLocalService;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
@@ -83,20 +85,23 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 				LayoutAdminPortletKeys.GROUP_PAGES, serviceContext);
 		}
 
-		String fileName =
-			layoutUtilityPageEntryId + "_preview." + fileEntry.getExtension();
-
-		FileEntry oldFileEntry = _portletFileRepository.fetchPortletFileEntry(
-			themeDisplay.getScopeGroupId(), repository.getDlFolderId(),
-			fileName);
+		LayoutUtilityPageEntry layoutUtilityPageEntry =
+			_layoutUtilityPageEntryService.fetchLayoutUtilityPageEntry(
+				layoutUtilityPageEntryId);
 
 		long folderId = 0;
 
-		if (oldFileEntry != null) {
-			folderId = oldFileEntry.getFolderId();
+		if (layoutUtilityPageEntry.getPreviewFileEntryId() > 0) {
+			DLFileEntry oldDLFileEntry =
+				_dlFileEntryLocalService.fetchDLFileEntry(
+					layoutUtilityPageEntry.getPreviewFileEntryId());
 
-			_portletFileRepository.deletePortletFileEntry(
-				oldFileEntry.getFileEntryId());
+			if (oldDLFileEntry != null) {
+				folderId = oldDLFileEntry.getFolderId();
+
+				_portletFileRepository.deletePortletFileEntry(
+					oldDLFileEntry.getFileEntryId());
+			}
 		}
 
 		if (folderId == 0) {
@@ -121,6 +126,9 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 			folderId = folder.getFolderId();
 		}
 
+		String fileName =
+			layoutUtilityPageEntryId + "_preview." + fileEntry.getExtension();
+
 		fileEntry = _portletFileRepository.addPortletFileEntry(
 			null, themeDisplay.getScopeGroupId(), themeDisplay.getUserId(),
 			LayoutUtilityPageEntry.class.getName(), layoutUtilityPageEntryId,
@@ -138,6 +146,9 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;
+
+	@Reference
+	private DLFileEntryLocalService _dlFileEntryLocalService;
 
 	@Reference
 	private DLFolderLocalService _dlFolderLocalService;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutUtilityPageEntryPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutUtilityPageEntryPreviewMVCActionCommand.java
@@ -104,10 +104,12 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 			}
 		}
 
+		String folderName = String.valueOf(layoutUtilityPageEntryId);
+
 		if (folderId == 0) {
 			DLFolder dlFolder = _dlFolderLocalService.fetchFolder(
 				themeDisplay.getScopeGroupId(), repository.getDlFolderId(),
-				String.valueOf(layoutUtilityPageEntryId));
+				folderName);
 
 			if (dlFolder != null) {
 				folderId = dlFolder.getFolderId();
@@ -120,8 +122,8 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 
 			Folder folder = _portletFileRepository.addPortletFolder(
 				themeDisplay.getUserId(), repository.getRepositoryId(),
-				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
-				String.valueOf(layoutUtilityPageEntryId), serviceContext);
+				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID, folderName,
+				serviceContext);
 
 			folderId = folder.getFolderId();
 		}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutUtilityPageEntryPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutUtilityPageEntryPreviewMVCActionCommand.java
@@ -101,7 +101,7 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 
 		if (folderId == 0) {
 			DLFolder dlFolder = _dlFolderLocalService.fetchFolder(
-				fileEntry.getGroupId(), repository.getDlFolderId(),
+				themeDisplay.getScopeGroupId(), repository.getDlFolderId(),
 				String.valueOf(layoutUtilityPageEntryId));
 
 			if (dlFolder != null) {
@@ -114,7 +114,7 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 				JournalFolder.class.getName(), actionRequest);
 
 			Folder folder = _portletFileRepository.addPortletFolder(
-				fileEntry.getUserId(), repository.getRepositoryId(),
+				themeDisplay.getUserId(), repository.getRepositoryId(),
 				DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 				String.valueOf(layoutUtilityPageEntryId), serviceContext);
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutUtilityPageEntryPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutUtilityPageEntryPreviewMVCActionCommand.java
@@ -70,8 +70,6 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 
 		FileEntry fileEntry = _dlAppLocalService.getFileEntry(fileEntryId);
 
-		FileEntry tempFileEntry = fileEntry;
-
 		Repository repository =
 			PortletFileRepositoryUtil.fetchPortletRepository(
 				themeDisplay.getScopeGroupId(),
@@ -136,7 +134,7 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 		_layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
 			layoutUtilityPageEntryId, fileEntry.getFileEntryId());
 
-		TempFileEntryUtil.deleteTempFileEntry(tempFileEntry.getFileEntryId());
+		TempFileEntryUtil.deleteTempFileEntry(fileEntryId);
 
 		sendRedirect(actionRequest, actionResponse);
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutUtilityPageEntryPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/UpdateLayoutUtilityPageEntryPreviewMVCActionCommand.java
@@ -99,7 +99,7 @@ public class UpdateLayoutUtilityPageEntryPreviewMVCActionCommand
 				oldFileEntry.getFileEntryId());
 		}
 
-		if (folderId <= 0) {
+		if (folderId == 0) {
 			DLFolder dlFolder = _dlFolderLocalService.fetchFolder(
 				fileEntry.getGroupId(), repository.getDlFolderId(),
 				String.valueOf(layoutUtilityPageEntryId));

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -33,7 +33,6 @@ import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
-import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
 import com.liferay.portal.kernel.repository.model.Folder;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
@@ -182,7 +181,7 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 		// Portlet file entry
 
 		if (layoutUtilityPageEntry.getPreviewFileEntryId() > 0) {
-			PortletFileRepositoryUtil.deletePortletFileEntry(
+			_portletFileRepository.deletePortletFileEntry(
 				layoutUtilityPageEntry.getPreviewFileEntryId());
 		}
 

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -181,8 +181,13 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 		// Portlet file entry
 
 		if (layoutUtilityPageEntry.getPreviewFileEntryId() > 0) {
-			_portletFileRepository.deletePortletFileEntry(
+			DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(
 				layoutUtilityPageEntry.getPreviewFileEntryId());
+
+			if (dlFileEntry != null) {
+				_portletFileRepository.deletePortletFolder(
+					dlFileEntry.getFolderId());
+			}
 		}
 
 		return layoutUtilityPageEntry;


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-171084)

When we delete a Utility Page (UP from now on) and this UP has a thumbnail, the delete option has to delete also the thumbnail, but not only the file, but also the folder.

## Proposed solution

Instead of delete the file, delete the folder.

## Test Scenario

1. Activate Staging.
2. Go to Site Builder > Pages and go to the Utility Pages tab.
3. Create a new Utility Page.
4. Change the Thumbnail of the Utility Page using the dropdown menu.
5. Copy the Utility Page.
6. Delete de copy you have made.
7. Try to copy the Utility Page again.

## Notes

This also happens without staging activated.


cc: @BarbaraCabrera 