### PR TITLE
LPS-97596 Global Site is not ordered correctly when displayed in Japanese

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.util.comparator.GroupDescriptiveNameComparator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.service.persistence.constants.UserGroupFinderConstants;
 import com.liferay.portlet.usersadmin.search.GroupSearch;
@@ -54,6 +55,7 @@ import com.liferay.site.util.GroupSearchProvider;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 
 import javax.portlet.PortletURL;
 
@@ -178,10 +180,24 @@ public class SiteAdminDisplayContext {
 	}
 
 	public GroupSearch getGroupSearch() throws PortalException {
-		GroupSearch groupSearch = _groupSearchProvider.getGroupSearch(
+		GroupSearch groupSearch = new GroupSearch(
 			_liferayPortletRequest, getPortletURL());
 
 		groupSearch.setId("sites");
+
+		groupSearch.setOrderByCol("descriptive-name");
+
+		ThemeDisplay themeDisplay =
+			(ThemeDisplay)_liferayPortletRequest.getAttribute(
+				WebKeys.THEME_DISPLAY);
+
+		groupSearch.setOrderByComparator(
+			new GroupDescriptiveNameComparator(
+				Objects.equals(groupSearch.getOrderByType(), "asc"),
+				themeDisplay.getLocale()));
+
+		_groupSearchProvider.setResultsAndTotal(
+			groupSearch, _liferayPortletRequest);
 
 		SiteChecker siteChecker = new SiteChecker(_liferayPortletResponse);
 

--- a/modules/apps/site/site-api/bnd.bnd
+++ b/modules/apps/site/site-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Site API
 Bundle-SymbolicName: com.liferay.site.api
-Bundle-Version: 16.1.1
+Bundle-Version: 16.2.0
 Export-Package:\
 	com.liferay.site.constants,\
 	com.liferay.site.display.context,\

--- a/modules/apps/site/site-api/src/main/java/com/liferay/site/util/GroupSearchProvider.java
+++ b/modules/apps/site/site-api/src/main/java/com/liferay/site/util/GroupSearchProvider.java
@@ -55,15 +55,24 @@ public class GroupSearchProvider {
 			PortletRequest portletRequest, PortletURL portletURL)
 		throws PortalException {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
 		GroupSearch groupSearch = new GroupSearch(portletRequest, portletURL);
+
+		setResultsAndTotal(groupSearch, portletRequest);
+
+		return groupSearch;
+	}
+
+	public void setResultsAndTotal(
+			GroupSearch groupSearch, PortletRequest portletRequest)
+		throws PortalException {
 
 		GroupSearchTerms searchTerms =
 			(GroupSearchTerms)groupSearch.getSearchTerms();
 
 		long parentGroupId = getParentGroupId(portletRequest);
+
+		ThemeDisplay themeDisplay = (ThemeDisplay)portletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 
 		Company company = themeDisplay.getCompany();
 
@@ -107,8 +116,6 @@ public class GroupSearchProvider {
 					getGroupParams(
 						portletRequest, searchTerms, parentGroupId)));
 		}
-
-		return groupSearch;
 	}
 
 	@Activate

--- a/modules/apps/site/site-api/src/main/resources/com/liferay/site/util/packageinfo
+++ b/modules/apps/site/site-api/src/main/resources/com/liferay/site/util/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.1
+version 5.1.0


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-97596)

The goal of these changes is to order correctly the sites in admin view. This error doesn't happen if the user has selected order by from the menu, which saves the value correctly in the preferences.

## Change summary:

* Separate GroupProvider in 2 methods, so that we can change at will the attributes before searching
* Change display context tied to the view


## Test Scenario

* Follow the steps in the ticket

![japanese](https://user-images.githubusercontent.com/4267448/217823166-7e5eceed-213e-4f44-9865-10d1c7a16ed8.gif)

