### PR TITLE
[TS] LPS-171667 | Site Template content page configuration is reset after saving its Page Design Options

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
@@ -157,6 +157,16 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 					"layout.instanceable.allowed", Boolean.TRUE);
 			}
 
+			if (layout.isDraftLayout()) {
+				UnicodeProperties layoutTypeSettingsUnicodeProperties =
+					layout.getTypeSettingsProperties();
+
+				serviceContext.setAttribute(
+					Sites.LAYOUT_UPDATEABLE,
+					layoutTypeSettingsUnicodeProperties.get(
+						Sites.LAYOUT_UPDATEABLE));
+			}
+
 			layout = _layoutService.updateLayout(
 				groupId, privateLayout, layoutId, layout.getParentLayoutId(),
 				nameMap, layout.getTitleMap(), layout.getDescriptionMap(),


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-171667
Thank you!

------

**Reproduction steps**

1. Control Panel --> Sites --> Site Templates
2. Add a Site Template
3. Go to Site Builder --> Pages and add a Content Page
4. Click on the configure gear icon on the upper right of the Page. Uncheck the option "Allow site administrators to modify this page for their site, even when propagation of changes is enabled." and Save
5. Publish the Page
6. Click on the configure gear icon on the upper right of the Page. Assert that the option "Allow site administrators to modify this page for their site, even when propagation of changes is enabled." is unchecked.
7. Edit the Page, go to the Page Design Options on the right panel (in master the panel is on the left) and click the "More Page Design Options" link to visit the "Look and Feel" configuration of the Page.
8. Save it without making any modifications
9. Publish the Page
10. Check the Page configuration

**Expected behaviour:** "Allow site administrators to modify this page for their site, even when propagation of changes is enabled." is unchecked
**Actual behaviour:** "Allow site administrators to modify this page for their site, even when propagation of changes is enabled." is checked

The root cause of the issue is that when the look and feel saved the layout upgrade is triggered only for the draft layout and the look and feel saving does not set the updateable value so it defaults back to true. I solved the issue by setting that value for the draft layout from the typesettings of the draft layout.