### PR TITLE
LPS-172282 Change the Field Name and Option Value based on the Field and Option Reference in Web Content Structures

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/AddDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/AddDataDefinitionMVCActionCommand.java
@@ -20,6 +20,7 @@ import com.liferay.data.engine.rest.dto.v2_0.DataLayout;
 import com.liferay.data.engine.rest.resource.exception.DataDefinitionValidationException;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
 import com.liferay.journal.constants.JournalPortletKeys;
+import com.liferay.journal.web.internal.portlet.action.util.DataDefinitionFieldNameUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseTransactionalMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -27,9 +28,6 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
-
-import java.util.Locale;
-import java.util.Map;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -98,22 +96,24 @@ public class AddDataDefinitionMVCActionCommand
 
 		long groupId = ParamUtil.getLong(actionRequest, "groupId");
 
-		String dataDefinitionString = ParamUtil.getString(
-			actionRequest, "dataDefinition");
-
 		DataDefinition dataDefinition = DataDefinition.toDTO(
-			dataDefinitionString);
+			ParamUtil.getString(actionRequest, "dataDefinition"));
 
-		String structureKey = ParamUtil.getString(
-			actionRequest, "structureKey");
-		String dataLayout = ParamUtil.getString(actionRequest, "dataLayout");
-		Map<Locale, String> descriptionMap = _localization.getLocalizationMap(
-			actionRequest, "description");
+		dataDefinition.setDataDefinitionKey(
+			ParamUtil.getString(actionRequest, "structureKey"));
 
-		dataDefinition.setDataDefinitionKey(structureKey);
-		dataDefinition.setDefaultDataLayout(DataLayout.toDTO(dataLayout));
+		DataLayout dataLayout = DataLayout.toDTO(
+			ParamUtil.getString(actionRequest, "dataLayout"));
+
+		DataDefinitionFieldNameUtil.normalizeFieldName(
+			dataDefinition, dataLayout);
+
+		dataDefinition.setDefaultDataLayout(dataLayout);
+
 		dataDefinition.setDescription(
-			LocalizedValueUtil.toStringObjectMap(descriptionMap));
+			LocalizedValueUtil.toStringObjectMap(
+				_localization.getLocalizationMap(
+					actionRequest, "description")));
 
 		dataDefinitionResource.postSiteDataDefinitionByContentType(
 			groupId, "journal", dataDefinition);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDataDefinitionMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateDataDefinitionMVCActionCommand.java
@@ -23,6 +23,7 @@ import com.liferay.journal.constants.JournalPortletKeys;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.service.persistence.JournalArticleUtil;
+import com.liferay.journal.web.internal.portlet.action.util.DataDefinitionFieldNameUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseTransactionalMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.servlet.SessionErrors;
@@ -32,8 +33,6 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
-import java.util.Locale;
-import java.util.Map;
 
 import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
@@ -103,22 +102,26 @@ public class UpdateDataDefinitionMVCActionCommand
 		long dataDefinitionId = ParamUtil.getLong(
 			actionRequest, "dataDefinitionId");
 
-		String dataDefinitionString = ParamUtil.getString(
-			actionRequest, "dataDefinition");
-
 		DataDefinition dataDefinition = DataDefinition.toDTO(
-			dataDefinitionString);
+			ParamUtil.getString(actionRequest, "dataDefinition"));
 
 		String structureKey = ParamUtil.getString(
 			actionRequest, "structureKey");
-		String dataLayout = ParamUtil.getString(actionRequest, "dataLayout");
-		Map<Locale, String> descriptionMap = _localization.getLocalizationMap(
-			actionRequest, "description");
 
 		dataDefinition.setDataDefinitionKey(structureKey);
-		dataDefinition.setDefaultDataLayout(DataLayout.toDTO(dataLayout));
+
+		DataLayout dataLayout = DataLayout.toDTO(
+			ParamUtil.getString(actionRequest, "dataLayout"));
+
+		DataDefinitionFieldNameUtil.normalizeFieldName(
+			dataDefinition, dataLayout);
+
+		dataDefinition.setDefaultDataLayout(dataLayout);
+
 		dataDefinition.setDescription(
-			LocalizedValueUtil.toStringObjectMap(descriptionMap));
+			LocalizedValueUtil.toStringObjectMap(
+				_localization.getLocalizationMap(
+					actionRequest, "description")));
 
 		dataDefinitionResource.putDataDefinition(
 			dataDefinitionId, dataDefinition);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/util/DataDefinitionFieldNameUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/util/DataDefinitionFieldNameUtil.java
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.web.internal.portlet.action.util;
+
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinitionField;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayout;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayoutColumn;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayoutPage;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayoutRow;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Carolina Barbosa
+ */
+public class DataDefinitionFieldNameUtil {
+
+	public static void normalizeFieldName(
+		DataDefinition dataDefinition, DataLayout dataLayout) {
+
+		Map<String, String> fieldReferences = new HashMap<>();
+
+		for (DataDefinitionField dataDefinitionField :
+				dataDefinition.getDataDefinitionFields()) {
+
+			Map<String, Object> customProperties =
+				dataDefinitionField.getCustomProperties();
+
+			String fieldReference = GetterUtil.getString(
+				customProperties.get("fieldReference"));
+
+			fieldReferences.put(dataDefinitionField.getName(), fieldReference);
+
+			dataDefinitionField.setName(fieldReference);
+
+			Map<String, Object[]> optionsMap =
+				(Map<String, Object[]>)customProperties.get("options");
+
+			if (MapUtil.isEmpty(optionsMap)) {
+				continue;
+			}
+
+			for (Object[] options : optionsMap.values()) {
+				for (Object option : options) {
+					Map<String, String> optionMap = (Map<String, String>)option;
+
+					optionMap.put("value", optionMap.get("reference"));
+				}
+			}
+		}
+
+		for (DataLayoutPage dataLayoutPage : dataLayout.getDataLayoutPages()) {
+			for (DataLayoutRow dataLayoutRows :
+					dataLayoutPage.getDataLayoutRows()) {
+
+				for (DataLayoutColumn dataLayoutColumn :
+						dataLayoutRows.getDataLayoutColumns()) {
+
+					String[] fieldNames = dataLayoutColumn.getFieldNames();
+
+					for (int i = 0; i < fieldNames.length; i++) {
+						fieldNames[i] = fieldReferences.get(fieldNames[i]);
+					}
+				}
+			}
+		}
+	}
+
+}

--- a/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/portlet/action/util/DataDefinitionFieldNameUtilTest.java
+++ b/modules/apps/journal/journal-web/src/test/java/com/liferay/journal/web/internal/portlet/action/util/DataDefinitionFieldNameUtilTest.java
@@ -1,0 +1,162 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.journal.web.internal.portlet.action.util;
+
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinition;
+import com.liferay.data.engine.rest.dto.v2_0.DataDefinitionField;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayout;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayoutColumn;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayoutPage;
+import com.liferay.data.engine.rest.dto.v2_0.DataLayoutRow;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Carolina Barbosa
+ */
+public class DataDefinitionFieldNameUtilTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testNormalizeFieldName() {
+		DataDefinition dataDefinition = new DataDefinition() {
+			{
+				dataDefinitionFields = new DataDefinitionField[] {
+					new DataDefinitionField() {
+						{
+							customProperties =
+								HashMapBuilder.<String, Object>put(
+									"fieldReference", "textFieldReference"
+								).build();
+							name = "textFieldName";
+						}
+					},
+					new DataDefinitionField() {
+						{
+							customProperties =
+								HashMapBuilder.<String, Object>put(
+									"fieldReference", "selectFieldReference"
+								).put(
+									"options",
+									HashMapBuilder.put(
+										"en_US",
+										new Object[] {
+											HashMapBuilder.put(
+												"reference", "optionReference1"
+											).put(
+												"value", "optionValue1"
+											).build(),
+											HashMapBuilder.put(
+												"reference", "optionReference2"
+											).put(
+												"value", "optionValue2"
+											).build()
+										}
+									).build()
+								).build();
+							name = "selectFieldName";
+						}
+					}
+				};
+			}
+		};
+
+		String[] dataDefinitionFieldNames = {
+			"textFieldName", "selectFieldName"
+		};
+
+		DataLayout dataLayout = new DataLayout() {
+			{
+				dataLayoutPages = new DataLayoutPage[] {
+					new DataLayoutPage() {
+						{
+							dataLayoutRows = new DataLayoutRow[] {
+								new DataLayoutRow() {
+									{
+										dataLayoutColumns =
+											new DataLayoutColumn[] {
+												new DataLayoutColumn() {
+													{
+														fieldNames =
+															dataDefinitionFieldNames;
+													}
+												}
+											};
+									}
+								}
+							};
+						}
+					}
+				};
+			}
+		};
+
+		DataDefinitionFieldNameUtil.normalizeFieldName(
+			dataDefinition, dataLayout);
+
+		DataDefinitionField[] dataDefinitionFields =
+			dataDefinition.getDataDefinitionFields();
+
+		Assert.assertEquals(
+			"textFieldReference", dataDefinitionFields[0].getName());
+		Assert.assertEquals(
+			"selectFieldReference", dataDefinitionFields[1].getName());
+
+		Map<String, Object> customProperties =
+			dataDefinitionFields[1].getCustomProperties();
+
+		Map<String, Object[]> optionsMap =
+			(Map<String, Object[]>)customProperties.get("options");
+
+		Assert.assertArrayEquals(
+			new Object[] {
+				HashMapBuilder.put(
+					"reference", "optionReference1"
+				).put(
+					"value", "optionReference1"
+				).build(),
+				HashMapBuilder.put(
+					"reference", "optionReference2"
+				).put(
+					"value", "optionReference2"
+				).build()
+			},
+			optionsMap.get("en_US"));
+
+		DataLayoutPage dataLayoutPage = dataLayout.getDataLayoutPages()[0];
+
+		DataLayoutRow dataLayoutRow = dataLayoutPage.getDataLayoutRows()[0];
+
+		DataLayoutColumn dataLayoutColumn =
+			dataLayoutRow.getDataLayoutColumns()[0];
+
+		Assert.assertEquals(
+			"textFieldReference", dataLayoutColumn.getFieldNames()[0]);
+		Assert.assertEquals(
+			"selectFieldReference", dataLayoutColumn.getFieldNames()[1]);
+	}
+
+}


### PR DESCRIPTION
**Context:**
https://issues.liferay.com/browse/LPS-172237

Allow users to easily update the `DDMFormField -> name` by copying the same value from the `DDMFormField -> fieldReference`. This behavior should also be applied to `options`.

**Previous PR**: https://github.com/liferay-forms/liferay-portal/pull/2101
