### PR TITLE
LPS-171382 Add Remove Thumbnail for Utility Pages

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/clay/servlet/taglib/LayoutUtilityPageEntryVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/clay/servlet/taglib/LayoutUtilityPageEntryVerticalCard.java
@@ -62,13 +62,23 @@ public class LayoutUtilityPageEntryVerticalCard extends BaseVerticalCard {
 
 	@Override
 	public List<DropdownItem> getActionDropdownItems() {
-		LayoutUtilityPageEntryActionDropdownItemsProvider
-			layoutUtilityPageEntryActionDropdownItemsProvider =
-				new LayoutUtilityPageEntryActionDropdownItemsProvider(
-					_layoutUtilityPageEntry, _renderRequest, _renderResponse);
+		try {
+			LayoutUtilityPageEntryActionDropdownItemsProvider
+				layoutUtilityPageEntryActionDropdownItemsProvider =
+					new LayoutUtilityPageEntryActionDropdownItemsProvider(
+						_layoutUtilityPageEntry, _renderRequest,
+						_renderResponse);
 
-		return layoutUtilityPageEntryActionDropdownItemsProvider.
-			getActionDropdownItems();
+			return layoutUtilityPageEntryActionDropdownItemsProvider.
+				getActionDropdownItems();
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return null;
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/clay/servlet/taglib/LayoutUtilityPageEntryVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/clay/servlet/taglib/LayoutUtilityPageEntryVerticalCard.java
@@ -62,23 +62,13 @@ public class LayoutUtilityPageEntryVerticalCard extends BaseVerticalCard {
 
 	@Override
 	public List<DropdownItem> getActionDropdownItems() {
-		try {
-			LayoutUtilityPageEntryActionDropdownItemsProvider
-				layoutUtilityPageEntryActionDropdownItemsProvider =
-					new LayoutUtilityPageEntryActionDropdownItemsProvider(
-						_layoutUtilityPageEntry, _renderRequest,
-						_renderResponse);
+		LayoutUtilityPageEntryActionDropdownItemsProvider
+			layoutUtilityPageEntryActionDropdownItemsProvider =
+				new LayoutUtilityPageEntryActionDropdownItemsProvider(
+					_layoutUtilityPageEntry, _renderRequest, _renderResponse);
 
-			return layoutUtilityPageEntryActionDropdownItemsProvider.
-				getActionDropdownItems();
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-		}
-
-		return null;
+		return layoutUtilityPageEntryActionDropdownItemsProvider.
+			getActionDropdownItems();
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DeleteLayoutUtilityPageEntryPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DeleteLayoutUtilityPageEntryPreviewMVCActionCommand.java
@@ -19,7 +19,7 @@ import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryService;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
-import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepository;
 import com.liferay.portal.kernel.util.ParamUtil;
 
 import javax.portlet.ActionRequest;
@@ -54,7 +54,7 @@ public class DeleteLayoutUtilityPageEntryPreviewMVCActionCommand
 				layoutUtilityPageEntryId);
 
 		if (layoutUtilityPageEntry != null) {
-			PortletFileRepositoryUtil.deletePortletFileEntry(
+			_portletFileRepository.deletePortletFileEntry(
 				layoutUtilityPageEntry.getPreviewFileEntryId());
 
 			_layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
@@ -64,5 +64,8 @@ public class DeleteLayoutUtilityPageEntryPreviewMVCActionCommand
 
 	@Reference
 	private LayoutUtilityPageEntryService _layoutUtilityPageEntryService;
+
+	@Reference
+	private PortletFileRepository _portletFileRepository;
 
 }

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DeleteLayoutUtilityPageEntryPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DeleteLayoutUtilityPageEntryPreviewMVCActionCommand.java
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.admin.web.internal.portlet.action;
+
+import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
+import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryService;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Bárbara Cabrera
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + LayoutAdminPortletKeys.GROUP_PAGES,
+		"mvc.command.name=/layout_admin/delete_layout_utility_page_entry_preview"
+	},
+	service = MVCActionCommand.class
+)
+public class DeleteLayoutUtilityPageEntryPreviewMVCActionCommand
+	extends BaseMVCActionCommand {
+
+	@Override
+	protected void doProcessAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		long layoutUtilityPageEntryId = ParamUtil.getLong(
+			actionRequest, "layoutUtilityPageEntryId");
+
+		LayoutUtilityPageEntry layoutUtilityPageEntry =
+			_layoutUtilityPageEntryService.fetchLayoutUtilityPageEntry(
+				layoutUtilityPageEntryId);
+
+		if (layoutUtilityPageEntry != null) {
+			PortletFileRepositoryUtil.deletePortletFileEntry(
+				layoutUtilityPageEntry.getPreviewFileEntryId());
+
+			_layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
+				layoutUtilityPageEntryId, 0);
+		}
+	}
+
+	@Reference
+	private LayoutUtilityPageEntryService _layoutUtilityPageEntryService;
+
+}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DeleteLayoutUtilityPageEntryPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DeleteLayoutUtilityPageEntryPreviewMVCActionCommand.java
@@ -55,7 +55,9 @@ public class DeleteLayoutUtilityPageEntryPreviewMVCActionCommand
 			_layoutUtilityPageEntryService.fetchLayoutUtilityPageEntry(
 				layoutUtilityPageEntryId);
 
-		if (layoutUtilityPageEntry != null) {
+		if ((layoutUtilityPageEntry != null) &&
+			(layoutUtilityPageEntry.getPreviewFileEntryId() > 0)) {
+
 			_layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
 				layoutUtilityPageEntryId, 0);
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DeleteLayoutUtilityPageEntryPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DeleteLayoutUtilityPageEntryPreviewMVCActionCommand.java
@@ -56,6 +56,9 @@ public class DeleteLayoutUtilityPageEntryPreviewMVCActionCommand
 				layoutUtilityPageEntryId);
 
 		if (layoutUtilityPageEntry != null) {
+			_layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
+				layoutUtilityPageEntryId, 0);
+
 			DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(
 				layoutUtilityPageEntry.getPreviewFileEntryId());
 
@@ -63,9 +66,6 @@ public class DeleteLayoutUtilityPageEntryPreviewMVCActionCommand
 				_portletFileRepository.deletePortletFolder(
 					dlFileEntry.getFolderId());
 			}
-
-			_layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
-				layoutUtilityPageEntryId, 0);
 		}
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DeleteLayoutUtilityPageEntryPreviewMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DeleteLayoutUtilityPageEntryPreviewMVCActionCommand.java
@@ -14,6 +14,8 @@
 
 package com.liferay.layout.admin.web.internal.portlet.action;
 
+import com.liferay.document.library.kernel.model.DLFileEntry;
+import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryService;
@@ -54,13 +56,21 @@ public class DeleteLayoutUtilityPageEntryPreviewMVCActionCommand
 				layoutUtilityPageEntryId);
 
 		if (layoutUtilityPageEntry != null) {
-			_portletFileRepository.deletePortletFileEntry(
+			DLFileEntry dlFileEntry = _dlFileEntryLocalService.fetchDLFileEntry(
 				layoutUtilityPageEntry.getPreviewFileEntryId());
+
+			if (dlFileEntry != null) {
+				_portletFileRepository.deletePortletFolder(
+					dlFileEntry.getFolderId());
+			}
 
 			_layoutUtilityPageEntryService.updateLayoutUtilityPageEntry(
 				layoutUtilityPageEntryId, 0);
 		}
 	}
+
+	@Reference
+	private DLFileEntryLocalService _dlFileEntryLocalService;
 
 	@Reference
 	private LayoutUtilityPageEntryService _layoutUtilityPageEntryService;

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutUtilityPageEntryActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutUtilityPageEntryActionDropdownItemsProvider.java
@@ -29,6 +29,8 @@ import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalServic
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
@@ -84,16 +86,12 @@ public class LayoutUtilityPageEntryActionDropdownItemsProvider {
 			WebKeys.THEME_DISPLAY);
 	}
 
-	public List<DropdownItem> getActionDropdownItems() throws Exception {
-		boolean hasUpdatePermission = LayoutUtilityPageEntryPermission.contains(
-			_themeDisplay.getPermissionChecker(), _layoutUtilityPageEntry,
-			ActionKeys.UPDATE);
-
+	public List<DropdownItem> getActionDropdownItems() {
 		return DropdownItemListBuilder.addGroup(
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
 					DropdownItemListBuilder.add(
-						() -> hasUpdatePermission,
+						() -> _hasUpdatePermission(),
 						_getEditLayoutUtilityPageEntryActionUnsafeConsumer()
 					).add(
 						() -> LayoutUtilityPageEntryPermission.contains(
@@ -107,17 +105,17 @@ public class LayoutUtilityPageEntryActionDropdownItemsProvider {
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
 					DropdownItemListBuilder.add(
-						() -> hasUpdatePermission,
+						() -> _hasUpdatePermission(),
 						_getMarkAsDefaultLayoutUtilityPageEntryActionUnsafeConsumer()
 					).add(
-						() -> hasUpdatePermission,
+						() -> _hasUpdatePermission(),
 						_getRenameLayoutUtilityPageEntryActionUnsafeConsumer()
 					).add(
-						() -> hasUpdatePermission,
+						() -> _hasUpdatePermission(),
 						_getUpdateLayoutUtilityPageEntryPreviewActionUnsafeConsumer()
 					).add(
 						() ->
-							hasUpdatePermission &&
+							_hasUpdatePermission() &&
 							(_layoutUtilityPageEntry.getPreviewFileEntryId() >
 								0),
 						_getDeleteLayoutUtilityPageEntryPreviewActionUnsafeConsumer()
@@ -497,6 +495,27 @@ public class LayoutUtilityPageEntryActionDropdownItemsProvider {
 		};
 	}
 
+	private boolean _hasUpdatePermission() {
+		if (_updatePermission != null) {
+			return _updatePermission;
+		}
+
+		try {
+			_updatePermission = LayoutUtilityPageEntryPermission.contains(
+				_themeDisplay.getPermissionChecker(), _layoutUtilityPageEntry,
+				ActionKeys.UPDATE);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return false;
+		}
+
+		return _updatePermission;
+	}
+
 	private boolean _isLiveGroup() {
 		Group group = _themeDisplay.getScopeGroup();
 
@@ -510,6 +529,9 @@ public class LayoutUtilityPageEntryActionDropdownItemsProvider {
 		return false;
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		LayoutUtilityPageEntryActionDropdownItemsProvider.class);
+
 	private final Layout _draftLayout;
 	private final HttpServletRequest _httpServletRequest;
 	private final ItemSelector _itemSelector;
@@ -519,5 +541,6 @@ public class LayoutUtilityPageEntryActionDropdownItemsProvider {
 		_layoutUtilityPageThumbnailConfiguration;
 	private final RenderResponse _renderResponse;
 	private final ThemeDisplay _themeDisplay;
+	private Boolean _updatePermission;
 
 }

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutUtilityPageEntryActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutUtilityPageEntryActionDropdownItemsProvider.java
@@ -119,6 +119,14 @@ public class LayoutUtilityPageEntryActionDropdownItemsProvider {
 							_themeDisplay.getPermissionChecker(),
 							_layoutUtilityPageEntry, ActionKeys.UPDATE),
 						_getUpdateLayoutUtilityPageEntryPreviewActionUnsafeConsumer()
+					).add(
+						() ->
+							LayoutUtilityPageEntryPermission.contains(
+								_themeDisplay.getPermissionChecker(),
+								_layoutUtilityPageEntry, ActionKeys.UPDATE) &&
+							(_layoutUtilityPageEntry.getPreviewFileEntryId() >
+								0),
+						_getDeleteLayoutUtilityPageEntryPreviewActionUnsafeConsumer()
 					).build());
 				dropdownGroupItem.setSeparator(true);
 			}
@@ -224,6 +232,33 @@ public class LayoutUtilityPageEntryActionDropdownItemsProvider {
 			dropdownItem.setIcon("trash");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "delete"));
+		};
+	}
+
+	private UnsafeConsumer<DropdownItem, Exception>
+		_getDeleteLayoutUtilityPageEntryPreviewActionUnsafeConsumer() {
+
+		return dropdownItem -> {
+			dropdownItem.putData(
+				"action", "deleteLayoutUtilityPageEntryPreview");
+			dropdownItem.putData(
+				"deleteLayoutUtilityPageEntryPreviewURL",
+				PortletURLBuilder.createActionURL(
+					_renderResponse
+				).setActionName(
+					"/layout_admin/delete_layout_utility_page_entry_preview"
+				).setRedirect(
+					_themeDisplay.getURLCurrent()
+				).setParameter(
+					"layoutUtilityPageEntryId",
+					_layoutUtilityPageEntry.getLayoutUtilityPageEntryId()
+				).buildString());
+			dropdownItem.putData(
+				"layoutUtilityPageEntryId",
+				String.valueOf(
+					_layoutUtilityPageEntry.getLayoutUtilityPageEntryId()));
+			dropdownItem.setLabel(
+				LanguageUtil.get(_httpServletRequest, "remove-thumbnail"));
 		};
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutUtilityPageEntryActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutUtilityPageEntryActionDropdownItemsProvider.java
@@ -84,14 +84,16 @@ public class LayoutUtilityPageEntryActionDropdownItemsProvider {
 			WebKeys.THEME_DISPLAY);
 	}
 
-	public List<DropdownItem> getActionDropdownItems() {
+	public List<DropdownItem> getActionDropdownItems() throws Exception {
+		boolean hasUpdatePermission = LayoutUtilityPageEntryPermission.contains(
+			_themeDisplay.getPermissionChecker(), _layoutUtilityPageEntry,
+			ActionKeys.UPDATE);
+
 		return DropdownItemListBuilder.addGroup(
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
 					DropdownItemListBuilder.add(
-						() -> LayoutUtilityPageEntryPermission.contains(
-							_themeDisplay.getPermissionChecker(),
-							_layoutUtilityPageEntry, ActionKeys.UPDATE),
+						() -> hasUpdatePermission,
 						_getEditLayoutUtilityPageEntryActionUnsafeConsumer()
 					).add(
 						() -> LayoutUtilityPageEntryPermission.contains(
@@ -105,25 +107,17 @@ public class LayoutUtilityPageEntryActionDropdownItemsProvider {
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
 					DropdownItemListBuilder.add(
-						() -> LayoutUtilityPageEntryPermission.contains(
-							_themeDisplay.getPermissionChecker(),
-							_layoutUtilityPageEntry, ActionKeys.UPDATE),
+						() -> hasUpdatePermission,
 						_getMarkAsDefaultLayoutUtilityPageEntryActionUnsafeConsumer()
 					).add(
-						() -> LayoutUtilityPageEntryPermission.contains(
-							_themeDisplay.getPermissionChecker(),
-							_layoutUtilityPageEntry, ActionKeys.UPDATE),
+						() -> hasUpdatePermission,
 						_getRenameLayoutUtilityPageEntryActionUnsafeConsumer()
 					).add(
-						() -> LayoutUtilityPageEntryPermission.contains(
-							_themeDisplay.getPermissionChecker(),
-							_layoutUtilityPageEntry, ActionKeys.UPDATE),
+						() -> hasUpdatePermission,
 						_getUpdateLayoutUtilityPageEntryPreviewActionUnsafeConsumer()
 					).add(
 						() ->
-							LayoutUtilityPageEntryPermission.contains(
-								_themeDisplay.getPermissionChecker(),
-								_layoutUtilityPageEntry, ActionKeys.UPDATE) &&
+							hasUpdatePermission &&
 							(_layoutUtilityPageEntry.getPreviewFileEntryId() >
 								0),
 						_getDeleteLayoutUtilityPageEntryPreviewActionUnsafeConsumer()

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutUtilityPageEntryDropdownPropsTransformer.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/LayoutUtilityPageEntryDropdownPropsTransformer.js
@@ -39,6 +39,12 @@ const ACTIONS = {
 		});
 	},
 
+	deleteLayoutUtilityPageEntryPreview({
+		deleteLayoutUtilityPageEntryPreviewURL,
+	}) {
+		send(deleteLayoutUtilityPageEntryPreviewURL);
+	},
+
 	markAsDefaultLayoutUtilityPageEntry({
 		markAsDefaultLayoutUtilityPageEntryURL,
 		message,


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-171382)

If we have the option to add a thumbnail to the Utility pages, we should also have the option for the user to delete and not just change the thumbnail.

## Proposed solution

Add the remove thumbnail action. 

## Test Scenario

1. Go to Site Builder > Pages and go to the Utility Pages tab.
2. Create a new Utility Page.
3. Change the Thumbnail of the Utility Page using the dropdown menu.
4. Try to remove the Utility Page thumbnail.

## Notes


https://user-images.githubusercontent.com/93203423/208663089-1692f5ee-7dee-4228-8f1a-c7ac9d49337e.mov

cc: @BarbaraCabrera 
