### PR TITLE
[TS] LPS-176405 live groups web contents will appear in the item selector, if staging is not set for web contents

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/display/context/JournalContentDisplayContext.java
@@ -444,7 +444,8 @@ public class JournalContentDisplayContext {
 		itemSelectorCriterion.setStatus(WorkflowConstants.STATUS_ANY);
 
 		return _itemSelector.getItemSelectorURL(
-			requestBackedPortletURLFactory,
+			requestBackedPortletURLFactory, _getGroup(),
+			_themeDisplay.getScopeGroupId(),
 			liferayRenderResponse.getNamespace() + "selectedItem",
 			itemSelectorCriterion);
 	}
@@ -1041,6 +1042,24 @@ public class JournalContentDisplayContext {
 		return DDMTemplateLocalServiceUtil.fetchTemplate(
 			article.getGroupId(), _ddmStructureClassNameId, ddmTemplateKey,
 			true);
+	}
+
+	private Group _getGroup() {
+		Group group = _themeDisplay.getScopeGroup();
+
+		StagingGroupHelper stagingGroupHelper =
+			StagingGroupHelperUtil.getStagingGroupHelper();
+
+		if (stagingGroupHelper.isLocalStagingGroup(group.getGroupId()) &&
+			!stagingGroupHelper.isStagedPortlet(
+				group.getGroupId(), JournalPortletKeys.JOURNAL)) {
+
+			Group scopeGroup = _themeDisplay.getScopeGroup();
+
+			group = scopeGroup.getLiveGroup();
+		}
+
+		return group;
 	}
 
 	private static final boolean _STAGING_LIVE_GROUP_LOCKING_ENABLED =


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-176405
Thank you!
-----
**Reproduction Steps:**

1. Go to Publishing --> Staging --> enable local staging and uncheck "Web Content" from the Staged Content.
2. Go to Content & Data --> Web Content and create basic web content.
3. Go to Site Builder --> Pages and create a widget page, then place a web content display portlet on it.
4. Click on the "Select web content to make it visible" link in the WCD and click "Select" in the Popup.

**Expected outcome:** The web content does not appear for selection.
**Actual outcome:** If web contents are not staged, the live group's web content should be displayed.

**Solution:**
This regression was caused by LPS-169729. If staging for web contents were disabled it was not taken into consideration, so I implemented a method where it checks that, and in this case, web contents from the live site will be visible.