### PR TITLE
LPS-171754 Success message is missing after copy OOTB fragment into Untitled Set

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/CopyFragmentEntryMVCActionCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/CopyFragmentEntryMVCActionCommand.java
@@ -35,7 +35,6 @@ import com.liferay.portal.kernel.portletfilerepository.PortletFileRepositoryUtil
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
-import com.liferay.portal.kernel.servlet.MultiSessionMessages;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -75,8 +74,6 @@ public class CopyFragmentEntryMVCActionCommand extends BaseMVCActionCommand {
 		throws Exception {
 
 		hideDefaultSuccessMessage(actionRequest);
-
-		MultiSessionMessages.add(actionRequest, "fragmentEntryCopied");
 
 		sendRedirect(
 			actionRequest, actionResponse,

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/CopyFragmentModal.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/CopyFragmentModal.js
@@ -75,6 +75,13 @@ export default function CopyFragmentModal({
 				if (response.redirected) {
 					navigate(response.url);
 				}
+
+				openToast({
+					message: Liferay.Language.get(
+						'the-fragment-was-copied-successfully'
+					),
+					type: 'success',
+				});
 			})
 			.catch(() => {
 				openToast({

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -24,8 +24,6 @@ List<FragmentCollection> systemFragmentCollections = (List<FragmentCollection>)r
 List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDisplayContext.getFragmentCollectionContributors(locale);
 %>
 
-<liferay-ui:success key="fragmentEntryCopied" message="the-fragment-was-copied-successfully" />
-
 <clay:container-fluid
 	cssClass="container-view"
 >


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-171754)

When copying a fragment to a collection, the success message is not shown in firefox, it works well in chrome and safari

## Change summary:

* Don't use multi session messages to render the success message, but a toast when the modal is closed


## Test Scenario

* Go to fragments
* Click on the kebab for a contributed fragment and select copy To
* Click save
* The fragment is copied and the success message is shown


![copy](https://user-images.githubusercontent.com/4267448/213145782-15cf85ce-baf9-497b-bf3d-86b8b686a8b5.gif)
