### PR TITLE
LPS-175716 Blank preview

### DIFF
--- a/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
+++ b/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/internal/events/ClientExtensionsServicePreAction.java
@@ -68,7 +68,9 @@ public class ClientExtensionsServicePreAction extends Action {
 			String mode = ParamUtil.getString(
 				httpServletRequest, "p_l_mode", Constants.VIEW);
 
-			if (!Objects.equals(mode, Constants.PREVIEW)) {
+			if (!Objects.equals(mode, Constants.PREVIEW) &&
+				!Objects.equals(mode, Constants.BLANK)) {
+
 				return;
 			}
 

--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/portlet/action/EditFileEntryMVCActionCommand.java
@@ -291,7 +291,9 @@ public class EditFileEntryMVCActionCommand extends BaseMVCActionCommand {
 
 				actionResponse.setRenderParameter("mvcPath", "/null.jsp");
 			}
-			else if (cmd.equals(Constants.PREVIEW)) {
+			else if (cmd.equals(Constants.PREVIEW) ||
+					 cmd.equals(Constants.BLANK)) {
+
 				SessionMessages.add(
 					actionRequest,
 					_portal.getPortletId(actionRequest) +

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -2419,7 +2419,13 @@ public class JournalArticleLocalServiceImpl
 		JournalArticle article = journalArticlePersistence.findByG_A_V(
 			groupId, articleId, version);
 
-		boolean preview = Objects.equals(viewMode, Constants.PREVIEW);
+		boolean preview = false;
+
+		if (Objects.equals(viewMode, Constants.PREVIEW) ||
+			Objects.equals(viewMode, Constants.BLANK)) {
+
+			preview = true;
+		}
 
 		if (article.isExpired() && !preview) {
 			Date expirationDate = article.getExpirationDate();

--- a/modules/apps/journal/journal-taglib/src/main/java/com/liferay/journal/taglib/servlet/taglib/JournalArticleTag.java
+++ b/modules/apps/journal/journal-taglib/src/main/java/com/liferay/journal/taglib/servlet/taglib/JournalArticleTag.java
@@ -229,7 +229,8 @@ public class JournalArticleTag extends IncludeTag {
 			"p_l_mode", Constants.VIEW);
 
 		if (Objects.equals(Constants.EDIT, mode) ||
-			Objects.equals(Constants.PREVIEW, mode)) {
+			Objects.equals(Constants.PREVIEW, mode) ||
+			Objects.equals(Constants.BLANK, mode)) {
 
 			return true;
 		}

--- a/modules/apps/journal/journal-taglib/src/main/resources/META-INF/resources/journal_article/page.jsp
+++ b/modules/apps/journal/journal-taglib/src/main/resources/META-INF/resources/journal_article/page.jsp
@@ -28,7 +28,7 @@ String wrapperCssClass = (String)request.getAttribute("liferay-journal:journal-a
 %>
 
 <c:choose>
-	<c:when test="<%= (article != null) && article.isExpired() && !viewMode.equals(Constants.PREVIEW) %>">
+	<c:when test="<%= (article != null) && article.isExpired() && !viewMode.equals(Constants.PREVIEW) && !viewMode.equals(Constants.BLANK) %>">
 		<div class="alert alert-warning">
 			<liferay-ui:message arguments="<%= HtmlUtil.escape(article.getTitle(locale)) %>" key="x-is-expired" />
 		</div>

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/renderer/JournalArticleRendererUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/renderer/JournalArticleRendererUtil.java
@@ -39,7 +39,8 @@ public class JournalArticleRendererUtil {
 			"p_l_mode", Constants.VIEW);
 
 		if (Objects.equals(Constants.EDIT, mode) ||
-			Objects.equals(Constants.PREVIEW, mode)) {
+			Objects.equals(Constants.PREVIEW, mode) ||
+			Objects.equals(Constants.BLANK, mode)) {
 
 			return true;
 		}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/template/LayoutEditModeTemplateContextContributor.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/template/LayoutEditModeTemplateContextContributor.java
@@ -44,7 +44,8 @@ public class LayoutEditModeTemplateContextContributor
 			httpServletRequest, "p_l_mode", Constants.VIEW);
 
 		if (layoutMode.equals(Constants.EDIT) ||
-			layoutMode.equals(Constants.PREVIEW)) {
+			layoutMode.equals(Constants.PREVIEW) ||
+			layoutMode.equals(Constants.BLANK)) {
 
 			contextObjects.put(
 				"bodyCssClass",

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -493,7 +493,7 @@ public class ContentPageEditorDisplayContext {
 						themeDisplay.getLayout(), themeDisplay);
 
 					layoutURL = HttpComponentsUtil.addParameter(
-						layoutURL, "p_l_mode", Constants.PREVIEW);
+						layoutURL, "p_l_mode", Constants.BLANK);
 
 					return HttpComponentsUtil.addParameter(
 						layoutURL, "disableCommonStyles", Boolean.TRUE);

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/layout/view/content.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/layout/view/content.jsp
@@ -17,6 +17,7 @@
 <%@ include file="/layout/view/init.jsp" %>
 
 <%
+String plmode = ParamUtil.getString(request, "p_l_mode");
 String ppid = ParamUtil.getString(request, "p_p_id");
 %>
 
@@ -24,30 +25,32 @@ String ppid = ParamUtil.getString(request, "p_p_id");
 
 <liferay-ui:success key="variantSaved" message="the-variant-was-saved-successfully" />
 
-<c:choose>
-	<c:when test="<%= (themeDisplay.isStatePopUp() || themeDisplay.isWidget()) && Validator.isNotNull(ppid) %>">
+<c:if test="<%= !Objects.equals(plmode, Constants.BLANK) %>">
+	<c:choose>
+		<c:when test="<%= (themeDisplay.isStatePopUp() || themeDisplay.isWidget()) && Validator.isNotNull(ppid) %>">
 
-		<%
-		String templateContent = LayoutTemplateLocalServiceUtil.getContent("pop_up", true, theme.getThemeId());
+			<%
+			String templateContent = LayoutTemplateLocalServiceUtil.getContent("pop_up", true, theme.getThemeId());
 
-		if (Validator.isNotNull(templateContent)) {
-			String templateId = theme.getThemeId() + LayoutTemplateConstants.STANDARD_SEPARATOR + "pop_up";
+			if (Validator.isNotNull(templateContent)) {
+				String templateId = theme.getThemeId() + LayoutTemplateConstants.STANDARD_SEPARATOR + "pop_up";
 
-			RuntimePageUtil.processTemplate(request, response, ppid, templateId, templateContent, LayoutTemplateLocalServiceUtil.getLangType("pop_up", true, theme.getThemeId()));
-		}
-		%>
+				RuntimePageUtil.processTemplate(request, response, ppid, templateId, templateContent, LayoutTemplateLocalServiceUtil.getLangType("pop_up", true, theme.getThemeId()));
+			}
+			%>
 
-	</c:when>
-	<c:when test="<%= layoutTypePortlet.hasStateMax() && Validator.isNotNull(ppid) %>">
-		<liferay-layout:render-state-max-layout-structure />
-	</c:when>
-	<c:otherwise>
-		<div class="layout-content portlet-layout" id="main-content" role="main">
-			<liferay-layout:render-fragment-layout
-				showPreview="<%= true %>"
-			/>
-		</div>
-	</c:otherwise>
-</c:choose>
+		</c:when>
+		<c:when test="<%= layoutTypePortlet.hasStateMax() && Validator.isNotNull(ppid) %>">
+			<liferay-layout:render-state-max-layout-structure />
+		</c:when>
+		<c:otherwise>
+			<div class="layout-content portlet-layout" id="main-content" role="main">
+				<liferay-layout:render-fragment-layout
+					showPreview="<%= true %>"
+				/>
+			</div>
+		</c:otherwise>
+	</c:choose>
 
-<liferay-layout:layout-common />
+	<liferay-layout:layout-common />
+</c:if>

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/layout/view/init.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/resources/META-INF/resources/layout/view/init.jsp
@@ -23,7 +23,10 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 <%@ page import="com.liferay.portal.kernel.layoutconfiguration.util.RuntimePageUtil" %><%@
 page import="com.liferay.portal.kernel.model.LayoutTemplateConstants" %><%@
 page import="com.liferay.portal.kernel.service.LayoutTemplateLocalServiceUtil" %><%@
+page import="com.liferay.portal.kernel.util.Constants" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %>
+
+<%@ page import="java.util.Objects" %>
 
 <liferay-theme:defineObjects />

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/template/ProductNavigationControlMenuTemplateContextContributor.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/java/com/liferay/product/navigation/control/menu/theme/contributor/internal/template/ProductNavigationControlMenuTemplateContextContributor.java
@@ -72,7 +72,9 @@ public class ProductNavigationControlMenuTemplateContextContributor
 		String layoutMode = ParamUtil.getString(
 			httpServletRequest, "p_l_mode", Constants.VIEW);
 
-		if (layoutMode.equals(Constants.PREVIEW)) {
+		if (layoutMode.equals(Constants.PREVIEW) ||
+			layoutMode.equals(Constants.BLANK)) {
+
 			return false;
 		}
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/portlet/ProductNavigationControlMenuPortlet.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/portlet/ProductNavigationControlMenuPortlet.java
@@ -83,7 +83,9 @@ public class ProductNavigationControlMenuPortlet extends MVCPortlet {
 		String layoutMode = ParamUtil.getString(
 			originalHttpServletRequest, "p_l_mode", Constants.VIEW);
 
-		if (layoutMode.equals(Constants.PREVIEW)) {
+		if (layoutMode.equals(Constants.PREVIEW) ||
+			layoutMode.equals(Constants.BLANK)) {
+
 			return;
 		}
 

--- a/modules/apps/product-navigation/product-navigation-product-menu-impl/src/main/java/com/liferay/product/navigation/product/menu/internal/helper/ProductNavigationProductMenuHelperImpl.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-impl/src/main/java/com/liferay/product/navigation/product/menu/internal/helper/ProductNavigationProductMenuHelperImpl.java
@@ -61,7 +61,9 @@ public class ProductNavigationProductMenuHelperImpl
 		String layoutMode = ParamUtil.getString(
 			httpServletRequest, "p_l_mode", Constants.VIEW);
 
-		if (layoutMode.equals(Constants.PREVIEW)) {
+		if (layoutMode.equals(Constants.PREVIEW) ||
+			layoutMode.equals(Constants.BLANK)) {
+
 			return false;
 		}
 

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/portlet/ProductNavigationProductMenuPortlet.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/portlet/ProductNavigationProductMenuPortlet.java
@@ -82,7 +82,9 @@ public class ProductNavigationProductMenuPortlet extends MVCPortlet {
 			_portal.getOriginalServletRequest(httpServletRequest), "p_l_mode",
 			Constants.VIEW);
 
-		if (layoutMode.equals(Constants.PREVIEW)) {
+		if (layoutMode.equals(Constants.PREVIEW) ||
+			layoutMode.equals(Constants.BLANK)) {
+
 			return;
 		}
 

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/servlet/taglib/ProductMenuBodyTopDynamicInclude.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/servlet/taglib/ProductMenuBodyTopDynamicInclude.java
@@ -72,7 +72,9 @@ public class ProductMenuBodyTopDynamicInclude extends BaseDynamicInclude {
 		String layoutMode = ParamUtil.getString(
 			httpServletRequest, "p_l_mode", Constants.VIEW);
 
-		if (layoutMode.equals(Constants.PREVIEW)) {
+		if (layoutMode.equals(Constants.PREVIEW) ||
+			layoutMode.equals(Constants.BLANK)) {
+
 			return;
 		}
 

--- a/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/java/com/liferay/product/navigation/simulation/theme/contributor/internal/servlet/taglib/ProductNavigationSimulationTopHeadDynamicInclude.java
+++ b/modules/apps/product-navigation/product-navigation-simulation-theme-contributor/src/main/java/com/liferay/product/navigation/simulation/theme/contributor/internal/servlet/taglib/ProductNavigationSimulationTopHeadDynamicInclude.java
@@ -61,7 +61,9 @@ public class ProductNavigationSimulationTopHeadDynamicInclude
 		String layoutMode = ParamUtil.getString(
 			httpServletRequest, "p_l_mode", Constants.VIEW);
 
-		if (layoutMode.equals(Constants.PREVIEW)) {
+		if (layoutMode.equals(Constants.PREVIEW) ||
+			layoutMode.equals(Constants.BLANK)) {
+
 			return;
 		}
 

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/java/com/liferay/product/navigation/simulation/web/internal/portlet/ProductNavigationSimulationPortlet.java
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/java/com/liferay/product/navigation/simulation/web/internal/portlet/ProductNavigationSimulationPortlet.java
@@ -71,7 +71,9 @@ public class ProductNavigationSimulationPortlet extends MVCPortlet {
 		String layoutMode = ParamUtil.getString(
 			originalHttpServletRequest, "p_l_mode", Constants.VIEW);
 
-		if (layoutMode.equals(Constants.PREVIEW)) {
+		if (layoutMode.equals(Constants.PREVIEW) ||
+			layoutMode.equals(Constants.BLANK)) {
+
 			return;
 		}
 

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/java/com/liferay/product/navigation/taglib/servlet/taglib/ProductNavigationControlMenuTag.java
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/java/com/liferay/product/navigation/taglib/servlet/taglib/ProductNavigationControlMenuTag.java
@@ -120,7 +120,9 @@ public class ProductNavigationControlMenuTag extends IncludeTag {
 		String layoutMode = ParamUtil.getString(
 			getOriginalServletRequest(), "p_l_mode", Constants.VIEW);
 
-		if (layoutMode.equals(Constants.PREVIEW)) {
+		if (layoutMode.equals(Constants.PREVIEW) ||
+			layoutMode.equals(Constants.BLANK)) {
+
 			return false;
 		}
 

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/AnalyticsReportsPortlet.java
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/java/com/liferay/analytics/reports/web/internal/portlet/AnalyticsReportsPortlet.java
@@ -77,7 +77,9 @@ public class AnalyticsReportsPortlet extends MVCPortlet {
 		String layoutMode = ParamUtil.getString(
 			originalHttpServletRequest, "p_l_mode", Constants.VIEW);
 
-		if (layoutMode.equals(Constants.PREVIEW)) {
+		if (layoutMode.equals(Constants.PREVIEW) ||
+			layoutMode.equals(Constants.BLANK)) {
+
 			return;
 		}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/theme/PortletDisplay.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/theme/PortletDisplay.java
@@ -518,7 +518,9 @@ public class PortletDisplay implements Cloneable, Serializable {
 			return false;
 		}
 
-		if (layoutMode.equals(Constants.PREVIEW)) {
+		if (layoutMode.equals(Constants.PREVIEW) ||
+			layoutMode.equals(Constants.BLANK)) {
+
 			return false;
 		}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/util/Constants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/Constants.java
@@ -37,6 +37,8 @@ public interface Constants {
 
 	public static final String ASSIGN = "assign";
 
+	public static final String BLANK = "blank";
+
 	public static final String CANCEL = "cancel";
 
 	public static final String CANCEL_CHECKOUT = "cancel_checkout";

--- a/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/util/packageinfo
@@ -1,1 +1,1 @@
-version 54.1.0
+version 54.2.0


### PR DESCRIPTION
Currently we are using "preview" p_l_mode to render the initial iframe for responsive viewports (during edit mode).

Rendering all fragments is actually not necessary because after the initial render we replace them using React.

With this new "blank" p_l_mode we can render a copy of the page without it's content, but preserving other theme elements like headers, footers, etc.