### PR TITLE
LPS-167609 - Mouse hover information is not available for keyboard

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
@@ -33,7 +33,7 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 
 		<div class="form-group input-group mb-2">
 			<div class="input-group-item">
-				<input class="field form-control lfr-input-text" id="<portlet:namespace />ddmTemplateName" readonly="readonly" title="<%= LanguageUtil.get(request, "template-name") %>" type="text" value="<%= (ddmTemplate != null) ? HtmlUtil.escape(ddmTemplate.getName(locale)) : LanguageUtil.get(request, "no-template") %>" />
+				<input class="field form-control lfr-input-text lfr-portal-tooltip" id="<portlet:namespace />ddmTemplateName" readonly="readonly" title="<%= LanguageUtil.get(request, "template-name") %>" type="text" value="<%= (ddmTemplate != null) ? HtmlUtil.escape(ddmTemplate.getName(locale)) : LanguageUtil.get(request, "no-template") %>" />
 			</div>
 
 			<c:if test="<%= (article != null) && !article.isNew() && (journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT) %>">


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-167609

This PR adds the `lfr-portal-tooltip` class so that title is visible onHover, onFocus, and read by screen readers.

![Screenshot 2023-03-15 at 11 31 48 AM](https://user-images.githubusercontent.com/1609196/225237748-931e5e35-af7c-4a1d-88a3-d6fff191bf0f.png)
