### PR TITLE
LPS-168841 Replace Liferay-ui:icon with clay:icon in site_administration_header_icon_sites.jspf

### DIFF
--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_icon_sites.jspf
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_icon_sites.jspf
@@ -15,14 +15,15 @@
 --%>
 
 <div class="icon-sites <%= (childPanelCategoriesSize == 1) ? "" : "collapsible-icon" %>">
-	<liferay-ui:icon
+	<clay:button
+		aria-label='<%= LanguageUtil.get(request, "go-to-other-site-or-library") %>'
+		borderless="<%= true %>"
+		cssClass="lfr-portal-tooltip text-white"
+		displayType="secondary"
 		icon="sites"
-		id="manageSitesLink"
-		label="<%= false %>"
-		linkCssClass="icon-monospaced"
-		markupView="lexicon"
-		message="go-to-other-site-or-library"
-		url="javascript:void(0);"
+		id='<%= liferayPortletResponse.getNamespace() + "manageSitesLink" %>'
+		monospaced="<%= true %>"
+		title='<%= LanguageUtil.get(request, "go-to-other-site-or-library") %>'
 	/>
 </div>
 


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-168841)

## Test Scenario
* Create a new site.
* Go to the Product Menu.
* Check the icon to go to other site or library.

<img width="368" alt="image" src="https://user-images.githubusercontent.com/93203423/218514200-d2d6a21d-f6df-49cf-a2dd-4b0c22d29fe4.png">