### PR TITLE
LPS-175928 Quit text-truncate in subtitle for Web Content  in the content tab for Widget Pages and Content Pages

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
@@ -230,7 +230,9 @@ export default function PageContent({
 					</span>
 
 					{subtype && (
-						<span className="text-secondary">{subtype}</span>
+						<span className="text-break text-secondary">
+							{subtype}
+						</span>
 					)}
 				</ClayLayout.ContentCol>
 

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabItem.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabItem.js
@@ -73,7 +73,7 @@ const TabItem = ({item}) => {
 					<div className="mr-1 text-truncate title">{item.label}</div>
 
 					{isContent && (
-						<div className="subtitle text-truncate">
+						<div className="subtitle text-break">
 							{item.category}
 						</div>
 					)}


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-173139)

## Test Scenario 1

* Navigate to Content & Data > Web Content and create two of them with the names:
	- Company_Liferay_article_new_week_Monday_1 	
	- Company_Liferay_article_new_week_Monday_2
* Navigate to Site Builder > Pages and create one Widget page.
* Navigate to the page and click on the add button.
* Go to “Content” tab and check the subtitle.

<img width="299" alt="image" src="https://user-images.githubusercontent.com/93203423/221173271-a584b377-076c-406c-9545-29139d078657.png">

## Test Scenario 2

* Navigate to Content & Data > Web Content and create one with the name:
	- Company_Liferay_article_new_week_Monday_1
* Navigate to Site Builder > Pages and create one Content page.
* Add one content display and select the web content.
* Check the subtitle in the page content tab.

<img width="277" alt="image" src="https://user-images.githubusercontent.com/93203423/221189310-09bd9485-092a-46c9-94b4-c117c3fe7776.png">
