### PR TITLE
LPS-175484 Fix NPE in Asset Publisher configuration

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
@@ -112,7 +112,7 @@ long[] groupIds = assetPublisherDisplayContext.getGroupIds();
 				<clay:dropdown-menu
 					additionalProps='<%=
 						HashMapBuilder.<String, Object>put(
-							"currentURL", currentURL
+							"currentURL", configurationRenderURL.toString()
 						).build()
 					%>'
 					aria-label="<%= title %>"


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-175484)

A NPE is thrown when trying to select manual asset entries for a second time in asset publisher configuration. This is because the redirect URL that is beeing used is incorrect

## Change summary:

* Use correct URL for redirection after calling the item selector when selecting manual asset entries


## Test Scenario

* Follow the steps in the ticket

