### PR TITLE
LPS-176194 Some  actions shouldn't be shown in page editor for a utility page

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutActionsDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutActionsDisplayContext.java
@@ -18,9 +18,13 @@ import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.admin.web.internal.security.permission.resource.LayoutUtilityPageEntryPermission;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil;
+import com.liferay.layout.utility.page.constants.LayoutUtilityPageActionKeys;
+import com.liferay.layout.utility.page.model.LayoutUtilityPageEntry;
+import com.liferay.layout.utility.page.service.LayoutUtilityPageEntryLocalServiceUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
@@ -31,6 +35,7 @@ import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
@@ -78,6 +83,7 @@ public class LayoutActionsDisplayContext {
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
 			LayoutUtilityPageEntryLocalServiceUtil.
 				fetchLayoutUtilityPageEntryByPlid(layout.getPlid());
+
 		return DropdownItemListBuilder.addGroup(
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
@@ -149,6 +155,7 @@ public class LayoutActionsDisplayContext {
 					DropdownItemListBuilder.add(
 						() ->
 							_isContentLayout(layout) &&
+							(layoutUtilityPageEntry == null) &&
 							_isShowDeleteAction(layout),
 						dropdownItem -> {
 							dropdownItem.putData("action", "deleteLayout");
@@ -188,6 +195,62 @@ public class LayoutActionsDisplayContext {
 										layout.getName(
 											_themeDisplay.getLocale()))));
 
+							dropdownItem.setIcon("trash");
+							dropdownItem.setLabel(
+								LanguageUtil.get(
+									_httpServletRequest, "delete"));
+						}
+					).build());
+				dropdownGroupItem.setSeparator(true);
+			}
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						() ->
+							_isContentLayout(layout) &&
+							(layoutUtilityPageEntry != null) &&
+							_isShowDeleteAction(layoutUtilityPageEntry),
+						dropdownItem -> {
+							dropdownItem.putData("action", "deleteLayout");
+
+							String key = "are-you-sure-you-want-to-delete-this";
+
+							if (layoutUtilityPageEntry.
+									isDefaultLayoutUtilityPageEntry()) {
+
+								key =
+									"are-you-sure-you-want-to-delete-the-" +
+										"default-utility-page";
+							}
+
+							dropdownItem.putData(
+								"deleteLayoutURL",
+								PortletURLBuilder.create(
+									PortalUtil.getControlPanelPortletURL(
+										_httpServletRequest,
+										LayoutAdminPortletKeys.GROUP_PAGES,
+										PortletRequest.ACTION_PHASE)
+								).setActionName(
+									"/layout_admin" +
+										"/delete_layout_utility_page_entry"
+								).setRedirect(
+									PortletURLBuilder.create(
+										PortalUtil.getControlPanelPortletURL(
+											_httpServletRequest,
+											LayoutAdminPortletKeys.GROUP_PAGES,
+											PortletRequest.RENDER_PHASE)
+									).setTabs1(
+										"utility-pages"
+									).buildString()
+								).setParameter(
+									"layoutUtilityPageEntryId",
+									layoutUtilityPageEntry.
+										getLayoutUtilityPageEntryId()
+								).buildString());
+							dropdownItem.putData(
+								"message",
+								LanguageUtil.get(_httpServletRequest, key));
 							dropdownItem.setIcon("trash");
 							dropdownItem.setLabel(
 								LanguageUtil.get(
@@ -374,6 +437,30 @@ public class LayoutActionsDisplayContext {
 		}
 
 		return true;
+	}
+
+	private boolean _isShowDeleteAction(
+			LayoutUtilityPageEntry layoutUtilityPageEntry)
+		throws PortalException {
+
+		boolean deletePermission = LayoutUtilityPageEntryPermission.contains(
+			_themeDisplay.getPermissionChecker(), layoutUtilityPageEntry,
+			ActionKeys.DELETE);
+
+		if (!layoutUtilityPageEntry.isDefaultLayoutUtilityPageEntry()) {
+			return deletePermission;
+		}
+
+		if (GroupPermissionUtil.contains(
+				_themeDisplay.getPermissionChecker(),
+				layoutUtilityPageEntry.getGroupId(),
+				LayoutUtilityPageActionKeys.
+					ASSIGN_DEFAULT_LAYOUT_UTILITY_PAGE_ENTRY)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private boolean _isShowPermissionsAction(Layout layout)

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutActionsDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutActionsDisplayContext.java
@@ -75,6 +75,9 @@ public class LayoutActionsDisplayContext {
 	public List<DropdownItem> getDropdownItems() {
 		Layout layout = _getLayout();
 
+		LayoutUtilityPageEntry layoutUtilityPageEntry =
+			LayoutUtilityPageEntryLocalServiceUtil.
+				fetchLayoutUtilityPageEntryByPlid(layout.getPlid());
 		return DropdownItemListBuilder.addGroup(
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
@@ -110,7 +113,9 @@ public class LayoutActionsDisplayContext {
 							dropdownItem.setTarget("_blank");
 						}
 					).add(
-						() -> _isContentLayout(layout),
+						() ->
+							_isContentLayout(layout) &&
+							(layoutUtilityPageEntry == null),
 						dropdownItem -> {
 							dropdownItem.putData(
 								"action", "convertToPageTemplate");

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalService.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalService.java
@@ -243,6 +243,9 @@ public interface LayoutUtilityPageEntryLocalService
 		fetchLayoutUtilityPageEntryByExternalReferenceCode(
 			String externalReferenceCode, long groupId);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public LayoutUtilityPageEntry fetchLayoutUtilityPageEntryByPlid(long plid);
+
 	/**
 	 * Returns the layout utility page entry matching the UUID and group.
 	 *

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalServiceUtil.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalServiceUtil.java
@@ -264,6 +264,12 @@ public class LayoutUtilityPageEntryLocalServiceUtil {
 			externalReferenceCode, groupId);
 	}
 
+	public static LayoutUtilityPageEntry fetchLayoutUtilityPageEntryByPlid(
+		long plid) {
+
+		return getService().fetchLayoutUtilityPageEntryByPlid(plid);
+	}
+
 	/**
 	 * Returns the layout utility page entry matching the UUID and group.
 	 *

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/LayoutUtilityPageEntryLocalServiceWrapper.java
@@ -297,6 +297,12 @@ public class LayoutUtilityPageEntryLocalServiceWrapper
 				externalReferenceCode, groupId);
 	}
 
+	@Override
+	public LayoutUtilityPageEntry fetchLayoutUtilityPageEntryByPlid(long plid) {
+		return _layoutUtilityPageEntryLocalService.
+			fetchLayoutUtilityPageEntryByPlid(plid);
+	}
+
 	/**
 	 * Returns the layout utility page entry matching the UUID and group.
 	 *

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/persistence/LayoutUtilityPageEntryPersistence.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/persistence/LayoutUtilityPageEntryPersistence.java
@@ -600,6 +600,51 @@ public interface LayoutUtilityPageEntryPersistence
 	public int filterCountByGroupId(long groupId);
 
 	/**
+	 * Returns the layout utility page entry where plid = &#63; or throws a <code>NoSuchLayoutUtilityPageEntryException</code> if it could not be found.
+	 *
+	 * @param plid the plid
+	 * @return the matching layout utility page entry
+	 * @throws NoSuchLayoutUtilityPageEntryException if a matching layout utility page entry could not be found
+	 */
+	public LayoutUtilityPageEntry findByPlid(long plid)
+		throws NoSuchLayoutUtilityPageEntryException;
+
+	/**
+	 * Returns the layout utility page entry where plid = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param plid the plid
+	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
+	 */
+	public LayoutUtilityPageEntry fetchByPlid(long plid);
+
+	/**
+	 * Returns the layout utility page entry where plid = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param plid the plid
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
+	 */
+	public LayoutUtilityPageEntry fetchByPlid(
+		long plid, boolean useFinderCache);
+
+	/**
+	 * Removes the layout utility page entry where plid = &#63; from the database.
+	 *
+	 * @param plid the plid
+	 * @return the layout utility page entry that was removed
+	 */
+	public LayoutUtilityPageEntry removeByPlid(long plid)
+		throws NoSuchLayoutUtilityPageEntryException;
+
+	/**
+	 * Returns the number of layout utility page entries where plid = &#63;.
+	 *
+	 * @param plid the plid
+	 * @return the number of matching layout utility page entries
+	 */
+	public int countByPlid(long plid);
+
+	/**
 	 * Returns all the layout utility page entries where groupId = &#63; and type = &#63;.
 	 *
 	 * @param groupId the group ID

--- a/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/persistence/LayoutUtilityPageEntryUtil.java
+++ b/modules/apps/layout/layout-utility-page-api/src/main/java/com/liferay/layout/utility/page/service/persistence/LayoutUtilityPageEntryUtil.java
@@ -806,6 +806,66 @@ public class LayoutUtilityPageEntryUtil {
 	}
 
 	/**
+	 * Returns the layout utility page entry where plid = &#63; or throws a <code>NoSuchLayoutUtilityPageEntryException</code> if it could not be found.
+	 *
+	 * @param plid the plid
+	 * @return the matching layout utility page entry
+	 * @throws NoSuchLayoutUtilityPageEntryException if a matching layout utility page entry could not be found
+	 */
+	public static LayoutUtilityPageEntry findByPlid(long plid)
+		throws com.liferay.layout.utility.page.exception.
+			NoSuchLayoutUtilityPageEntryException {
+
+		return getPersistence().findByPlid(plid);
+	}
+
+	/**
+	 * Returns the layout utility page entry where plid = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param plid the plid
+	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
+	 */
+	public static LayoutUtilityPageEntry fetchByPlid(long plid) {
+		return getPersistence().fetchByPlid(plid);
+	}
+
+	/**
+	 * Returns the layout utility page entry where plid = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param plid the plid
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
+	 */
+	public static LayoutUtilityPageEntry fetchByPlid(
+		long plid, boolean useFinderCache) {
+
+		return getPersistence().fetchByPlid(plid, useFinderCache);
+	}
+
+	/**
+	 * Removes the layout utility page entry where plid = &#63; from the database.
+	 *
+	 * @param plid the plid
+	 * @return the layout utility page entry that was removed
+	 */
+	public static LayoutUtilityPageEntry removeByPlid(long plid)
+		throws com.liferay.layout.utility.page.exception.
+			NoSuchLayoutUtilityPageEntryException {
+
+		return getPersistence().removeByPlid(plid);
+	}
+
+	/**
+	 * Returns the number of layout utility page entries where plid = &#63;.
+	 *
+	 * @param plid the plid
+	 * @return the number of matching layout utility page entries
+	 */
+	public static int countByPlid(long plid) {
+		return getPersistence().countByPlid(plid);
+	}
+
+	/**
 	 * Returns all the layout utility page entries where groupId = &#63; and type = &#63;.
 	 *
 	 * @param groupId the group ID

--- a/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/service/packageinfo
+++ b/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/service/packageinfo
@@ -1,1 +1,1 @@
-version 6.2.0
+version 6.3.0

--- a/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/service/persistence/packageinfo
+++ b/modules/apps/layout/layout-utility-page-api/src/main/resources/com/liferay/layout/utility/page/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/layout/layout-utility-page-service/service.xml
+++ b/modules/apps/layout/layout-utility-page-service/service.xml
@@ -41,6 +41,9 @@
 		<finder name="GroupId" return-type="Collection">
 			<finder-column name="groupId" />
 		</finder>
+		<finder name="Plid" return-type="LayoutUtilityPageEntry" unique="true">
+			<finder-column name="plid" />
+		</finder>
 		<finder name="G_T" return-type="Collection">
 			<finder-column name="groupId" />
 			<finder-column name="type" />

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/model/impl/LayoutUtilityPageEntryModelImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/model/impl/LayoutUtilityPageEntryModelImpl.java
@@ -161,13 +161,19 @@ public class LayoutUtilityPageEntryModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long TYPE_COLUMN_BITMASK = 32L;
+	public static final long PLID_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 64L;
+	public static final long TYPE_COLUMN_BITMASK = 64L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 128L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -645,6 +651,15 @@ public class LayoutUtilityPageEntryModelImpl
 		}
 
 		_plid = plid;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public long getOriginalPlid() {
+		return GetterUtil.getLong(this.<Long>getColumnOriginalValue("plid"));
 	}
 
 	@JSON

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -246,6 +246,11 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 	}
 
 	@Override
+	public LayoutUtilityPageEntry fetchLayoutUtilityPageEntryByPlid(long plid) {
+		return layoutUtilityPageEntryPersistence.fetchByPlid(plid);
+	}
+
+	@Override
 	public LayoutUtilityPageEntry getDefaultLayoutUtilityPageEntry(
 			long groupId, String type)
 		throws PortalException {

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/persistence/impl/LayoutUtilityPageEntryPersistenceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/persistence/impl/LayoutUtilityPageEntryPersistenceImpl.java
@@ -2438,6 +2438,220 @@ public class LayoutUtilityPageEntryPersistenceImpl
 	private static final String _FINDER_COLUMN_GROUPID_GROUPID_2 =
 		"layoutUtilityPageEntry.groupId = ?";
 
+	private FinderPath _finderPathFetchByPlid;
+	private FinderPath _finderPathCountByPlid;
+
+	/**
+	 * Returns the layout utility page entry where plid = &#63; or throws a <code>NoSuchLayoutUtilityPageEntryException</code> if it could not be found.
+	 *
+	 * @param plid the plid
+	 * @return the matching layout utility page entry
+	 * @throws NoSuchLayoutUtilityPageEntryException if a matching layout utility page entry could not be found
+	 */
+	@Override
+	public LayoutUtilityPageEntry findByPlid(long plid)
+		throws NoSuchLayoutUtilityPageEntryException {
+
+		LayoutUtilityPageEntry layoutUtilityPageEntry = fetchByPlid(plid);
+
+		if (layoutUtilityPageEntry == null) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("plid=");
+			sb.append(plid);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchLayoutUtilityPageEntryException(sb.toString());
+		}
+
+		return layoutUtilityPageEntry;
+	}
+
+	/**
+	 * Returns the layout utility page entry where plid = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param plid the plid
+	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
+	 */
+	@Override
+	public LayoutUtilityPageEntry fetchByPlid(long plid) {
+		return fetchByPlid(plid, true);
+	}
+
+	/**
+	 * Returns the layout utility page entry where plid = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param plid the plid
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching layout utility page entry, or <code>null</code> if a matching layout utility page entry could not be found
+	 */
+	@Override
+	public LayoutUtilityPageEntry fetchByPlid(
+		long plid, boolean useFinderCache) {
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			LayoutUtilityPageEntry.class);
+
+		Object[] finderArgs = null;
+
+		if (useFinderCache && productionMode) {
+			finderArgs = new Object[] {plid};
+		}
+
+		Object result = null;
+
+		if (useFinderCache && productionMode) {
+			result = finderCache.getResult(
+				_finderPathFetchByPlid, finderArgs, this);
+		}
+
+		if (result instanceof LayoutUtilityPageEntry) {
+			LayoutUtilityPageEntry layoutUtilityPageEntry =
+				(LayoutUtilityPageEntry)result;
+
+			if (plid != layoutUtilityPageEntry.getPlid()) {
+				result = null;
+			}
+		}
+
+		if (result == null) {
+			StringBundler sb = new StringBundler(3);
+
+			sb.append(_SQL_SELECT_LAYOUTUTILITYPAGEENTRY_WHERE);
+
+			sb.append(_FINDER_COLUMN_PLID_PLID_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(plid);
+
+				List<LayoutUtilityPageEntry> list = query.list();
+
+				if (list.isEmpty()) {
+					if (useFinderCache && productionMode) {
+						finderCache.putResult(
+							_finderPathFetchByPlid, finderArgs, list);
+					}
+				}
+				else {
+					LayoutUtilityPageEntry layoutUtilityPageEntry = list.get(0);
+
+					result = layoutUtilityPageEntry;
+
+					cacheResult(layoutUtilityPageEntry);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		if (result instanceof List<?>) {
+			return null;
+		}
+		else {
+			return (LayoutUtilityPageEntry)result;
+		}
+	}
+
+	/**
+	 * Removes the layout utility page entry where plid = &#63; from the database.
+	 *
+	 * @param plid the plid
+	 * @return the layout utility page entry that was removed
+	 */
+	@Override
+	public LayoutUtilityPageEntry removeByPlid(long plid)
+		throws NoSuchLayoutUtilityPageEntryException {
+
+		LayoutUtilityPageEntry layoutUtilityPageEntry = findByPlid(plid);
+
+		return remove(layoutUtilityPageEntry);
+	}
+
+	/**
+	 * Returns the number of layout utility page entries where plid = &#63;.
+	 *
+	 * @param plid the plid
+	 * @return the number of matching layout utility page entries
+	 */
+	@Override
+	public int countByPlid(long plid) {
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			LayoutUtilityPageEntry.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByPlid;
+
+			finderArgs = new Object[] {plid};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+		}
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(2);
+
+			sb.append(_SQL_COUNT_LAYOUTUTILITYPAGEENTRY_WHERE);
+
+			sb.append(_FINDER_COLUMN_PLID_PLID_2);
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(plid);
+
+				count = (Long)query.uniqueResult();
+
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_PLID_PLID_2 =
+		"layoutUtilityPageEntry.plid = ?";
+
 	private FinderPath _finderPathWithPaginationFindByG_T;
 	private FinderPath _finderPathWithoutPaginationFindByG_T;
 	private FinderPath _finderPathCountByG_T;
@@ -5247,6 +5461,11 @@ public class LayoutUtilityPageEntryPersistenceImpl
 			layoutUtilityPageEntry);
 
 		finderCache.putResult(
+			_finderPathFetchByPlid,
+			new Object[] {layoutUtilityPageEntry.getPlid()},
+			layoutUtilityPageEntry);
+
+		finderCache.putResult(
 			_finderPathFetchByG_N_T,
 			new Object[] {
 				layoutUtilityPageEntry.getGroupId(),
@@ -5359,6 +5578,12 @@ public class LayoutUtilityPageEntryPersistenceImpl
 		finderCache.putResult(_finderPathCountByUUID_G, args, Long.valueOf(1));
 		finderCache.putResult(
 			_finderPathFetchByUUID_G, args, layoutUtilityPageEntryModelImpl);
+
+		args = new Object[] {layoutUtilityPageEntryModelImpl.getPlid()};
+
+		finderCache.putResult(_finderPathCountByPlid, args, Long.valueOf(1));
+		finderCache.putResult(
+			_finderPathFetchByPlid, args, layoutUtilityPageEntryModelImpl);
 
 		args = new Object[] {
 			layoutUtilityPageEntryModelImpl.getGroupId(),
@@ -6113,6 +6338,8 @@ public class LayoutUtilityPageEntryPersistenceImpl
 
 		_uniqueIndexColumnNames.add(new String[] {"uuid_", "groupId"});
 
+		_uniqueIndexColumnNames.add(new String[] {"plid"});
+
 		_uniqueIndexColumnNames.add(new String[] {"groupId", "name", "type_"});
 
 		_uniqueIndexColumnNames.add(
@@ -6203,6 +6430,14 @@ public class LayoutUtilityPageEntryPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByGroupId",
 			new String[] {Long.class.getName()}, new String[] {"groupId"},
 			false);
+
+		_finderPathFetchByPlid = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByPlid",
+			new String[] {Long.class.getName()}, new String[] {"plid"}, true);
+
+		_finderPathCountByPlid = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByPlid",
+			new String[] {Long.class.getName()}, new String[] {"plid"}, false);
 
 		_finderPathWithPaginationFindByG_T = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_T",

--- a/modules/apps/layout/layout-utility-page-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/layout/layout-utility-page-service/src/main/resources/META-INF/sql/indexes.sql
@@ -4,6 +4,7 @@ create unique index IX_E84DFDB8 on LayoutUtilityPageEntry (groupId, externalRefe
 create unique index IX_D08C3F1 on LayoutUtilityPageEntry (groupId, name[$COLUMN_LENGTH:75$], type_[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_B1A82450 on LayoutUtilityPageEntry (groupId, type_[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_BF95A05E on LayoutUtilityPageEntry (groupId, type_[$COLUMN_LENGTH:75$], defaultLayoutUtilityPageEntry, ctCollectionId);
+create unique index IX_6D96DD70 on LayoutUtilityPageEntry (plid, ctCollectionId);
 create index IX_2CA6CC99 on LayoutUtilityPageEntry (uuid_[$COLUMN_LENGTH:75$], companyId, ctCollectionId);
 create index IX_1740222B on LayoutUtilityPageEntry (uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 create unique index IX_F81461DB on LayoutUtilityPageEntry (uuid_[$COLUMN_LENGTH:75$], groupId, ctCollectionId);

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/persistence/test/LayoutUtilityPageEntryPersistenceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/persistence/test/LayoutUtilityPageEntryPersistenceTest.java
@@ -291,6 +291,13 @@ public class LayoutUtilityPageEntryPersistenceTest {
 	}
 
 	@Test
+	public void testCountByPlid() throws Exception {
+		_persistence.countByPlid(RandomTestUtil.nextLong());
+
+		_persistence.countByPlid(0L);
+	}
+
+	@Test
 	public void testCountByG_T() throws Exception {
 		_persistence.countByG_T(RandomTestUtil.nextLong(), "");
 
@@ -674,6 +681,12 @@ public class LayoutUtilityPageEntryPersistenceTest {
 			ReflectionTestUtil.<Long>invoke(
 				layoutUtilityPageEntry, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "groupId"));
+
+		Assert.assertEquals(
+			Long.valueOf(layoutUtilityPageEntry.getPlid()),
+			ReflectionTestUtil.<Long>invoke(
+				layoutUtilityPageEntry, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "plid"));
 
 		Assert.assertEquals(
 			Long.valueOf(layoutUtilityPageEntry.getGroupId()),


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-176194)

Show same actions when editing a utility page than when editing a display page

## How to test

* Edit a utility page and kebab options should show only prefiew and configure


