### PR TITLE
LPS-179120 Only ‘Success:’ displays after changing default language in category

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/action/EditAssetCategoryMVCActionCommand.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/portlet/action/EditAssetCategoryMVCActionCommand.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
@@ -82,6 +83,12 @@ public class EditAssetCategoryMVCActionCommand extends BaseMVCActionCommand {
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
+		String title = titleMap.get(themeDisplay.getLocale());
+
+		if (Validator.isBlank(title)) {
+			title = titleMap.get(themeDisplay.getSiteDefaultLocale());
+		}
+
 		AssetCategory category = null;
 
 		if (categoryId <= 0) {
@@ -99,9 +106,7 @@ public class EditAssetCategoryMVCActionCommand extends BaseMVCActionCommand {
 				_language.format(
 					_portal.getHttpServletRequest(actionRequest),
 					"x-was-created-successfully",
-					new Object[] {
-						HtmlUtil.escape(titleMap.get(themeDisplay.getLocale()))
-					}));
+					new Object[] {HtmlUtil.escape(title)}));
 		}
 		else {
 
@@ -120,9 +125,7 @@ public class EditAssetCategoryMVCActionCommand extends BaseMVCActionCommand {
 				_language.format(
 					_portal.getHttpServletRequest(actionRequest),
 					"x-was-updated-successfully",
-					new Object[] {
-						HtmlUtil.escape(titleMap.get(themeDisplay.getLocale()))
-					}));
+					new Object[] {HtmlUtil.escape(title)}));
 		}
 
 		// Asset display page


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-179120)

## Test Scenario
- Go to Configuration > Site Settings > Localization
- Change default language to Spanish
- Add a vocabulary
- Add a category, name it cat1
Note: Check the success message when creating the category.
<img width="382" alt="image" src="https://user-images.githubusercontent.com/93203423/228194867-4b67ca99-293b-47ef-9a72-68996c8845b1.png">

- Edit the category.
Note: Check the success message when update the category.
<img width="395" alt="image" src="https://user-images.githubusercontent.com/93203423/228194977-2f7cd467-1ab3-4ec5-a09e-e0e73ecdd745.png">
