### PR TITLE
LPS-172332 Cannot predefined an expiration date for web content

### DIFF
--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/UpdateDataEngineDefaultValuesMVCActionCommandTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/web/internal/portlet/action/test/UpdateDataEngineDefaultValuesMVCActionCommandTest.java
@@ -1,0 +1,201 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.web.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.servlet.PortletServlet;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.upload.UploadPortletRequest;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upload.UploadPortletRequestImpl;
+import com.liferay.portal.upload.UploadServletRequestImpl;
+import com.liferay.portletmvc4spring.test.mock.web.portlet.MockActionRequest;
+
+import java.util.Calendar;
+import java.util.Collections;
+import java.util.HashMap;
+
+import javax.portlet.ActionRequest;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+
+/**
+ * @author Jürgen Kappler
+ */
+@RunWith(Arquillian.class)
+public class UpdateDataEngineDefaultValuesMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testAddArticleDefaultValuesWithoutDisplayDate()
+		throws Exception {
+
+		DDMStructure ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		MockActionRequest mockActionRequest = new MockActionRequest();
+
+		mockActionRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST,
+			new MockHttpServletRequest());
+
+		mockActionRequest.addParameter(
+			ActionRequest.ACTION_NAME,
+			"/journal/add_data_engine_default_values");
+		mockActionRequest.addParameter(
+			"groupId", String.valueOf(ddmStructure.getGroupId()));
+
+		Calendar calendar = Calendar.getInstance();
+
+		calendar.set(Calendar.HOUR_OF_DAY, 1);
+		calendar.set(Calendar.SECOND, 0);
+		calendar.set(Calendar.MILLISECOND, 0);
+
+		calendar.add(Calendar.MONTH, 1);
+
+		Calendar reviewCalendar = calendar;
+
+		calendar.add(Calendar.MONTH, 1);
+
+		Calendar expireCalendar = calendar;
+
+		UploadPortletRequest uploadPortletRequest =
+			new UploadPortletRequestImpl(
+				new UploadServletRequestImpl(
+					new MockHttpServletRequest(), new HashMap<>(),
+					HashMapBuilder.put(
+						ActionRequest.ACTION_NAME,
+						Collections.singletonList(
+							"/journal/add_data_engine_default_values")
+					).put(
+						"classNameId",
+						Collections.singletonList(
+							String.valueOf(
+								_portal.getClassNameId(
+									DDMStructure.class.getName())))
+					).put(
+						"classPK",
+						Collections.singletonList(
+							String.valueOf(ddmStructure.getStructureId()))
+					).put(
+						"ddmStructureKey",
+						Collections.singletonList(
+							ddmStructure.getStructureKey())
+					).put(
+						"expirationDateDay",
+						Collections.singletonList(
+							String.valueOf(
+								expireCalendar.get(Calendar.DAY_OF_MONTH)))
+					).put(
+						"expirationDateHour",
+						Collections.singletonList(
+							String.valueOf(expireCalendar.get(Calendar.HOUR)))
+					).put(
+						"expirationDateMinute",
+						Collections.singletonList(
+							String.valueOf(expireCalendar.get(Calendar.MINUTE)))
+					).put(
+						"expirationDateMonth",
+						Collections.singletonList(
+							String.valueOf(expireCalendar.get(Calendar.MONTH)))
+					).put(
+						"expirationDateYear",
+						Collections.singletonList(
+							String.valueOf(expireCalendar.get(Calendar.YEAR)))
+					).put(
+						"groupId",
+						Collections.singletonList(
+							String.valueOf(ddmStructure.getGroupId()))
+					).put(
+						"reviewDateDay",
+						Collections.singletonList(
+							String.valueOf(
+								reviewCalendar.get(Calendar.DAY_OF_MONTH)))
+					).put(
+						"reviewDateHour",
+						Collections.singletonList(
+							String.valueOf(reviewCalendar.get(Calendar.HOUR)))
+					).put(
+						"reviewDateMinute",
+						Collections.singletonList(
+							String.valueOf(reviewCalendar.get(Calendar.MINUTE)))
+					).put(
+						"reviewDateMonth",
+						Collections.singletonList(
+							String.valueOf(reviewCalendar.get(Calendar.MONTH)))
+					).put(
+						"reviewDateYear",
+						Collections.singletonList(
+							String.valueOf(reviewCalendar.get(Calendar.YEAR)))
+					).build()),
+				null, RandomTestUtil.randomString());
+
+		uploadPortletRequest.setAttribute(
+			WebKeys.CURRENT_URL, "http://localhost:8080");
+
+		JournalArticle article = ReflectionTestUtil.invoke(
+			_mvcActionCommand, "_addOrUpdateArticleDefaultValues",
+			new Class<?>[] {ActionRequest.class, UploadPortletRequest.class},
+			mockActionRequest, uploadPortletRequest);
+
+		Assert.assertNotNull(article);
+
+		Assert.assertEquals(
+			expireCalendar.getTime(), article.getExpirationDate());
+		Assert.assertEquals(reviewCalendar.getTime(), article.getReviewDate());
+	}
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(filter = "mvc.command.name=/journal/add_data_engine_default_values")
+	private MVCActionCommand _mvcActionCommand;
+
+	@Inject
+	private Portal _portal;
+
+}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDataEngineDefaultValuesMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDataEngineDefaultValuesMVCActionCommand.java
@@ -200,7 +200,7 @@ public class UpdateDataEngineDefaultValuesMVCActionCommand
 			uploadPortletRequest, "expirationDateAmPm");
 
 		boolean neverExpire = ParamUtil.getBoolean(
-			uploadPortletRequest, "neverExpire", displayDateYear == 0);
+			uploadPortletRequest, "neverExpire");
 
 		if (!PropsValues.SCHEDULER_ENABLED) {
 			neverExpire = true;
@@ -224,7 +224,7 @@ public class UpdateDataEngineDefaultValuesMVCActionCommand
 			uploadPortletRequest, "reviewDateAmPm");
 
 		boolean neverReview = ParamUtil.getBoolean(
-			uploadPortletRequest, "neverReview", displayDateYear == 0);
+			uploadPortletRequest, "neverReview");
 
 		if (!PropsValues.SCHEDULER_ENABLED) {
 			neverReview = true;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDataEngineDefaultValuesMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDataEngineDefaultValuesMVCActionCommand.java
@@ -98,8 +98,20 @@ public class UpdateDataEngineDefaultValuesMVCActionCommand
 			throw new PortalException(throwable);
 		}
 
-		UploadPortletRequest uploadPortletRequest =
-			_portal.getUploadPortletRequest(actionRequest);
+		JournalArticle article = _addOrUpdateArticleDefaultValues(
+			actionRequest, _portal.getUploadPortletRequest(actionRequest));
+
+		// Asset display page
+
+		_assetDisplayPageEntryFormProcessor.process(
+			JournalArticle.class.getName(), article.getResourcePrimKey(),
+			actionRequest);
+	}
+
+	private JournalArticle _addOrUpdateArticleDefaultValues(
+			ActionRequest actionRequest,
+			UploadPortletRequest uploadPortletRequest)
+		throws Exception {
 
 		String actionName = ParamUtil.getString(
 			actionRequest, ActionRequest.ACTION_NAME);
@@ -290,11 +302,7 @@ public class UpdateDataEngineDefaultValuesMVCActionCommand
 				smallImage, smallImageURL, smallFile, serviceContext);
 		}
 
-		// Asset display page
-
-		_assetDisplayPageEntryFormProcessor.process(
-			JournalArticle.class.getName(), article.getResourcePrimKey(),
-			actionRequest);
+		return article;
 	}
 
 	@Reference


### PR DESCRIPTION
## Motivation

[Link to task](https://issues.liferay.com/browse/LPS-172332)

There was a change recently where the display date is now no longer mandatory for default values of a given DDM Structure. Because of this, if a user unchecks the "never expire" option, it's not reflected when saving


## Change summary:

* Remove the constraint for forcing the expire and review dates to be disabled if no display date is selected
* Add integration tests


## Test Scenario

* Create a new structure
* Edit the default values
* Uncheck the option "never expire" and provide a date
* Save and edit again

![expire](https://user-images.githubusercontent.com/4267448/211543760-1d27958b-063c-4639-bb7b-698581cc16db.gif)
