### PR TITLE
[TS] LPS-176401 | After upgrade from u35 to u62 fragment view usage not accessible

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/resources/META-INF/custom-sql/default.xml
+++ b/modules/apps/fragment/fragment-service/src/main/resources/META-INF/custom-sql/default.xml
@@ -134,7 +134,10 @@
 					WHERE
 						(FragmentEntryLink.groupId = ?) AND
 						(FragmentEntryLink.fragmentEntryId = ?) AND
-						(FragmentEntryLink.deleted = [$FALSE$])
+						(
+							(FragmentEntryLink.deleted = [$FALSE$]) OR
+							(FragmentEntryLink.deleted IS NULL)
+						)
 				) TEMP_TABLE
 		]]>
 	</sql>
@@ -201,7 +204,10 @@
 			WHERE
 				(FragmentEntryLink.groupId = ?) AND
 				(FragmentEntryLink.fragmentEntryId = ?) AND
-				(FragmentEntryLink.deleted = [$FALSE$]) AND
+				(
+					(FragmentEntryLink.deleted = [$FALSE$]) OR
+					(FragmentEntryLink.deleted IS NULL)
+				) AND
 				(
 					FragmentEntryLink.createDate =
 						(


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-176401
Thank you!

-----

**Steps to reproduce:**

1. Start Liferay u35
2. design->Fragments->Create new fragment
3. Copy this code to new fragment
```
<div class="fragment_1">
<h1> Test </h1>
</div>
```
4. Go to home page, edit and add the new fragment to the page, then publish.
5. You can check in Design->Fragments in the new fragment’s menu that the “view usage” Shows everything correctly
6. Shut down 7.4.13 u35
7. Add “upgrade.database.auto.run=true” to portal-ext.properties
8. Start the 7.4.13 u62 or a newer master bundle and let it update
9. Log in, and go to design->fragment, click on the previously created fragments menu and try clicking “view usage”

 **Expected result:** You can open view usage and shows the proper values
**Actual result:** You can’t open View usage until you add the fragment to a page after the upgrade.


The root cause of the issue is that the newly created deleted column is not populated for older entries. So as a fallback behavior, I changed the count and find by methods related to fragment usage to also count entrylinks without a value in the deleted column.
related LPS: https://issues.liferay.com/browse/LPS-162484