### PR TITLE
LPS-176518 Include the externalReferenceCode in the TaxonomyCategory for the /taxonomy-categories/ranked endpoint

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/TaxonomyCategoryResourceImpl.java
@@ -541,6 +541,8 @@ public class TaxonomyCategoryResourceImpl
 		projectionList.add(ProjectionFactoryUtil.property("companyId"));
 		projectionList.add(ProjectionFactoryUtil.property("createDate"));
 		projectionList.add(ProjectionFactoryUtil.property("description"));
+		projectionList.add(
+			ProjectionFactoryUtil.property("externalReferenceCode"));
 		projectionList.add(ProjectionFactoryUtil.property("groupId"));
 		projectionList.add(ProjectionFactoryUtil.property("modifiedDate"));
 		projectionList.add(ProjectionFactoryUtil.property("name"));
@@ -611,11 +613,12 @@ public class TaxonomyCategoryResourceImpl
 				setCompanyId((long)assetCategory[2]);
 				setCreateDate(_toDate((Timestamp)assetCategory[3]));
 				setDescription((String)assetCategory[4]);
-				setGroupId((long)assetCategory[5]);
-				setModifiedDate(_toDate((Timestamp)assetCategory[6]));
-				setName((String)assetCategory[7]);
-				setUserId((long)assetCategory[8]);
-				setVocabularyId((long)assetCategory[9]);
+				setExternalReferenceCode((String)assetCategory[5]);
+				setGroupId((long)assetCategory[6]);
+				setModifiedDate(_toDate((Timestamp)assetCategory[7]));
+				setName((String)assetCategory[8]);
+				setUserId((long)assetCategory[9]);
+				setVocabularyId((long)assetCategory[10]);
 			}
 		};
 	}


### PR DESCRIPTION
This PR contains the code to fix this bug: https://issues.liferay.com/browse/LPS-176518

It is related to this LPP: https://issues.liferay.com/browse/LPP-48059

The `externalReferenceCode` field has been included into the Projection of the dynamicQuery that is being used to get the Taxonomy Categories. With that, the field is returned in the response of the query and it is returned properly.

The field has been included in the list of fields that must be validated in the ResourceTests.

---

**Before the PR:**

```
curl -X 'GET' \
    'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/ranked' \
     -H 'accept: application/json' \
     -u 'test@liferay.com:test'
```

```
{
  "actions" : { },
  "facets" : [ ],
  "items" : [ {
    "[...]
    "externalReferenceCode" : "",
    [...]
  } ],
  [...]
}
```

**After the PR:**

```
curl -X 'GET' \
    'http://localhost:8080/o/headless-admin-taxonomy/v1.0/taxonomy-categories/ranked' \
     -H 'accept: application/json' \
     -u 'test@liferay.com:test'
```

```
{
  "actions" : { },
  "facets" : [ ],
  "items" : [ {
    "[...]
    "externalReferenceCode" : "42c581b7-1232-5d0a-fddb-25167743c8d3",
    [...]
  } ],
  [...]
}
```