### PR TITLE
Lps-179318 Evaluation of segments entry is not working if it have a user custom field

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/retriever/OrganizationODataRetriever.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/retriever/OrganizationODataRetriever.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.segments.internal.odata.entity.OrganizationEntityModel;
 import com.liferay.segments.odata.retriever.ODataRetriever;
 import com.liferay.segments.odata.search.ODataSearchAdapter;
@@ -50,9 +51,11 @@ public class OrganizationODataRetriever
 			int end)
 		throws PortalException {
 
+		FilterParser filterParser = _filterParserProvider.provide(_entityModel);
+
 		Hits hits = _oDataSearchAdapter.search(
-			companyId, _filterParser, filterString,
-			Organization.class.getName(), _entityModel, locale, start, end);
+			companyId, filterParser, filterString, Organization.class.getName(),
+			_entityModel, locale, start, end);
 
 		return _getOrganizations(hits);
 	}
@@ -62,9 +65,11 @@ public class OrganizationODataRetriever
 			long companyId, String filterString, Locale locale)
 		throws PortalException {
 
+		FilterParser filterParser = _filterParserProvider.provide(_entityModel);
+
 		return _oDataSearchAdapter.searchCount(
-			companyId, _filterParser, filterString,
-			Organization.class.getName(), _entityModel, locale);
+			companyId, filterParser, filterString, Organization.class.getName(),
+			_entityModel, locale);
 	}
 
 	private Organization _getOrganization(Document document)
@@ -95,10 +100,8 @@ public class OrganizationODataRetriever
 	)
 	private EntityModel _entityModel;
 
-	@Reference(
-		target = "(entity.model.name=" + OrganizationEntityModel.NAME + ")"
-	)
-	private FilterParser _filterParser;
+	@Reference
+	private FilterParserProvider _filterParserProvider;
 
 	@Reference
 	private ODataSearchAdapter _oDataSearchAdapter;

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/retriever/UserODataRetriever.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/odata/retriever/UserODataRetriever.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.odata.entity.EntityModel;
 import com.liferay.portal.odata.filter.FilterParser;
+import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.segments.internal.odata.entity.UserEntityModel;
 import com.liferay.segments.odata.retriever.ODataRetriever;
 import com.liferay.segments.odata.search.ODataSearchAdapter;
@@ -49,8 +50,10 @@ public class UserODataRetriever implements ODataRetriever<User> {
 			int end)
 		throws PortalException {
 
+		FilterParser filterParser = _filterParserProvider.provide(_entityModel);
+
 		Hits hits = _oDataSearchAdapter.search(
-			companyId, _filterParser, filterString, User.class.getName(),
+			companyId, filterParser, filterString, User.class.getName(),
 			_entityModel, locale, start, end);
 
 		return _getUsers(hits);
@@ -61,8 +64,10 @@ public class UserODataRetriever implements ODataRetriever<User> {
 			long companyId, String filterString, Locale locale)
 		throws PortalException {
 
+		FilterParser filterParser = _filterParserProvider.provide(_entityModel);
+
 		return _oDataSearchAdapter.searchCount(
-			companyId, _filterParser, filterString, User.class.getName(),
+			companyId, filterParser, filterString, User.class.getName(),
 			_entityModel, locale);
 	}
 
@@ -87,8 +92,8 @@ public class UserODataRetriever implements ODataRetriever<User> {
 	@Reference(target = "(entity.model.name=" + UserEntityModel.NAME + ")")
 	private EntityModel _entityModel;
 
-	@Reference(target = "(entity.model.name=" + UserEntityModel.NAME + ")")
-	private FilterParser _filterParser;
+	@Reference
+	private FilterParserProvider _filterParserProvider;
 
 	@Reference
 	private ODataSearchAdapter _oDataSearchAdapter;

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/OrganizationODataRetrieverCustomFieldsTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/odata/retriever/test/OrganizationODataRetrieverCustomFieldsTest.java
@@ -24,13 +24,11 @@ import com.liferay.expando.kernel.service.ExpandoColumnLocalService;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.ListTypeConstants;
-import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.Organization;
 import com.liferay.portal.kernel.model.OrganizationConstants;
 import com.liferay.portal.kernel.service.OrganizationLocalService;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
-import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.OrganizationTestUtil;
@@ -41,6 +39,7 @@ import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.odata.normalizer.Normalizer;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -1175,10 +1174,11 @@ public class OrganizationODataRetrieverCustomFieldsTest {
 			false, serviceContext);
 	}
 
-	private String _encodeName(ExpandoColumn expandoColumn) throws Exception {
-		return ReflectionTestUtil.invoke(
-			_modelListener, "_encodeName", new Class<?>[] {ExpandoColumn.class},
-			expandoColumn);
+	private String _encodeName(ExpandoColumn expandoColumn) {
+		return StringBundler.concat(
+			StringPool.UNDERLINE, expandoColumn.getColumnId(),
+			StringPool.UNDERLINE,
+			Normalizer.normalizeIdentifier(expandoColumn.getName()));
 	}
 
 	private ODataRetriever<Organization> _getODataRetriever() {
@@ -1194,11 +1194,6 @@ public class OrganizationODataRetrieverCustomFieldsTest {
 
 	@DeleteAfterTestRun
 	private ExpandoTable _expandoTable;
-
-	@Inject(
-		filter = "component.name=com.liferay.segments.internal.model.listener.OrganizationExpandoColumnModelListener"
-	)
-	private ModelListener<ExpandoColumn> _modelListener;
 
 	@Inject
 	private OrganizationLocalService _organizationLocalService;


### PR DESCRIPTION
[Link to the bug](https://issues.liferay.com/browse/LPS-179318)

Motivation
=======
When a segment entry containing a custom field is evaluating, odata throws an error because the custom field of the segments entry does not belong to the entity data model passed as a parameter. So , for that reason there ir no showing the correct experience even the user match with that experience.

Proposed Solution
========
Create the fileParser through FilterParserProvider to add the entity data model containing the recently created custom fields.

Steps to Verify:
----------------

1. Add a user custom field.
2. Create a segments entry with the above custom field and set a value for the criteria.
3. Create a page and inside it create an experience with the above segments entry and prioritize it.
4. Go to user management and set in your logged user the same value as the value of the created segments entry.
5. Navigate to the page that you created and you will see the content of the created experience.


Integration tests are provided in : OrganizationODataRetrieverCustomFieldsTest and UserODataRetrieverCustomFieldsTest. 