### PR TITLE
LPS-172534 Import Master Templates as private as well

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/GroupPagesPortletDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/GroupPagesPortletDataHandler.java
@@ -218,8 +218,11 @@ public class GroupPagesPortletDataHandler extends BasePortletDataHandler {
 
 				boolean privateLayout = portletDataContext.isPrivateLayout();
 
-				if (layoutPageTemplateEntry.getType() ==
-						LayoutPageTemplateEntryTypeConstants.TYPE_BASIC) {
+				if ((layoutPageTemplateEntry.getType() ==
+						LayoutPageTemplateEntryTypeConstants.TYPE_BASIC) ||
+					(layoutPageTemplateEntry.getType() ==
+						LayoutPageTemplateEntryTypeConstants.
+							TYPE_MASTER_LAYOUT)) {
 
 					portletDataContext.setPrivateLayout(true);
 				}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -470,7 +470,9 @@ public class LayoutStagedModelDataHandler
 		if ((portletDataContext.isPrivateLayout() &&
 			 !layout.isTypeAssetDisplay()) ||
 			GetterUtil.getBoolean(
-				layoutElement.attributeValue("layout-content-page-template"))) {
+				layoutElement.attributeValue("layout-content-page-template")) ||
+			GetterUtil.getBoolean(
+				layoutElement.attributeValue("layout-master-page-template"))) {
 
 			privateLayout = true;
 		}
@@ -2668,12 +2670,22 @@ public class LayoutStagedModelDataHandler
 						fetchLayoutPageTemplateEntryByPlid(layout.getClassPK());
 			}
 
-			if ((layoutPageTemplateEntry != null) &&
-				(layoutPageTemplateEntry.getType() ==
-					LayoutPageTemplateEntryTypeConstants.TYPE_BASIC)) {
+			if (layoutPageTemplateEntry != null) {
+				if (layoutPageTemplateEntry.getType() ==
+						LayoutPageTemplateEntryTypeConstants.TYPE_BASIC) {
 
-				layoutElement.addAttribute(
-					"layout-content-page-template", Boolean.TRUE.toString());
+					layoutElement.addAttribute(
+						"layout-content-page-template",
+						Boolean.TRUE.toString());
+				}
+
+				if (layoutPageTemplateEntry.getType() ==
+						LayoutPageTemplateEntryTypeConstants.
+							TYPE_MASTER_LAYOUT) {
+
+					layoutElement.addAttribute(
+						"layout-master-page-template", Boolean.TRUE.toString());
+				}
 			}
 		}
 


### PR DESCRIPTION
Hey guys,

This fix is an extension of [LPS-156013](https://issues.liferay.com/browse/LPS-156013) and [LPS-97509](https://issues.liferay.com/browse/LPS-97509), the goal is to handle Master Page Templates as private pages as well.

**Note:**
I tend to think that Widget Page Templates (WPD) should be handled similarly, however I couldn't really test this, so I didn't involve them.
I created a WPD and exported the Site.  Then I tried to import it to a new Site, but an exception was thrown during the [validation](https://github.com/liferay/liferay-portal/blob/9e4840ba092cf968b6d90ffd4f6c42fd25744640/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateEntryStagedModelDataHandler.java#L504-L510) that there is already template with the same UUID.
When I deleted the export Site, the import was successful, however instead of portlet typed layout, 2 asset_display typed layout was created during the import.

Let me know if you have any questions.
Thanks,
Tamas