### PR TITLE
[TECHNICAL SUPPORT] LPS-179846 TitleBar floats over content with a gap when there is a warning message above it

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -88,6 +88,7 @@ $productMenuWidth: 320px;
 			left: 0;
 			min-height: 3.5rem;
 			position: fixed;
+			top: $controlMenuHeight;
 			transition: left ease $productMenuTransitionDuration,
 				width ease $productMenuTransitionDuration;
 			width: 100%;
@@ -218,19 +219,13 @@ $productMenuWidth: 320px;
 		.edit-article-sidebar {
 			border-left: 1px #e7e7ed solid;
 			box-shadow: none;
-			margin-top: $toolbarHeight;
 			max-width: 90vw;
 			outline: 0;
 			overflow-y: scroll;
 			padding-top: 0;
 			position: fixed;
-			top: auto;
 			width: $productMenuWidth;
 			z-index: 1;
-
-			@include media-breakpoint-up(lg) {
-				margin-top: $toolbarDesktopHeight;
-			}
 
 			.article-content-description {
 				@extend .article-content-content;


### PR DESCRIPTION
Hey,
[LPS-179846](https://issues.liferay.com/browse/LPS-179846)

When we enable staging, without enabling it on web content, the warning about the data is not staged will push the titleBar down and it will leave a gap whenever the user scrolls down.

My changes restores the behaviour from 7.2, where this warning was not visible during edit mode. Please review my changes.

Thanks