### PR TITLE
[TS] LPS-171968 Error popup shows when loading a page with an image for which the user does not have view permission

### DIFF
--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java
@@ -18,7 +18,10 @@ import com.liferay.petra.io.unsync.UnsyncStringWriter;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.servlet.PipingServletResponse;
+import com.liferay.portal.kernel.servlet.PortalMessages;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+import com.liferay.portal.kernel.servlet.SessionMessages;
 import com.liferay.portal.kernel.struts.StrutsAction;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.theme.ThemeUtil;
@@ -71,15 +74,22 @@ public class StatusStrutsAction implements StrutsAction {
 
 		requestDispatcher.include(httpServletRequest, pipingServletResponse);
 
+		String output = unsyncStringWriter.toString();
+
+		SessionErrors.clear(httpServletRequest);
+
 		Document document = Jsoup.parse(
 			ThemeUtil.include(
 				httpServletRequest.getServletContext(), httpServletRequest,
 				httpServletResponse, "portal_normal.ftl", layoutSet.getTheme(),
 				false));
 
+		PortalMessages.clear(httpServletRequest);
+		SessionMessages.clear(httpServletRequest);
+
 		Element contentElement = document.getElementById("content");
 
-		contentElement.html(unsyncStringWriter.toString());
+		contentElement.html(output);
 
 		ServletResponseUtil.write(httpServletResponse, document.html());
 


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
When a user is viewing a web content with an image that he has no permission to view, a pop-up error message will appear, with the generic, default message "Your request failed to complete".
This issue appeared after [LPS-156404](https://issues.liferay.com/browse/LPS-156404).

As @dacousalr identified it, the root cause is that the new `StrutsAction` is rendering the _portal_normal_ template without calling `SessionErrors.clear(request)` afterward.

Proposed Solution
========
Clearing the request from session errors.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-171968

Thank you and best regards,
István