### PR TITLE
LPS-177203 Default utility page is lost when publishing twice the site in staging

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateEntryStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateEntryStagedModelDataHandler.java
@@ -379,7 +379,9 @@ public class LayoutPageTemplateEntryStagedModelDataHandler
 			LayoutPageTemplateEntry layoutPageTemplateEntry)
 		throws Exception {
 
-		if (layoutPageTemplateEntry.isDefaultTemplate()) {
+		if (!ExportImportThreadLocal.isStagingInProcess() &&
+			layoutPageTemplateEntry.isDefaultTemplate()) {
+
 			LayoutPageTemplateEntry defaultLayoutPageTemplateEntry =
 				_layoutPageTemplateEntryLocalService.
 					fetchDefaultLayoutPageTemplateEntry(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutUtilityPageEntryStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutUtilityPageEntryStagedModelDataHandler.java
@@ -16,6 +16,7 @@ package com.liferay.layout.admin.web.internal.exportimport.data.handler;
 
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
@@ -165,7 +166,9 @@ public class LayoutUtilityPageEntryStagedModelDataHandler
 			LayoutUtilityPageEntry layoutUtilityPageEntry)
 		throws Exception {
 
-		if (layoutUtilityPageEntry.isDefaultLayoutUtilityPageEntry()) {
+		if (!ExportImportThreadLocal.isStagingInProcess() &&
+			layoutUtilityPageEntry.isDefaultLayoutUtilityPageEntry()) {
+
 			LayoutUtilityPageEntry defaultLayoutUtilityPageEntry =
 				_layoutUtilityPageEntryLocalService.
 					fetchDefaultLayoutUtilityPageEntry(

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -115,13 +115,18 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 		layoutUtilityPageEntry.setPlid(plid);
 
 		layoutUtilityPageEntry.setPreviewFileEntryId(previewFileEntryId);
-		layoutUtilityPageEntry.setDefaultLayoutUtilityPageEntry(
-			defaultLayoutUtilityPageEntry);
 		layoutUtilityPageEntry.setName(name);
 		layoutUtilityPageEntry.setType(type);
 
 		layoutUtilityPageEntry = layoutUtilityPageEntryPersistence.update(
 			layoutUtilityPageEntry);
+
+		if (defaultLayoutUtilityPageEntry) {
+			layoutUtilityPageEntry =
+				layoutUtilityPageEntryLocalService.
+					setDefaultLayoutUtilityPageEntry(
+						layoutUtilityPageEntry.getLayoutUtilityPageEntryId());
+		}
 
 		_resourceLocalService.addResources(
 			layoutUtilityPageEntry.getCompanyId(),

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/internal/exportimport/data/handler/test/LayoutUtilityPageEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/internal/exportimport/data/handler/test/LayoutUtilityPageEntryStagedModelDataHandlerTest.java
@@ -52,6 +52,74 @@ public class LayoutUtilityPageEntryStagedModelDataHandlerTest
 		new LiferayIntegrationTestRule();
 
 	@Test
+	public void testChangeDefaultLayoutUtilityPageEntry() throws Exception {
+		initExport();
+
+		LayoutUtilityPageEntry layoutUtilityPageEntry1 =
+			_addLayoutUtilityPageEntry(true, stagingGroup);
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, layoutUtilityPageEntry1);
+
+		initImport();
+
+		LayoutUtilityPageEntry exportedLayoutUtilityPageEntry1 =
+			(LayoutUtilityPageEntry)readExportedStagedModel(
+				layoutUtilityPageEntry1);
+
+		LayoutUtilityPageEntry importedLayoutUtilityPageEntry1 =
+			_getImportedLayoutUtilityPageEntry(
+				exportedLayoutUtilityPageEntry1, liveGroup,
+				layoutUtilityPageEntry1);
+
+		Assert.assertTrue(
+			importedLayoutUtilityPageEntry1.isDefaultLayoutUtilityPageEntry());
+
+		initExport();
+
+		LayoutUtilityPageEntry layoutUtilityPageEntry2 =
+			_addLayoutUtilityPageEntry(true, stagingGroup);
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, layoutUtilityPageEntry2);
+
+		// We changed the default utility page entry, so we have to export
+		// the model again
+
+		layoutUtilityPageEntry1 =
+			_layoutUtilityPageEntryLocalService.getLayoutUtilityPageEntry(
+				layoutUtilityPageEntry1.getLayoutUtilityPageEntryId());
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, layoutUtilityPageEntry1);
+
+		initImport();
+
+		exportedLayoutUtilityPageEntry1 =
+			(LayoutUtilityPageEntry)readExportedStagedModel(
+				layoutUtilityPageEntry1);
+
+		importedLayoutUtilityPageEntry1 = _getImportedLayoutUtilityPageEntry(
+			exportedLayoutUtilityPageEntry1, liveGroup,
+			layoutUtilityPageEntry1);
+
+		Assert.assertFalse(
+			importedLayoutUtilityPageEntry1.isDefaultLayoutUtilityPageEntry());
+
+		LayoutUtilityPageEntry exportedLayoutUtilityPageEntry2 =
+			(LayoutUtilityPageEntry)readExportedStagedModel(
+				layoutUtilityPageEntry2);
+
+		LayoutUtilityPageEntry importedLayoutUtilityPageEntry2 =
+			_getImportedLayoutUtilityPageEntry(
+				exportedLayoutUtilityPageEntry2, liveGroup,
+				layoutUtilityPageEntry2);
+
+		Assert.assertTrue(
+			importedLayoutUtilityPageEntry2.isDefaultLayoutUtilityPageEntry());
+	}
+
+	@Test
 	public void testDefaultLayoutUtilityPageEntryAfterUpdate()
 		throws Exception {
 

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/internal/exportimport/data/handler/test/LayoutUtilityPageEntryStagedModelDataHandlerTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/internal/exportimport/data/handler/test/LayoutUtilityPageEntryStagedModelDataHandlerTest.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.DateTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.test.rule.Inject;
@@ -56,15 +57,8 @@ public class LayoutUtilityPageEntryStagedModelDataHandlerTest
 
 		initExport();
 
-		long userId = TestPropsValues.getUserId();
-
 		LayoutUtilityPageEntry layoutUtilityPageEntry =
-			_layoutUtilityPageEntryLocalService.addLayoutUtilityPageEntry(
-				null, userId, stagingGroup.getGroupId(), 0, 0, false,
-				"Test Entry", LayoutUtilityPageEntryConstants.TYPE_SC_NOT_FOUND,
-				0,
-				ServiceContextTestUtil.getServiceContext(
-					stagingGroup.getGroupId(), userId));
+			_addLayoutUtilityPageEntry(false, stagingGroup);
 
 		StagedModelDataHandlerUtil.exportStagedModel(
 			portletDataContext, layoutUtilityPageEntry);
@@ -75,12 +69,10 @@ public class LayoutUtilityPageEntryStagedModelDataHandlerTest
 			(LayoutUtilityPageEntry)readExportedStagedModel(
 				layoutUtilityPageEntry);
 
-		StagedModelDataHandlerUtil.importStagedModel(
-			portletDataContext, exportedLayoutUtilityPageEntry);
-
 		LayoutUtilityPageEntry importedLayoutUtilityPageEntry =
-			(LayoutUtilityPageEntry)getStagedModel(
-				layoutUtilityPageEntry.getUuid(), liveGroup);
+			_getImportedLayoutUtilityPageEntry(
+				exportedLayoutUtilityPageEntry, liveGroup,
+				layoutUtilityPageEntry);
 
 		Assert.assertFalse(
 			importedLayoutUtilityPageEntry.isDefaultLayoutUtilityPageEntry());
@@ -101,11 +93,8 @@ public class LayoutUtilityPageEntryStagedModelDataHandlerTest
 			(LayoutUtilityPageEntry)readExportedStagedModel(
 				layoutUtilityPageEntry);
 
-		StagedModelDataHandlerUtil.importStagedModel(
-			portletDataContext, exportedLayoutUtilityPageEntry);
-
-		importedLayoutUtilityPageEntry = (LayoutUtilityPageEntry)getStagedModel(
-			layoutUtilityPageEntry.getUuid(), liveGroup);
+		importedLayoutUtilityPageEntry = _getImportedLayoutUtilityPageEntry(
+			exportedLayoutUtilityPageEntry, liveGroup, layoutUtilityPageEntry);
 
 		Assert.assertTrue(
 			importedLayoutUtilityPageEntry.isDefaultLayoutUtilityPageEntry());
@@ -160,6 +149,30 @@ public class LayoutUtilityPageEntryStagedModelDataHandlerTest
 		Assert.assertEquals(
 			layoutUtilityPageEntry.getType(),
 			importLayoutUtilityPageEntry.getType());
+	}
+
+	private LayoutUtilityPageEntry _addLayoutUtilityPageEntry(
+			boolean defaultLayoutUtilityPageEntry, Group group)
+		throws Exception {
+
+		return _layoutUtilityPageEntryLocalService.addLayoutUtilityPageEntry(
+			null, TestPropsValues.getUserId(), group.getGroupId(), 0, 0,
+			defaultLayoutUtilityPageEntry, RandomTestUtil.randomString(),
+			LayoutUtilityPageEntryConstants.TYPE_SC_NOT_FOUND, 0,
+			ServiceContextTestUtil.getServiceContext(
+				group.getGroupId(), TestPropsValues.getUserId()));
+	}
+
+	private LayoutUtilityPageEntry _getImportedLayoutUtilityPageEntry(
+			LayoutUtilityPageEntry exportedLayoutUtilityPageEntry, Group group,
+			LayoutUtilityPageEntry layoutUtilityPageEntry)
+		throws Exception {
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedLayoutUtilityPageEntry);
+
+		return (LayoutUtilityPageEntry)getStagedModel(
+			layoutUtilityPageEntry.getUuid(), group);
 	}
 
 	@Inject


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-177203)

This PR fixes several issues: 

* Default utility pages and display pages are lost on certain occasions when publishing to staging
* If calling the service, an inconsistency happens if we set the default utility page template to true

For the first issue, it depends on the order of the entries. For example, if we had an utility page with a numeric name set as default and we change the default to a non numeric name and publish, we would lose the default utility page in live. Same happens with utility pages.

We change this so as to only honour the default entry when we are not in staging mode


## Change summary:

* Check in staged model data handler for utility pages and page templates if we are in staging process or not before overriding the default entry
* Change local service for utility page to use the service that changes the default entry, and not set it directly
* Adds integration tests


## Test Scenario

* Follow the steps in the ticket, the naming of the entries is important to reproduce them