### PR TITLE
[TS] LPS-171955 | Sitemap gets generated even after the site is deactivated

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/SitemapImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/SitemapImpl.java
@@ -24,9 +24,11 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.LayoutTypeController;
+import com.liferay.portal.kernel.service.GroupService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -191,6 +193,12 @@ public class SitemapImpl implements Sitemap {
 			String layoutUuid, long groupId, boolean privateLayout,
 			ThemeDisplay themeDisplay)
 		throws PortalException {
+
+		Group currentGroup = _groupService.getGroup(groupId);
+
+		if (!currentGroup.isActive()) {
+			return null;
+		}
 
 		if (Validator.isNull(layoutUuid) &&
 			PropsValues.XML_SITEMAP_INDEX_ENABLED) {
@@ -437,6 +445,9 @@ public class SitemapImpl implements Sitemap {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SitemapImpl.class.getName());
+
+	@Reference
+	private GroupService _groupService;
 
 	@Reference
 	private Language _language;


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-171955
Thank you!
---------
**Reproduction Steps:**

1. Create a new site
2. In the settings, the new site under SITE URL → Public Pages add a virtual host under which the site can be used.
3. Add at least one page to the site
4. Deactivate the site
5. Go to [virtualhost]:8080/sitemap.xml

**Expected outcome:** The sitemap cannot be generated or does not include pages referring to the site.
**Actual outcome:** The sitemap is generated and can be accessed.

The root cause is that before generating the sitemap.xml, it did not take in to consideration the active or deactive state of the group. It was an issue as through the sitemap the set virtualhost could be reached and the sitemap was generated. To fix this, I added a check before the sitemap generation.