### PR TITLE
[TS] LPS-173828

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -131,6 +131,12 @@ export default function _JournalPortlet({
 		publishingLock.unlock();
 		console.error(error);
 
+		const workflowActionInput = document.getElementById(
+			`${namespace}workflowAction`
+		);
+
+		workflowActionInput.value = Liferay.Workflow.ACTION_SAVE_DRAFT;
+
 		const titleInputComponent = Liferay.component(
 			`${namespace}titleMapAsXML`
 		);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-173828

When initially creating a new journal article with workflow enabled, [the workflowAction is set to `ACTION_SAVE_DRAFT`](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp#L55), which will save the article as a draft.

When clicking "submit for publication", [the `workflowActionInput.value` changes to the published status](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js#L220-L222), regardless of whether or not an error it thrown.  This value is now stuck in this state, as it's not possible to go back to `ACTION_SAVE_DRAFT` without a browser refresh.

So, even when properly saving as a draft (on the same page without reloading), the `workflowActionInput.value` is still set to publish, so the article is sent for review rather than saved as a draft.

The solution is to revert the `workflowActionInput.value` back to `ACTION_SAVE_DRAFT` during a form error.  This will reset back to our default status, so it should be completely safe.

Please let me know if you have any questions, thanks!