### PR TITLE
[TECHNICAL-SUPPORT] LPS-171768 Web Content lose inputs on first save, if Web Content Structure "Edit Default Values" saved on different localization than the default

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -54,7 +54,10 @@ export default function _JournalPortlet({
 	);
 	const saveButton = document.getElementById(`${namespace}saveButton`);
 
-	const availableLocales = [...initialAvailableLocales];
+	const availableLocales = [
+		...initialAvailableLocales,
+		initialDefaultLanguageId,
+	];
 
 	let articleId = initialArticleId;
 	let defaultLanguageId = initialDefaultLanguageId;


### PR DESCRIPTION
Dear Team,

Motivation
=======
When a web content is created with a structure whose default language is not available, the value corresponding to the site default language will not be saved.

https://issues.liferay.com/browse/LPS-171768

Proposed Solution
========
Adding the default language to the `availableLocales` array.

Steps to Verify
========
Please consult the reproduction steps in the linked LPS.

Thank you and best regards,
István