### PR TITLE
LPS-172108 Links are missing in display pages and page templates

### DIFF
--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/layout-page-templates/display-page-templates/test-display-page-template/display-page-template.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/layout-page-templates/display-page-templates/test-display-page-template/display-page-template.json
@@ -1,0 +1,9 @@
+{
+	"contentSubtype": {
+		"subtypeKey": "TEST DDM STRUCTURE NAME"
+	},
+	"contentType": {
+		"className": "com.liferay.journal.model.JournalArticle"
+	},
+	"name": "Test Display Page Template"
+}

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/layout-page-templates/display-page-templates/test-display-page-template/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test-bundle/src/main/resources/site-initializer/layout-page-templates/display-page-templates/test-display-page-template/page-definition.json
@@ -1,0 +1,48 @@
+{
+	"pageElement": {
+		"pageElements": [
+			{
+				"definition": {
+					"fragment": {
+						"key": "BASIC_COMPONENT-button"
+					},
+					"fragmentConfig": {
+						"buttonSize": "nm",
+						"buttonType": "primary"
+					},
+					"fragmentFields": [
+						{
+							"id": "link",
+							"value": {
+								"fragmentLink": {
+									"value": {
+										"href": {
+											"mapping": {
+												"itemReference": {
+													"className": "com.liferay.portal.kernel.model.Layout",
+													"fields": [
+														{
+															"fieldName": "friendlyURL",
+															"fieldValue": "/home"
+														},
+														{
+															"fieldName": "privatePage",
+															"fieldValue": "false"
+														}
+													]
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					],
+					"indexed": true
+				},
+				"type": "Fragment"
+			}
+		],
+		"type": "Root"
+	}
+}

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -643,6 +643,17 @@ public class BundleSiteInitializerTest {
 		Assert.assertEquals(productLayoutUuid, publicLayout.getUuid());
 	}
 
+	private void _assertDisplayPages(Group group) {
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.fetchLayoutPageTemplateEntry(
+				group.getGroupId(), "Test Display Page Template",
+				LayoutPageTemplateEntryTypeConstants.TYPE_DISPLAY_PAGE);
+
+		Assert.assertNotNull(layoutPageTemplateEntry);
+		Assert.assertEquals(
+			"Test Display Page Template", layoutPageTemplateEntry.getName());
+	}
+
 	private void _assertDLFileEntry(Group group) throws Exception {
 		DLFileEntry dlFileEntry = _dlFileEntryLocalService.getFileEntry(
 			group.getGroupId(), DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
@@ -1776,6 +1787,7 @@ public class BundleSiteInitializerTest {
 			_assertCPInstanceProperties(group);
 			_assertDDMStructure(group);
 			_assertDDMTemplate(group);
+			_assertDisplayPages(group);
 			_assertDLFileEntry(group);
 			_assertExpandoColumns(serviceContext);
 			_assertFragmentEntries(group, serviceContext);

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender-test/src/testIntegration/java/com/liferay/site/initializer/extender/internal/test/BundleSiteInitializerTest.java
@@ -789,17 +789,6 @@ public class BundleSiteInitializerTest {
 			"This is the body for Test KB Article 3.", kbArticle3.getContent());
 	}
 
-	private void _assertLayoutPageTemplateEntry(Group group) throws Exception {
-		LayoutPageTemplateEntry layoutPageTemplateEntry =
-			_layoutPageTemplateEntryLocalService.fetchLayoutPageTemplateEntry(
-				group.getGroupId(), "Test Master Page",
-				LayoutPageTemplateEntryTypeConstants.TYPE_MASTER_LAYOUT);
-
-		Assert.assertNotNull(layoutPageTemplateEntry);
-		Assert.assertEquals(
-			"Test Master Page", layoutPageTemplateEntry.getName());
-	}
-
 	private void _assertLayouts(Group group, ServiceContext serviceContext)
 		throws Exception {
 
@@ -886,6 +875,17 @@ public class BundleSiteInitializerTest {
 
 		Assert.assertNotNull(listTypeEntry2);
 		Assert.assertEquals("testlisttypeentry2", listTypeEntry2.getKey());
+	}
+
+	private void _assertMasterLayouts(Group group) {
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.fetchLayoutPageTemplateEntry(
+				group.getGroupId(), "Test Master Page",
+				LayoutPageTemplateEntryTypeConstants.TYPE_MASTER_LAYOUT);
+
+		Assert.assertNotNull(layoutPageTemplateEntry);
+		Assert.assertEquals(
+			"Test Master Page", layoutPageTemplateEntry.getName());
 	}
 
 	private void _assertNotificationTemplate(ServiceContext serviceContext)
@@ -1781,10 +1781,10 @@ public class BundleSiteInitializerTest {
 			_assertFragmentEntries(group, serviceContext);
 			_assertJournalArticles(group);
 			_assertKBArticles(group);
-			_assertLayoutPageTemplateEntry(group);
 			_assertLayouts(group, serviceContext);
 			_assertLayoutSets(group);
 			_assertListTypeDefinitions(serviceContext);
+			_assertMasterLayouts(group);
 			_assertNotificationTemplate(serviceContext);
 			_assertObjectDefinitions(group, serviceContext);
 			_assertOrganizations(serviceContext);

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -485,13 +485,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 							siteNavigationMenuItemSettingsBuilder));
 
 			_invoke(
-				() -> _addLayoutPageTemplates(
-					assetListEntryIdsStringUtilReplaceValues,
-					documentsStringUtilReplaceValues,
-					objectDefinitionIdsAndObjectEntryIdsStringUtilReplaceValues,
-					serviceContext,
-					taxonomyCategoryIdsStringUtilReplaceValues));
-			_invoke(
 				() -> _addOrUpdateNotificationTemplates(
 					documentsStringUtilReplaceValues,
 					objectDefinitionIdsAndObjectEntryIdsStringUtilReplaceValues,
@@ -509,6 +502,17 @@ public class BundleSiteInitializer implements SiteInitializer {
 					documentsStringUtilReplaceValues,
 					objectDefinitionIdsAndObjectEntryIdsStringUtilReplaceValues,
 					serviceContext));
+
+			// LPS-172108 Layouts have to be created first so that links in page
+			// templates work
+
+			_invoke(
+				() -> _addLayoutPageTemplates(
+					assetListEntryIdsStringUtilReplaceValues,
+					documentsStringUtilReplaceValues,
+					objectDefinitionIdsAndObjectEntryIdsStringUtilReplaceValues,
+					serviceContext,
+					taxonomyCategoryIdsStringUtilReplaceValues));
 
 			// TODO Review order/dependency
 


### PR DESCRIPTION
## Motivation

[Link to task](https://issues.liferay.com/browse/LPS-172108)

In [LPS-143303](https://issues.liferay.com/browse/LPS-143303) we split the way we added layouts through the site initializer. First we create the entry, and then we specify the content. This is done so that we could add links in page templates and display pages.

This was changed in [LPS-168479](https://issues.liferay.com/browse/LPS-168479) by accident, so in this PR que are using the correct order again.


## Change summary:

* Move the method to create the display pages and page templates so it's executed after the layouts are created


## Test Scenario

* Follow the steps in the ticket

![extranet](https://user-images.githubusercontent.com/4267448/211555682-878a2ca9-2ef0-472c-b70e-15ac5e69a86a.gif)