### PR TITLE
LPS-175170 Replace icons in product-navigation-simulation-web

### DIFF
--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/META-INF/resources/portlet/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/META-INF/resources/portlet/init.jsp
@@ -16,7 +16,7 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/META-INF/resources/portlet/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/META-INF/resources/portlet/view.jsp
@@ -36,9 +36,15 @@ PanelCategoryHelper panelCategoryHelper = new PanelCategoryHelper(panelAppRegist
 					<a aria-controls="<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" aria-expanded="<%= true %>" class="collapse-icon collapse-icon-middle list-group-heading panel-header pl-0 text-decoration-none" data-toggle="liferay-collapse" href="#<portlet:namespace /><%= AUIUtil.normalizeId(panelApp.getKey()) %>Collapse" role="button">
 						<span class="category-name font-weight-semi-bold text-truncate text-uppercase"><%= panelApp.getLabel(locale) %></span>
 
-						<aui:icon cssClass="collapse-icon-closed" image="angle-right" markupView="lexicon" />
+						<clay:icon
+							cssClass="collapse-icon-closed"
+							symbol="angle-right"
+						/>
 
-						<aui:icon cssClass="collapse-icon-open" image="angle-down" markupView="lexicon" />
+						<clay:icon
+							cssClass="collapse-icon-open"
+							symbol="angle-down"
+						/>
 					</a>
 				</div>
 


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-175170)

## Test Steps

1. Go to Home page
2. Up to the right side you can see the simulation icon -> click it and see the menu
3. Collapse/expand it to see the icons 
![Screenshot 2023-02-08 at 19 34 19](https://user-images.githubusercontent.com/91208451/217623331-8ab559a7-3a3c-43ac-8efa-ee17bc0a28cd.png)
