### PR TITLE
LPS-171974 Replace liferay-ui:icon and aui:icon in view.jsp

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -122,21 +122,20 @@
 														%>"
 													>
 														<span class="text-truncate"><%= HtmlUtil.escape(vocabulary.getTitle(locale)) %></span>
-
-														<liferay-ui:icon
-															icon="lock"
-															iconCssClass="ml-1 text-muted"
-															markupView="lexicon"
-															message="this-vocabulary-can-only-be-edited-from-the-global-site"
-														/>
+														<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "this-vocabulary-can-only-be-edited-from-the-global-site") %>">
+															<clay:icon
+																cssClass="ml-1 mt-1 text-muted"
+																symbol="lock"
+															/>
+														</span>
 
 														<c:if test="<%= vocabulary.getVisibilityType() == AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL %>">
-															<liferay-ui:icon
-																icon="low-vision"
-																iconCssClass="ml-1 text-muted"
-																markupView="lexicon"
-																message="for-internal-use-only"
-															/>
+															<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "for-internal-use-only") %>">
+																<clay:icon
+																	cssClass="ml-1 mt-1 text-muted"
+																	symbol="low-vision"
+																/>
+															</span>
 														</c:if>
 													</a>
 												</li>
@@ -177,12 +176,12 @@
 													<span class="text-truncate"><%= HtmlUtil.escape(vocabulary.getTitle(locale)) %></span>
 
 													<c:if test="<%= vocabulary.getVisibilityType() == AssetVocabularyConstants.VISIBILITY_TYPE_INTERNAL %>">
-														<liferay-ui:icon
-															icon="low-vision"
-															iconCssClass="ml-1 text-muted"
-															markupView="lexicon"
-															message="for-internal-use-only"
-														/>
+														<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "for-internal-use-only") %>">
+															<clay:icon
+																cssClass="ml-1 mt-1 text-muted"
+																symbol="low-vision"
+															/>
+														</span>
 													</c:if>
 												</a>
 											</li>

--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -283,7 +283,9 @@
 					<c:if test="<%= assetCategoriesDisplayContext.isAssetCategoriesLimitExceeded() %>">
 						<div class="alert alert-warning">
 							<span class="alert-indicator">
-								<aui:icon image="warning" markupView="lexicon" />
+								<clay:icon
+									symbol="warning"
+								/>
 							</span>
 
 							<liferay-ui:message arguments="<%= assetCategoriesDisplayContext.getMaximumNumberOfCategoriesPerVocabulary() %>" key="you-have-reached-the-limit-of-x-categories-for-this-vocabulary" />


### PR DESCRIPTION
## Test Scenario

### Case A

1. Create a new site.
2. Go to Categorization > Categories.
3. Hover the symbols next to the global vocabularies to check the text info. 

![image](https://user-images.githubusercontent.com/93203423/210338842-949e3013-a1bf-49cd-99fe-17fbb53b3359.png)
![image](https://user-images.githubusercontent.com/93203423/210339626-e99778ba-3415-49d4-8dc9-9eb0376b3acf.png)

### Case B
In the same site.

1. Create a new vocabulary with internal visibility.
2. Hover the symbols next to the new vocabulary to check the text info. 

![image](https://user-images.githubusercontent.com/93203423/210340097-8197c6e4-79cb-436e-87fc-b73f802774b5.png)
![image](https://user-images.githubusercontent.com/93203423/210340237-1f8e81af-4442-4e72-84c2-ffb7a2ac356e.png)
