### PR TITLE
LPS-175961 | Master

### DIFF
--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/Editor.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/Editor.js
@@ -106,7 +106,7 @@ export function Editor({autocompleteData, initialScript, mode}) {
 				id={`${portletNamespace}scriptContent`}
 				name={`${portletNamespace}scriptContent`}
 				type="hidden"
-				value={btoa(script)}
+				value={formatInputScript(script)}
 			/>
 		</>
 	);
@@ -130,4 +130,10 @@ const exportScript = (script) => {
 	link.click();
 
 	URL.revokeObjectURL(fileURL);
+};
+
+const formatInputScript = (script) => {
+	const scriptEncoded = btoa(encodeURIComponent(script));
+
+	return decodeURIComponent(atob(scriptEncoded));
 };


### PR DESCRIPTION
***Steps to verify:***
 1. Under default DXP site go to Design > Templates
 2. Create a new Widget Template
 3. Set a title
 4. Try to insert any combination that generates a character outside the Latin1. 
_Example:_ the vowels I or E with a tilde (ĩ ; ẽ) or a consonant along with an acute accent

_Result:_ The editor template is locked and nothing can be done except exit the page

***Proposed Solution:***

When the layout editor is locked, an error is displayed in the console browser:

> Uncaught DOMException: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.

I did some research and discovered that this is an base64 escaping related issue. To fix it, we need to first escape the string with encodeURIComponent before encoding it to base64.

https://issues.liferay.com/browse/LPS-175961