### PR TITLE
[TS] LPS-171901 - reindex journals related to an structure filtering by groupId

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleDDMStructureIndexer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/JournalArticleDDMStructureIndexer.java
@@ -26,7 +26,6 @@ import com.liferay.portal.kernel.dao.orm.DynamicQueryFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.ProjectionFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.Property;
 import com.liferay.portal.kernel.dao.orm.PropertyFactoryUtil;
-import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -39,6 +38,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.index.IndexStatusManager;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
@@ -68,6 +68,7 @@ public class JournalArticleDDMStructureIndexer implements DDMStructureIndexer {
 			}
 
 			String[] ddmStructureKeys = new String[ddmStructureIds.size()];
+			ArrayList<Long> groupIds = new ArrayList<>();
 
 			for (int i = 0; i < ddmStructureIds.size(); i++) {
 				long ddmStructureId = ddmStructureIds.get(i);
@@ -76,6 +77,7 @@ public class JournalArticleDDMStructureIndexer implements DDMStructureIndexer {
 					ddmStructureLocalService.getDDMStructure(ddmStructureId);
 
 				ddmStructureKeys[i] = ddmStructure.getStructureKey();
+				groupIds.add(ddmStructure.getGroupId());
 			}
 
 			ActionableDynamicQuery actionableDynamicQuery =
@@ -93,14 +95,9 @@ public class JournalArticleDDMStructureIndexer implements DDMStructureIndexer {
 					journalArticleDynamicQuery.setProjection(
 						ProjectionFactoryUtil.property("resourcePrimKey"));
 
-					journalArticleDynamicQuery.add(
-						RestrictionsFactoryUtil.eqProperty(
-							"journalArticle.resourcePrimKey",
-							"this.resourcePrimKey"));
+					Property groupId = PropertyFactoryUtil.forName("groupId");
 
-					journalArticleDynamicQuery.add(
-						RestrictionsFactoryUtil.eqProperty(
-							"journalArticle.groupId", "this.groupId"));
+					journalArticleDynamicQuery.add(groupId.in(groupIds));
 
 					Property ddmStructureKey = PropertyFactoryUtil.forName(
 						"DDMStructureKey");


### PR DESCRIPTION
Motivation
=======
This PR try to fix the problem mentioned in the ticket.
[Link to task](https://issues.liferay.com/browse/LPS-171901)

Whenever an structure is update, journal articles related to are re-indexed, but the indexer doesn't filter journals by groupId properly. It makes when an structure is update in an staging site, live journals articles are also re-indexed.

Proposed Solution
========
To modify the way ActionableDynamicQuery exectuted in the JournalArticleDDMStructureIndexer search for results filtering by groupId.

Steps to Verify
========
1. Create Site A
2. Create structure stA
3. Export site A
4. Create Site B
5. import site A into site B
6. Create a journal from site B with stA
7. Define com.liferay.portal.search.elasticsearch7 log level to ALL
8. Go to site A, edit the stA and save.
