### PR TITLE
LPS-171971 Replace liferay-ui:icon-help in edit_asset_vocabulary.jsp

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/edit_asset_vocabulary.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/edit_asset_vocabulary.jsp
@@ -62,7 +62,13 @@ renderResponse.setTitle((vocabulary == null) ? LanguageUtil.get(request, "add-vo
 
 			<aui:input helpMessage="multi-valued-help" inlineLabel="right" label="allow-multiple-categories" labelCssClass="simple-toggle-switch" name="multiValued" type="toggle-switch" value="<%= (vocabulary != null) ? vocabulary.isMultiValued() : true %>" />
 
-			<label><liferay-ui:message key="visibility" /> <liferay-ui:icon-help message="visibility-help" /></label>
+			<label><liferay-ui:message key="visibility" />
+				<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "visibility-help") %>">
+					<clay:icon
+						symbol="info-circle"
+					/>
+				</span>
+			</label>
 
 			<div class="form-group" id="<portlet:namespace />visibilityOptions">
 				<aui:input checked="<%= (vocabulary != null) ? (vocabulary.getVisibilityType() == AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC) : true %>" disabled="<%= !(vocabulary == null) %>" id="visibilityTypePublic" label="public" name="visibilityType" type="radio" value="<%= AssetVocabularyConstants.VISIBILITY_TYPE_PUBLIC %>" />


### PR DESCRIPTION
## Test Scenario

1. Navigate to Categorization > Categories.
2. Click on the Add button (+) to create a new vocabulary.
3. Hover the info icon next to the Visibility label and see the message: _When visibility is set to internal, the vocabulary will not be displayed in pages, either through widgets, fragments, or content mapping, and can be used for internal searches and categorization only. Visibility configuration cannot be reverted._
![image](https://user-images.githubusercontent.com/93203423/210281161-91f0cb24-1db0-4521-8c4d-50f11b2860bf.png)
