### PR TITLE
LPS-173474 Delete based on document fields

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -1763,7 +1763,9 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 				GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)));
 
 			if (layout == null) {
-				indexer.delete(layout);
+				indexer.delete(
+					GetterUtil.getLong(document.get(Field.COMPANY_ID)),
+					document.getUID());
 
 				continue;
 			}
@@ -1857,7 +1859,9 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 				GetterUtil.getLong(document.get(Field.ENTRY_CLASS_PK)));
 
 			if (layout == null) {
-				indexer.delete(layout);
+				indexer.delete(
+					GetterUtil.getLong(document.get(Field.COMPANY_ID)),
+					document.getUID());
 
 				continue;
 			}


### PR DESCRIPTION
Hi Team,
Can you please review?

Motivation
=======
https://issues.liferay.com/browse/LPS-173474
Indexer can't delete the search document based on a null object

Proposed Solution
========
Use fields from the search document to avoid null looked-up objects

Steps to Verify
========
N/A

References to existing code (if applies)
========
This pattern is used in [JournalHelperImpl ](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalHelperImpl.java#L258-L261) as well

Cheers,
Balázs