### PR TITLE
LPS-165509 Experience selected in view mode is incorrect

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/LayoutStructureCommonStylesCSSServlet.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/LayoutStructureCommonStylesCSSServlet.java
@@ -20,7 +20,6 @@ import com.liferay.frontend.token.definition.FrontendTokenDefinitionRegistry;
 import com.liferay.frontend.token.definition.FrontendTokenMapping;
 import com.liferay.layout.provider.LayoutStructureProvider;
 import com.liferay.layout.responsive.ViewportSize;
-import com.liferay.layout.taglib.internal.util.SegmentsExperienceUtil;
 import com.liferay.layout.util.structure.CommonStylesUtil;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
@@ -56,6 +55,8 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringBundler;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.util.DefaultStyleBookEntryUtil;
 
@@ -159,8 +160,7 @@ public class LayoutStructureCommonStylesCSSServlet extends HttpServlet {
 		LayoutStructure layoutStructure =
 			_layoutStructureProvider.getLayoutStructure(
 				layout.getPlid(),
-				SegmentsExperienceUtil.getSegmentsExperienceId(
-					httpServletRequest));
+				_getSegmentsExperienceId(httpServletRequest, layout));
 
 		if (layoutStructure == null) {
 			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
@@ -382,6 +382,33 @@ public class LayoutStructureCommonStylesCSSServlet extends HttpServlet {
 		return cssSB.toString();
 	}
 
+	private long _getSegmentsExperienceId(
+		HttpServletRequest httpServletRequest, Layout layout) {
+
+		long segmentsExperienceId = ParamUtil.getLong(
+			httpServletRequest, "segmentsExperienceId", -1);
+
+		if (segmentsExperienceId == -1) {
+			return _segmentsExperienceLocalService.
+				fetchDefaultSegmentsExperienceId(layout.getPlid());
+		}
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				segmentsExperienceId);
+
+		if ((segmentsExperience == null) ||
+			((_portal.getClassNameId(Layout.class.getName()) !=
+				segmentsExperience.getClassNameId()) &&
+			 (layout.getPlid() != segmentsExperience.getClassPK()))) {
+
+			return _segmentsExperienceLocalService.
+				fetchDefaultSegmentsExperienceId(layout.getPlid());
+		}
+
+		return segmentsExperience.getSegmentsExperienceId();
+	}
+
 	private String _getStyleFromStyleBookEntry(
 		JSONObject frontendTokensJSONObject, String styleValue) {
 
@@ -553,6 +580,9 @@ public class LayoutStructureCommonStylesCSSServlet extends HttpServlet {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/SegmentsExperienceUtil.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/SegmentsExperienceUtil.java
@@ -15,7 +15,10 @@
 package com.liferay.layout.taglib.internal.util;
 
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.segments.manager.SegmentsExperienceManager;
 
 import javax.servlet.http.HttpServletRequest;
@@ -32,7 +35,16 @@ public class SegmentsExperienceUtil {
 			httpServletRequest, "segmentsExperienceId", -1);
 
 		if (selectedSegmentsExperienceId != -1) {
-			return selectedSegmentsExperienceId;
+			long[] currentSegmentsExperienceIds = GetterUtil.getLongValues(
+				httpServletRequest.getAttribute(
+					SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS));
+
+			if (ArrayUtil.contains(
+					currentSegmentsExperienceIds,
+					selectedSegmentsExperienceId)) {
+
+				return selectedSegmentsExperienceId;
+			}
 		}
 
 		SegmentsExperienceManager segmentsExperienceManager =

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/product/navigation/control/menu/EditLayoutModeProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/product/navigation/control/menu/EditLayoutModeProductNavigationControlMenuEntry.java
@@ -44,6 +44,8 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.product.navigation.control.menu.BaseProductNavigationControlMenuEntry;
 import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
 import com.liferay.product.navigation.control.menu.constants.ProductNavigationControlMenuCategoryKeys;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.sites.kernel.util.Sites;
 import com.liferay.staging.StagingGroupHelper;
 
@@ -228,8 +230,18 @@ public class EditLayoutModeProductNavigationControlMenuEntry
 			httpServletRequest, "segmentsExperienceId", -1);
 
 		if (segmentsExperienceId != -1) {
-			redirect = HttpComponentsUtil.setParameter(
-				redirect, "segmentsExperienceId", segmentsExperienceId);
+			SegmentsExperience segmentsExperience =
+				_segmentsExperienceLocalService.fetchSegmentsExperience(
+					segmentsExperienceId);
+
+			if ((segmentsExperience != null) &&
+				(_portal.getClassNameId(Layout.class.getName()) ==
+					segmentsExperience.getClassNameId()) &&
+				(layout.getPlid() == segmentsExperience.getClassPK())) {
+
+				redirect = HttpComponentsUtil.setParameter(
+					redirect, "segmentsExperienceId", segmentsExperienceId);
+			}
 		}
 
 		return redirect;
@@ -258,6 +270,9 @@ public class EditLayoutModeProductNavigationControlMenuEntry
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 	@Reference
 	private Sites _sites;

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
@@ -96,15 +96,13 @@ public class SegmentsExperienceSelectorDisplayContext {
 					_httpServletRequest);
 		}
 
-		if (segmentsExperienceId > 0){
-
+		if (segmentsExperienceId > 0) {
 			long[] currentSegmentsExperienceIds = GetterUtil.getLongValues(
 				_httpServletRequest.getAttribute(
 					SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS));
 
 			if (ArrayUtil.contains(
-				currentSegmentsExperienceIds,
-				segmentsExperienceId)) {
+					currentSegmentsExperienceIds, segmentsExperienceId)) {
 
 				return _segmentsExperienceLocalService.fetchSegmentsExperience(
 					segmentsExperienceId);
@@ -273,18 +271,11 @@ public class SegmentsExperienceSelectorDisplayContext {
 		SegmentsExperience parentSegmentsExperience =
 			_getParentSegmentsExperience(segmentsExperience);
 
-		if ((segmentsExperience != null) &&
-			(parentSegmentsExperience != null)) {
-
-			segmentsExperience = parentSegmentsExperience;
+		if (parentSegmentsExperience != null) {
+			return parentSegmentsExperience.getName(_themeDisplay.getLocale());
 		}
 
-		if (segmentsExperience != null) {
-			return segmentsExperience.getName(_themeDisplay.getLocale());
-		}
-
-		return SegmentsEntryConstants.getDefaultSegmentsEntryName(
-			_themeDisplay.getLocale());
+		return segmentsExperience.getName(_themeDisplay.getLocale());
 	}
 
 	private boolean _isActive(

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
@@ -25,14 +25,11 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.constants.SegmentsEntryConstants;
-import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.segments.manager.SegmentsExperienceManager;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsExperience;
@@ -89,21 +86,20 @@ public class SegmentsExperienceSelectorDisplayContext {
 		long segmentsExperienceId = ParamUtil.getLong(
 			_httpServletRequest, "segmentsExperienceId", -1);
 
-		long[] currentSegmentsExperienceIds = GetterUtil.getLongValues(
-			_httpServletRequest.getAttribute(
-				SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS));
-
-		if ((segmentsExperienceId == -1) ||
-			!ArrayUtil.contains(
-				currentSegmentsExperienceIds, segmentsExperienceId)) {
-
+		if (segmentsExperienceId == -1) {
 			segmentsExperienceId =
 				_segmentsExperienceManager.getSegmentsExperienceId(
 					_httpServletRequest);
 		}
 
+		if (segmentsExperienceId > 0) {
+			return _segmentsExperienceLocalService.fetchSegmentsExperience(
+				segmentsExperienceId);
+		}
+
 		return _segmentsExperienceLocalService.fetchSegmentsExperience(
-			segmentsExperienceId);
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				_themeDisplay.getPlid()));
 	}
 
 	private SegmentsExperience _getParentSegmentsExperience(

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
@@ -24,12 +24,16 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.constants.SegmentsEntryConstants;
+import com.liferay.segments.constants.SegmentsExperienceConstants;
+import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.segments.manager.SegmentsExperienceManager;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsExperience;
@@ -92,14 +96,26 @@ public class SegmentsExperienceSelectorDisplayContext {
 					_httpServletRequest);
 		}
 
-		if (segmentsExperienceId > 0) {
-			return _segmentsExperienceLocalService.fetchSegmentsExperience(
-				segmentsExperienceId);
+		if (segmentsExperienceId > 0){
+
+			long[] currentSegmentsExperienceIds = GetterUtil.getLongValues(
+				_httpServletRequest.getAttribute(
+					SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS));
+
+			if (ArrayUtil.contains(
+				currentSegmentsExperienceIds,
+				segmentsExperienceId)) {
+
+				return _segmentsExperienceLocalService.fetchSegmentsExperience(
+					segmentsExperienceId);
+			}
 		}
 
+		Layout layout = _themeDisplay.getLayout();
+
 		return _segmentsExperienceLocalService.fetchSegmentsExperience(
-			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
-				_themeDisplay.getPlid()));
+			layout.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,
+			_portal.getClassNameId(Layout.class), _themeDisplay.getPlid());
 	}
 
 	private SegmentsExperience _getParentSegmentsExperience(

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
@@ -25,11 +25,14 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.constants.SegmentsEntryConstants;
+import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.segments.manager.SegmentsExperienceManager;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsExperience;
@@ -86,7 +89,14 @@ public class SegmentsExperienceSelectorDisplayContext {
 		long segmentsExperienceId = ParamUtil.getLong(
 			_httpServletRequest, "segmentsExperienceId", -1);
 
-		if (segmentsExperienceId == -1) {
+		long[] currentSegmentsExperienceIds = GetterUtil.getLongValues(
+			_httpServletRequest.getAttribute(
+				SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS));
+
+		if ((segmentsExperienceId == -1) ||
+			!ArrayUtil.contains(
+				currentSegmentsExperienceIds, segmentsExperienceId)) {
+
 			segmentsExperienceId =
 				_segmentsExperienceManager.getSegmentsExperienceId(
 					_httpServletRequest);

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
@@ -24,8 +24,6 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -33,7 +31,6 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
-import com.liferay.segments.constants.SegmentsWebKeys;
 import com.liferay.segments.manager.SegmentsExperienceManager;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsExperience;
@@ -96,20 +93,21 @@ public class SegmentsExperienceSelectorDisplayContext {
 					_httpServletRequest);
 		}
 
+		Layout layout = _themeDisplay.getLayout();
+
 		if (segmentsExperienceId > 0) {
-			long[] currentSegmentsExperienceIds = GetterUtil.getLongValues(
-				_httpServletRequest.getAttribute(
-					SegmentsWebKeys.SEGMENTS_EXPERIENCE_IDS));
-
-			if (ArrayUtil.contains(
-					currentSegmentsExperienceIds, segmentsExperienceId)) {
-
-				return _segmentsExperienceLocalService.fetchSegmentsExperience(
+			SegmentsExperience segmentsExperience =
+				_segmentsExperienceLocalService.fetchSegmentsExperience(
 					segmentsExperienceId);
+
+			if ((segmentsExperience != null) &&
+				(_portal.getClassNameId(Layout.class.getName()) ==
+					segmentsExperience.getClassNameId()) &&
+				(layout.getPlid() == segmentsExperience.getClassPK())) {
+
+				return segmentsExperience;
 			}
 		}
-
-		Layout layout = _themeDisplay.getLayout();
 
 		return _segmentsExperienceLocalService.fetchSegmentsExperience(
 			layout.getGroupId(), SegmentsExperienceConstants.KEY_DEFAULT,


### PR DESCRIPTION
Motivation
=======
[Link to ticket](https://issues.liferay.com/browse/LPS-165509)

Bug fixing: The selected experience in view mode after editing that page  where an experience is created but the page is not saved is not correct.

Proposed Solution
========
Check if the experience that is in the parameter is in fact an experience of the page, if not return the default one.

Steps to Verify
========

1. Go to Home page, edit the page and create one experience
2. Create a new page from the Home page clicking in the '+' icon in the menu display element
3. Create a new experience in the new page
4. Click in the '<' (back) icon to return to the home page

**Actual result:**
See the home page and experience selected in the experience selector is the experience created for the new page.

**Expected:**
See the home page and experience selected in the experience selector is the active experience for the home page.

