### PR TITLE
LPS-176893 | Master

### DIFF
--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/CodeMirrorEditor.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/CodeMirrorEditor.js
@@ -50,6 +50,9 @@ import CodeMirror from 'codemirror';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
 
+
+import {debounce} from 'frontend-js-web';
+
 export function CodeMirrorEditor({
 	autocompleteData,
 	content,
@@ -248,7 +251,7 @@ export function CodeMirrorEditor({
 			onChange(editor.getValue());
 		};
 
-		editor.on('change', handleChange);
+		editor.on('change', debounce(handleChange));
 
 		return () => {
 			editor.off('change', handleChange);

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/CodeMirrorEditor.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/CodeMirrorEditor.js
@@ -47,11 +47,9 @@ import 'codemirror/mode/htmlmixed/htmlmixed';
 import 'codemirror/mode/javascript/javascript';
 import {CodeMirrorKeyboardMessage} from '@liferay/layout-content-page-editor-web';
 import CodeMirror from 'codemirror';
+import {debounce} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useEffect, useRef, useState} from 'react';
-
-
-import {debounce} from 'frontend-js-web';
 
 export function CodeMirrorEditor({
 	autocompleteData,


### PR DESCRIPTION
**Motivation:** 
[LPS-176893 - Double clicking the accent key in the template editor using a browser with Windows crashes the entire page](https://issues.liferay.com/browse/LPS-176893)

When accidentally double-clicking the accent key, to try to write for example "á", it locks everything and does not allow anything else to be done.

**Steps to Verify**
1. Under default DXP site go to Design > Templates
2. Create a new Widget Template
3. Set a title
4. Double-click the "´´" or "``" accent key

**Results of Investigation**
I hosted my environment for testing purposes. Two machines with OS Windows and one with OS Linux were used. It was discovered that this issue _**is only reproducible when a user is using a browser with Windows**_. 

Using a debug fix, it was discovered that this is a javascript related issue. When the accent key is double-clicked, the [handleChange method in the CodeMirrorEditor.js](https://github.com/liferay/liferay-portal/blob/master/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/CodeMirrorEditor.js#L247) is called in loop as it tries to print two accent instead.

**Proposed Solution**
Use a debounce function in the handleChange to delay the character processing.