### PR TITLE
LPS-174483 Use placeholder in edit mode

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.html
@@ -1,9 +1,118 @@
 <div class="rich-text-input [#if !input.showLabel || !input.label?has_content]rich-text-input--hidden-label[/#if]">
 	<div class="form-group mb-0">
-		[@liferay_editor["editor"] contents=input.value editorName="ckeditor" name=input.name placeholder=input.label required=input.required /]
+
+		[#if layoutMode == "edit"]
+			[@liferay_editor["resources"] editorName="ckeditor" /]
+
+			<link href="/o/frontend-editor-ckeditor-web/ckeditor/skins/moono-lexicon/editor_gecko.css" rel="stylesheet" />
+
+			<div role="presentation">
+				[#if input.showLabel && input.label?has_content]
+					<label role="presentation">
+						${htmlUtil.escape(input.label)}
+						[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+					</label>
+				[/#if]
+
+				<div class="cke cke_chrome cke_reset cke_ltr">
+					<div class="cke_inner">
+						<div class="cke_top cke_reset_all">
+							<div class="cke_toolbox">
+								<div class="cke_toolbar">
+									<div class="cke_toolgroup mb-0">
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__undo_icon"></div>
+										</a>
+
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__redo_icon"></div>
+										</a>
+									</div>
+								</div>
+
+								<div class="cke_toolbar">
+									<a class="cke_button cke_button_disabled">
+										<div class="cke_button_label cke_button__source_label text-muted">Styles</div>
+									</a>
+
+									<div class="cke_toolgroup mb-0">
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__bold_icon"></div>
+										</a>
+
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__italic_icon"></div>
+										</a>
+
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__underline_icon"></div>
+										</a>
+									</div>
+								</div>
+
+								<div class="cke_toolbar">
+									<div class="cke_toolgroup mb-0">
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__bulletedlist_icon"></div>
+										</a>
+
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__numberedlist_icon"></div>
+										</a>
+									</div>
+								</div>
+
+								<div class="cke_toolbar">
+									<div class="cke_toolgroup mb-0">
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__link_icon"></div>
+										</a>
+
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__unlink_icon"></div>
+										</a>
+									</div>
+								</div>
+
+								<div class="cke_toolbar">
+									<div class="cke_toolgroup mb-0">
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__table_icon"></div>
+										</a>
+
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__image_icon"></div>
+										</a>
+
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__videoselector_icon"></div>
+										</a>
+									</div>
+								</div>
+
+								<div class="cke_toolbar">
+									<div class="cke_toolgroup mb-0">
+										<a class="cke_button cke_button_disabled">
+											<div class="cke_button_icon cke_button__source_icon"></div>
+											<div class="cke_button_label cke_button__source_label text-muted">Source</div>
+										</a>
+									</div>
+								</div>
+							</div>
+						</div>
+
+						<div class="cke_contents cke_editable" style="height: 200px"></div>
+					</div>
+				</div>
+			</div>
+		[#else]
+			[@liferay_editor["editor"] contents=input.value editorName="ckeditor" name=input.name placeholder=input.label required=input.required /]
+		[/#if]
 
 		[#if input.showHelpText && input.helpText?has_content]
-			<p class="mb-0 mt-1 text-secondary" id="${fragmentEntryLinkNamespace}-rich-text-input-help-text">${htmlUtil.escape(input.helpText)}</p>
+			<p class="mb-0 mt-1 text-secondary" id="${fragmentEntryLinkNamespace}-rich-text-input-help-text">
+				${htmlUtil.escape(input.helpText)}
+			</p>
 		[/#if]
 	</div>
 </div>


### PR DESCRIPTION
Instead of modifying existing taglib (which has some issues in edit mode) we can replace it with some fake HTML during edit mode, as it does not need to be interactive.