### PR TITLE
LPS-168835 Replace liferay-ui:icon with clay:icon in fragment-web

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view.jsp
@@ -118,11 +118,11 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 												>
 													<span class="text-truncate"><%= HtmlUtil.escape(fragmentCollectionContributor.getName(locale)) %></span>
 
-													<liferay-ui:icon
-														icon="lock"
-														iconCssClass="ml-1 text-muted"
-														markupView="lexicon"
-													/>
+													<span class="ml-1 text-muted">
+														<clay:icon
+															symbol="lock"
+														/>
+													</span>
 												</a>
 											</li>
 
@@ -146,11 +146,11 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 													<span class="text-truncate"><%= HtmlUtil.escape(fragmentCollection.getName()) %></span>
 
 													<c:if test="<%= fragmentDisplayContext.isLocked(fragmentCollection) %>">
-														<liferay-ui:icon
-															icon="lock"
-															iconCssClass="ml-1 text-muted"
-															markupView="lexicon"
-														/>
+														<span class="ml-1 text-muted">
+															<clay:icon
+																symbol="lock"
+															/>
+														</span>
 													</c:if>
 												</a>
 											</li>
@@ -187,11 +187,11 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 												>
 													<span class="text-truncate"><%= HtmlUtil.escape(fragmentCollection.getName()) %></span>
 
-													<liferay-ui:icon
-														icon="lock"
-														iconCssClass="ml-1 text-muted"
-														markupView="lexicon"
-													/>
+													<span class="ml-1 text-muted">
+														<clay:icon
+															symbol="lock"
+														/>
+													</span>
 												</a>
 											</li>
 
@@ -224,11 +224,11 @@ List<FragmentCollectionContributor> fragmentCollectionContributors = fragmentDis
 													<span class="text-truncate"><%= HtmlUtil.escape(fragmentCollection.getName()) %></span>
 
 													<c:if test="<%= fragmentDisplayContext.isLocked(fragmentCollection) %>">
-														<liferay-ui:icon
-															icon="lock"
-															iconCssClass="ml-1 text-muted"
-															markupView="lexicon"
-														/>
+														<span class="ml-1 text-muted">
+															<clay:icon
+																symbol="lock"
+															/>
+														</span>
 													</c:if>
 												</a>
 											</li>


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-168835)

## Test Scenario 1 - Contributed  Fragment Set 

* Navigate to Design - > Fragments.
* Check the lock icon in the fragment sets by default.
<img width="308" alt="Screen Shot 2023-01-30 at 09 13 44" src="https://user-images.githubusercontent.com/93203423/215426456-00a39ad8-2f3a-4ce7-b210-424bd06ffdc3.png">


## Test Scenario 2 - Inherited  Fragment Set 

* Go to Global site and navigate to Design - > Fragments.
* Create a new Fragment Collection (set).
* Crate a new Site and go to Design - > Fragments.
* Check the icon for global fragments.
<img width="341" alt="image" src="https://user-images.githubusercontent.com/93203423/215736711-daafc085-3f75-48ab-9fd8-0da1c66c0376.png">

## Test Scenario 3 - System  Fragment Set 

* Download the .zip in the ticket.
* Place it in the deploy folder of your bundle.
* Refresh the portal for the new site (the one you created for the second scenario) and navigate to Design - > Fragments.
* Check the new Default Fragment set "coleccion 1" with the lock icon.

![image](https://user-images.githubusercontent.com/93203423/215751506-50091401-2bf1-453b-bcac-b6a3c9441464.png)
