### PR TITLE
[TS] LPS-178064

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/internal/display/context/AssetCategoriesNavigationDisplayContext.java
@@ -184,8 +184,7 @@ public class AssetCategoriesNavigationDisplayContext {
 		).put(
 			"id", category.getCategoryId()
 		).put(
-			"name",
-			HtmlUtil.escape(category.getTitle(_themeDisplay.getLocale()))
+			"name", category.getTitle(_themeDisplay.getLocale())
 		).put(
 			"url", _getPortletURL(category.getCategoryId())
 		).put(
@@ -246,9 +245,7 @@ public class AssetCategoriesNavigationDisplayContext {
 				).put(
 					"id", vocabulary.getVocabularyId()
 				).put(
-					"name",
-					HtmlUtil.escape(
-						vocabulary.getTitle(_themeDisplay.getLocale()))
+					"name", vocabulary.getTitle(_themeDisplay.getLocale())
 				));
 		}
 


### PR DESCRIPTION
**Motivation**
Hello team, this tries to fix case described in https://issues.liferay.com/browse/LPS-178064:

Steps to reproduce:

1. Add a new vocabulary called 'D&M'
2. For 'D&M' add a category named 'C&A'
3. Add the Category Filter widget to a page (default config)
4. Expected result: the tree shows 'D&M' and 'C&A' 

Current result: the tree shows 'D&M' and 'C&A'

**Proposed Solution**
Removing the escaping of the attributes would solve the issue. With this solution I haven't been able to reproduce any XSS by inyecting code in both names:

1. Add a new vocabulary called <script>alert('vocabularyname')</script>
2. For 'D&M' add a category named <script>alert('categoryName')</script>
3. Add the Category Filter widget to a page (default config)

Result: no alert shows up
