### PR TITLE
LPS-168839 Replace liferay-ui:icon in layout-admin-web

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/customization_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/customization_settings.jsp
@@ -21,18 +21,16 @@ String portletNamespace = PortalUtil.getPortletNamespace(LayoutAdminPortletKeys.
 %>
 
 <div class="active control-menu-link customization-link d-block d-md-none">
-	<liferay-ui:icon
+	<clay:icon
+		aria-label='<%= LanguageUtil.get(request, "this-page-can-be-customized") %>'
+		cssClass="lfr-portal-tooltip"
 		data='<%=
 			HashMapBuilder.<String, Object>put(
 				"qa-id", "customizations"
 			).build()
 		%>'
-		icon="pencil"
 		id='<%= portletNamespace + "customizationButton" %>'
-		label="<%= false %>"
-		linkCssClass="btn btn-monospaced btn-sm control-menu-icon"
-		markupView="lexicon"
-		message="this-page-can-be-customized"
-		url="javascript:void(0);"
+		symbol="pencil"
+		title='<%= LanguageUtil.get(request, "this-page-can-be-customized") %>'
 	/>
 </div>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/customization_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/customization_settings.jsp
@@ -20,15 +20,10 @@
 String portletNamespace = PortalUtil.getPortletNamespace(LayoutAdminPortletKeys.GROUP_PAGES);
 %>
 
-<div class="active control-menu-link customization-link d-block d-md-none">
+<div class="active control-menu-link customization-link d-block d-md-none lfr-portal-tooltip">
 	<clay:icon
 		aria-label='<%= LanguageUtil.get(request, "this-page-can-be-customized") %>'
-		cssClass="lfr-portal-tooltip"
-		data='<%=
-			HashMapBuilder.<String, Object>put(
-				"qa-id", "customizations"
-			).build()
-		%>'
+		data-qa-id="customizations"
 		id='<%= portletNamespace + "customizationButton" %>'
 		symbol="pencil"
 		title='<%= LanguageUtil.get(request, "this-page-can-be-customized") %>'

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/init.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/init.jsp
@@ -16,8 +16,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.layout.admin.constants.LayoutAdminPortletKeys" %><%@
 page import="com.liferay.layout.admin.web.internal.constants.LayoutAdminWebKeys" %><%@

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/customization_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/customization_settings.jsp
@@ -31,26 +31,16 @@ boolean hasUpdateLayoutPermission = GetterUtil.getBoolean(request.getAttribute(C
 <div id="<%= portletNamespace %>customizationBar">
 	<div class="control-menu-level-2 py-2">
 		<clay:container-fluid>
-			<div class="control-menu-level-2-heading d-block d-md-none">
-				<liferay-ui:message key="customization-options" />
-
-				<button aria-label="<%= LanguageUtil.get(request, "close") %>" class="close" id="<%= portletNamespace %>closeCustomizationOptions" type="button">
-					<aui:icon image="times" markupView="lexicon" />
-				</button>
-			</div>
-
 			<ul class="control-menu-level-2-nav control-menu-nav flex-column flex-md-row">
 				<li class="control-menu-nav-item flex-shrink-1 mb-0">
 					<span class="text-info">
-						<liferay-ui:icon
+						<clay:icon
 							data='<%=
 								HashMapBuilder.<String, Object>put(
 									"qa-id", "customizations"
 								).build()
 							%>'
-							icon="info-circle"
-							label="<%= false %>"
-							markupView="lexicon"
+							symbol="info-circle"
 						/>
 
 						<c:choose>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/information_messages.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/information_messages.jsp
@@ -20,13 +20,14 @@
 LayoutInformationMessagesDisplayContext layoutInformationMessagesDisplayContext = new LayoutInformationMessagesDisplayContext(request);
 %>
 
-<li class="control-menu-nav-item">
-	<liferay-ui:icon
+<li class="control-menu-nav-item lfr-portal-tooltip">
+	<clay:button
+		aria-label='<%= LanguageUtil.get(request, "additional-information") %>'
 		cssClass="control-menu-icon icon-monospaced"
-		icon="information-live"
-		label="<%= false %>"
-		markupView="lexicon"
-		message="additional-information"
+		data-qa-id="info"
+		displayType="unstyled"
+		symbol="information-live"
+		title='<%= LanguageUtil.get(request, "additional-information") %>'
 	/>
 
 	<react:component

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/error_friendly_url_exception.jspf
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/error_friendly_url_exception.jspf
@@ -15,10 +15,10 @@
 --%>
 
 <c:if test="<%= exceptionLocale != null %>">
-	<liferay-ui:icon
-		image='<%= "../language/" + LocaleUtil.toLanguageId(exceptionLocale) %>'
-		lang="<%= LocaleUtil.toW3cLanguageId(exceptionLocale) %>"
-		message=""
+	<clay:icon
+		aria-label="<%= LocaleUtil.toLanguageId(exceptionLocale) %>"
+		symbol="<%= LocaleUtil.toW3cLanguageId(exceptionLocale).toLowerCase() %>"
+		title="<%= LocaleUtil.toLanguageId(exceptionLocale) %>"
 	/>
 </c:if>
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/orphan_portlets_action.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/orphan_portlets_action.jsp
@@ -28,9 +28,11 @@ Portlet portlet = (Portlet)row.getObject();
 	<portlet:param name="selPlid" value="<%= String.valueOf(layoutsAdminDisplayContext.getSelPlid()) %>" />
 </portlet:actionURL>
 
-<liferay-ui:icon
+<clay:link
+	aria-label='<%= LanguageUtil.get(request, "delete") %>'
+	cssClass="lfr-portal-tooltip"
+	href="<%= deleteOrphanPortletsURL %>"
 	icon="trash"
-	linkCssClass="icon-monospaced text-default"
-	markupView="lexicon"
-	url="<%= deleteOrphanPortletsURL %>"
+	monospaced="<%= true %>"
+	title='<%= LanguageUtil.get(request, "delete") %>'
 />


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-168839)

## Test Scenario 1

* Navigate to Site Builder > Pages and create a Widget page.
* In the configuration, go to General > Advanced and activate the customization settings.
<img width="267" alt="Pasted Graphic 6" src="https://user-images.githubusercontent.com/93203423/217043162-52e6ad90-22f8-42e9-9855-e7ae913e4996.png">
* Save and go to View to see the behaviour of the icon for help in the top of the page.
<img width="1265" alt="Liferay DXP" src="https://user-images.githubusercontent.com/93203423/217043235-36d6b574-ac0f-44db-9d9a-e015e05e0128.png">

# Test Scenario 2

* After following the steps in “test scenario 1” to check this you only have to make the tab browser small and check the icon that appears next to the name of the page.
<img width="657" alt="Widget page test" src="https://user-images.githubusercontent.com/93203423/217043299-734b04c8-7d24-49ae-8a4c-be5c3fce9bf1.png">
Note: the actual is an icon instead of a button because it only informs but there’s not an associated action.

# Test Scenario 3

* Create a new Site Template with a content page.
* Create a site based on this Site Template and then edit the page you created before. Publish it.
* Then go to edit again and you should be able to see this button next to the name. Verify the behaviour.
<img width="341" alt="Additional Information" src="https://user-images.githubusercontent.com/93203423/217043404-6c6b9075-8328-40f6-b8ee-53c379202273.png">

# Test Scenario 4

* Using the content page of “test scenario 3”, go to Configure Page in the top options of the page, and go to the friendly URL tab.
* Delete the slash at the beginning and check the message:
<img width="773" alt="General" src="https://user-images.githubusercontent.com/93203423/217043496-a91539c6-1f16-458d-8079-9e11b547ba51.png">

# Test Scenario 5

* After following the steps in “test scenario 1”, add some widgets to the widget page created and then go to the miller columns.
* Then open the dropdown menu and select “Orphan widgets”.
* Check the delete button on the right column.
<img width="1256" alt="Pasted Graphic 11" src="https://user-images.githubusercontent.com/93203423/217043545-4f42e65e-c454-432d-ac4e-902776fe6b0d.png">
