### PR TITLE
LPS-175207 Make react fragments work with clustering

### DIFF
--- a/modules/apps/fragment/fragment-renderer-react-impl/src/main/java/com/liferay/fragment/renderer/react/internal/model/listener/FragmentEntryLinkModelListener.java
+++ b/modules/apps/fragment/fragment-renderer-react-impl/src/main/java/com/liferay/fragment/renderer/react/internal/model/listener/FragmentEntryLinkModelListener.java
@@ -51,15 +51,7 @@ public class FragmentEntryLinkModelListener
 			return;
 		}
 
-		NPMRegistryUpdate npmRegistryUpdate = _npmRegistry.update();
-
-		npmRegistryUpdate.registerJSModule(
-			_jsPackage,
-			FragmentEntryFragmentRendererReactUtil.getModuleName(
-				fragmentEntryLink),
-			_dependencies, _getJs(fragmentEntryLink), null);
-
-		npmRegistryUpdate.finish();
+		_updateNPMRegistry(MethodType.ADD, null, fragmentEntryLink);
 	}
 
 	@Override
@@ -68,14 +60,7 @@ public class FragmentEntryLinkModelListener
 			return;
 		}
 
-		NPMRegistryUpdate npmRegistryUpdate = _npmRegistry.update();
-
-		npmRegistryUpdate.unregisterJSModule(
-			_jsPackage.getJSModule(
-				FragmentEntryFragmentRendererReactUtil.getModuleName(
-					fragmentEntryLink)));
-
-		npmRegistryUpdate.finish();
+		_updateNPMRegistry(MethodType.REMOVE, fragmentEntryLink, null);
 	}
 
 	@Override
@@ -87,20 +72,8 @@ public class FragmentEntryLinkModelListener
 			return;
 		}
 
-		NPMRegistryUpdate npmRegistryUpdate = _npmRegistry.update();
-
-		npmRegistryUpdate.unregisterJSModule(
-			_jsPackage.getJSModule(
-				FragmentEntryFragmentRendererReactUtil.getModuleName(
-					originalFragmentEntryLink)));
-
-		npmRegistryUpdate.registerJSModule(
-			_jsPackage,
-			FragmentEntryFragmentRendererReactUtil.getModuleName(
-				fragmentEntryLink),
-			_dependencies, _getJs(fragmentEntryLink), null);
-
-		npmRegistryUpdate.finish();
+		_updateNPMRegistry(
+			MethodType.UPDATE, originalFragmentEntryLink, fragmentEntryLink);
 	}
 
 	@Activate
@@ -170,6 +143,34 @@ public class FragmentEntryLinkModelListener
 			});
 	}
 
+	private void _updateNPMRegistry(
+		MethodType methodType, FragmentEntryLink oldFragmentEntryLink,
+		FragmentEntryLink newFragmentEntryLink) {
+
+		NPMRegistryUpdate npmRegistryUpdate = _npmRegistry.update();
+
+		if ((methodType == MethodType.REMOVE) ||
+			(methodType == MethodType.UPDATE)) {
+
+			npmRegistryUpdate.unregisterJSModule(
+				_jsPackage.getJSModule(
+					FragmentEntryFragmentRendererReactUtil.getModuleName(
+						oldFragmentEntryLink)));
+		}
+
+		if ((methodType == MethodType.ADD) ||
+			(methodType == MethodType.UPDATE)) {
+
+			npmRegistryUpdate.registerJSModule(
+				_jsPackage,
+				FragmentEntryFragmentRendererReactUtil.getModuleName(
+					newFragmentEntryLink),
+				_dependencies, _getJs(newFragmentEntryLink), null);
+		}
+
+		npmRegistryUpdate.finish();
+	}
+
 	private static final String _DEPENDENCY_PORTAL_REACT =
 		"liferay!frontend-js-react-web$react";
 
@@ -186,5 +187,11 @@ public class FragmentEntryLinkModelListener
 
 	@Reference
 	private NPMResolver _npmResolver;
+
+	private enum MethodType {
+
+		ADD, REMOVE, UPDATE
+
+	}
 
 }


### PR DESCRIPTION
Motivation
=======
The FragmentEntryLinkModelListener for react fragments is not cluster-aware. This is a problem since its logic only gets applied to the node that runs it. This means that React fragments do not work properly in a cluster currently, since the NPM registry only gets updated on the node that modified the fragment.

See [LPS-175207](https://issues.liferay.com/browse/LPS-175207) for more information.

Proposed Solution
========
Make the FragmentEntryLinkModelListener cluster-aware. It should send a request to the other cluster nodes to run the same NPM update logic used by the node that updated the React FragmentEntryLink in the database.

Steps to Verify
========
1. Set up a 2-node cluster of Liferay (let's call them "Node 1" and "Node 2").
2. Start up each node and log in as the admin user on Node 1. Perform steps 3-9 on Node 1.
3. Create a new Site named "Test Site".
4. On "Test Site", navigate to Design > Fragments.
5. Click the peapod menu next to Fragment Sets and then click Import.
6. Import the attached react-fragment-example.zip file from [LPS-175207](https://issues.liferay.com/browse/LPS-175207).
7. Navigate to Site Builder > Pages and create a new Content Page named "Test Page".
8. Add a React Fragment Example to Test Page and then publish it.
9. View the Test Page from Node 1 and verify that it says "Hello World" (/)
10. Now view the Test Page from Node 2.

References to existing code (if applies)
========
The [PLOEntryModelListener](https://github.com/liferay/liferay-portal/blob/master/modules/apps/portal-language/portal-language-override-service/src/main/java/com/liferay/portal/language/override/internal/PLOEntryModelListener.java) is an example of another ModelListener that uses similar cluster-aware logic.