### PR TITLE
LPS-170765 Use toString before toLowercase to ensure that it is a string

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/LengthField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/common/components/LengthField.js
@@ -50,7 +50,7 @@ const getInitialValue = (value) => {
 		return {unit: UNITS[0], value: ''};
 	}
 
-	const match = value.toLowerCase().match(REGEX);
+	const match = value.toString().toLowerCase().match(REGEX);
 
 	if (match) {
 		const [, number, unit] = match;
@@ -236,7 +236,7 @@ export function LengthInput({
 			return;
 		}
 
-		const [, , unit] = value.toLowerCase().match(REGEX) || [];
+		const [, , unit] = value.toString().toLowerCase().match(REGEX) || [];
 
 		setNextUnit(unit || CUSTOM);
 	}, [value]);


### PR DESCRIPTION
Original comment from @javalosjr96:

> Ticket:
> [LPS-170765](https://issues.liferay.com/browse/LPS-170765)
> 
> Issue:
> Some of the variables in the are not being parsed as Strings when the Styles menu is being rendered.  When t.toLowerCase is applied, the method throws an exception.
> 
> Solution:
> Parse as string before using toLowerCase.
> 
> Testing:
> Used steps from LPS to create database dump and upgrade.  Before fix, the Styles menu would not appear and an error is thrown in the console.  
> 
> After the fix, the Styles menu appears with all of the relevant data.  
> 
