### PR TITLE
[TS] LPS-174627 | Content page loses portlet configuration after opening the translation feature

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/util/InfoFieldUtil.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/util/InfoFieldUtil.java
@@ -68,6 +68,10 @@ public class InfoFieldUtil {
 					layout.getPlid());
 
 		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
+			if (fragmentEntryLink.isTypePortlet()) {
+				continue;
+			}
+
 			String defaultElementName =
 				"defaultElementName" + StringUtil.randomId();
 


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-174627
Thank you!

----

**Steps to reproduce:**

1. Create a content page
2. Put an Asset Publisher on the page and configure it do 'Dynamic' and set Web content article as the source
3. Publish, then go to its context menu -> Translate
4. Put 'AR' in the HTML fragment on the right side, save as draft
5. Open the page

**Current behavior:** The asset publisher lost the selected dynamic configuration
**Expected behavior:** The asset publisher should keep the configuration



The root cause of the issue is that when we call the getHTML for a fragmentEntryLink for a widget the processors will create a new portletPreference while generating the HTML for the control panel which will belong to the Plid = 1. This portletPreference will be handled as a shared preference and will overrule the live version. As the modified part of the code only tries to collect editableTypes we can skip all fragmentEntrylinks with isTypePortlet() = true.