### PR TITLE
[TS ] LPP-47896 > LPS-175473 fix duplicate ERC for importedClientExtensionEntryRel

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/exportimport/data/handler/ClientExtensionEntryRelStagedModelDataHandler.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/exportimport/data/handler/ClientExtensionEntryRelStagedModelDataHandler.java
@@ -163,6 +163,8 @@ public class ClientExtensionEntryRelStagedModelDataHandler
 					portletDataContext, importedClientExtensionEntryRel);
 		}
 		else {
+			importedClientExtensionEntryRel.setExternalReferenceCode(
+				existingClientExtensionEntryRel.getExternalReferenceCode());
 			importedClientExtensionEntryRel.setMvccVersion(
 				existingClientExtensionEntryRel.getMvccVersion());
 			importedClientExtensionEntryRel.setClientExtensionEntryRelId(


### PR DESCRIPTION
Hi team, this ticket has passed our internal review here: https://github.com/ces-huynguyen/liferay-portal/pull/106. Please help us to review the work and give us your feedback. Thank you in advance!

Please see [LPS-175473](https://issues.liferay.com/browse/LPS-175473) for reproducible steps.

## Root cause analysis.
When the imported clientextensionRel is referenced in multiple places, at the second time it is imported, it has the ERC not null but the clientextensionRelId is not different from the pre-existing clientextensionRel. Therefore a DuplicateClientExtensionEntryRelExternalReferenceCodeException will be thrown as Liferay think they are not identical [ClientExtensionEntryRelPersistenceImpl.java#L3951-L3961](https://github.com/liferay-echo/liferay-portal/blob/master/modules/apps/client-extension/client-extension-service/src/main/java/com/liferay/client/extension/service/persistence/impl/ClientExtensionEntryRelPersistenceImpl.java#L3951-L3961)


## Proposed solution.
In Data Mirror Strategy: the content will initially be imported as new within the target environment with new ids and updated references, but subsequent imports will retain the same ids:
- If there is an entry with the same unique ID (ERC) on the target Site, the new one replaces it.
 