### PR TITLE
LPS-167882 Don't use aui:input to avoid field validation

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
@@ -29,6 +29,7 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 		method="post"
 		name="fm"
 		onSubmit="event.preventDefault();"
+		validateOnBlur="<%= false %>"
 	>
 		<liferay-frontend:edit-form-body>
 			<aui:input label="name" name="name" placeholder='<%= LanguageUtil.get(request, "add-page-name") %>' required="<%= true %>" />


### PR DESCRIPTION
Motivation
=======
This is a follow-up of https://github.com/liferay-echo/liferay-portal/pull/11171. After testing it, the QA told us that the Cancel button was not being well read by the screen reader, as it announces the field error when focusing it.
The fix recommendation was removing the field validation, as we already have the alert for it.

Proposed Solution
========
What I have done is removing the use of `aui:input` and adding the markup manually, so we avoid the field validation. I'm not super convinced of this fix but it was the only idea that came to my mind.

Steps to Verify
========
1. Go to Site Builder > Pages
2. Click + button
3. Click on Add button without filling a name
4. See how field validation doesn't appear 
5. Focus Cancel button and see how the screen reader reads it properly


