### PR TITLE
LPS-172119 using the portlet prefernce to get the delta instead of request

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/display/context/AssetPublisherDisplayContext.java
@@ -841,7 +841,7 @@ public class AssetPublisherDisplayContext {
 	}
 
 	public Integer getDelta() {
-		return _assetPublisherCustomizer.getDelta(_httpServletRequest);
+		return _assetPublisherCustomizer.getDelta(_portletPreferences);
 	}
 
 	public String getDisplayStyle() {

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherCustomizer.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/AssetPublisherCustomizer.java
@@ -17,6 +17,8 @@ package com.liferay.asset.publisher.web.internal.util;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.util.AssetEntryQueryProcessor;
 
+import javax.portlet.PortletPreferences;
+
 import javax.servlet.http.HttpServletRequest;
 
 /**
@@ -25,6 +27,8 @@ import javax.servlet.http.HttpServletRequest;
 public interface AssetPublisherCustomizer {
 
 	public Integer getDelta(HttpServletRequest httpServletRequest);
+
+	public Integer getDelta(PortletPreferences portletPreferences);
 
 	public String getPortletId();
 

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/DefaultAssetPublisherCustomizer.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/util/DefaultAssetPublisherCustomizer.java
@@ -60,6 +60,13 @@ public class DefaultAssetPublisherCustomizer
 	}
 
 	@Override
+	public Integer getDelta(PortletPreferences portletPreferences) {
+		return GetterUtil.getInteger(
+			portletPreferences.getValue("delta", null),
+			SearchContainer.DEFAULT_DELTA);
+	}
+
+	@Override
 	public String getPortletId() {
 		return AssetPublisherPortletKeys.ASSET_PUBLISHER;
 	}


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-172119
Thank you!
---------
**Reproduction Steps:**

 1. Go to Site menu > Content & Data > Documents and Media, upload at least two files
 2. Go to the Home page and place an Asset publisher widget on the page
 3. Enter the configuration of the Asset publisher
 4. Set asset selection to Dynamic
 5. At the Display settings tab, set the Number of Items to Display to 1
 6. Pagination type to Regular
 7. Save all changes
 8. Enter preview mode by choosing Preview in a new tab from the kebab menu in the upper right corner. 

**Actual behavior:**
Every asset will be loaded within the pagination default limit

**Expected behavior:**
Only one asset will be loaded

The root cause of the issue is when the asset publisher is displayed in preview mode, it gets the delta parameter from the default portal preference from the request and did not use the modified one. After the change, it will use the modified one.