### PR TITLE
LPS-171438 Uses the group in the url, since if the site doesn't have pages it is redirected to the guest site

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutUtilityPageEntryTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutUtilityPageEntryTag.java
@@ -19,7 +19,11 @@ import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
 import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalServiceUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
 import com.liferay.taglib.util.IncludeTag;
@@ -81,6 +85,20 @@ public class RenderLayoutUtilityPageEntryTag extends IncludeTag {
 			_getLayoutStructure());
 	}
 
+	private long _getGroupId(String path, long companyId) {
+		int[] friendlyURLIndices = PortalUtil.getGroupFriendlyURLIndex(path);
+
+		Group group = GroupLocalServiceUtil.fetchFriendlyURLGroup(
+			companyId,
+			path.substring(friendlyURLIndices[0], friendlyURLIndices[1]));
+
+		if ((group == null) || !group.isActive()) {
+			return 0;
+		}
+
+		return group.getGroupId();
+	}
+
 	private LayoutStructure _getLayoutStructure() {
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
 			_getLayoutUtilityPageEntry();
@@ -107,9 +125,13 @@ public class RenderLayoutUtilityPageEntryTag extends IncludeTag {
 			(ThemeDisplay)httpServletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
+		long groupId = GetterUtil.getLong(
+			_getGroupId(
+				themeDisplay.getURLCurrent(), themeDisplay.getCompanyId()),
+			themeDisplay.getScopeGroupId());
+
 		return LayoutUtilityPageEntryLocalServiceUtil.
-			fetchDefaultLayoutUtilityPageEntry(
-				themeDisplay.getScopeGroupId(), getType());
+			fetchDefaultLayoutUtilityPageEntry(groupId, getType());
 	}
 
 	private static final String _PAGE =


### PR DESCRIPTION
When a site doesn't have pages and you try to go to a page of that site, for example, http://localhost:8080/group/site-name/non-existing-page it's redirect to the guest site -> home page, so when we try to get the default utility page for that site (site-name) it is not finding the default utility page because you are in guest site.

As you can see in the screenshot, the utility page is rendered inside the home page of guest site.

<img width="1385" alt="Status_-_Liferay_DXP" src="https://user-images.githubusercontent.com/922631/210383707-88830592-6f6f-4a24-b98c-c6650f027774.png">

We should analyze if it should be the correct behavior or not.
