### PR TITLE
LPS-174041 Enable keyboard navigation in Fragments and Widgets panel

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/config/constants/listItemTypes.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/config/constants/listItemTypes.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export const LIST_ITEM_TYPES = {
+	header: 'header',
+	listItem: 'listItem',
+};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/SearchResultsPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/SearchResultsPanel.js
@@ -32,14 +32,16 @@ export default function SearchResultsPanel({filteredTabs, loading = false}) {
 						{tab.label}
 					</div>
 
-					{tab.collections.map((collection, index) => (
-						<TabCollection
-							collection={collection}
-							initialOpen
-							isSearchResult
-							key={index}
-						/>
-					))}
+					<ul className="list-unstyled">
+						{tab.collections.map((collection, index) => (
+							<TabCollection
+								collection={collection}
+								initialOpen
+								isSearchResult
+								key={index}
+							/>
+						))}
+					</ul>
 				</div>
 			))}
 		</div>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/SearchResultsPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/SearchResultsPanel.js
@@ -32,7 +32,11 @@ export default function SearchResultsPanel({filteredTabs, loading = false}) {
 						{tab.label}
 					</div>
 
-					<ul className="list-unstyled">
+					<ul
+						aria-orientation="vertical"
+						className="list-unstyled"
+						role="menubar"
+					>
 						{tab.collections.map((collection, index) => (
 							<TabCollection
 								collection={collection}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabCollection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabCollection.js
@@ -53,7 +53,9 @@ export default function TabCollection({
 				))}
 
 			<ul
+				aria-orientation="vertical"
 				className={`list-unstyled page-editor__fragments-widgets__tab-collection-${displayStyle} pb-2 w-100`}
+				role="menu"
 			>
 				{collection.children.map((item) => (
 					<React.Fragment key={item.itemId}>
@@ -119,9 +121,13 @@ function TabCollectionCollapse({children, open, setOpen, title}) {
 	});
 
 	return (
-		<li className="page-editor__collapse panel-group panel-group-flush">
+		<li
+			className="page-editor__collapse panel-group panel-group-flush"
+			role="none"
+		>
 			<button
 				aria-expanded={open}
+				aria-haspopup="menu"
 				className={classNames(
 					'btn',
 					'btn-unstyled',
@@ -133,6 +139,7 @@ function TabCollectionCollapse({children, open, setOpen, title}) {
 				)}
 				onClick={() => setOpen(!open)}
 				ref={setElement}
+				role="menuitem"
 				tabIndex={isActive ? 0 : -1}
 				type="button"
 			>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabCollection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabCollection.js
@@ -18,8 +18,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 
 import {FRAGMENTS_DISPLAY_STYLES} from '../../../app/config/constants/fragmentsDisplayStyles';
+import {LIST_ITEM_TYPES} from '../../../app/config/constants/listItemTypes';
 import {config} from '../../../app/config/index';
 import {useSessionState} from '../../../common/hooks/useSessionState';
+import useKeyboardNavigation from '../hooks/useKeyboardNavigation';
 import TabItem from './TabItem';
 
 export default function TabCollection({
@@ -107,6 +109,15 @@ TabPortletItems.proptypes = {
 };
 
 function TabCollectionCollapse({children, open, setOpen, title}) {
+	const handleOpen = (nextOpen) => {
+		setOpen(!nextOpen);
+	};
+
+	const {isActive, setElement} = useKeyboardNavigation({
+		handleOpen,
+		type: LIST_ITEM_TYPES.header,
+	});
+
 	return (
 		<li className="page-editor__collapse panel-group panel-group-flush">
 			<button
@@ -121,6 +132,8 @@ function TabCollectionCollapse({children, open, setOpen, title}) {
 					}
 				)}
 				onClick={() => setOpen(!open)}
+				ref={setElement}
+				tabIndex={isActive ? 0 : -1}
 				type="button"
 			>
 				<span className="c-inner text-truncate" tabIndex={-1}>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabCollection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabCollection.js
@@ -12,12 +12,13 @@
  * details.
  */
 
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
 
 import {FRAGMENTS_DISPLAY_STYLES} from '../../../app/config/constants/fragmentsDisplayStyles';
 import {config} from '../../../app/config/index';
-import Collapse from '../../../common/components/Collapse';
 import {useSessionState} from '../../../common/hooks/useSessionState';
 import TabItem from './TabItem';
 
@@ -32,16 +33,11 @@ export default function TabCollection({
 		initialOpen
 	);
 
-	const handleOpen = (nextOpen) => {
-		setOpen(nextOpen);
-	};
-
 	return (
-		<Collapse
-			key={collection.collectionId}
-			label={collection.label}
-			onOpen={handleOpen}
-			open={isSearchResult || open}
+		<TabCollectionCollapse
+			open={open}
+			setOpen={setOpen}
+			title={collection.label}
 		>
 			{collection.collections &&
 				collection.collections.map((collection, index) => (
@@ -71,7 +67,7 @@ export default function TabCollection({
 					</React.Fragment>
 				))}
 			</ul>
-		</Collapse>
+		</TabCollectionCollapse>
 	);
 }
 
@@ -108,4 +104,47 @@ TabPortletItems.proptypes = {
 	portletItems: PropTypes.array,
 	preview: PropTypes.string,
 	type: PropTypes.string,
+};
+
+function TabCollectionCollapse({children, open, setOpen, title}) {
+	return (
+		<li className="page-editor__collapse panel-group panel-group-flush">
+			<button
+				aria-expanded={open}
+				className={classNames(
+					'btn',
+					'btn-unstyled',
+					'collapse-icon',
+					'sheet-subtitle',
+					{
+						collapsed: !open,
+					}
+				)}
+				onClick={() => setOpen(!open)}
+				type="button"
+			>
+				<span className="c-inner text-truncate" tabIndex={-1}>
+					{title}
+
+					<span
+						className={`text-secondary collapse-icon-${
+							open ? 'open' : 'closed'
+						}`}
+					>
+						<ClayIcon
+							symbol={open ? 'angle-down' : 'angle-right'}
+						/>
+					</span>
+				</span>
+			</button>
+
+			{open && children}
+		</li>
+	);
+}
+
+TabCollectionCollapse.proptypes = {
+	open: PropTypes.bool.isRequired,
+	setOpen: PropTypes.func.isRequired,
+	title: PropTypes.string.isRequired,
 };

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
@@ -23,6 +23,7 @@ import React, {useCallback, useRef} from 'react';
 
 import {FRAGMENTS_DISPLAY_STYLES} from '../../../app/config/constants/fragmentsDisplayStyles';
 import {LAYOUT_DATA_ITEM_TYPES} from '../../../app/config/constants/layoutDataItemTypes';
+import {LIST_ITEM_TYPES} from '../../../app/config/constants/listItemTypes';
 import {
 	useDisableKeyboardMovement,
 	useSetMovementSource,
@@ -34,6 +35,7 @@ import addWidget from '../../../app/thunks/addWidget';
 import toggleFragmentHighlighted from '../../../app/thunks/toggleFragmentHighlighted';
 import toggleWidgetHighlighted from '../../../app/thunks/toggleWidgetHighlighted';
 import {useDragSymbol} from '../../../app/utils/drag_and_drop/useDragAndDrop';
+import useKeyboardNavigation from '../hooks/useKeyboardNavigation';
 
 const ITEM_PROPTYPES_SHAPE = PropTypes.shape({
 	data: PropTypes.object.isRequired,
@@ -125,6 +127,10 @@ TabItem.propTypes = {
 };
 
 const ListItem = ({disabled, handlerRef, item, onToggleHighlighted}) => {
+	const {isActive, setElement} = useKeyboardNavigation({
+		type: LIST_ITEM_TYPES.listItem,
+	});
+
 	return (
 		<li
 			className={classNames(
@@ -135,6 +141,8 @@ const ListItem = ({disabled, handlerRef, item, onToggleHighlighted}) => {
 						item.data.portletItemId,
 				}
 			)}
+			ref={setElement}
+			tabIndex={isActive ? 0 : -1}
 		>
 			<div
 				className="align-items-center d-flex h-100 justify-content-between w-100"
@@ -146,10 +154,11 @@ const ListItem = ({disabled, handlerRef, item, onToggleHighlighted}) => {
 					<div className="text-truncate title">{item.label}</div>
 				</div>
 
-				{!disabled && <AddButton item={item} />}
+				{!disabled && <AddButton item={item} itemIsActive={isActive} />}
 
 				<HighlightButton
 					item={item}
+					itemIsActive={isActive}
 					onToggleHighlighted={onToggleHighlighted}
 				/>
 			</div>
@@ -165,12 +174,18 @@ ListItem.propTypes = {
 };
 
 const CardItem = ({disabled, handlerRef, item, onToggleHighlighted}) => {
+	const {isActive, setElement} = useKeyboardNavigation({
+		type: LIST_ITEM_TYPES.listItem,
+	});
+
 	return (
 		<li
 			className={classNames(
 				'page-editor__fragments-widgets__tab-card-item',
 				{disabled}
 			)}
+			ref={setElement}
+			tabIndex={isActive ? 0 : -1}
 		>
 			<div ref={handlerRef}>
 				<ClayCard
@@ -212,10 +227,16 @@ const CardItem = ({disabled, handlerRef, item, onToggleHighlighted}) => {
 								</section>
 							</div>
 
-							{!disabled && <AddButton item={item} />}
+							{!disabled && (
+								<AddButton
+									item={item}
+									itemIsActive={isActive}
+								/>
+							)}
 
 							<HighlightButton
 								item={item}
+								itemIsActive={isActive}
 								onToggleHighlighted={onToggleHighlighted}
 							/>
 						</ClayCard.Row>
@@ -233,7 +254,7 @@ CardItem.propTypes = {
 	onToggleHighlighted: PropTypes.func.isRequired,
 };
 
-const HighlightButton = ({item, onToggleHighlighted}) => {
+const HighlightButton = ({item, itemIsActive, onToggleHighlighted}) => {
 	if (item.data.portletItemId) {
 		return null;
 	}
@@ -254,6 +275,7 @@ const HighlightButton = ({item, onToggleHighlighted}) => {
 			displayType="secondary"
 			onClick={onToggleHighlighted}
 			symbol={highlighted ? 'star' : 'star-o'}
+			tabIndex={itemIsActive ? 0 : -1}
 			title={title}
 		/>
 	);
@@ -261,10 +283,11 @@ const HighlightButton = ({item, onToggleHighlighted}) => {
 
 HighlightButton.propTypes = {
 	item: ITEM_PROPTYPES_SHAPE.isRequired,
+	itemIsActive: PropTypes.bool.isRequired,
 	onToggleHighlighted: PropTypes.func.isRequired,
 };
 
-const AddButton = ({item}) => {
+const AddButton = ({item, itemIsActive}) => {
 	const setMovementSource = useSetMovementSource();
 	const disableMovement = useDisableKeyboardMovement();
 
@@ -291,6 +314,7 @@ const AddButton = ({item}) => {
 			ref={buttonRef}
 			role="application"
 			symbol="plus"
+			tabIndex={itemIsActive ? 0 : -1}
 			title={sub(Liferay.Language.get('add-x'), item.label)}
 		/>
 	);
@@ -298,4 +322,5 @@ const AddButton = ({item}) => {
 
 AddButton.propTypes = {
 	item: PropTypes.object.isRequired,
+	itemIsActive: PropTypes.bool.isRequired,
 };

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
@@ -142,6 +142,7 @@ const ListItem = ({disabled, handlerRef, item, onToggleHighlighted}) => {
 				}
 			)}
 			ref={setElement}
+			role="menuitem"
 			tabIndex={isActive ? 0 : -1}
 		>
 			<div
@@ -185,6 +186,7 @@ const CardItem = ({disabled, handlerRef, item, onToggleHighlighted}) => {
 				{disabled}
 			)}
 			ref={setElement}
+			role="menuitem"
 			tabIndex={isActive ? 0 : -1}
 		>
 			<div ref={handlerRef}>
@@ -312,7 +314,6 @@ const AddButton = ({item, itemIsActive}) => {
 				})
 			}
 			ref={buttonRef}
-			role="application"
 			symbol="plus"
 			tabIndex={itemIsActive ? 0 : -1}
 			title={sub(Liferay.Language.get('add-x'), item.label)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
@@ -105,16 +105,16 @@ export default function TabItem({displayStyle, item}) {
 	return displayStyle === FRAGMENTS_DISPLAY_STYLES.CARDS ? (
 		<CardItem
 			disabled={item.disabled || isDraggingSource}
+			handlerRef={item.disabled ? null : sourceRef}
 			item={item}
 			onToggleHighlighted={onToggleHighlighted}
-			ref={sourceRef}
 		/>
 	) : (
 		<ListItem
 			disabled={item.disabled || isDraggingSource}
+			handlerRef={item.disabled ? null : sourceRef}
 			item={item}
 			onToggleHighlighted={onToggleHighlighted}
-			ref={item.disabled ? null : sourceRef}
 		/>
 	);
 }
@@ -124,19 +124,21 @@ TabItem.propTypes = {
 	item: ITEM_PROPTYPES_SHAPE.isRequired,
 };
 
-const ListItem = React.forwardRef(
-	({disabled, item, onToggleHighlighted}, ref) => {
-		return (
-			<li
-				className={classNames(
-					'align-items-center d-flex justify-content-between mb-1 page-editor__fragments-widgets__tab-list-item rounded',
-					{
-						disabled,
-						'ml-3 page-editor__fragments-widgets__tab-portlet-item':
-							item.data.portletItemId,
-					}
-				)}
-				ref={ref}
+const ListItem = ({disabled, handlerRef, item, onToggleHighlighted}) => {
+	return (
+		<li
+			className={classNames(
+				'mb-1 page-editor__fragments-widgets__tab-list-item rounded',
+				{
+					disabled,
+					'ml-3 page-editor__fragments-widgets__tab-portlet-item':
+						item.data.portletItemId,
+				}
+			)}
+		>
+			<div
+				className="align-items-center d-flex h-100 justify-content-between w-100"
+				ref={handlerRef}
 			>
 				<div className="align-items-center d-flex page-editor__fragments-widgets__tab-list-item-body">
 					<ClayIcon className="mr-3" symbol={item.icon} />
@@ -150,27 +152,27 @@ const ListItem = React.forwardRef(
 					item={item}
 					onToggleHighlighted={onToggleHighlighted}
 				/>
-			</li>
-		);
-	}
-);
+			</div>
+		</li>
+	);
+};
 
 ListItem.propTypes = {
 	disabled: PropTypes.bool.isRequired,
+	handlerRef: PropTypes.func.isRequired,
 	item: ITEM_PROPTYPES_SHAPE.isRequired,
 	onToggleHighlighted: PropTypes.func.isRequired,
 };
 
-const CardItem = React.forwardRef(
-	({disabled, item, onToggleHighlighted}, ref) => {
-		return (
-			<li
-				className={classNames(
-					'page-editor__fragments-widgets__tab-card-item',
-					{disabled}
-				)}
-				ref={ref}
-			>
+const CardItem = ({disabled, handlerRef, item, onToggleHighlighted}) => {
+	return (
+		<li
+			className={classNames(
+				'page-editor__fragments-widgets__tab-card-item',
+				{disabled}
+			)}
+		>
+			<div ref={handlerRef}>
 				<ClayCard
 					aria-label={item.label}
 					className="mb-0"
@@ -225,13 +227,14 @@ const CardItem = React.forwardRef(
 						</ClayCard.Row>
 					</ClayCard.Body>
 				</ClayCard>
-			</li>
-		);
-	}
-);
+			</div>
+		</li>
+	);
+};
 
 CardItem.propTypes = {
 	disabled: PropTypes.bool.isRequired,
+	handlerRef: PropTypes.func.isRequired,
 	item: ITEM_PROPTYPES_SHAPE.isRequired,
 	onToggleHighlighted: PropTypes.func.isRequired,
 };

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
@@ -212,18 +212,12 @@ const CardItem = ({disabled, handlerRef, item, onToggleHighlighted}) => {
 								</section>
 							</div>
 
-							{!disabled && (
-								<div className="autofit-col">
-									<AddButton item={item} />
-								</div>
-							)}
+							{!disabled && <AddButton item={item} />}
 
-							<div className="autofit-col">
-								<HighlightButton
-									item={item}
-									onToggleHighlighted={onToggleHighlighted}
-								/>
-							</div>
+							<HighlightButton
+								item={item}
+								onToggleHighlighted={onToggleHighlighted}
+							/>
 						</ClayCard.Row>
 					</ClayCard.Body>
 				</ClayCard>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabsPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabsPanel.js
@@ -148,23 +148,27 @@ export default function TabsPanel({
 							key={index}
 						>
 							{tab.collections.length ? (
-								<ul className="list-unstyled">
+								<ul
+									aria-orientation="vertical"
+									className="list-unstyled"
+									role="menubar"
+								>
 									{tab.collections.map(
 										(collection, index) => (
-									<TabCollection
-										collection={collection}
-										displayStyle={
+											<TabCollection
+												collection={collection}
+												displayStyle={
 													tab.id ===
 													COLLECTION_IDS.widgets
-												? FRAGMENTS_DISPLAY_STYLES.LIST
-												: displayStyle
-										}
-										initialOpen={
-											index <
-											INITIAL_EXPANDED_ITEM_COLLECTIONS
-										}
-										key={index}
-									/>
+														? FRAGMENTS_DISPLAY_STYLES.LIST
+														: displayStyle
+												}
+												initialOpen={
+													index <
+													INITIAL_EXPANDED_ITEM_COLLECTIONS
+												}
+												key={index}
+											/>
 										)
 									)}
 								</ul>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabsPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabsPanel.js
@@ -148,11 +148,14 @@ export default function TabsPanel({
 							key={index}
 						>
 							{tab.collections.length ? (
-								tab.collections.map((collection, index) => (
+								<ul className="list-unstyled">
+									{tab.collections.map(
+										(collection, index) => (
 									<TabCollection
 										collection={collection}
 										displayStyle={
-											tab.id === COLLECTION_IDS.widgets
+													tab.id ===
+													COLLECTION_IDS.widgets
 												? FRAGMENTS_DISPLAY_STYLES.LIST
 												: displayStyle
 										}
@@ -162,7 +165,9 @@ export default function TabsPanel({
 										}
 										key={index}
 									/>
-								))
+										)
+									)}
+								</ul>
 							) : (
 								<ClayLoadingIndicator size="sm" />
 							)}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/_TabItem.scss
@@ -14,8 +14,10 @@ html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 			}
 		}
 
-		&:hover:not(.disabled) {
+		&:hover:not(.disabled),
+		&:focus {
 			box-shadow: 0 4px 8px fade_out($cadmin-gray-900, 0.9);
+			outline: none;
 			transform: translateY(-4px);
 
 			.card {
@@ -115,9 +117,11 @@ html#{$cadmin-selector} .cadmin .page-editor__fragments-widgets__tab {
 			}
 		}
 
-		&:hover:not(.disabled) {
+		&:hover:not(.disabled),
+		&:focus {
 			box-shadow: 0 0 0 2px $cadmin-primary-l1,
 				0 4px 8px fade_out($cadmin-gray-900, 0.9);
+			outline: 0;
 			transform: translateX(-4px);
 
 			.page-editor__fragments-widgets__tab__highlight-button {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/hooks/useKeyboardNavigation.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/hooks/useKeyboardNavigation.js
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {useEventListener} from '@liferay/frontend-js-react-web';
+import {useEffect, useState} from 'react';
+
+import {
+	ARROW_DOWN_KEYCODE,
+	ARROW_LEFT_KEYCODE,
+	ARROW_RIGHT_KEYCODE,
+	ARROW_UP_KEYCODE,
+} from '../../../app/config/constants/keycodes';
+import {LIST_ITEM_TYPES} from '../../../app/config/constants/listItemTypes';
+
+const ALLOWED_KEYCODES = [
+	ARROW_DOWN_KEYCODE,
+	ARROW_LEFT_KEYCODE,
+	ARROW_RIGHT_KEYCODE,
+	ARROW_UP_KEYCODE,
+];
+
+export default function useKeyboardNavigation({handleOpen, type}) {
+	const [element, setElement] = useState(null);
+	const [isActive, setIsActive] = useState(false);
+
+	useEffect(() => {
+		const list = element?.closest('[role="menubar"]');
+		const listItem = element?.closest('li');
+
+		const isFirstChild = listItem === list?.firstChild;
+
+		setIsActive(isFirstChild);
+	}, [element]);
+
+	useEventListener(
+		'keydown',
+		(event) => {
+			if (!ALLOWED_KEYCODES.includes(event.keyCode)) {
+				return;
+			}
+
+			event.preventDefault();
+
+			if (type === LIST_ITEM_TYPES.header) {
+				onHeaderKeyDown(element, event.keyCode, handleOpen);
+			}
+			else if (type === LIST_ITEM_TYPES.listItem) {
+				onListItemKeyDown(element, event.keyCode);
+			}
+		},
+		true,
+		element
+	);
+
+	useEventListener('focus', () => setIsActive(true), true, element);
+
+	useEventListener(
+		'blur',
+		(event) => {
+			const list = event.target.closest('[role="menubar"]');
+
+			const nextActiveElement = event.relatedTarget;
+
+			if (list.contains(nextActiveElement)) {
+				setIsActive(false);
+			}
+		},
+		true,
+		element
+	);
+
+	return {isActive, setElement};
+}
+
+function onHeaderKeyDown(element, keyCode, handleOpen) {
+	if (keyCode === ARROW_DOWN_KEYCODE) {
+
+		// Target first item of the list. If it's collapsed, target next header
+
+		const list = element.nextSibling;
+		const firstItem = list?.querySelector('li');
+
+		if (firstItem) {
+			firstItem.focus();
+		}
+		else {
+			const collapse = element.parentElement;
+			const nextCollapse = collapse.nextSibling;
+			const nextHeader = nextCollapse?.querySelector('button');
+
+			nextHeader?.focus();
+		}
+	}
+	else if (keyCode === ARROW_UP_KEYCODE) {
+
+		// Target last item of the previous list. If it's collapsed, target previous header
+
+		const collapse = element.parentElement;
+		const previousCollapse = collapse.previousSibling;
+
+		if (!previousCollapse) {
+			return;
+		}
+
+		const previousList = previousCollapse.querySelector('ul');
+
+		if (previousList) {
+			const lastItem = previousList.lastChild;
+
+			lastItem.focus();
+		}
+		else {
+			const previousHeader = previousCollapse.querySelector('button');
+
+			previousHeader.focus();
+		}
+	}
+	else if (keyCode === ARROW_RIGHT_KEYCODE) {
+
+		// Expand
+
+		handleOpen(true);
+	}
+	else if (keyCode === ARROW_LEFT_KEYCODE) {
+
+		// Collapse
+
+		handleOpen(false);
+	}
+}
+
+function onListItemKeyDown(element, keyCode) {
+	if (keyCode === ARROW_UP_KEYCODE) {
+
+		// Target previous list item. If it's the first one, target header
+
+		if (element.previousSibling) {
+			element.previousSibling.focus();
+		}
+		else {
+			const collapse = element.closest('.page-editor__collapse');
+			const header = collapse.querySelector('button');
+
+			header.focus();
+		}
+	}
+	else if (keyCode === ARROW_DOWN_KEYCODE) {
+
+		// Target next list item. If it's the last one, target next header
+
+		if (element.nextSibling) {
+			element.nextSibling.focus();
+		}
+		else {
+			const collapse = element.closest('.page-editor__collapse');
+			const nextCollapse = collapse.nextSibling;
+			const nextHeader = nextCollapse?.querySelector('button');
+
+			nextHeader?.focus();
+		}
+	}
+	else if (keyCode === ARROW_RIGHT_KEYCODE) {
+
+		// If the active element is the list item itself, target first option button
+
+		// If the active element is an option button, target the next one
+
+		if (document.activeElement === element) {
+			const firstButton = element.querySelector('button');
+
+			firstButton.focus();
+		}
+		else {
+			const nextButton = document.activeElement.nextSibling;
+
+			nextButton?.focus();
+		}
+	}
+	else if (keyCode === ARROW_LEFT_KEYCODE) {
+
+		// If the previous element is another button, target it, otherwise target the list item
+
+		const previousSibling = document.activeElement.previousSibling;
+
+		if (previousSibling?.tagName === 'BUTTON') {
+			previousSibling.focus();
+		}
+		else {
+			element.focus();
+		}
+	}
+}


### PR DESCRIPTION
Motivation
=======
This PR introduces keyboard navigation in Fragments and Widgets panel. From now, we are able to navigate with keyboard arrows in this way:
- ⬆️ and ⬇️: move from one list item to another
- ➡️ and ⬅️: open/close collapses when focusing a header, and move between fragment/widget buttons (➕ and ⭐️) when focusing a fragment/widget

Markup and roles are updated to make it more readable and correct in terms of accesibility. The solution implements [roving tabIndex pattern](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex), so users can leave the list by tabing without the need of traversing the whole list. 

Solution is tested with **JAWS**.

Steps to Verify
========
1. Add a content page
1. Open Fragments and Widgets sidebar panel
1. Tab with keyboard until reaching first fragment set header
1. Navigate with keyboard arrows
