### PR TITLE
LPS-177945 Date Fragment custom format not working on Display Page Template Preview

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/CollectionItemContext.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/CollectionItemContext.js
@@ -259,6 +259,7 @@ const useGetFieldValue = () => {
 
 			if (isMappedToStructure(editable) && displayPagePreviewItem) {
 				return InfoItemService.getInfoItemFieldValue({
+					...editable,
 					...displayPagePreviewItem.data,
 					fieldId: editable.mappedField,
 					languageId: editable.languageId,


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-177945)

## Steps 

1. Go to Content & Data > Web Content
2. Create a Basic Web Content: title w1
3. Go to Design > Page Templates > Display Page Templates
4. Create a new Display Page Template for Basic Web Contents
5. Add a Date fragment to the page
6. Map the Publish Date field to the Date fragment
7. Set The custom format of the Date fragment to "YYYY"
8. Publish the Display Page Template
9. Edit the Display Page Template again
10. From the top menu, Preview with, select the Basic Web 
![Screenshot 2023-03-15 at 14 08 02](https://user-images.githubusercontent.com/91208451/225317955-42eb7b7c-af4f-4331-ada9-aa30c2bd89ce.png)
Content w1

