### PR TITLE
LPS-173139 Long web content titles are not readable in Widget and Content pages

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
@@ -214,6 +214,7 @@ export default function PageContent({
 				className={classNames('d-flex', {
 					'align-items-center': !subtype,
 				})}
+				data-title={title}
 			>
 				<ClayIcon
 					className={classNames('mr-3 flex-shrink-0', {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
@@ -201,7 +201,7 @@ export default function PageContent({
 	return (
 		<li
 			className={classNames(
-				'page-editor__page-contents__page-content mb-1 py-2',
+				'page-editor__page-contents__page-content mb-1 p-1',
 				{
 					'page-editor__page-contents__page-content--mapped-item-hovered':
 						isHovered || activeActions || isBeingEdited,
@@ -210,23 +210,21 @@ export default function PageContent({
 			onMouseLeave={handleMouseLeave}
 			onMouseOver={handleMouseOver}
 		>
-			<div
-				className={classNames('d-flex', {
-					'align-items-center': !subtype,
-				})}
-				data-title={title}
+			<ClayLayout.ContentRow
+				className={classNames({'align-items-center': !subtype})}
+				padded
 			>
-				<ClayIcon
-					className={classNames('mr-3 flex-shrink-0', {
-						'mt-1': subtype,
-					})}
-					focusable="false"
-					monospaced="true"
-					role="presentation"
-					symbol={icon || 'document-text'}
-				/>
+				<ClayLayout.ContentCol>
+					<ClayIcon
+						className={subtype ? 'mt-1' : 'm-0'}
+						focusable="false"
+						monospaced="true"
+						role="presentation"
+						symbol={icon || 'document-text'}
+					/>
+				</ClayLayout.ContentCol>
 
-				<ClayLayout.ContentCol expand>
+				<ClayLayout.ContentCol expand title={title}>
 					<span className="font-weight-semi-bold text-truncate">
 						{title}
 					</span>
@@ -236,55 +234,64 @@ export default function PageContent({
 					)}
 				</ClayLayout.ContentCol>
 
-				{dropdownItems?.length ? (
-					<ClayDropDownWithItems
-						active={activeActions}
-						className="align-self-center"
-						items={dropdownItems}
-						menuElementAttrs={{
-							containerProps: {
-								className: 'cadmin',
-							},
-						}}
-						onActiveChange={setActiveActions}
-						trigger={
-							<ClayButton
-								aria-label={sub(
-									Liferay.Language.get('actions-for-x'),
-									title
-								)}
-								className="btn-sm flex-shrink-0 mr-1 page-editor__page-contents__button"
-								displayType="unstyled"
-								title={sub(
-									Liferay.Language.get('open-actions-menu'),
-									title
-								)}
-							>
-								<ClayIcon symbol="ellipsis-v" />
-							</ClayButton>
-						}
-					/>
-				) : (
-					<ClayButton
-						aria-label={sub(
-							Liferay.Language.get('edit-inline-text-x'),
-							title
-						)}
-						className={classNames(
-							'flex-shrink-0 btn-sm mr-2 page-editor__page-contents__button',
-							{
-								'not-allowed':
-									isBeingEdited || !canUpdateEditables,
+				<ClayLayout.ContentCol>
+					{dropdownItems?.length ? (
+						<ClayDropDownWithItems
+							active={activeActions}
+							className="align-self-center"
+							items={dropdownItems}
+							menuElementAttrs={{
+								containerProps: {
+									className: 'cadmin',
+								},
+							}}
+							onActiveChange={setActiveActions}
+							trigger={
+								<ClayButton
+									aria-label={sub(
+										Liferay.Language.get('actions-for-x'),
+										title
+									)}
+									className={classNames(
+										'page-editor__page-contents__button',
+										{'mt-1': subtype}
+									)}
+									displayType="unstyled"
+									size="sm"
+									title={sub(
+										Liferay.Language.get(
+											'open-actions-menu'
+										),
+										title
+									)}
+								>
+									<ClayIcon symbol="ellipsis-v" />
+								</ClayButton>
 							}
-						)}
-						disabled={isBeingEdited || !canUpdateEditables}
-						displayType="unstyled"
-						onClick={onClickEditInlineText}
-					>
-						<ClayIcon symbol="pencil" />
-					</ClayButton>
-				)}
-			</div>
+						/>
+					) : (
+						<ClayButton
+							aria-label={sub(
+								Liferay.Language.get('edit-inline-text-x'),
+								title
+							)}
+							className={classNames(
+								'page-editor__page-contents__button',
+								{
+									'not-allowed':
+										isBeingEdited || !canUpdateEditables,
+								}
+							)}
+							disabled={isBeingEdited || !canUpdateEditables}
+							displayType="unstyled"
+							onClick={onClickEditInlineText}
+							size="sm"
+						>
+							<ClayIcon symbol="pencil" />
+						</ClayButton>
+					)}
+				</ClayLayout.ContentCol>
+			</ClayLayout.ContentRow>
 
 			{imageEditorParams && (
 				<ImageEditorModal

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
@@ -253,13 +253,13 @@ export default function PageContent({
 									Liferay.Language.get('actions-for-x'),
 									title
 								)}
-								className="btn-sm flex-shrink-0 mr-2 page-editor__page-contents__button"
+								className="btn-sm flex-shrink-0 mr-1 page-editor__page-contents__button"
 								displayType="unstyled"
+								title={sub(
+									Liferay.Language.get('open-actions-menu'),
+									title
+								)}
 							>
-								<span className="sr-only">
-									{Liferay.Language.get('open-actions-menu')}
-								</span>
-
 								<ClayIcon symbol="ellipsis-v" />
 							</ClayButton>
 						}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page_content/components/PageContent.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page_content/components/PageContent.test.js
@@ -12,8 +12,7 @@
  * details.
  */
 
-import {render, screen} from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import {fireEvent, render, screen} from '@testing-library/react';
 import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
@@ -132,7 +131,7 @@ describe('PageContent', () => {
 		];
 		renderPageContent(contents[1]);
 
-		userEvent.click(screen.queryByText('open-actions-menu'));
+		fireEvent.click(screen.getByTitle('open-actions-menu'));
 
 		shownActions.forEach((action) => {
 			expect(screen.queryByText(action)).toBeInTheDocument();
@@ -143,8 +142,8 @@ describe('PageContent', () => {
 	it('shows all items to be added when the Add Item action is clicked', () => {
 		renderPageContent(contents[1]);
 
-		userEvent.click(screen.queryByText('open-actions-menu'));
-		userEvent.click(screen.queryByText('add-items'));
+		fireEvent.click(screen.getByTitle('open-actions-menu'));
+		fireEvent.click(screen.queryByText('add-items'));
 
 		expect(
 			screen.queryByText('Basic Web Content to be added')
@@ -154,8 +153,8 @@ describe('PageContent', () => {
 	it('open image editor modal when the Edit Image action is clicked', () => {
 		const {baseElement} = renderPageContent(contents[2]);
 
-		userEvent.click(screen.queryByText('open-actions-menu'));
-		userEvent.click(screen.queryByText('edit-image'));
+		fireEvent.click(screen.getByTitle('open-actions-menu'));
+		fireEvent.click(screen.getByText('edit-image'));
 
 		expect(
 			baseElement.querySelector('.image-editor-modal')
@@ -172,7 +171,7 @@ describe('PageContent', () => {
 		const selectItem = useSelectItem();
 		renderPageContent(inlineText);
 
-		userEvent.click(screen.getByLabelText('edit-inline-text-x'));
+		fireEvent.click(screen.getByLabelText('edit-inline-text-x'));
 
 		expect(selectItem).toHaveBeenCalledWith('11113-element-text', {
 			itemType: 'editable',

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/AddContentPanelDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/display/context/AddContentPanelDisplayContext.java
@@ -51,7 +51,6 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.SessionClicks;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.ArrayList;
@@ -194,9 +193,7 @@ public class AddContentPanelDisplayContext {
 				).put(
 					"title",
 					HtmlUtil.escape(
-						StringUtil.shorten(
-							assetRenderer.getTitle(_themeDisplay.getLocale()),
-							60))
+						assetRenderer.getTitle(_themeDisplay.getLocale()))
 				).put(
 					"type",
 					_getAssetEntryTypeLabel(

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabItem.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabItem.js
@@ -42,7 +42,6 @@ const TabItem = ({item}) => {
 	const {plid, setWidgets, widgets} = useContext(AddPanelContext);
 
 	const isContent = item.type === LAYOUT_DATA_ITEM_TYPES.content;
-	const title = `${Liferay.Language.get('add')} ${item.label}`;
 
 	const {sourceRef} = useDragSymbol({
 		data: item.data,
@@ -62,7 +61,10 @@ const TabItem = ({item}) => {
 			})}
 			ref={item.disabled ? null : sourceRef}
 		>
-			<div className="sidebar-body__add-panel__tab-item-body">
+			<div
+				className="sidebar-body__add-panel__tab-item-body"
+				title={item.label}
+			>
 				<div className="icon">
 					<ClayIcon symbol={item.icon} />
 				</div>
@@ -80,15 +82,15 @@ const TabItem = ({item}) => {
 
 			{!item.disabled && (
 				<ClayButton
+					aria-label={`${Liferay.Language.get('add-content')}`}
 					className="btn-monospaced sidebar-body__add-panel__tab-item-add"
+					data-tooltip-align="top-left"
 					displayType="unstyled"
 					onClick={() => addItem({item, plid, setWidgets, widgets})}
 					size="sm"
-					title={title}
+					title={`${Liferay.Language.get('add-content')}`}
 				>
 					<ClayIcon symbol="plus" />
-
-					<span className="sr-only">{title}</span>
 				</ClayButton>
 			)}
 		</li>

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabItem.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabItem.js
@@ -70,7 +70,7 @@ const TabItem = ({item}) => {
 				</div>
 
 				<div className="text">
-					<div className="text-truncate title">{item.label}</div>
+					<div className="mr-1 text-truncate title">{item.label}</div>
 
 					{isContent && (
 						<div className="subtitle text-truncate">


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-173139)

## Test Scenario 1

* Navigate to Content & Data > Web Content and create two of them with the names:
	- Company_Liferay_article_new_week_Monday_1 	
	- Company_Liferay_article_new_week_Monday_2
* Navigate to Site Builder > Pages and create one Widget page.
* Navigate to the page and click on the add button.
* Go to “Content” tab and check te tooltip for both and the tooltip of the add button on the right side.

<img width="998" alt="Test WP" src="https://user-images.githubusercontent.com/93203423/219397030-428e9dd7-1fd9-4f5f-a99b-b3981dcd806e.png">
<img width="1000" alt="Liferay DXP" src="https://user-images.githubusercontent.com/93203423/219397061-5ff31b5b-688c-403a-83ff-a35ecffcbb12.png">


## Test Scenario 2

* Navigate to Content & Data > Web Content and create one with the name:
	- Company_Liferay_article_new_week_Monday_1
* Navigate to Site Builder > Pages and create one Content page.
* Add one content display and select the web content.
* Check the tooltip with the name in the page content tab.

<img width="1674" alt="image" src="https://user-images.githubusercontent.com/93203423/219432392-e29bf31c-e0af-40d1-bd52-7e60293b7881.png">
