### PR TITLE
[TS] LPP-47459 -> LPS-175068 Display Date in the web content structure is auto reset to blank

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -766,6 +766,12 @@ public class JournalArticleLocalServiceImpl
 			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
 			displayDateMinute, user.getTimeZone(), null);
 
+		if ((displayDateMonth == displayDateDay) &&
+			(displayDateDay == displayDateYear) && (displayDateYear == 0)) {
+
+			displayDate = null;
+		}
+
 		Date expirationDate = null;
 		Date reviewDate = null;
 
@@ -6313,6 +6319,13 @@ public class JournalArticleLocalServiceImpl
 		}
 
 		JournalArticle article = getArticle(groupId, articleId);
+
+		if ((article.getClassNameId() > 0) &&
+			(displayDateMonth == displayDateDay) &&
+			(displayDateDay == displayDateYear) && (displayDateYear == 0)) {
+
+			displayDate = null;
+		}
 
 		serviceContext.validateModifiedDate(
 			article, ArticleVersionException.class);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -406,6 +406,8 @@ public class JournalEditArticleDisplayContext {
 		).put(
 			"defaultLanguageId", getDefaultArticleLanguageId()
 		).put(
+			"displayDate", (_article == null) ? null : _article.getDisplayDate()
+		).put(
 			"hasSavePermission", hasSavePermission()
 		).build();
 	}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/schedule.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/schedule.jsp
@@ -18,6 +18,13 @@
 
 <%
 JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalEditArticleDisplayContext(request, liferayPortletResponse, journalDisplayContext.getArticle());
+
+Calendar cal = CalendarFactoryUtil.getCalendar(timeZone, locale);
+JournalArticle article = journalDisplayContext.getArticle();
+
+if ((article != null) && (article.getDisplayDate() != null)) {
+	cal.setTime(article.getDisplayDate());
+}
 %>
 
 <liferay-ui:error-marker
@@ -31,7 +38,40 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 <liferay-ui:error exception="<%= ArticleExpirationDateException.class %>" message="please-enter-a-valid-expiration-date" />
 
 <div class="schedule">
-	<aui:input formName="fm1" name="displayDate" wrapperCssClass="mb-3" />
+	<div class="form-group display-date mb-3 input-Date-wrapper">
+		<label class="control-label"><liferay-ui:message key="display-date" /></label>
+
+		<div class="form-group-autofit">
+			<div class="form-group-item">
+				<liferay-ui:input-date
+					dayParam="displayDateDay"
+					dayValue="<%= cal.get(Calendar.DATE) %>"
+					disabled="<%= false %>"
+					formName="fm1"
+					monthParam="displayDateMonth"
+					monthValue="<%= cal.get(Calendar.MONTH) %>"
+					name="displayDate"
+					nullable="<%= journalEditArticleDisplayContext.getClassNameId() != 0 %>"
+					showDisableCheckbox="<%= false %>"
+					yearParam="displayDateYear"
+					yearValue="<%= cal.get(Calendar.YEAR) %>"
+				/>
+			</div>
+
+			<div class="form-group-item">
+				<liferay-ui:input-time
+					amPmParam="displayDateAmPm"
+					amPmValue="<%= cal.get(Calendar.AM_PM) %>"
+					cssClass="form-group form-group-inline"
+					hourParam="displayDateHour"
+					hourValue="<%= cal.get(Calendar.HOUR) %>"
+					minuteParam="displayDateMinute"
+					minuteValue="<%= cal.get(Calendar.MINUTE) %>"
+					name="displayDateTime"
+				/>
+			</div>
+		</div>
+	</div>
 
 	<aui:input dateTogglerCheckboxLabel="never-expire" disabled="<%= journalEditArticleDisplayContext.isNeverExpire() %>" formName="fm1" name="expirationDate" wrapperCssClass="expiration-date mb-3" />
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
@@ -177,6 +177,7 @@ page import="com.liferay.portal.kernel.upload.FileItem" %><%@
 page import="com.liferay.portal.kernel.upload.LiferayFileItemException" %><%@
 page import="com.liferay.portal.kernel.util.ArrayUtil" %><%@
 page import="com.liferay.portal.kernel.util.Base64" %><%@
+page import="com.liferay.portal.kernel.util.CalendarFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.FastDateFormatFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
@@ -210,6 +211,7 @@ page import="com.liferay.taglib.util.CustomAttributesUtil" %>
 
 <%@ page import="java.util.ArrayList" %><%@
 page import="java.util.Arrays" %><%@
+page import="java.util.Calendar" %><%@
 page import="java.util.Collections" %><%@
 page import="java.util.Date" %><%@
 page import="java.util.List" %><%@

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -32,6 +32,8 @@ export default function _JournalPortlet({
 	classNameId,
 	contentTitle,
 	defaultLanguageId: initialDefaultLanguageId,
+
+	displayDate,
 	hasSavePermission,
 	namespace,
 }) {
@@ -79,7 +81,7 @@ export default function _JournalPortlet({
 		const resetInput = (inputName) => {
 			const input = document.getElementById(`${namespace}${inputName}`);
 
-			if (input) {
+			if (input && !displayDate) {
 				input.value = '';
 			}
 		};


### PR DESCRIPTION

Motivation
=======
This work solves the problem reported in the ticket https://issues.liferay.com/browse/LPS-175068
cc: @locpham97

Proposed Solution
========
What we did to solve this problem.
we tweak `JournalPortlet.es.js` for condition checking `articleId`

Steps to Verify
========
1. Create a web content structure
2. Open "Edit Default Values" of the created structure
3. Update the display date to the specific date and submit.
4. Reopen "Edit default values"

Actual result: The display date is blank
Expected result: Display date changed
