### PR TITLE
LPS-171484 | The categories in keywords meta tag are not localized

### DIFF
--- a/modules/apps/asset/asset-api/bnd.bnd
+++ b/modules/apps/asset/asset-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset API
 Bundle-SymbolicName: com.liferay.asset.api
-Bundle-Version: 7.0.2
+Bundle-Version: 8.0.0
 Export-Package:\
 	com.liferay.asset.constants,\
 	com.liferay.asset.exception,\

--- a/modules/apps/asset/asset-api/src/main/java/com/liferay/asset/util/AssetHelper.java
+++ b/modules/apps/asset/asset-api/src/main/java/com/liferay/asset/util/AssetHelper.java
@@ -76,6 +76,9 @@ public interface AssetHelper {
 
 	public String getAssetKeywords(String className, long classPK);
 
+	public String getAssetKeywords(
+		String className, long classPK, Locale locale);
+
 	public List<AssetPublisherAddItemHolder> getAssetPublisherAddItemHolders(
 			LiferayPortletRequest liferayPortletRequest,
 			LiferayPortletResponse liferayPortletResponse, long groupId,

--- a/modules/apps/asset/asset-api/src/main/resources/com/liferay/asset/util/packageinfo
+++ b/modules/apps/asset/asset-api/src/main/resources/com/liferay/asset/util/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 4.0.0

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -47,7 +47,7 @@ if (Validator.isNotNull(assetPublisherViewContentDisplayContext.getReturnToFullP
 			PortalUtil.setPageDescription(summary, request);
 		}
 
-		PortalUtil.setPageKeywords(assetHelper.getAssetKeywords(assetEntry.getClassName(), assetEntry.getClassPK()), request);
+		PortalUtil.setPageKeywords(assetHelper.getAssetKeywords(assetEntry.getClassName(), assetEntry.getClassPK(), locale), request);
 		PortalUtil.setPageTitle(assetRenderer.getTitle(locale), request);
 		%>
 

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/AssetHelperImpl.java
@@ -329,6 +329,31 @@ public class AssetHelperImpl implements AssetHelper {
 	}
 
 	@Override
+	public String getAssetKeywords(
+		String className, long classPK, Locale locale) {
+
+		String[] tagNames = _assetTagLocalService.getTagNames(
+			className, classPK);
+
+		List<AssetCategory> assetCategories =
+			_assetCategoryLocalService.getCategories(className, classPK);
+
+		List<String> categoryTitles = new ArrayList<>();
+
+		for (AssetCategory assetCategory : assetCategories) {
+			categoryTitles.add(assetCategory.getTitle(locale));
+		}
+
+		String[] categoryNames = categoryTitles.toArray(new String[0]);
+
+		String[] keywords = new String[tagNames.length + categoryNames.length];
+
+		ArrayUtil.combine(tagNames, categoryNames, keywords);
+
+		return StringUtil.merge(keywords);
+	}
+
+	@Override
 	public List<AssetPublisherAddItemHolder> getAssetPublisherAddItemHolders(
 			LiferayPortletRequest liferayPortletRequest,
 			LiferayPortletResponse liferayPortletResponse, long groupId,

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/layout/display/page/BlogsLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/layout/display/page/BlogsLayoutDisplayPageObjectProvider.java
@@ -14,14 +14,11 @@
 
 package com.liferay.blogs.web.internal.layout.display.page;
 
-import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
-import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
+import com.liferay.asset.util.AssetHelper;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Locale;
 
@@ -31,10 +28,12 @@ import java.util.Locale;
 public class BlogsLayoutDisplayPageObjectProvider
 	implements LayoutDisplayPageObjectProvider<BlogsEntry> {
 
-	public BlogsLayoutDisplayPageObjectProvider(BlogsEntry blogsEntry)
+	public BlogsLayoutDisplayPageObjectProvider(
+			BlogsEntry blogsEntry, AssetHelper assetHelper)
 		throws PortalException {
 
 		_blogsEntry = blogsEntry;
+		_assetHelper = assetHelper;
 	}
 
 	@Override
@@ -74,18 +73,8 @@ public class BlogsLayoutDisplayPageObjectProvider
 
 	@Override
 	public String getKeywords(Locale locale) {
-		String[] assetTagNames = AssetTagLocalServiceUtil.getTagNames(
-			BlogsEntry.class.getName(), _blogsEntry.getEntryId());
-		String[] assetCategoryNames =
-			AssetCategoryLocalServiceUtil.getCategoryNames(
-				BlogsEntry.class.getName(), _blogsEntry.getEntryId());
-
-		String[] keywords =
-			new String[assetTagNames.length + assetCategoryNames.length];
-
-		ArrayUtil.combine(assetTagNames, assetCategoryNames, keywords);
-
-		return StringUtil.merge(keywords);
+		return _assetHelper.getAssetKeywords(
+			BlogsEntry.class.getName(), _blogsEntry.getEntryId(), locale);
 	}
 
 	@Override
@@ -98,6 +87,7 @@ public class BlogsLayoutDisplayPageObjectProvider
 		return _blogsEntry.getUrlTitle();
 	}
 
+	private final AssetHelper _assetHelper;
 	private final BlogsEntry _blogsEntry;
 
 }

--- a/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/layout/display/page/BlogsLayoutDisplayPageProvider.java
+++ b/modules/apps/blogs/blogs-web/src/main/java/com/liferay/blogs/web/internal/layout/display/page/BlogsLayoutDisplayPageProvider.java
@@ -14,6 +14,7 @@
 
 package com.liferay.blogs.web.internal.layout.display.page;
 
+import com.liferay.asset.util.AssetHelper;
 import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.blogs.service.BlogsEntryLocalService;
 import com.liferay.info.item.InfoItemReference;
@@ -52,7 +53,8 @@ public class BlogsLayoutDisplayPageProvider
 				return null;
 			}
 
-			return new BlogsLayoutDisplayPageObjectProvider(blogsEntry);
+			return new BlogsLayoutDisplayPageObjectProvider(
+				blogsEntry, _assetHelper);
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
@@ -71,7 +73,8 @@ public class BlogsLayoutDisplayPageProvider
 				return null;
 			}
 
-			return new BlogsLayoutDisplayPageObjectProvider(blogsEntry);
+			return new BlogsLayoutDisplayPageObjectProvider(
+				blogsEntry, _assetHelper);
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
@@ -82,6 +85,9 @@ public class BlogsLayoutDisplayPageProvider
 	public String getURLSeparator() {
 		return FriendlyURLResolverConstants.URL_SEPARATOR_BLOGS_ENTRY;
 	}
+
+	@Reference
+	private AssetHelper _assetHelper;
 
 	@Reference
 	private BlogsEntryLocalService _blogsEntryLocalService;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageObjectProvider.java
@@ -18,13 +18,10 @@ import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetRenderer;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
-import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
-import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
+import com.liferay.asset.util.AssetHelper;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Locale;
 
@@ -34,10 +31,12 @@ import java.util.Locale;
 public class JournalArticleLayoutDisplayPageObjectProvider
 	implements LayoutDisplayPageObjectProvider<JournalArticle> {
 
-	public JournalArticleLayoutDisplayPageObjectProvider(JournalArticle article)
+	public JournalArticleLayoutDisplayPageObjectProvider(
+			JournalArticle article, AssetHelper assetHelper)
 		throws PortalException {
 
 		_article = article;
+		_assetHelper = assetHelper;
 
 		_assetEntry = _getAssetEntry(article);
 	}
@@ -79,18 +78,8 @@ public class JournalArticleLayoutDisplayPageObjectProvider
 
 	@Override
 	public String getKeywords(Locale locale) {
-		String[] assetTagNames = AssetTagLocalServiceUtil.getTagNames(
-			_assetEntry.getClassName(), _assetEntry.getClassPK());
-		String[] assetCategoryNames =
-			AssetCategoryLocalServiceUtil.getCategoryNames(
-				_assetEntry.getClassName(), _assetEntry.getClassPK());
-
-		String[] keywords =
-			new String[assetTagNames.length + assetCategoryNames.length];
-
-		ArrayUtil.combine(assetTagNames, assetCategoryNames, keywords);
-
-		return StringUtil.merge(keywords);
+		return _assetHelper.getAssetKeywords(
+			_assetEntry.getClassName(), _assetEntry.getClassPK(), locale);
 	}
 
 	@Override
@@ -119,5 +108,6 @@ public class JournalArticleLayoutDisplayPageObjectProvider
 
 	private final JournalArticle _article;
 	private final AssetEntry _assetEntry;
+	private final AssetHelper _assetHelper;
 
 }

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/layout/display/page/JournalArticleLayoutDisplayPageProvider.java
@@ -14,6 +14,7 @@
 
 package com.liferay.journal.web.internal.layout.display.page;
 
+import com.liferay.asset.util.AssetHelper;
 import com.liferay.depot.group.provider.SiteConnectedGroupGroupProvider;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.journal.model.JournalArticle;
@@ -56,7 +57,8 @@ public class JournalArticleLayoutDisplayPageProvider
 		}
 
 		try {
-			return new JournalArticleLayoutDisplayPageObjectProvider(article);
+			return new JournalArticleLayoutDisplayPageObjectProvider(
+				article, _assetHelper);
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
@@ -74,7 +76,8 @@ public class JournalArticleLayoutDisplayPageProvider
 				return null;
 			}
 
-			return new JournalArticleLayoutDisplayPageObjectProvider(article);
+			return new JournalArticleLayoutDisplayPageObjectProvider(
+				article, _assetHelper);
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
@@ -95,7 +98,8 @@ public class JournalArticleLayoutDisplayPageProvider
 				return null;
 			}
 
-			return new JournalArticleLayoutDisplayPageObjectProvider(article);
+			return new JournalArticleLayoutDisplayPageObjectProvider(
+				article, _assetHelper);
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
@@ -139,5 +143,8 @@ public class JournalArticleLayoutDisplayPageProvider
 
 		return null;
 	}
+
+	@Reference
+	private AssetHelper _assetHelper;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/build.gradle
+++ b/modules/apps/knowledge-base/knowledge-base-web/build.gradle
@@ -16,6 +16,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
 	compileOnly project(":apps:application-list:application-list-api")
+	compileOnly project(":apps:asset:asset-api")
 	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:asset:asset-info-api")
 	compileOnly project(":apps:asset:asset-info-display-api")

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/layout/display/page/KBArticleLayoutDisplayPageObjectProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/layout/display/page/KBArticleLayoutDisplayPageObjectProvider.java
@@ -17,8 +17,7 @@ package com.liferay.knowledge.base.web.internal.layout.display.page;
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
-import com.liferay.asset.kernel.service.AssetCategoryLocalServiceUtil;
-import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
+import com.liferay.asset.util.AssetHelper;
 import com.liferay.knowledge.base.constants.KBFolderConstants;
 import com.liferay.knowledge.base.model.KBArticle;
 import com.liferay.knowledge.base.model.KBFolder;
@@ -26,9 +25,7 @@ import com.liferay.knowledge.base.service.KBFolderLocalServiceUtil;
 import com.liferay.layout.display.page.LayoutDisplayPageObjectProvider;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 
 import java.util.Locale;
 
@@ -38,10 +35,12 @@ import java.util.Locale;
 public class KBArticleLayoutDisplayPageObjectProvider
 	implements LayoutDisplayPageObjectProvider<KBArticle> {
 
-	public KBArticleLayoutDisplayPageObjectProvider(KBArticle kbArticle)
+	public KBArticleLayoutDisplayPageObjectProvider(
+			KBArticle kbArticle, AssetHelper assetHelper)
 		throws PortalException {
 
 		_kbArticle = kbArticle;
+		_assetHelper = assetHelper;
 
 		_assetEntry = _getAssetEntry(kbArticle);
 	}
@@ -83,18 +82,8 @@ public class KBArticleLayoutDisplayPageObjectProvider
 
 	@Override
 	public String getKeywords(Locale locale) {
-		String[] assetTagNames = AssetTagLocalServiceUtil.getTagNames(
-			_assetEntry.getClassName(), _assetEntry.getClassPK());
-		String[] assetCategoryNames =
-			AssetCategoryLocalServiceUtil.getCategoryNames(
-				_assetEntry.getClassName(), _assetEntry.getClassPK());
-
-		String[] keywords =
-			new String[assetTagNames.length + assetCategoryNames.length];
-
-		ArrayUtil.combine(assetTagNames, assetCategoryNames, keywords);
-
-		return StringUtil.merge(keywords);
+		return _assetHelper.getAssetKeywords(
+			_assetEntry.getClassName(), _assetEntry.getClassPK(), locale);
 	}
 
 	@Override
@@ -135,6 +124,7 @@ public class KBArticleLayoutDisplayPageObjectProvider
 	}
 
 	private final AssetEntry _assetEntry;
+	private final AssetHelper _assetHelper;
 	private final KBArticle _kbArticle;
 
 }

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/layout/display/page/KBArticleLayoutDisplayPageProvider.java
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/java/com/liferay/knowledge/base/web/internal/layout/display/page/KBArticleLayoutDisplayPageProvider.java
@@ -14,6 +14,7 @@
 
 package com.liferay.knowledge.base.web.internal.layout.display.page;
 
+import com.liferay.asset.util.AssetHelper;
 import com.liferay.info.item.InfoItemReference;
 import com.liferay.knowledge.base.constants.KBFolderConstants;
 import com.liferay.knowledge.base.model.KBArticle;
@@ -55,7 +56,8 @@ public class KBArticleLayoutDisplayPageProvider
 				return null;
 			}
 
-			return new KBArticleLayoutDisplayPageObjectProvider(kbArticle);
+			return new KBArticleLayoutDisplayPageObjectProvider(
+				kbArticle, _assetHelper);
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
@@ -78,7 +80,8 @@ public class KBArticleLayoutDisplayPageProvider
 				return null;
 			}
 
-			return new KBArticleLayoutDisplayPageObjectProvider(kbArticle);
+			return new KBArticleLayoutDisplayPageObjectProvider(
+				kbArticle, _assetHelper);
 		}
 		catch (PortalException portalException) {
 			throw new RuntimeException(portalException);
@@ -105,6 +108,9 @@ public class KBArticleLayoutDisplayPageProvider
 
 		return KBFolderConstants.DEFAULT_PARENT_FOLDER_ID;
 	}
+
+	@Reference
+	private AssetHelper _assetHelper;
 
 	@Reference
 	private KBArticleLocalService _kbArticleLocalService;


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-171484
Thank you!

------

The root cause of the issue is twofold. First, the assetHelperImple does not have an implementation where a localized version of the keywords can be requested. Second, the DPOP had a localized getKeywords method but the implementation never tried to get an actual localized value. First I implemented a localized version of the getKeywords in the AssetHelper and after that, I used it in the three DPOPs where I found an implemented getKeywords method. Now, these three DPOPs use the asset helper and all of them use the same logic to get the keywords.