### PR TITLE
LPS-175108 Replace icons in product-navigation-product-menu-web

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/init.jsp
@@ -19,7 +19,6 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/application-list" prefix="liferay-application-list" %><%@
-taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
 taglib uri="http://liferay.com/tld/staging" prefix="liferay-staging" %><%@

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/product_menu.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/product_menu.jsp
@@ -46,9 +46,15 @@
 									<a aria-controls="<portlet:namespace /><%= AUIUtil.normalizeId(childPanelCategory.getKey()) %>Collapse" aria-expanded="<%= Objects.equals(childPanelCategory.getKey(), productMenuDisplayContext.getRootPanelCategoryKey()) %>" class="collapse-icon collapse-icon-middle panel-toggler panel-header-link <%= Objects.equals(childPanelCategory.getKey(), productMenuDisplayContext.getRootPanelCategoryKey()) ? StringPool.BLANK : "collapsed" %>" data-parent="#<portlet:namespace />Accordion" data-qa-id="productMenu<%= childPanelCategoryClass.getSimpleName() %>" data-toggle="liferay-collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(childPanelCategory.getKey()) %>Collapse" role="button">
 										<%@ include file="/portlet/product_menu_title.jspf" %>
 
-										<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
+										<clay:icon
+											cssClass="collapse-icon-closed"
+											symbol="angle-right"
+										/>
 
-										<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
+										<clay:icon
+											cssClass="collapse-icon-open"
+											symbol="angle-down"
+										/>
 									</a>
 								</c:if>
 							</div>

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
@@ -42,7 +42,11 @@ ApplicationsMenuInstanceConfiguration applicationsMenuInstanceConfiguration = Co
 				</clay:content-col>
 
 				<clay:content-col>
-					<aui:icon cssClass="d-inline-block d-md-none icon-monospaced sidenav-close" image="times" markupView="lexicon" url="javascript:void(0);" />
+					<clay:button
+						cssClass="d-md-none sidenav-close text-white"
+						displayType="unstyled"
+						icon="times"
+					/>
 				</clay:content-col>
 			</clay:content-row>
 		</div>


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-175108)

## Test Steps

1. Go to Control Panel -> System Settings 
2. In Content & Data section -> Navigation 
3. In left menu -> Applications Menu -> Disable Applications Menu
4. Go to Product menu -> see at the left side the Control Menu together with Product Menu
5. Collapse/expand the categories to see the icons
6. **NOTE: you have to reduce the window size of your browser to see the CLOSING button, because the button disappears with window sizes smaller than "md" sizes.**
![Screenshot 2023-02-08 at 19 08 27](https://user-images.githubusercontent.com/91208451/217615754-96009ca5-d6c0-419e-9bdb-16348f5d258a.png)

