### PR TITLE
LPS-178747 Add aria-label to button

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/StyleBookConfiguration.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/look_and_feel/StyleBookConfiguration.js
@@ -69,6 +69,7 @@ export default function StyleBookConfiguration({
 				</ClayForm.Group>
 
 				<ClayButtonWithIcon
+					aria-label={Liferay.Language.get('change-style-book')}
 					className="ml-2"
 					displayType="secondary"
 					onClick={handleChangeStyleBookClick}


### PR DESCRIPTION
This is a fix from this pull https://github.com/brianchandotcom/liferay-portal/pull/131990/commits

1. Go to Product Menu > Pages
2. Select kebab of Search Page or any Widget Page > Configure
3. Go to look and feel > Style Book section
<img width="942" alt="Screenshot 2023-03-23 at 11 49 23" src="https://user-images.githubusercontent.com/91208451/227184467-100a13fb-64ec-4b2a-a0e5-c11a9a4a2933.png">
