### PR TITLE
LPS-179206 The screen size button loses focus when pressed multiple times

### DIFF
--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/components/SizeSelector.tsx
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/components/SizeSelector.tsx
@@ -67,11 +67,11 @@ export default function SizeSelector({
 	return (
 		<ClayLayout.Container>
 			<ClayLayout.Row className="size-selector">
-				{sizesList.map((size) => (
+				{sizesList.map((size, index) => (
 					<SizeButton
 						activeSize={activeSize}
 						customSizeSelectorId={customSizeSelectorId}
-						key={size.id}
+						key={index}
 						onRotate={onRotate}
 						setActiveSize={setActiveSize}
 						size={size}


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-179206)

## Test Scenario
- Go to Simulation panel > open it
- Navigate by keyboard
- Press the Mobile screen size button
- Press again the Mobile button (landscape mobile)


https://user-images.githubusercontent.com/93203423/227903104-5a54831d-4901-4c26-8162-969f26f382df.mov

