### PR TITLE
[TS] LPS-176401 | After upgrade from u35 to u62 fragment view usage not accessible

### DIFF
--- a/modules/apps/fragment/fragment-service/bnd.bnd
+++ b/modules/apps/fragment/fragment-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.fragment.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 2.10.1
+Liferay-Require-SchemaVersion: 2.10.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/registry/FragmentServiceUpgradeStepRegistrator.java
@@ -189,6 +189,11 @@ public class FragmentServiceUpgradeStepRegistrator
 			"2.10.0", "2.10.1",
 			new com.liferay.fragment.internal.upgrade.v2_10_1.
 				FragmentCollectionUpgradeProcess(_dlFolderLocalService));
+
+		registry.register(
+			"2.10.1", "2.10.2",
+			new com.liferay.fragment.internal.upgrade.v2_10_2.
+				FragmentEntryLinkUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v2_10_2/FragmentEntryLinkUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v2_10_2/FragmentEntryLinkUpgradeProcess.java
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.fragment.internal.upgrade.v2_10_2;
+
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Attila Bakay
+ */
+public class FragmentEntryLinkUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		_updateFragmentEntryLinkDeleted();
+	}
+
+	private void _updateFragmentEntryLinkDeleted() throws Exception {
+		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
+				"select fragmentEntryLinkId, deleted fromFragmentEntryLink " +
+					"where deleted is null");
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					"update FragmentEntryLink set deleted = ? where " +
+						"fragmentEntryLinkId = ?")) {
+
+			ResultSet resultSet = preparedStatement1.executeQuery();
+
+			while (resultSet.next()) {
+				long fragmentEntryLinkId = resultSet.getLong(1);
+
+				preparedStatement2.setBoolean(1, false);
+				preparedStatement2.setLong(2, fragmentEntryLinkId);
+
+				preparedStatement2.addBatch();
+			}
+
+			preparedStatement2.executeBatch();
+		}
+	}
+
+}


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-176401
Thank you!

-----

**Steps to reproduce:**

1. Start Liferay u35
2. design->Fragments->Create new fragment
3. Copy this code to new fragment
```
<div class="fragment_1">
<h1> Test </h1>
</div>
```
4. Go to home page, edit and add the new fragment to the page, then publish.
5. You can check in Design->Fragments in the new fragment’s menu that the “view usage” Shows everything correctly
6. Shut down 7.4.13 u35
7. Add “upgrade.database.auto.run=true” to portal-ext.properties
8. Start the 7.4.13 u62 or a newer master bundle and let it update
9. Log in, and go to design->fragment, click on the previously created fragments menu and try clicking “view usage”

 **Expected result:** You can open view usage and shows the proper values
**Actual result:** You can’t open View usage until you add the fragment to a page after the upgrade.


The root cause of the issue is that the newly created deleted column is not populated for older entries. Based on Brian's feedback on the previous version of the fix I created an upgrade step to provide the default value for the field.
previous pull request: https://github.com/brianchandotcom/liferay-portal/pull/130725
related LPS: https://issues.liferay.com/browse/LPS-162484