### PR TITLE
[TS] LPS-174456 Form Container fragment is not showing correctly title from a picklist object field

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.js
@@ -286,7 +286,7 @@ function createOptionElement(option) {
 	// eslint-disable-next-line no-undef
 	optionElement.id = `${fragmentEntryLinkNamespace}-option-${option.value}`;
 
-	if(typeof option.textContent === 'object'){
+	if (typeof option.textContent === 'object') {
 		optionElement.textContent = option.textContent.name;
 	}
 	else {

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.js
@@ -285,8 +285,13 @@ function createOptionElement(option) {
 	optionElement.dataset.optionValue = option.value;
 	// eslint-disable-next-line no-undef
 	optionElement.id = `${fragmentEntryLinkNamespace}-option-${option.value}`;
-	optionElement.textContent = option.textContent;
 
+	if(typeof option.textContent === 'object'){
+		optionElement.textContent = option.textContent.name;
+	}
+	else {
+		optionElement.textContent = option.textContent;
+	}
 	optionElement.classList.add('dropdown-item');
 	optionElement.setAttribute('role', 'option');
 


### PR DESCRIPTION
Motivation
=======
This PR is aimed to solve [LPS-174456](https://issues.liferay.com/browse/LPS-174456), If you map an object with a picklist field into a form container, it doesn't show the title of the options, [Object Object] is shown.

Proposed Solution
========
When the option fields are created, check if the "option.textContent" is an object, and get the name of it.

Steps to Verify
========

1. Create a Picklist with some values.
2. Create an Object (A) with a picklist field (use the one form step 1), use this field as Title field and publish it.
3. Create an Obejct (B) with a text field and publish it.
4. Create "One to Many" relationship from A to B.
5. Create several items of Object A.
6. Create a content page, add the Form Container fragment and map it with object B.
7. Publish the page.
8. View the page and click on the dropdown menu that relates B with A.

Screenshots (if applies)
========
Images/animations that showcase the changes
![image](https://user-images.githubusercontent.com/48210442/216333442-84fc7fc9-318d-4a7c-8442-67f1ac041357.png)
![image](https://user-images.githubusercontent.com/48210442/216333348-1f18a080-20a1-4fa8-afc1-750f34ade29f.png)


Checklist (optional)
========

CODE:
- [X] I have considered breaking this PR into smaller PRs if the amount of changed code is too large
- [X] I have performed a self-review of my own code following Liferay's code conventions
- [X] I have checked other areas of the product for solutions to similar problems
- [ ] I have added tests that prove my fix is effective or that my feature works

COMMITS:
- [X] My commits organize changes in coherent units
- [X] There are no commits which should be combined into others
- [X] My commits are ordered in a way that ease understanding
- [X] My commit messages are well formatted and concisely describe what was changed and why it was changed