### PR TITLE
LPS-172129 Template Reserved El - Fix the order of parameters for articleId

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/transformer/JournalTransformer.java
@@ -471,8 +471,8 @@ public class JournalTransformer {
 		Map<String, String> tokens) {
 
 		_addReservedEl(
-			article.getArticleId(), templateNodes, themeDisplay, tokens,
-			JournalStructureConstants.RESERVED_ARTICLE_ID);
+			JournalStructureConstants.RESERVED_ARTICLE_ID, templateNodes,
+			themeDisplay, tokens, article.getArticleId());
 
 		_addReservedEl(
 			JournalStructureConstants.RESERVED_ARTICLE_VERSION, templateNodes,


### PR DESCRIPTION
Motivation
=======
ArticleId is no longer added to Web Content Templates as a reserved variable
https://issues.liferay.com/browse/LPS-172129

Proposed Solution
========
Fixing the parameter order

Steps to Verify
========
1. Add a new Web Content Structure with an html field
2. Add a Template to the Structure from the snippet
3. Create a new Web Content from the new Structure, use the new Template
4. Create a Widget page
5. Add the newly created Web Content to the Widget page

**Expected behaviour:** The variable 'reserved-article-id' should be available
**Actual behaviour:** The 'reserved-article-id' is not available

Snippet
=======
```
<ul>
<#list [
'reserved-article-asset-tag-names',
'reserved-article-author-comments',
'reserved-article-author-email-address',
'reserved-article-author-id',
'reserved-article-author-job-title',
'reserved-article-author-name',
'reserved-article-create-date',
'reserved-article-description',
'reserved-article-display-date',
'reserved-article-id',
'reserved-article-modified-date',
'reserved-article-small-image-url',
'reserved-article-title',
'reserved-article-url-title',
'reserved-article-version'] as theVar>
  <li>
	  <#if (.vars[theVar])??>
		  <@clay["icon"] symbol="check" />
		<#else>
		  <@clay["icon"] symbol="exclamation-full" />
		</#if>&nbsp; ${theVar}
</#list>
</ul>
```