### PR TITLE
LPS-168834 Replace liferay-ui:icon with clay:icon in asset-taglib

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
@@ -19,10 +19,8 @@
 <liferay-util:buffer
 	var="removeLinkIcon"
 >
-	<liferay-ui:icon
-		icon="times-circle"
-		markupView="lexicon"
-		message="remove"
+	<clay:icon
+		symbol="times-circle"
 	/>
 </liferay-util:buffer>
 
@@ -78,7 +76,17 @@
 		<liferay-ui:search-container-column-text
 			cssClass="text-right"
 		>
-			<a class="modify-link" data-rowId="<%= assetLinkEntry.getEntryId() %>" href="javascript:void(0);"><%= removeLinkIcon %></a>
+			<span class="lfr-portal-tooltip ml-1">
+				<clay:link
+					aria-label='<%= LanguageUtil.get(request, "remove") %>'
+					cssClass="modify-link"
+					data-rowId="<%= assetLinkEntry.getEntryId() %>"
+					href="javascript:void(0);"
+					icon="times-circle"
+					title='<%= LanguageUtil.get(request, "remove") %>'
+					type="button"
+				/>
+			</span>
 		</liferay-ui:search-container-column-text>
 	</liferay-ui:search-container-row>
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/InputAssetLinkDropdownDefaultPropsTransformer.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/js/InputAssetLinkDropdownDefaultPropsTransformer.js
@@ -76,7 +76,15 @@ export default function propsTransformer({
 											</p>`);
 
 										rowColumns.push(
-											`<a class="float-right modify-link" data-rowId="${entityId}" href="javascript:void(0);">${additionalProps.removeIcon}</a>`
+											`<span class="float-right lfr-portal-tooltip ml-1">
+												<a 
+													aria-label=${Liferay.Language.get('remove')}
+													class="btn modify-link" data-rowId="${entityId}" href="javascript:void(0);" 
+													title=${Liferay.Language.get('remove')}
+												>
+													${additionalProps.removeIcon}
+												</a>
+											</span>`
 										);
 
 										searchContainer.addRow(


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-168834)


## Test Scenario

* Navigate to Content & Data - > Web Content
* Create a New web content and publish it.
* Click on the add button to create another Web content and go to the Related Asset tag on the right menu. 
* Select the first web content as the related asset and then check the icon to delete the asset.
<img width="344" alt="Screen Shot 2023-01-30 at 10 20 47" src="https://user-images.githubusercontent.com/93203423/215449693-e5dd60ab-9ef7-4613-a78c-4db8f1bf1b20.png">
