### PR TITLE
[TS] LPS-176530 Web content assets are not anonymized when the user data is deleted

### DIFF
--- a/modules/apps/journal/journal-uad/src/main/java/com/liferay/journal/uad/anonymizer/JournalArticleUADAnonymizer.java
+++ b/modules/apps/journal/journal-uad/src/main/java/com/liferay/journal/uad/anonymizer/JournalArticleUADAnonymizer.java
@@ -14,6 +14,8 @@
 
 package com.liferay.journal.uad.anonymizer;
 
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.journal.model.JournalArticle;
 import com.liferay.user.associated.data.anonymizer.UADAnonymizer;
 
 import org.osgi.service.component.annotations.Component;
@@ -24,4 +26,11 @@ import org.osgi.service.component.annotations.Component;
 @Component(service = UADAnonymizer.class)
 public class JournalArticleUADAnonymizer
 	extends BaseJournalArticleUADAnonymizer {
+
+	protected AssetEntry fetchAssetEntry(JournalArticle journalArticle) {
+		return assetEntryLocalService.fetchEntry(
+			JournalArticle.class.getName(),
+			journalArticle.getResourcePrimKey());
+	}
+
 }


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
By deleting a user, the web content's asset entry is not anonymized. This is because the asset entry's `classPK` is the ID of the journal article **resource**, not the journal article.

Proposed Solution
========
It is overriding `BaseJournalArticleUADAnonymizer`'s `fetchAssetEntry` method so that it fetches the asset entry of the journal article's `ResourcePrimKey`. 

Steps to Verify
========
Please see the linked LPS for reproduction steps.
https://issues.liferay.com/browse/LPS-176530

Thank you and best regards,
István