### PR TITLE
[TS] LPS-174480 | Content page live version disappears after publishing a translation from the translation feature

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/helper/LayoutInfoItemFieldValuesUpdaterHelper.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/info/item/helper/LayoutInfoItemFieldValuesUpdaterHelper.java
@@ -29,7 +29,6 @@ import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
 
@@ -193,14 +192,6 @@ public class LayoutInfoItemFieldValuesUpdaterHelper {
 
 		if (layout.isDraftLayout()) {
 			layout.setStatus(WorkflowConstants.STATUS_DRAFT);
-
-			UnicodeProperties unicodeProperties =
-				layout.getTypeSettingsProperties();
-
-			unicodeProperties.setProperty(
-				"published", Boolean.FALSE.toString());
-
-			layout.setTypeSettingsProperties(unicodeProperties);
 		}
 
 		return _layoutLocalService.updateLayout(layout);


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-174480
Thank you!

-------

**Steps to reproduce:**
1. Create a content page
2. Put an HTML fragment on it, edit it and put 'EN' in it somewhere
3. Publish, then go to its context menu -> Translate
4. Put 'AR' in the HTML fragment on the right side, publish
5. Notice that the layout is in draft state
6. Try to open the page by its URL in incognito mode

**Current behavior:** Resource not found error and a 404 error in the browser console
**Expected behavior:** Page should be opened


Based on my tests and understanding, the live versions of the layouts are created at the same time as the draft versions. To avoid displaying empty pages, we do not show live layouts without a publised=live typesettings in their draft counterpart. The translation feature sets this published to false. This behavior results in the disappearance of the live layout, even though only the draft layout was changed. My solution simply removes the typesettings relevant part and only changes the draft layout into draft status.
