### PR TITLE
[Urgent] [TS] LPS-178900 Deleted experience resets widget configuration on default experience

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
@@ -380,7 +380,15 @@ public class SegmentsExperienceUtil {
 			newFragmentEntryLink.setSegmentsExperienceId(
 				targetSegmentsExperienceId);
 
-			String newNamespace = fragmentEntryLink.getNamespace();
+			String newNamespace = StringUtil.randomId();
+
+			if (SegmentsExperimentLocalServiceUtil.hasSegmentsExperiment(
+					sourceSegmentsExperienceId,
+					PortalUtil.getClassNameId(Layout.class.getName()), plid,
+					null)) {
+
+				newNamespace = fragmentEntryLink.getNamespace();
+			}
 
 			newFragmentEntryLink.setEditableValues(
 				_getNewEditableValues(


### PR DESCRIPTION
Ticket: [LPS-178900](https://issues.liferay.com/browse/LPS-178900)

I'm sending this to the Echo team because I saw that the Tango team was being sunset and their components passed to Echo. Please let me know if I should instead send this to Tango or to a different team.

I've marked this as [Urgent] because it is a blocker for our customer.

Motivation
=======
Experiences are not working properly right now because any the existing portlets are not receiving a new namespace when a new Experience is created. This means that all portlets across Experiences share the same namespace, and therefore the same PortletPreferences as well, so modifying the PortletPreferences of a Portlet on one experience will cause that modification to be applied to all experiences.

This is due to https://github.com/liferay/liferay-portal/commit/f1e2f9214a1dcb766c9ad5733b85c0bee9b49a4c, which was made to fix a bug with A/B test variations (see [LPS-152323](https://issues.liferay.com/browse/LPS-152323)). However, this commit was overly broad; this change should have only applied to A/B test variations (i.e. Experiences that are associated to an Experiment), not to all Experiences as a whole.

Proposed Solution
========
Modify the changes from https://github.com/liferay/liferay-portal/commit/f1e2f9214a1dcb766c9ad5733b85c0bee9b49a4c so that they only apply to A/B test variations, and not to all Experiences as a whole. Regular experiences should still use the same logic as before, generating a new namespace for the copied portlets and fragments.

Steps to Verify
========
1. Start up Liferay and log in as the admin user.
2. Add a web content article named "Test Content".
3. Edit the home page; this should take you to the Default Experience. Add an Asset Publisher display to the page.
4. Configure the Asset Publisher to dynamically display web content articles
5. Publish the changes and verify that homepage shows the web content
6. Edit the home page again
7. Add a new experience
8. Delete the new experience and refresh the page

**Expected Result:** The Asset Publisher would still be displaying the web content
**Actual Result:** The Asset Publisher configuration has been reset; it is no longer displaying the web content.