### PR TITLE
LPS 178820

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5747,7 +5747,7 @@ public class JournalArticleLocalServiceImpl
 				article.getClassNameId())) {
 
 			urlTitle = urlTitleMap.get(
-				LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
+				LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()));
 
 			if (Validator.isNull(urlTitle)) {
 				throw new ArticleFriendlyURLException();

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5746,7 +5746,12 @@ public class JournalArticleLocalServiceImpl
 			(_classNameLocalService.getClassNameId(DDMStructure.class) !=
 				article.getClassNameId())) {
 
-			throw new ArticleFriendlyURLException();
+			urlTitle = urlTitleMap.get(
+				LocaleUtil.toLanguageId(LocaleUtil.getDefault()));
+
+			if (Validator.isNull(urlTitle)) {
+				throw new ArticleFriendlyURLException();
+			}
 		}
 
 		article.setFolderId(folderId);


### PR DESCRIPTION
Motivation
=======
You can find more details about how to reproduce this issue in [LPS-178820](https://issues.liferay.com/browse/LPS-178820).

Proposed Solution
========
@antonio-ortega originally wrote:

> Originally I thought about introducing some change in friendly-url-taglib to consider this case, or even adding a new param to that taglib so we can pass a defaulLanguage to it, but after the conversation we both have on Slack with @robertoDiaz I decided to just check on JournalArticle whether there is an URL for Site's default language before returning an exception.

Steps to Verify
========

1. Start Liferay DXP 7.0
2. Set Spanish and Basque as available languages.
3. Set Spanish as default language.
4. Create a Basic Web Content
5. Set Basque as default language
6. Upgrade to Liferay DXP 7.4 (or master)
7. Try to save a new version for that content

*Expected behavior*
- You can save it

*Actual behavior*
- You can not save it. If you enable SessionError log category you'll see ArticleFriendlyURLException