### PR TITLE
[TS] LPS-172218 Wrong theme name when editing a Style Book in a Site Template

### DIFF
--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -594,8 +594,10 @@ public class EditStyleBookEntryDisplayContext {
 	}
 
 	private String _getThemeName() {
+		Group group = _themeDisplay.getScopeGroup();
+
 		LayoutSet layoutSet = LayoutSetLocalServiceUtil.fetchLayoutSet(
-			_themeDisplay.getSiteGroupId(), false);
+			_themeDisplay.getSiteGroupId(), group.isLayoutSetPrototype());
 
 		Theme theme = layoutSet.getTheme();
 


### PR DESCRIPTION
Motivation
=======
This issue ([LPS-172218](https://issues.liferay.com/browse/LPS-172218)) was reported by a customer. It fixes the name of the theme shown when editing a Style Book for a Site Template. It showed _Classic_ even when another theme applied.

Proposed Solution
========
The solution is basically the same used for [LPS-164648](https://issues.liferay.com/browse/LPS-164648): take into account that site templates have private layout sets. 

Steps to Verify
========
Those in ([LPS-172218](https://issues.liferay.com/browse/LPS-172218)). (If your installation already has an additional theme besides Classic, it can be used instead of the attached one.)

References to existing code
========
6ec89064208ab200dc2fe78a2343ebeb54879b71 ([LPS-164648](https://issues.liferay.com/browse/LPS-164648))

Checklist (optional)
========

CODE:
- [x] I have considered breaking this PR into smaller PRs if the amount of changed code is too large
- [x] I have performed a self-review of my own code following Liferay's code conventions
- [x] I have checked other areas of the product for solutions to similar problems
- [ ] I have added tests that prove my fix is effective or that my feature works

COMMITS:
- [x] My commits organize changes in coherent units
- [x] There are no commits which should be combined into others
- [x] My commits are ordered in a way that ease understanding
- [x] My commit messages are well formatted and concisely describe what was changed and why it was changed

PR TITLE & DESCRIPTION:
- [x] My PR title includes an issue number and a descriptive title
- [x] My PR description explains the motivation for this change
- [x] My PR description explains the proposed solution
- [x] My PR description includes the steps to verify the change
- [x] My PR description includes references to other places where this solution is used (if applies)
- [ ] My PR description includes visual aids to understand what has changed (if applies)
- [ ] My PR description explains alternative approaches considered and why they were discarded (if applies)