### PR TITLE
LPS-175383 Fix react FragmentEntryLinkModelListener initialization

### DIFF
--- a/modules/apps/fragment/fragment-renderer-react-impl/src/main/java/com/liferay/fragment/renderer/react/internal/model/listener/FragmentEntryLinkModelListener.java
+++ b/modules/apps/fragment/fragment-renderer-react-impl/src/main/java/com/liferay/fragment/renderer/react/internal/model/listener/FragmentEntryLinkModelListener.java
@@ -26,6 +26,8 @@ import com.liferay.frontend.js.loader.modules.extender.npm.NPMResolver;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -41,9 +43,53 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Iván Zaera Avellón
  */
-@Component(service = ModelListener.class)
+@Component(
+	service = {FragmentEntryLinkModelListener.class, ModelListener.class}
+)
 public class FragmentEntryLinkModelListener
 	extends BaseModelListener<FragmentEntryLink> {
+
+	public void ensureInitialized() {
+		if (_initialized) {
+			return;
+		}
+
+		synchronized (this) {
+			if (_initialized) {
+				return;
+			}
+
+			_jsPackage = _npmResolver.getJSPackage();
+
+			if (_jsPackage == null) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Unable to initialize because JS package is null");
+				}
+
+				return;
+			}
+
+			List<FragmentEntryLink> fragmentEntryLinks =
+				_fragmentEntryLinkLocalService.getFragmentEntryLinks(
+					FragmentConstants.TYPE_REACT, QueryUtil.ALL_POS,
+					QueryUtil.ALL_POS, null);
+
+			NPMRegistryUpdate npmRegistryUpdate = _npmRegistry.update();
+
+			for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
+				npmRegistryUpdate.registerJSModule(
+					_jsPackage,
+					FragmentEntryFragmentRendererReactUtil.getModuleName(
+						fragmentEntryLink),
+					_dependencies, _getJs(fragmentEntryLink), null);
+			}
+
+			npmRegistryUpdate.finish();
+
+			_initialized = true;
+		}
+	}
 
 	@Override
 	public void onAfterCreate(FragmentEntryLink fragmentEntryLink) {
@@ -105,24 +151,6 @@ public class FragmentEntryLinkModelListener
 
 	@Activate
 	protected void activate() {
-		_jsPackage = _npmResolver.getJSPackage();
-
-		List<FragmentEntryLink> fragmentEntryLinks =
-			_fragmentEntryLinkLocalService.getFragmentEntryLinks(
-				FragmentConstants.TYPE_REACT, QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS, null);
-
-		NPMRegistryUpdate npmRegistryUpdate = _npmRegistry.update();
-
-		for (FragmentEntryLink fragmentEntryLink : fragmentEntryLinks) {
-			npmRegistryUpdate.registerJSModule(
-				_jsPackage,
-				FragmentEntryFragmentRendererReactUtil.getModuleName(
-					fragmentEntryLink),
-				_dependencies, _getJs(fragmentEntryLink), null);
-		}
-
-		npmRegistryUpdate.finish();
 	}
 
 	@Deactivate
@@ -173,12 +201,16 @@ public class FragmentEntryLinkModelListener
 	private static final String _DEPENDENCY_PORTAL_REACT =
 		"liferay!frontend-js-react-web$react";
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		FragmentEntryLinkModelListener.class);
+
 	private static final List<String> _dependencies = Collections.singletonList(
 		_DEPENDENCY_PORTAL_REACT);
 
 	@Reference
 	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
 
+	private volatile boolean _initialized;
 	private JSPackage _jsPackage;
 
 	@Reference

--- a/modules/apps/fragment/fragment-renderer-react-impl/src/main/java/com/liferay/fragment/renderer/react/internal/model/listener/FragmentEntryLinkModelListener.java
+++ b/modules/apps/fragment/fragment-renderer-react-impl/src/main/java/com/liferay/fragment/renderer/react/internal/model/listener/FragmentEntryLinkModelListener.java
@@ -149,10 +149,6 @@ public class FragmentEntryLinkModelListener
 		npmRegistryUpdate.finish();
 	}
 
-	@Activate
-	protected void activate() {
-	}
-
 	@Deactivate
 	protected void deactivate() {
 		_jsPackage = _npmResolver.getJSPackage();

--- a/modules/apps/fragment/fragment-renderer-react-impl/src/main/java/com/liferay/fragment/renderer/react/internal/renderer/FragmentEntryFragmentRendererReact.java
+++ b/modules/apps/fragment/fragment-renderer-react-impl/src/main/java/com/liferay/fragment/renderer/react/internal/renderer/FragmentEntryFragmentRendererReact.java
@@ -21,6 +21,7 @@ import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.renderer.FragmentRenderer;
 import com.liferay.fragment.renderer.FragmentRendererContext;
 import com.liferay.fragment.renderer.constants.FragmentRendererConstants;
+import com.liferay.fragment.renderer.react.internal.model.listener.FragmentEntryLinkModelListener;
 import com.liferay.fragment.renderer.react.internal.util.FragmentEntryFragmentRendererReactUtil;
 import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
 import com.liferay.frontend.js.loader.modules.extender.npm.JSPackage;
@@ -95,6 +96,8 @@ public class FragmentEntryFragmentRendererReact implements FragmentRenderer {
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws IOException {
+
+		_fragmentEntryLinkModelListener.ensureInitialized();
 
 		try {
 			PrintWriter printWriter = httpServletResponse.getWriter();
@@ -257,6 +260,9 @@ public class FragmentEntryFragmentRendererReact implements FragmentRenderer {
 
 	@Reference
 	private FragmentEntryConfigurationParser _fragmentEntryConfigurationParser;
+
+	@Reference
+	private FragmentEntryLinkModelListener _fragmentEntryLinkModelListener;
 
 	@Reference
 	private JSONFactory _jsonFactory;


### PR DESCRIPTION
Please note that this is only a proposed solution. I'm no expert in the Fragments infrastructure, so it is possible that this breaks another thing.

Alternative solutions to this problems I evaluated with @victorg1991 and we discarded:

1. Create a new event listener interface in NPMRegistry so that the ModelListener knows when to trigger the initialization (discarded because we have had such listener interfaces in the past and ended up removing them because they were problematic from the POV of performance).
2. Implement an active wait (polling) in the activate method (this could work since the time elapsed between the ModelListener activation and the NPMRegistry processing should be short; however we don't know if it could lead to OSGi locks or delays)
3. Schedule future calls to check if it is possible to initialize (using a scheduler or something alike). This is equivalent to 1, so why making the solution more complex? :shrug: )

Again: please make sure that this works and doesn't break anything else :pray: 