### PR TITLE
LPS-165509 Experience selected in view mode is incorrect

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/SegmentsExperienceUtil.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/SegmentsExperienceUtil.java
@@ -15,7 +15,10 @@
 package com.liferay.layout.taglib.internal.util;
 
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.segments.manager.SegmentsExperienceManager;
 
 import javax.servlet.http.HttpServletRequest;
@@ -32,7 +35,16 @@ public class SegmentsExperienceUtil {
 			httpServletRequest, "segmentsExperienceId", -1);
 
 		if (selectedSegmentsExperienceId != -1) {
-			return selectedSegmentsExperienceId;
+			long[] currentSegmentsExperienceIds = GetterUtil.getLongValues(
+				httpServletRequest.getAttribute(
+					SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS));
+
+			if (ArrayUtil.contains(
+					currentSegmentsExperienceIds,
+					selectedSegmentsExperienceId)) {
+
+				return selectedSegmentsExperienceId;
+			}
 		}
 
 		SegmentsExperienceManager segmentsExperienceManager =

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
@@ -96,15 +96,13 @@ public class SegmentsExperienceSelectorDisplayContext {
 					_httpServletRequest);
 		}
 
-		if (segmentsExperienceId > 0){
-
+		if (segmentsExperienceId > 0) {
 			long[] currentSegmentsExperienceIds = GetterUtil.getLongValues(
 				_httpServletRequest.getAttribute(
 					SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS));
 
 			if (ArrayUtil.contains(
-				currentSegmentsExperienceIds,
-				segmentsExperienceId)) {
+					currentSegmentsExperienceIds, segmentsExperienceId)) {
 
 				return _segmentsExperienceLocalService.fetchSegmentsExperience(
 					segmentsExperienceId);
@@ -273,18 +271,11 @@ public class SegmentsExperienceSelectorDisplayContext {
 		SegmentsExperience parentSegmentsExperience =
 			_getParentSegmentsExperience(segmentsExperience);
 
-		if ((segmentsExperience != null) &&
-			(parentSegmentsExperience != null)) {
-
-			segmentsExperience = parentSegmentsExperience;
+		if (parentSegmentsExperience != null) {
+			return parentSegmentsExperience.getName(_themeDisplay.getLocale());
 		}
 
-		if (segmentsExperience != null) {
-			return segmentsExperience.getName(_themeDisplay.getLocale());
-		}
-
-		return SegmentsEntryConstants.getDefaultSegmentsEntryName(
-			_themeDisplay.getLocale());
+		return segmentsExperience.getName(_themeDisplay.getLocale());
 	}
 
 	private boolean _isActive(

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
@@ -25,14 +25,11 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.constants.SegmentsEntryConstants;
-import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.segments.manager.SegmentsExperienceManager;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsExperience;
@@ -89,21 +86,20 @@ public class SegmentsExperienceSelectorDisplayContext {
 		long segmentsExperienceId = ParamUtil.getLong(
 			_httpServletRequest, "segmentsExperienceId", -1);
 
-		long[] currentSegmentsExperienceIds = GetterUtil.getLongValues(
-			_httpServletRequest.getAttribute(
-				SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS));
-
-		if ((segmentsExperienceId == -1) ||
-			!ArrayUtil.contains(
-				currentSegmentsExperienceIds, segmentsExperienceId)) {
-
+		if (segmentsExperienceId == -1) {
 			segmentsExperienceId =
 				_segmentsExperienceManager.getSegmentsExperienceId(
 					_httpServletRequest);
 		}
 
+		if (segmentsExperienceId > 0) {
+			return _segmentsExperienceLocalService.fetchSegmentsExperience(
+				segmentsExperienceId);
+		}
+
 		return _segmentsExperienceLocalService.fetchSegmentsExperience(
-			segmentsExperienceId);
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				_themeDisplay.getPlid()));
 	}
 
 	private SegmentsExperience _getParentSegmentsExperience(

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
@@ -24,12 +24,16 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.constants.SegmentsEntryConstants;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.segments.manager.SegmentsExperienceManager;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsExperience;
@@ -92,14 +96,26 @@ public class SegmentsExperienceSelectorDisplayContext {
 					_httpServletRequest);
 		}
 
-		if (segmentsExperienceId > 0) {
-			return _segmentsExperienceLocalService.fetchSegmentsExperience(
-				segmentsExperienceId);
+		if (segmentsExperienceId > 0){
+
+			long[] currentSegmentsExperienceIds = GetterUtil.getLongValues(
+				_httpServletRequest.getAttribute(
+					SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS));
+
+			if (ArrayUtil.contains(
+				currentSegmentsExperienceIds,
+				segmentsExperienceId)) {
+
+				return _segmentsExperienceLocalService.fetchSegmentsExperience(
+					segmentsExperienceId);
+			}
 		}
 
+		Layout layout = _themeDisplay.getLayout();
+
 		return _segmentsExperienceLocalService.fetchSegmentsExperience(
-			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
-				_themeDisplay.getPlid()));
+			layout.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
+			_portal.getClassNameId(Layout.class), _themeDisplay.getPlid());
 	}
 
 	private SegmentsExperience _getParentSegmentsExperience(

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
@@ -25,11 +25,14 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.constants.SegmentsEntryConstants;
+import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.segments.manager.SegmentsExperienceManager;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsExperience;
@@ -86,7 +89,14 @@ public class SegmentsExperienceSelectorDisplayContext {
 		long segmentsExperienceId = ParamUtil.getLong(
 			_httpServletRequest, "segmentsExperienceId", -1);
 
-		if (segmentsExperienceId == -1) {
+		long[] currentSegmentsExperienceIds = GetterUtil.getLongValues(
+			_httpServletRequest.getAttribute(
+				SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS));
+
+		if ((segmentsExperienceId == -1) ||
+			!ArrayUtil.contains(
+				currentSegmentsExperienceIds, segmentsExperienceId)) {
+
 			segmentsExperienceId =
 				_segmentsExperienceManager.getSegmentsExperienceId(
 					_httpServletRequest);


### PR DESCRIPTION
Motivation
=======
Bug fixing: The selected experience in view mode after editing that page  where an experience is created but the page is not saved is not correct.

Proposed Solution
========
Check if the experience that is in the parameter is in fact an experience of the page, if not return the default one.

Steps to Verify
========

1. Go to Home page, edit the page and create one experience
2. Create a new page from the Home page clicking in the '+' icon in the menu display element
3. Create a new experience in the new page
4. Click in the '<' (back) icon to return to the home page

**Actual result:**
See the home page and experience selected in the experience selector is the experience created for the new page.

**Expected:**
See the home page and experience selected in the experience selector is the active experience for the home page.

Checklist 
========

COMMITS:

- LPS-165509 We should control if the experience that is in the parameter is in fact an experience of the page
- LPS-165509 Check if the segmentsExperience from parameter belongs to the layout, if not return the default one
