### PR TITLE
LPS-173995 Styles are lost in utility pages

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutUtilityPageEntryDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutUtilityPageEntryDisplayContext.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.taglib.internal.display.context;
+
+import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
+
+import java.util.Date;
+
+/**
+ * @author Jürgen Kappler
+ */
+public class RenderLayoutUtilityPageEntryDisplayContext {
+
+	public RenderLayoutUtilityPageEntryDisplayContext(
+		LayoutUtilityPageEntry layoutUtilityPageEntry) {
+
+		_layoutUtilityPageEntry = layoutUtilityPageEntry;
+	}
+
+	public String getHref() {
+		if (_layoutUtilityPageEntry == null) {
+			return StringPool.BLANK;
+		}
+
+		Layout layout = LayoutLocalServiceUtil.fetchLayout(
+			_layoutUtilityPageEntry.getPlid());
+
+		if (layout == null) {
+			return StringPool.BLANK;
+		}
+
+		StringBundler sb = new StringBundler(8);
+
+		sb.append(PortalUtil.getPathContext());
+		sb.append("/o/layout-common-styles/main.css?plid=");
+		sb.append(_layoutUtilityPageEntry.getPlid());
+		sb.append("&segmentsExperienceId=");
+		sb.append(
+			SegmentsExperienceLocalServiceUtil.fetchDefaultSegmentsExperienceId(
+				layout.getPlid()));
+		sb.append("&t=");
+		sb.append(_getModifiedDate(layout));
+
+		Layout masterLayout = LayoutLocalServiceUtil.fetchLayout(
+			layout.getMasterLayoutPlid());
+
+		if (masterLayout != null) {
+			sb.append(_getModifiedDate(masterLayout));
+		}
+
+		return sb.toString();
+	}
+
+	private String _getModifiedDate(Layout layout) {
+		Date modifiedDate = layout.getModifiedDate();
+
+		if (modifiedDate != null) {
+			return String.valueOf(modifiedDate.getTime());
+		}
+
+		return String.valueOf(System.currentTimeMillis());
+	}
+
+	private final LayoutUtilityPageEntry _layoutUtilityPageEntry;
+
+}

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutUtilityPageEntryTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutUtilityPageEntryTag.java
@@ -76,14 +76,20 @@ public class RenderLayoutUtilityPageEntryTag extends IncludeTag {
 	protected void setAttributes(HttpServletRequest httpServletRequest) {
 		super.setAttributes(httpServletRequest);
 
-		httpServletRequest.setAttribute(
-			"liferay-layout:render-layout-utility-page-entry:layoutStructure",
-			_getLayoutStructure());
-	}
-
-	private LayoutStructure _getLayoutStructure() {
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
 			_getLayoutUtilityPageEntry();
+
+		httpServletRequest.setAttribute(
+			"liferay-layout:render-layout-utility-page-entry:layoutStructure",
+			_getLayoutStructure(layoutUtilityPageEntry));
+		httpServletRequest.setAttribute(
+			"liferay-layout:render-layout-utility-page-entry:" +
+				"layoutUtilityPageEntry",
+			layoutUtilityPageEntry);
+	}
+
+	private LayoutStructure _getLayoutStructure(
+		LayoutUtilityPageEntry layoutUtilityPageEntry) {
 
 		if (layoutUtilityPageEntry == null) {
 			return null;

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_utility_page_entry/init.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_utility_page_entry/init.jsp
@@ -19,6 +19,8 @@
 <%@ taglib uri="http://liferay.com/tld/layout" prefix="liferay-layout" %>
 
 <%@ page import="com.liferay.layout.adaptive.media.LayoutAdaptiveMediaProcessor" %><%@
+page import="com.liferay.layout.taglib.internal.display.context.RenderLayoutUtilityPageEntryDisplayContext" %><%@
 page import="com.liferay.layout.taglib.internal.servlet.ServletContextUtil" %><%@
 page import="com.liferay.layout.util.structure.LayoutStructure" %><%@
+page import="com.liferay.layout.utility.page.model.LayoutUtilityPageEntry" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_utility_page_entry/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_utility_page_entry/page.jsp
@@ -18,9 +18,14 @@
 
 <%
 LayoutStructure layoutStructure = (LayoutStructure)request.getAttribute("liferay-layout:render-layout-utility-page-entry:layoutStructure");
+
+LayoutUtilityPageEntry layoutUtilityPageEntry = (LayoutUtilityPageEntry)request.getAttribute("liferay-layout:render-layout-utility-page-entry:layoutUtilityPageEntry");
+
+RenderLayoutUtilityPageEntryDisplayContext renderLayoutUtilityPageEntryDisplayContext = new RenderLayoutUtilityPageEntryDisplayContext(layoutUtilityPageEntry);
 %>
 
 <c:if test="<%= layoutStructure != null %>">
+	<link data-senna-track="temporary" href="<%= renderLayoutUtilityPageEntryDisplayContext.getHref() %>" rel="stylesheet" type="text/css" />
 
 	<%
 	try {


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-173995)

The goal of these changes is to prevent the loss of styles in utility pages view mode

## Change summary:

* Add a new dynamic include to include the styles of the utility page


## Test Scenario

* Enable FF feature.flag.LPS-162765=true
* Create a new site based on welcome site initializer
* Go to Site Builder > Pages
* Go to Utility Pages tab
* Mark existing 404 utility page as default
* Navigate to a non existing page in the site

![utility pages](https://user-images.githubusercontent.com/4267448/215794051-5ffe2a1d-8012-4bfd-878a-e78ebf9a1857.gif)


