### PR TITLE
LPS-179841 Replace ddmStructureKey document field pre-filtering by the classTypeId field

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelDocumentContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelDocumentContributor.java
@@ -142,8 +142,6 @@ public class JournalArticleModelDocumentContributor
 			StringUtil.split(journalArticle.getTreePath(), CharPool.SLASH));
 		document.addKeyword(Field.VERSION, journalArticle.getVersion());
 		document.addKeyword(
-			"ddmStructureKey", journalArticle.getDDMStructureKey());
-		document.addKeyword(
 			"ddmTemplateKey", journalArticle.getDDMTemplateKey());
 
 		if (ddmFormValues != null) {

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/query/contributor/JournalArticleModelPreFilterContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/query/contributor/JournalArticleModelPreFilterContributor.java
@@ -121,13 +121,6 @@ public class JournalArticleModelPreFilterContributor
 			}
 		}
 
-		String ddmStructureKey = (String)searchContext.getAttribute(
-			"ddmStructureKey");
-
-		if (Validator.isNotNull(ddmStructureKey)) {
-			booleanFilter.addRequiredTerm("ddmStructureKey", ddmStructureKey);
-		}
-
 		String ddmTemplateKey = (String)searchContext.getAttribute(
 			"ddmTemplateKey");
 

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalArticleItemSelectorViewDisplayContext.java
@@ -472,6 +472,19 @@ public class JournalArticleItemSelectorViewDisplayContext {
 		return ddmStructure.getStructureId();
 	}
 
+	private long _getDDMStructureId() {
+		if (_ddmStructureId != null) {
+			return _ddmStructureId;
+		}
+
+		_ddmStructureId = ParamUtil.getLong(
+			_httpServletRequest, "ddmStructureId",
+			GetterUtil.getLong(
+				_infoItemItemSelectorCriterion.getItemSubtype()));
+
+		return _ddmStructureId;
+	}
+
 	private String _getDDMStructureKey() {
 		if (_ddmStructureKey != null) {
 			return _ddmStructureKey;
@@ -670,10 +683,14 @@ public class JournalArticleItemSelectorViewDisplayContext {
 			Field.CLASS_NAME_ID, JournalArticleConstants.CLASS_NAME_ID_DEFAULT);
 		searchContext.setAttribute(
 			Field.STATUS, _infoItemItemSelectorCriterion.getStatus());
-		searchContext.setAttribute("ddmStructureKey", _getDDMStructureKey());
 		searchContext.setAttribute("head", Boolean.TRUE);
 		searchContext.setAttribute("latest", Boolean.TRUE);
 		searchContext.setAttribute("showNonindexable", Boolean.TRUE);
+
+		if (_getDDMStructureId() > 0) {
+			searchContext.setClassTypeIds(new long[] {_getDDMStructureId()});
+		}
+
 		searchContext.setCompanyId(_themeDisplay.getCompanyId());
 		searchContext.setEnd(end);
 		searchContext.setFolderIds(folderIds);
@@ -741,6 +758,7 @@ public class JournalArticleItemSelectorViewDisplayContext {
 	}
 
 	private SearchContainer<?> _articleSearchContainer;
+	private Long _ddmStructureId;
 	private String _ddmStructureKey;
 	private String _displayStyle;
 	private JournalFolder _folder;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1461,7 +1461,6 @@ public class JournalDisplayContext {
 		attributes.put(Field.DESCRIPTION, getKeywords());
 		attributes.put(Field.STATUS, getStatus());
 		attributes.put(Field.TITLE, getKeywords());
-		attributes.put("ddmStructureKey", getDDMStructureKey());
 		attributes.put("head", !showVersions);
 		attributes.put("latest", !showVersions);
 		attributes.put(
@@ -1474,6 +1473,13 @@ public class JournalDisplayContext {
 		attributes.put("showNonindexable", !showVersions);
 
 		searchContext.setAttributes(attributes);
+
+		long ddmStructureId = ParamUtil.getLong(
+			_httpServletRequest, "ddmStructureId");
+
+		if (ddmStructureId > 0) {
+			searchContext.setClassTypeIds(new long[] {ddmStructureId});
+		}
 
 		searchContext.setCompanyId(_themeDisplay.getCompanyId());
 		searchContext.setEnd(end);

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/helper/JournalRSSHelper.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/helper/JournalRSSHelper.java
@@ -24,7 +24,9 @@ import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.document.library.kernel.util.ImageProcessorUtil;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.Value;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.storage.DDMFormFieldValue;
 import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.journal.constants.JournalFeedConstants;
@@ -513,10 +515,6 @@ public class JournalRSSHelper {
 
 		attributes.put(Field.STATUS, WorkflowConstants.STATUS_APPROVED);
 
-		if (Validator.isNotNull(feed.getDDMStructureKey())) {
-			attributes.put("ddmStructureKey", feed.getDDMStructureKey());
-		}
-
 		if (Validator.isNotNull(feed.getDDMTemplateKey())) {
 			attributes.put("ddmTemplateKey", feed.getDDMTemplateKey());
 		}
@@ -524,6 +522,19 @@ public class JournalRSSHelper {
 		attributes.put("head", true);
 
 		searchContext.setAttributes(attributes);
+
+		if (Validator.isNotNull(feed.getDDMStructureKey())) {
+			DDMStructure ddmStructure =
+				_ddmStructureLocalService.fetchStructure(
+					feed.getGroupId(),
+					_portal.getClassNameId(JournalArticle.class),
+					feed.getDDMStructureKey(), true);
+
+			if (ddmStructure != null) {
+				searchContext.setClassTypeIds(
+					new long[] {ddmStructure.getStructureId()});
+			}
+		}
 
 		searchContext.setCompanyId(feed.getCompanyId());
 		searchContext.setEnd(feed.getDelta());
@@ -687,6 +698,9 @@ public class JournalRSSHelper {
 
 	@Reference
 	private AssetCategoryLocalService _assetCategoryLocalService;
+
+	@Reference
+	private DDMStructureLocalService _ddmStructureLocalService;
 
 	@Reference
 	private DLAppLocalService _dlAppLocalService;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/collection/provider/BasicWebContentSingleFormVariationInfoCollectionProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/collection/provider/BasicWebContentSingleFormVariationInfoCollectionProvider.java
@@ -110,15 +110,7 @@ public class BasicWebContentSingleFormVariationInfoCollectionProvider
 
 	@Override
 	public String getFormVariationKey() {
-		ServiceContext serviceContext =
-			ServiceContextThreadLocal.getServiceContext();
-
-		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
-			serviceContext.getScopeGroupId(),
-			_portal.getClassNameId(JournalArticle.class.getName()),
-			"BASIC-WEB-CONTENT", true);
-
-		return String.valueOf(ddmStructure.getStructureId());
+		return String.valueOf(_getDDDMStructureId());
 	}
 
 	@Override
@@ -170,16 +162,29 @@ public class BasicWebContentSingleFormVariationInfoCollectionProvider
 		return finalStep.build();
 	}
 
+	private long _getDDDMStructureId() {
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
+			serviceContext.getScopeGroupId(),
+			_portal.getClassNameId(JournalArticle.class.getName()),
+			"BASIC-WEB-CONTENT", true);
+
+		return ddmStructure.getStructureId();
+	}
+
 	private SearchContext _populateSearchContext(
 		CollectionQuery collectionQuery, SearchContext searchContext) {
 
 		Map<String, Serializable> attributes = searchContext.getAttributes();
 
 		attributes.put(Field.STATUS, WorkflowConstants.STATUS_APPROVED);
-		attributes.put("ddmStructureKey", "BASIC-WEB-CONTENT");
 		attributes.put("head", true);
 
 		searchContext.setAttributes(attributes);
+
+		searchContext.setClassTypeIds(new long[] {_getDDDMStructureId()});
 
 		Map<String, String[]> configuration =
 			collectionQuery.getConfiguration();

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/collection/provider/DDMStructureRelatedInfoCollectionProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/collection/provider/DDMStructureRelatedInfoCollectionProvider.java
@@ -153,7 +153,6 @@ public class DDMStructureRelatedInfoCollectionProvider
 		Map<String, Serializable> attributes = searchContext.getAttributes();
 
 		attributes.put(Field.STATUS, WorkflowConstants.STATUS_APPROVED);
-		attributes.put("ddmStructureKey", _ddmStructure.getStructureKey());
 		attributes.put("head", true);
 
 		searchContext.setAttributes(attributes);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-179841

@david-gutierrez-mesa @liulukiwi @tim-cao @alessandromalves @rafaellajordao

This PR removes the ddmStructureKey field from JournalArticle's document in the index. Therefore, at least, [this assertion](https://github.com/liferay/liferay-portal/blob/552b422030fce581ab8962f793ffba5649fb0a39/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructureee/search/searchexperiences/Blueprints.testcase#L4155-L4158) can no longer be made. I don't know if we should delete it or replace it with another one, could you please take a look at it? Thanks in advance ❤️ 