### PR TITLE
LPS-175928 Add a tooltip with the full content name in the content tab for Content Pages

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
@@ -211,9 +211,10 @@ export default function PageContent({
 			onMouseOver={handleMouseOver}
 		>
 			<div
-				className={classNames('d-flex', {
+				className={classNames('lfr-portal-tooltip', 'd-flex', {
 					'align-items-center': !subtype,
 				})}
+				title={title}
 			>
 				<ClayIcon
 					className={classNames('mr-3 flex-shrink-0', {


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-175928)

## Test Scenario 

* Navigate to Content & Data > Web Content and create one with the name:
	- Company_Liferay_article_new_week_Monday_1
* Navigate to Site Builder > Pages and create one Content page.
* Add one content display and select the web content.
* Check the tooltip with the name in the page content tab.

<img width="1674" alt="image" src="https://user-images.githubusercontent.com/93203423/219432392-e29bf31c-e0af-40d1-bd52-7e60293b7881.png">
