### PR TITLE
LPS-176657 Display page preview in Categories doesn't have back button

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/servlet/taglib/util/AssetCategoryActionDropdownItemsProvider.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/servlet/taglib/util/AssetCategoryActionDropdownItemsProvider.java
@@ -39,6 +39,7 @@ import com.liferay.portal.kernel.portlet.PortletProviderUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portlet.asset.service.permission.AssetCategoryPermission;
@@ -125,7 +126,11 @@ public class AssetCategoryActionDropdownItemsProvider {
 					).add(
 						() -> _getDisplayPageURL(category) != null,
 						dropdownItem -> {
-							dropdownItem.setHref(_getDisplayPageURL(category));
+							dropdownItem.setHref(
+								HttpComponentsUtil.addParameters(
+									_getDisplayPageURL(category),
+									"p_l_back_url",
+									_themeDisplay.getURLCurrent()));
 							dropdownItem.setIcon("view");
 							dropdownItem.setLabel(
 								LanguageUtil.get(


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-176657)

## Test Scenario 

* Create a display page for categories and publish it
* Add a Category, edit it and assign it the previously created display page
* Back to Categories administration, open the category options dropdown and select View Display Page
Expected: The display page is shown and we have Back button available to come back to Categories admin.
<img width="442" alt="image" src="https://user-images.githubusercontent.com/93203423/223153602-b27462ec-8076-4010-85f6-1ec19a19ff4b.png">
