### PR TITLE
LPS-174194 Empty taglib

### DIFF
--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entries.jspf
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/view_entries.jspf
@@ -22,8 +22,8 @@
 </c:if>
 
 <c:if test="<%= ListUtil.isEmpty(searchContainer.getResults()) %>">
-	<liferay-ui:empty-result-message
-		message="no-entries-were-found"
+	<liferay-frontend:empty-result-message
+		title='<%= LanguageUtil.get(resourceBundle, "no-entries-were-found") %>'
 	/>
 </c:if>
 

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/init.jsp
@@ -49,6 +49,7 @@ page import="com.liferay.change.tracking.web.internal.display.context.ViewSchedu
 page import="com.liferay.change.tracking.web.internal.display.context.ViewTemplatesDisplayContext" %><%@
 page import="com.liferay.change.tracking.web.internal.display.context.ViewTemplatesManagementToolbarDisplayContext" %><%@
 page import="com.liferay.change.tracking.web.internal.security.permission.resource.CTCollectionPermission" %><%@
+page import="com.liferay.frontend.taglib.servlet.taglib.util.EmptyResultMessageKeys" %><%@
 page import="com.liferay.petra.string.StringBundler" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.dao.search.ResultRow" %><%@

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/view_history.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/view_history.jsp
@@ -34,14 +34,14 @@ SearchContainer<CTProcess> searchContainer = viewHistoryDisplayContext.getSearch
 	<div class="container-view">
 		<c:choose>
 			<c:when test="<%= !searchContainer.hasResults() && viewHistoryDisplayContext.isSearch() %>">
-				<liferay-ui:empty-result-message
-					message="no-publication-has-been-published-yet"
-					search="<%= true %>"
+				<liferay-frontend:empty-result-message
+					animationType="<%= EmptyResultMessageKeys.AnimationType.SEARCH %>"
+					title='<%= LanguageUtil.get(resourceBundle, "no-publication-has-been-published-yet") %>'
 				/>
 			</c:when>
 			<c:when test="<%= !searchContainer.hasResults() %>">
-				<liferay-ui:empty-result-message
-					message="no-publication-has-been-published-yet"
+				<liferay-frontend:empty-result-message
+					title='<%= LanguageUtil.get(resourceBundle, "no-publication-has-been-published-yet") %>'
 				/>
 			</c:when>
 			<c:otherwise>

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -47,6 +47,7 @@ page import="com.liferay.configuration.admin.web.internal.util.ConfigurationEntr
 page import="com.liferay.configuration.admin.web.internal.util.ConfigurationEntryRetriever" %><%@
 page import="com.liferay.configuration.admin.web.internal.util.ConfigurationModelIterator" %><%@
 page import="com.liferay.configuration.admin.web.internal.util.ResourceBundleLoaderProvider" %><%@
+page import="com.liferay.frontend.taglib.servlet.taglib.util.EmptyResultMessageKeys" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition" %><%@
 page import="com.liferay.portal.configuration.persistence.listener.ConfigurationModelListenerException" %><%@

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -45,8 +45,9 @@ ConfigurationScopeDisplayContext configurationScopeDisplayContext = Configuratio
 	cssClass="container-view"
 >
 	<c:if test="<%= configurationCategorySectionDisplays.isEmpty() %>">
-		<liferay-ui:empty-result-message
-			message="no-configurations-were-found"
+		<liferay-frontend:empty-result-message
+			animationType="<%= EmptyResultMessageKeys.AnimationType.SEARCH %>"
+			title='<%= LanguageUtil.get(resourceBundle, "no-configurations-were-found") %>'
 		/>
 	</c:if>
 

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/util/EmptyResultMessageKeys.java
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/java/com/liferay/frontend/taglib/servlet/taglib/util/EmptyResultMessageKeys.java
@@ -25,10 +25,10 @@ public class EmptyResultMessageKeys {
 		if (animationType == AnimationType.EMPTY) {
 			return "taglib-empty-state";
 		}
-		else if (animationType == AnimationType.SEARCH) {
+		else if (animationType == AnimationType.SUCCESS) {
 			return "taglib-success-state";
 		}
-		else if (animationType == AnimationType.SUCCESS) {
+		else if (animationType == AnimationType.SEARCH) {
 			return "taglib-search-state";
 		}
 

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/init.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/init.jsp
@@ -57,6 +57,7 @@ page import="com.liferay.document.library.kernel.exception.FileNameException" %>
 page import="com.liferay.document.library.kernel.exception.FileSizeException" %><%@
 page import="com.liferay.document.library.kernel.model.DLFileEntry" %><%@
 page import="com.liferay.document.library.kernel.util.DLValidatorUtil" %><%@
+page import="com.liferay.frontend.taglib.servlet.taglib.util.EmptyResultMessageKeys" %><%@
 page import="com.liferay.message.boards.constants.MBCategoryConstants" %><%@
 page import="com.liferay.message.boards.constants.MBConstants" %><%@
 page import="com.liferay.message.boards.constants.MBMessageConstants" %><%@

--- a/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view.jsp
+++ b/modules/apps/message-boards/message-boards-web/src/main/resources/META-INF/resources/message_boards/view.jsp
@@ -421,8 +421,9 @@ request.setAttribute("view.jsp-viewCategory", Boolean.TRUE.toString());
 					</c:if>
 
 					<c:if test="<%= (categoryEntriesSearchContainer.getTotal() <= 0) && (threadEntriesSearchContainer.getTotal() <= 0) %>">
-						<liferay-ui:empty-result-message
-							message="there-are-no-threads-or-categories"
+						<liferay-frontend:empty-result-message
+							animationType="<%= EmptyResultMessageKeys.AnimationType.EMPTY %>"
+							title='<%= LanguageUtil.get(resourceBundle, "there-are-no-threads-or-categories") %>'
 						/>
 					</c:if>
 

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/search/results/view.jsp
@@ -20,6 +20,7 @@
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/ddm" prefix="liferay-ddm" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
@@ -54,8 +55,9 @@ SearchContainer<Document> searchContainer = searchResultsPortletDisplayContext.g
 <c:choose>
 	<c:when test="<%= searchResultSummaryDisplayContexts.isEmpty() %>">
 		<div class="sheet">
-			<liferay-ui:empty-result-message
-				message='<%= LanguageUtil.format(request, "no-results-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>", false) %>'
+			<liferay-frontend:empty-result-message
+				description='<%= LanguageUtil.format(request, "no-results-were-found-that-matched-the-keywords-x", "<strong>" + HtmlUtil.escape(searchResultsPortletDisplayContext.getKeywords()) + "</strong>", false) %>'
+				title='<%= LanguageUtil.format(request, "no-results-were-found", false) %>'
 			/>
 		</div>
 	</c:when>

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/anonymize_nonreviewable_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/anonymize_nonreviewable_uad_data.jsp
@@ -70,8 +70,8 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 			<clay:sheet-section>
 				<c:choose>
 					<c:when test="<%= totalReviewableUADEntitiesCount == 0 %>">
-						<liferay-ui:empty-result-message
-							message="all-data-that-does-not-require-review-has-been-anonymized"
+						<liferay-frontend:empty-result-message
+							title='<%= LanguageUtil.get(resourceBundle, "all-data-that-does-not-require-review-has-been-anonymized") %>'
 						/>
 					</c:when>
 					<c:otherwise>

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/completed_data_erasure.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/completed_data_erasure.jsp
@@ -29,8 +29,8 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 <clay:container-fluid
 	cssClass="container-form-lg"
 >
-	<liferay-ui:empty-result-message
-		message="you-have-successfully-anonymized-all-remaining-data"
+	<liferay-frontend:empty-result-message
+		title='<%= LanguageUtil.get(resourceBundle, "you-have-successfully-anonymized-all-remaining-data") %>'
 	/>
 </clay:container-fluid>
 

--- a/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
+++ b/modules/apps/user-associated-data/user-associated-data-web/src/main/resources/META-INF/resources/review_uad_data.jsp
@@ -204,8 +204,8 @@ renderResponse.setTitle(StringBundler.concat(selectedUser.getFullName(), " - ", 
 				<clay:sheet-section>
 					<c:choose>
 						<c:when test="<%= totalReviewableUADEntitiesCount == 0 %>">
-							<liferay-ui:empty-result-message
-								message="all-data-that-requires-review-has-been-anonymized"
+							<liferay-frontend:empty-result-message
+								title='<%= LanguageUtil.get(resourceBundle, "all-data-that-requires-review-has-been-anonymized") %>'
 							/>
 						</c:when>
 						<c:otherwise>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/common/addresses.jsp
@@ -64,8 +64,9 @@ List<Address> addresses = AddressServiceUtil.getAddresses(className, classPK);
 
 <c:if test="<%= addresses.isEmpty() %>">
 	<div class="contact-information-empty-results-message-wrapper">
-		<liferay-ui:empty-result-message
-			message="<%= emptyResultsMessage %>"
+		<liferay-frontend:empty-result-message
+			animationType="<%= EmptyResultMessageKeys.AnimationType.EMPTY %>"
+			title="<%= LanguageUtil.get(resourceBundle, emptyResultsMessage) %>"
 		/>
 	</div>
 </c:if>

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -38,6 +38,7 @@ page import="com.liferay.announcements.kernel.service.AnnouncementsDeliveryLocal
 page import="com.liferay.asset.kernel.model.AssetVocabularyConstants" %><%@
 page import="com.liferay.expando.kernel.model.ExpandoColumn" %><%@
 page import="com.liferay.expando.util.ExpandoAttributesUtil" %><%@
+page import="com.liferay.frontend.taglib.servlet.taglib.util.EmptyResultMessageKeys" %><%@
 page import="com.liferay.petra.string.CharPool" %><%@
 page import="com.liferay.petra.string.StringBundler" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/opening_hours.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/opening_hours.jsp
@@ -62,8 +62,9 @@ List<OrgLabor> orgLabors = OrgLaborServiceUtil.getOrgLabors(organizationId);
 
 <c:if test="<%= orgLabors.isEmpty() %>">
 	<div class="contact-information-empty-results-message-wrapper">
-		<liferay-ui:empty-result-message
-			message="this-organization-does-not-have-any-opening-hours"
+		<liferay-frontend:empty-result-message
+			animationType="<%= EmptyResultMessageKeys.AnimationType.EMPTY %>"
+			title='<%= LanguageUtil.get(resourceBundle, "this-organization-does-not-have-any-opening-hours") %>'
 		/>
 	</div>
 </c:if>


### PR DESCRIPTION
I simply have replaced the deprecated `liferay-ui:empty-result-message` with the incredible brand new...

:star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2:
```liferay-frontend:empty-result-message```
:star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2::star2:

It has incredible feature like

# _Accessible titles_

![image](https://user-images.githubusercontent.com/800645/218047847-4e258315-b8be-4615-b7c8-d36e43d08cf4.png)

Don't worry any more about those horrible inaccessible page titles. A `div`? What's that? You will forget about those tags with the new awesome taglib!

# _Custom icons_

![image](https://user-images.githubusercontent.com/800645/218048247-57667396-5514-4d71-8bfd-2730cb1ff12b.png)

Do you want to show a telescope? A rocket? Do whatever you want! Now we have the _unlimited power_ of five different icons that can be used.

# _Our clients_

"Since I moved to the new taglib, my kids are much happier and no one punches me in the face anymore." — Anonymous.

"Every night before going to bed I watch my favorite TV Shows together with my taglib." — Tim Berners Lee.