### PR TITLE
LPS-175380 Cannot delete an utility page that is not marked as default if the user doesn't have the specific permission

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutUtilityPageEntryActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutUtilityPageEntryActionDropdownItemsProvider.java
@@ -545,6 +545,12 @@ public class LayoutUtilityPageEntryActionDropdownItemsProvider {
 			return false;
 		}
 
+		if (!_layoutUtilityPageEntry.isDefaultLayoutUtilityPageEntry()) {
+			_deletePermission = true;
+
+			return true;
+		}
+
 		_deletePermission = _hasAssignDefaultLayoutUtilityPagePermission();
 
 		return _deletePermission;


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-175380)

The goal of these changes is to only check for the required permission if the utility page is marked as default

## Change summary:

* Add a check if the utility page is marked as default. If it isn't we use the default permissions and return true 


## Test Scenario

* Follow the steps in the ticket

