### PR TITLE
LPS-163681 Page tree select all

### DIFF
--- a/modules/apps/staging/staging-taglib/src/main/java/com/liferay/staging/taglib/internal/display/context/LayoutsTreeDisplayContext.java
+++ b/modules/apps/staging/staging-taglib/src/main/java/com/liferay/staging/taglib/internal/display/context/LayoutsTreeDisplayContext.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -32,6 +33,7 @@ import com.liferay.portal.util.PropsValues;
 import com.liferay.staging.taglib.internal.servlet.ServletContextUtil;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -138,6 +140,21 @@ public class LayoutsTreeDisplayContext {
 
 	private Set<Long> _getSelectedPlids() {
 		Set<Long> plids = new HashSet<>();
+
+		if (ArrayUtil.contains(
+				_selectedLayoutIds, LayoutConstants.DEFAULT_PARENT_LAYOUT_ID)) {
+
+			plids.add(LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);
+
+			List<Layout> allLayouts = LayoutLocalServiceUtil.getLayouts(
+				_groupId, _privateLayout);
+
+			for (Layout layout : allLayouts) {
+				plids.add(layout.getPlid());
+			}
+
+			return plids;
+		}
 
 		for (long layoutId : _selectedLayoutIds) {
 			if (layoutId == 0) {


### PR DESCRIPTION
Dear @liferay-echo , 

According to [LPS-163681](https://issues.liferay.com/browse/LPS-163681) the expected behavior is when the root "Pages" node is selected, all pages should be exported/published. Currently, when a new page is created, its `plid` is not automatically added to the ExportImportConfiguration, which stores the selected pages to be published. I added this code to [LayoutsTreeDisplayContext](https://github.com/liferay/liferay-portal/blob/master/modules/apps/staging/staging-taglib/src/main/java/com/liferay/staging/taglib/internal/display/context/LayoutsTreeDisplayContext.java), so if page '0' was selected, we add all other pages to the selected list of the tree component. 

Test results of previous PR: https://github.com/vendeltoreki/liferay-portal/pull/248#issuecomment-1397835454

Please review my changes.

Thanks,
Vendel