### PR TITLE
LPS-177954 Set CanDeleteSystemScopedReadOnlyDeployedFragmentInGlobalSiteOfDefaultInstance to not be run with DB partitioning

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsDeploy.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/FragmentsDeploy.testcase
@@ -81,6 +81,7 @@ definition {
 	@priority = 5
 	@uitest
 	test CanDeleteSystemScopedReadOnlyDeployedFragmentInGlobalSiteOfDefaultInstance {
+		property database.partition.enabled = "false";
 		property portal.acceptance = "true";
 		property test.name.skip.portal.instance = "FragmentsDeploy#CanDeleteSystemScopedReadOnlyDeployedFragmentInGlobalSiteOfDefaultInstance";
 

--- a/test.properties
+++ b/test.properties
@@ -4164,6 +4164,7 @@
         functional-tomcat90-mysql57-jdk8
 
     test.batch.run.property.query[functional-tomcat90-mysql57-jdk8][echo-db-partition]=\
+        (database.partition.enabled != false) AND \
         (portal.acceptance == true) AND \
         (portal.upstream == true) AND \
         (\


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-177954