### PR TITLE
LPS-172696 Improve Page indexing 

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/search/spi/model/index/contributor/LayoutModelDocumentContributor.java
@@ -21,11 +21,16 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.search.spi.model.index.contributor.ModelDocumentContributor;
 
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -52,14 +57,19 @@ public class LayoutModelDocumentContributor
 
 		document.addText(
 			Field.DEFAULT_LANGUAGE_ID, layout.getDefaultLanguageId());
-		document.addLocalizedText(Field.NAME, layout.getNameMap());
 		document.addText(
 			"privateLayout", String.valueOf(layout.isPrivateLayout()));
 		document.addKeyword(Field.STATUS, _getStatus(layout));
 		document.addText(Field.TYPE, layout.getType());
 
+		Map<Locale, String> nameMap = layout.getNameMap();
+
 		for (String languageId : layout.getAvailableLanguageIds()) {
 			Locale locale = LocaleUtil.fromLanguageId(languageId);
+
+			document.addText(
+				_localization.getLocalizedName(Field.NAME, languageId),
+				nameMap.get(locale));
 
 			document.addText(
 				Field.getLocalizedName(locale, Field.TITLE),
@@ -70,11 +80,20 @@ public class LayoutModelDocumentContributor
 			_layoutLocalizationLocalService.getLayoutLocalizations(
 				layout.getPlid());
 
+		String[] availableLanguages = layout.getAvailableLanguageIds();
+
+		Set<String> availableLanguagesSet = new HashSet<>(
+			Arrays.asList(availableLanguages));
+
 		for (LayoutLocalization layoutLocalization : layoutLocalizations) {
-			document.addText(
-				Field.getLocalizedName(
-					layoutLocalization.getLanguageId(), Field.CONTENT),
-				layoutLocalization.getContent());
+			if (availableLanguagesSet.contains(
+					layoutLocalization.getLanguageId())) {
+
+				document.addText(
+					Field.getLocalizedName(
+						layoutLocalization.getLanguageId(), Field.CONTENT),
+					layoutLocalization.getContent());
+			}
 		}
 	}
 
@@ -91,5 +110,8 @@ public class LayoutModelDocumentContributor
 
 	@Reference
 	private LayoutLocalizationLocalService _layoutLocalizationLocalService;
+
+	@Reference
+	private Localization _localization;
 
 }

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerIndexedFieldsTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutIndexerIndexedFieldsTest.java
@@ -215,8 +215,6 @@ public class LayoutIndexerIndexedFieldsTest {
 	}
 
 	private void _populateName(Layout layout, Map<String, String> map) {
-		map.put(Field.NAME, layout.getName(layout.getDefaultLanguageId()));
-
 		for (String languageId : layout.getAvailableLanguageIds()) {
 			Locale locale = LocaleUtil.fromLanguageId(languageId);
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutMultiLanguageSearchTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/search/test/LayoutMultiLanguageSearchTest.java
@@ -153,17 +153,8 @@ public class LayoutMultiLanguageSearchTest {
 			});
 	}
 
-	private Map<String, String> _getMapResult(String prefix, String keyWords) {
+	private Map<String, String> _getMapResult(String prefix) {
 		return HashMapBuilder.put(
-			() -> {
-				if (prefix != _TITLE) {
-					return prefix;
-				}
-
-				return null;
-			},
-			keyWords
-		).put(
 			prefix + "_en_US", _ENGLISH_KEYWORD
 		).put(
 			prefix + "_ja_JP", _JAPANESE_KEYWORD
@@ -178,7 +169,7 @@ public class LayoutMultiLanguageSearchTest {
 
 		_addLayoutMultiLanguage();
 
-		Map<String, String> map = _getMapResult(prefix, keyWords);
+		Map<String, String> map = _getMapResult(prefix);
 
 		assertFieldValues(prefix, locale, map, keyWords);
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-172696

**Author:** @joshuacords

Tested here: https://github.com/joshuacords/liferay-portal/pull/105

Hello @liferay-echo,
I came across this behavior when investigating [LPP-47666](https://issues.liferay.com/browse/LPP-47666). 

Currently content in a single language locale of Layout is being indexed across all locales. This creates inconsistent searching behavior when compared to other Assets. Best practice is to only index localized content into it's specific localized field as it will make searches more meaningful and properly utilizes language analyzers.

Please consider pushing these changes I've made.