### PR TITLE
LPS-112879 AssertionError on AssetInfoCollectionProviderTest on SQL Server

### DIFF
--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/BaseAssetsInfoCollectionProvider.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/BaseAssetsInfoCollectionProvider.java
@@ -29,7 +29,8 @@ import org.osgi.service.component.annotations.Reference;
 public abstract class BaseAssetsInfoCollectionProvider {
 
 	protected AssetEntryQuery getAssetEntryQuery(
-		long companyId, long groupId, Pagination pagination, Sort sort) {
+		long companyId, long groupId, Pagination pagination, Sort sort1,
+		Sort sort2) {
 
 		AssetEntryQuery assetEntryQuery = new AssetEntryQuery();
 
@@ -46,11 +47,13 @@ public abstract class BaseAssetsInfoCollectionProvider {
 		}
 
 		assetEntryQuery.setOrderByCol1(
-			(sort != null) ? sort.getFieldName() : Field.MODIFIED_DATE);
-		assetEntryQuery.setOrderByCol2(Field.CREATE_DATE);
+			(sort1 != null) ? sort1.getFieldName() : Field.MODIFIED_DATE);
+		assetEntryQuery.setOrderByCol2(
+			(sort2 != null) ? sort2.getFieldName() : Field.CREATE_DATE);
 		assetEntryQuery.setOrderByType1(
-			(sort != null) ? _getOrderByType(sort) : "DESC");
-		assetEntryQuery.setOrderByType2("DESC");
+			(sort1 != null) ? _getOrderByType(sort1) : "DESC");
+		assetEntryQuery.setOrderByType1(
+			(sort2 != null) ? _getOrderByType(sort2) : "DESC");
 
 		return assetEntryQuery;
 	}

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/BaseAssetsInfoCollectionProvider.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/BaseAssetsInfoCollectionProvider.java
@@ -38,6 +38,7 @@ public abstract class BaseAssetsInfoCollectionProvider {
 				companyId, true));
 		assetEntryQuery.setEnablePermissions(true);
 		assetEntryQuery.setGroupIds(new long[] {groupId});
+		assetEntryQuery.setListable(null);
 
 		if (pagination != null) {
 			assetEntryQuery.setStart(pagination.getStart());

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/HighestRatedAssetsInfoCollectionProvider.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/HighestRatedAssetsInfoCollectionProvider.java
@@ -50,7 +50,8 @@ public class HighestRatedAssetsInfoCollectionProvider
 
 		AssetEntryQuery assetEntryQuery = getAssetEntryQuery(
 			serviceContext.getCompanyId(), serviceContext.getScopeGroupId(),
-			collectionQuery.getPagination(), new Sort("ratings", true), null);
+			collectionQuery.getPagination(), new Sort("ratings", true),
+			new Sort("title", true));
 
 		try {
 			return InfoPage.of(

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/HighestRatedAssetsInfoCollectionProvider.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/HighestRatedAssetsInfoCollectionProvider.java
@@ -50,7 +50,7 @@ public class HighestRatedAssetsInfoCollectionProvider
 
 		AssetEntryQuery assetEntryQuery = getAssetEntryQuery(
 			serviceContext.getCompanyId(), serviceContext.getScopeGroupId(),
-			collectionQuery.getPagination(), new Sort("ratings", true));
+			collectionQuery.getPagination(), new Sort("ratings", true), null);
 
 		try {
 			return InfoPage.of(

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/MostViewedAssetsInfoCollectionProvider.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/MostViewedAssetsInfoCollectionProvider.java
@@ -50,7 +50,8 @@ public class MostViewedAssetsInfoCollectionProvider
 
 		AssetEntryQuery assetEntryQuery = getAssetEntryQuery(
 			serviceContext.getCompanyId(), serviceContext.getScopeGroupId(),
-			collectionQuery.getPagination(), new Sort("viewCount", true), null);
+			collectionQuery.getPagination(), new Sort("viewCount", true),
+			new Sort("title", true));
 
 		try {
 			return InfoPage.of(

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/MostViewedAssetsInfoCollectionProvider.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/MostViewedAssetsInfoCollectionProvider.java
@@ -50,7 +50,7 @@ public class MostViewedAssetsInfoCollectionProvider
 
 		AssetEntryQuery assetEntryQuery = getAssetEntryQuery(
 			serviceContext.getCompanyId(), serviceContext.getScopeGroupId(),
-			collectionQuery.getPagination(), new Sort("viewCount", true));
+			collectionQuery.getPagination(), new Sort("viewCount", true), null);
 
 		try {
 			return InfoPage.of(

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/RecentContentInfoCollectionProvider.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/RecentContentInfoCollectionProvider.java
@@ -58,7 +58,7 @@ public class RecentContentInfoCollectionProvider
 		AssetEntryQuery assetEntryQuery = getAssetEntryQuery(
 			serviceContext.getCompanyId(), serviceContext.getScopeGroupId(),
 			collectionQuery.getPagination(),
-			new com.liferay.info.sort.Sort(Field.MODIFIED_DATE, true));
+			new com.liferay.info.sort.Sort(Field.MODIFIED_DATE, true), null);
 
 		try {
 			SearchContext searchContext = _getSearchContext();

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/RelatedAssetsRelatedInfoItemCollectionProvider.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/info/collection/provider/RelatedAssetsRelatedInfoItemCollectionProvider.java
@@ -55,7 +55,8 @@ public class RelatedAssetsRelatedInfoItemCollectionProvider
 		try {
 			AssetEntryQuery assetEntryQuery = getAssetEntryQuery(
 				assetEntry.getCompanyId(), assetEntry.getGroupId(),
-				collectionQuery.getPagination(), collectionQuery.getSort());
+				collectionQuery.getPagination(), collectionQuery.getSort(),
+				null);
 
 			assetEntryQuery.setLinkedAssetEntryIds(
 				new long[] {assetEntry.getEntryId()});


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-112879)

The goal of these changes is to match the asset entry queries that come from highest rated and most viewed collection providers with those from the legacy widgets. 

## Change summary:

* Allow a second type of ordering for asset entry queries in collection providers
* Change second ordering for highest rated and most viewed collection providers
* Integration tests are already present

## Test Scenario in SQL Server and any other DB

* Add a web content
* Add a second web content
* Create a widget page and add a highest rating widget to the page
* Configure it so that it shows the rating
* Change the ratings of the web contents several times
* Add a new widget page with an asset publisher and configure it so that it uses the highest rating collection provider
* Order of the list should match the order in the first page everytime the rating changes


Note: Tested on MySQL and SQL Server