### PR TITLE
LPS-172712 Asset Categories Selector is temporarily unavailable

### DIFF
--- a/modules/apps/asset/asset-categories-selector-web/src/main/java/com/liferay/asset/categories/selector/web/internal/display/context/AssetCategoriesSelectorDisplayContext.java
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/java/com/liferay/asset/categories/selector/web/internal/display/context/AssetCategoriesSelectorDisplayContext.java
@@ -314,11 +314,7 @@ public class AssetCategoriesSelectorDisplayContext {
 				AssetVocabularyLocalServiceUtil.fetchAssetVocabulary(
 					vocabularyId);
 
-			if ((assetVocabulary != null) &&
-				(isMoveCategory() ||
-				 (!isMoveCategory() &&
-				  (assetVocabulary.getCategoriesCount() > 0)))) {
-
+			if (assetVocabulary != null) {
 				assetVocabularies.add(assetVocabulary);
 			}
 		}
@@ -348,6 +344,10 @@ public class AssetCategoriesSelectorDisplayContext {
 		boolean allowedSelectVocabularies = isAllowedSelectVocabularies();
 
 		for (AssetVocabulary vocabulary : _getVocabularies()) {
+			if (!isMoveCategory() && (vocabulary.getCategoriesCount() == 0)) {
+				continue;
+			}
+
 			jsonArray.put(
 				JSONUtil.put(
 					"children",

--- a/modules/apps/asset/asset-categories-selector-web/src/main/java/com/liferay/asset/categories/selector/web/internal/display/context/AssetCategoriesSelectorDisplayContext.java
+++ b/modules/apps/asset/asset-categories-selector-web/src/main/java/com/liferay/asset/categories/selector/web/internal/display/context/AssetCategoriesSelectorDisplayContext.java
@@ -73,7 +73,7 @@ public class AssetCategoriesSelectorDisplayContext {
 	public String getAddCategoryURL() throws Exception {
 		List<AssetVocabulary> vocabularies = _getVocabularies();
 
-		if (vocabularies.size() > 1) {
+		if (vocabularies.size() != 1) {
 			return null;
 		}
 


### PR DESCRIPTION
## Motivation

[Link to task](https://issues.liferay.com/browse/LPS-172712)

This PR fixes the problem mentioned in the ticket, while at the same trying to not regress

[LPS-171805](https://issues.liferay.com/browse/LPS-171805)
[LPS-171737](https://issues.liferay.com/browse/LPS-171737)
[LPS-171689](https://issues.liferay.com/browse/LPS-171689)


The idea is to differ the check for the visibility of the vocabularies and do it only when creating the json structure for them. This will avoid affecting other elements of the component


## Change summary:

* Change the point where we check if we want to show the vocabularios or not


## Test Scenario 1 (related to this bug)

* Go to Content and Data > Blogs
* Create a new Blog
* Click on Topic
* No categories were found message should be shown


## Test Scenario 2 (related to LPS-171805)

* Go to Global Site
* Go to Content and Data > Documents and Media
* Click on File Upload 
* Click on Categorization -> Topic
* In the modal, a + button should be shown to add a new category to the vocabulary


## Test Scenario 3 (related to LPS-171737)

* Go to Categorization > Categories
* Create 2 vocabularies
* Add a category to one of the vocabularies
* Click on the kebab to move the category to the other vocabulary 
* In the modal, the empty vocabularies should be shown


## Test Scenario 4 (related to LPS-171689)

* Go to Site Builder > Collections
* Create a dynamic collection
* Change filter to categories and press "select"
* Only vocabularies with categories should be shown