### PR TITLE
LPS-179876 Update DnD feedback

### DIFF
--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/App.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/App.js
@@ -19,6 +19,7 @@ import {HTML5Backend} from 'react-dnd-html5-backend';
 import {SIDEBAR_PANEL_IDS} from '../constants/sidebarPanelIds';
 import {ConstantsProvider} from '../contexts/ConstantsContext';
 import {ItemsProvider, useItems} from '../contexts/ItemsContext';
+import {KeyboardDndProvider} from '../contexts/KeyboardDndContext';
 import {SelectedMenuItemIdProvider} from '../contexts/SelectedMenuItemIdContext';
 import {SidebarPanelIdProvider} from '../contexts/SidebarPanelIdContext';
 import {DragDropProvider} from '../utils/useDragAndDrop';
@@ -48,15 +49,17 @@ export function App(props) {
 		<DndProvider backend={HTML5Backend}>
 			<ConstantsProvider constants={props}>
 				<ItemsProvider initialItems={siteNavigationMenuItems}>
-					<DragPreview />
+					<KeyboardDndProvider>
+						<DragPreview />
 
-					<DragDropProvider>
-						<SelectedMenuItemIdProvider>
-							<SidebarPanelIdProvider>
-								<AppLayoutWrapper />
-							</SidebarPanelIdProvider>
-						</SelectedMenuItemIdProvider>
-					</DragDropProvider>
+						<DragDropProvider>
+							<SelectedMenuItemIdProvider>
+								<SidebarPanelIdProvider>
+									<AppLayoutWrapper />
+								</SidebarPanelIdProvider>
+							</SelectedMenuItemIdProvider>
+						</DragDropProvider>
+					</KeyboardDndProvider>
 				</ItemsProvider>
 			</ConstantsProvider>
 		</DndProvider>

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/DragPreview.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/DragPreview.js
@@ -18,6 +18,7 @@ import {useDragLayer} from 'react-dnd';
 
 import {useConstants} from '../contexts/ConstantsContext';
 import {useItems} from '../contexts/ItemsContext';
+import {useDragLayer as useKeyboardDragLayer} from '../contexts/KeyboardDndContext';
 import getDescendantsCount from '../utils/getDescendantsCount';
 
 const HANDLER_OFFSET = 10;
@@ -51,17 +52,22 @@ export default function DragPreview() {
 	const items = useItems();
 	const rtl = Liferay.Language.direction[languageId] === 'rtl';
 
-	const {
-		currentOffset,
-		isDragging,
-		itemId,
-		namespace: itemNamespace,
-	} = useDragLayer((monitor) => ({
+	const dragLayer = useDragLayer((monitor) => ({
 		currentOffset: monitor.getClientOffset(),
 		isDragging: monitor.isDragging(),
 		itemId: monitor.getItem()?.id,
 		namespace: monitor.getItem()?.namespace,
 	}));
+
+	const keyboardDragLayer = useKeyboardDragLayer();
+
+	const currentOffset =
+		dragLayer.currentOffset || keyboardDragLayer?.currentOffset;
+	const isDragging = dragLayer.isDragging || Boolean(keyboardDragLayer);
+	const itemId =
+		dragLayer.itemId || keyboardDragLayer?.siteNavigationMenuItemId;
+	const itemNamespace =
+		dragLayer.namespace || (keyboardDragLayer ? portletNamespace : null);
 
 	const [label, setLabel] = useState();
 

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/DragPreview.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/DragPreview.js
@@ -36,11 +36,9 @@ const getItemStyles = (currentOffset, ref, rtl) => {
 		: currentOffset.x - HANDLER_OFFSET;
 	const y = currentOffset.y - rect.height * 0.5;
 
-	const transform = `translate(${x}px, ${y}px)`;
-
 	return {
-		WebkitTransform: transform,
-		transform,
+		left: x,
+		top: y,
 	};
 };
 
@@ -89,6 +87,12 @@ export default function DragPreview() {
 			);
 		}
 	}, [itemId, items]);
+
+	useEffect(() => {
+		if (ref.current) {
+			ref.current.scrollIntoView();
+		}
+	}, [currentOffset]);
 
 	if (!isDragging || itemNamespace !== portletNamespace) {
 		return null;

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/KeyboardMovementText.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/KeyboardMovementText.js
@@ -12,25 +12,51 @@
  * details.
  */
 
-import React, {useEffect} from 'react';
+import {sub} from 'frontend-js-web';
+import React, {useEffect, useState} from 'react';
 
-export default function KeyboardMovementText({setText, text}) {
+import {useDragLayer} from '../contexts/KeyboardDndContext';
+
+function getMovementText(dragLayer) {
+	if (!dragLayer) {
+		return '';
+	}
+
+	return sub(
+		dragLayer.eventKey === 'ArrowDown'
+			? Liferay.Language.get('x-moved-down')
+			: Liferay.Language.get('x-moved-up'),
+		`${dragLayer.menuItemTitle} (${dragLayer.menuItemType})`
+	);
+}
+
+export default function KeyboardMovementText() {
+	const dragLayer = useDragLayer();
+
+	const [internalText, setInternalText] = useState(() =>
+		getMovementText(dragLayer)
+	);
+
 	useEffect(() => {
+		setInternalText(getMovementText(dragLayer));
+
 		const handler = setTimeout(() => {
-			setText(null);
+			setInternalText(null);
 		}, 500);
 
-		return () => clearTimeout(handler);
-	}, [text, setText]);
+		return () => {
+			clearTimeout(handler);
+		};
+	}, [dragLayer]);
 
-	return text ? (
+	return internalText ? (
 		<span
 			aria-live="assertive"
 			aria-relevant="additions"
 			className="sr-only"
 			role="log"
 		>
-			{text}
+			{internalText}
 		</span>
 	) : null;
 }

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/Menu.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/Menu.js
@@ -12,16 +12,12 @@
  * details.
  */
 
-import React, {useRef, useState} from 'react';
+import React, {useRef} from 'react';
 
 import {useItems} from '../contexts/ItemsContext';
-import KeyboardMovementText from './KeyboardMovementText';
 import {MenuItem} from './MenuItem';
 
 export function Menu() {
-	const [movementText, setMovementText] = useState('');
-	const [isMovementEnabled, setIsMovementEnabled] = useState(false);
-
 	const items = useItems();
 	const menuRef = useRef();
 
@@ -44,19 +40,11 @@ export function Menu() {
 			ref={menuRef}
 			role="menubar"
 		>
-			<KeyboardMovementText
-				setText={setMovementText}
-				text={movementText}
-			/>
-
 			{items.map((item, index) => (
 				<MenuItem
-					isMovementEnabled={isMovementEnabled}
 					item={item}
 					key={item.siteNavigationMenuItemId}
 					onMenuItemRemoved={() => onMenuItemRemoved(index)}
-					setIsMovementEnabled={setIsMovementEnabled}
-					setMovementText={setMovementText}
 				/>
 			))}
 		</div>

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/Menu.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/Menu.js
@@ -37,6 +37,7 @@ export function Menu() {
 		<div
 			aria-orientation="vertical"
 			className="container ml-lg-auto ml-sm-0 p-3 pt-4"
+			data-item-id="0"
 			ref={menuRef}
 			role="menubar"
 		>

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
@@ -237,6 +237,8 @@ export function MenuItem({item, onMenuItemRemoved}) {
 				return;
 			}
 
+			event.preventDefault();
+
 			setKeyboardDragLayer({
 				eventKey,
 				menuItemTitle: title,

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
@@ -185,7 +185,16 @@ export function MenuItem({item, onMenuItemRemoved}) {
 			event.stopPropagation();
 
 			if (isKeyboardDragging) {
-				setKeyboardDragLayer(null);
+				updateMenuItem({
+					editSiteNavigationMenuItemParentURL,
+					itemId: keyboardDragLayer.siteNavigationMenuItemId,
+					order: keyboardDragLayer.order,
+					parentId: keyboardDragLayer.parentSiteNavigationMenuItemId,
+					portletNamespace,
+				}).then(({siteNavigationMenuItems}) => {
+					setKeyboardDragLayer(null);
+					setItems(getFlatItems(siteNavigationMenuItems));
+				});
 			}
 			else {
 				setKeyboardDragLayer({
@@ -218,9 +227,10 @@ export function MenuItem({item, onMenuItemRemoved}) {
 
 			const result = computeFunction({
 				items,
-				order,
-				parentSiteNavigationMenuItemId:
-					item.parentSiteNavigationMenuItemId,
+				order: keyboardDragLayer ? keyboardDragLayer.order : order,
+				parentSiteNavigationMenuItemId: keyboardDragLayer
+					? keyboardDragLayer.parentSiteNavigationMenuItemId
+					: item.parentSiteNavigationMenuItemId,
 			});
 
 			if (!result) {
@@ -235,16 +245,6 @@ export function MenuItem({item, onMenuItemRemoved}) {
 				parentSiteNavigationMenuItemId:
 					result.parentSiteNavigationMenuItemId,
 				siteNavigationMenuItemId,
-			});
-
-			updateMenuItem({
-				editSiteNavigationMenuItemParentURL,
-				itemId: item.siteNavigationMenuItemId,
-				order: result.order,
-				parentId: result.parentSiteNavigationMenuItemId,
-				portletNamespace,
-			}).then(({siteNavigationMenuItems}) => {
-				setItems(getFlatItems(siteNavigationMenuItems));
 			});
 		}
 	};

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
@@ -164,6 +164,70 @@ export function MenuItem({
 		setElement,
 	} = useKeyboardNavigation();
 
+	const onDragHandlerKeyDown = (event) => {
+		if (!Liferay.FeatureFlags['LPS-134527']) {
+			return;
+		}
+
+		if (event.key === 'Enter') {
+			event.preventDefault();
+			event.stopPropagation();
+
+			setIsMovementEnabled(
+				(previousIsMovementEnabled) => !previousIsMovementEnabled
+			);
+		}
+
+		if (event.key === 'Escape') {
+			setIsMovementEnabled(false);
+		}
+
+		if (!isMovementEnabled) {
+			return;
+		}
+
+		event.stopPropagation();
+
+		const eventKey = event.key;
+
+		if (eventKey === 'ArrowDown' || eventKey === 'ArrowUp') {
+			const computeFunction =
+				eventKey === 'ArrowDown' ? getDownPosition : getUpPosition;
+
+			const result = computeFunction({
+				items,
+				order,
+				parentSiteNavigationMenuItemId:
+					item.parentSiteNavigationMenuItemId,
+			});
+
+			if (!result) {
+				return;
+			}
+
+			updateMenuItem({
+				editSiteNavigationMenuItemParentURL,
+				itemId: item.siteNavigationMenuItemId,
+				order: result.order,
+				parentId: result.parentSiteNavigationMenuItemId,
+				portletNamespace,
+			}).then(({siteNavigationMenuItems}) => {
+				const newItems = getFlatItems(siteNavigationMenuItems);
+
+				setItems(newItems);
+
+				setMovementText(
+					sub(
+						eventKey === 'ArrowDown'
+							? Liferay.Language.get('x-moved-down')
+							: Liferay.Language.get('x-moved-up'),
+						`${title} (${type})`
+					)
+				);
+			});
+		}
+	};
+
 	return (
 		<>
 			<div
@@ -230,94 +294,7 @@ export function MenuItem({
 										onBlur={() =>
 											setIsMovementEnabled(false)
 										}
-										onKeyDown={(event) => {
-											if (
-												!Liferay.FeatureFlags[
-													'LPS-134527'
-												]
-											) {
-												return;
-											}
-
-											if (event.key === 'Enter') {
-												event.preventDefault();
-												event.stopPropagation();
-
-												setIsMovementEnabled(
-													(
-														previousIsMovementEnabled
-													) =>
-														!previousIsMovementEnabled
-												);
-											}
-
-											if (event.key === 'Escape') {
-												setIsMovementEnabled(false);
-											}
-
-											if (!isMovementEnabled) {
-												return;
-											}
-
-											event.stopPropagation();
-
-											const eventKey = event.key;
-
-											if (
-												eventKey === 'ArrowDown' ||
-												eventKey === 'ArrowUp'
-											) {
-												const computeFunction =
-													eventKey === 'ArrowDown'
-														? getDownPosition
-														: getUpPosition;
-
-												const result = computeFunction({
-													items,
-													order,
-													parentSiteNavigationMenuItemId:
-														item.parentSiteNavigationMenuItemId,
-												});
-
-												if (!result) {
-													return;
-												}
-
-												updateMenuItem({
-													editSiteNavigationMenuItemParentURL,
-													itemId:
-														item.siteNavigationMenuItemId,
-													order: result.order,
-													parentId:
-														result.parentSiteNavigationMenuItemId,
-													portletNamespace,
-												}).then(
-													({
-														siteNavigationMenuItems,
-													}) => {
-														const newItems = getFlatItems(
-															siteNavigationMenuItems
-														);
-
-														setItems(newItems);
-
-														setMovementText(
-															sub(
-																eventKey ===
-																	'ArrowDown'
-																	? Liferay.Language.get(
-																			'x-moved-down'
-																	  )
-																	: Liferay.Language.get(
-																			'x-moved-up'
-																	  ),
-																`${title} (${type})`
-															)
-														);
-													}
-												);
-											}
-										}}
+										onKeyDown={onDragHandlerKeyDown}
 										size="sm"
 										symbol="drag"
 										tabIndex={

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
@@ -27,6 +27,7 @@ import {NESTING_MARGIN} from '../constants/nestingMargin';
 import {SIDEBAR_PANEL_IDS} from '../constants/sidebarPanelIds';
 import {useConstants} from '../contexts/ConstantsContext';
 import {useItems, useSetItems} from '../contexts/ItemsContext';
+import {useDragLayer, useSetDragLayer} from '../contexts/KeyboardDndContext';
 import {
 	useSelectedMenuItemId,
 	useSetSelectedMenuItemId,
@@ -39,13 +40,7 @@ import {useDragItem, useDropTarget} from '../utils/useDragAndDrop';
 import useKeyboardNavigation from '../utils/useKeyboardNavigation';
 import DeletionModal from './DeletionModal';
 
-export function MenuItem({
-	isMovementEnabled,
-	item,
-	onMenuItemRemoved,
-	setIsMovementEnabled,
-	setMovementText,
-}) {
+export function MenuItem({item, onMenuItemRemoved}) {
 	const setItems = useSetItems();
 	const setSelectedMenuItemId = useSetSelectedMenuItemId();
 	const setSidebarPanelId = useSetSidebarPanelId();
@@ -145,8 +140,24 @@ export function MenuItem({
 			});
 	};
 
+	const keyboardDragLayer = useDragLayer();
+	const setKeyboardDragLayer = useSetDragLayer();
 	const {handlerRef, isDragging} = useDragItem(item, updateMenuItemParent);
 	const {targetRef} = useDropTarget(item);
+
+	const isKeyboardDragging = useMemo(
+		() =>
+			keyboardDragLayer?.siteNavigationMenuItemId
+				? getItemPath(siteNavigationMenuItemId, items).includes(
+						keyboardDragLayer.siteNavigationMenuItemId
+				  )
+				: false,
+		[
+			items,
+			keyboardDragLayer?.siteNavigationMenuItemId,
+			siteNavigationMenuItemId,
+		]
+	);
 
 	const rtl = Liferay.Language.direction[languageId] === 'rtl';
 	const itemStyle = rtl
@@ -173,16 +184,27 @@ export function MenuItem({
 			event.preventDefault();
 			event.stopPropagation();
 
-			setIsMovementEnabled(
-				(previousIsMovementEnabled) => !previousIsMovementEnabled
-			);
+			if (isKeyboardDragging) {
+				setKeyboardDragLayer(null);
+			}
+			else {
+				setKeyboardDragLayer({
+					eventKey: 'ArrowDown',
+					menuItemTitle: title,
+					menuItemType: type,
+					order,
+					parentSiteNavigationMenuItemId:
+						item.parentSiteNavigationMenuItemId,
+					siteNavigationMenuItemId,
+				});
+			}
 		}
 
 		if (event.key === 'Escape') {
-			setIsMovementEnabled(false);
+			setKeyboardDragLayer(null);
 		}
 
-		if (!isMovementEnabled) {
+		if (!isKeyboardDragging) {
 			return;
 		}
 
@@ -205,6 +227,16 @@ export function MenuItem({
 				return;
 			}
 
+			setKeyboardDragLayer({
+				eventKey,
+				menuItemTitle: title,
+				menuItemType: type,
+				order: result.order,
+				parentSiteNavigationMenuItemId:
+					result.parentSiteNavigationMenuItemId,
+				siteNavigationMenuItemId,
+			});
+
 			updateMenuItem({
 				editSiteNavigationMenuItemParentURL,
 				itemId: item.siteNavigationMenuItemId,
@@ -212,18 +244,7 @@ export function MenuItem({
 				parentId: result.parentSiteNavigationMenuItemId,
 				portletNamespace,
 			}).then(({siteNavigationMenuItems}) => {
-				const newItems = getFlatItems(siteNavigationMenuItems);
-
-				setItems(newItems);
-
-				setMovementText(
-					sub(
-						eventKey === 'ArrowDown'
-							? Liferay.Language.get('x-moved-down')
-							: Liferay.Language.get('x-moved-up'),
-						`${title} (${type})`
-					)
-				);
+				setItems(getFlatItems(siteNavigationMenuItems));
 			});
 		}
 	};
@@ -247,14 +268,14 @@ export function MenuItem({
 					'focusable-menu-item site_navigation_menu_editor_MenuItem',
 					{
 						active: selected,
-						dragging: isDragging,
+						dragging: isDragging || isKeyboardDragging,
 					}
 				)}
 				data-item-id={item.siteNavigationMenuItemId}
 				data-parent-item-id={parentItemId}
 				onBlur={onBlur}
 				onClick={() => {
-					if (!isMovementEnabled) {
+					if (!isKeyboardDragging) {
 						setSelectedMenuItemId(siteNavigationMenuItemId);
 						setSidebarPanelId(SIDEBAR_PANEL_IDS.menuItemSettings);
 					}
@@ -263,7 +284,7 @@ export function MenuItem({
 				onKeyDown={(event) => {
 					if (
 						(event.key === ' ' || event.key === 'Enter') &&
-						!isMovementEnabled
+						!isKeyboardDragging
 					) {
 						setSelectedMenuItemId(siteNavigationMenuItemId);
 						setSidebarPanelId(SIDEBAR_PANEL_IDS.menuItemSettings);
@@ -292,7 +313,7 @@ export function MenuItem({
 										displayType="unstyled"
 										monospaced={false}
 										onBlur={() =>
-											setIsMovementEnabled(false)
+											setKeyboardDragLayer(null)
 										}
 										onKeyDown={onDragHandlerKeyDown}
 										size="sm"

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/contexts/KeyboardDndContext.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/contexts/KeyboardDndContext.js
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import React, {useContext, useState} from 'react';
+
+const KeyboardDndContext = React.createContext();
+
+export function KeyboardDndProvider({children}) {
+	const [dragLayer, setDragLayer] = useState(null);
+
+	return (
+		<KeyboardDndContext.Provider value={{dragLayer, setDragLayer}}>
+			{children}
+		</KeyboardDndContext.Provider>
+	);
+}
+
+export function useDragLayer() {
+	return useContext(KeyboardDndContext).dragLayer;
+}
+
+export function useSetDragLayer() {
+	return useContext(KeyboardDndContext).setDragLayer;
+}


### PR DESCRIPTION
This is the initial approach I've followed to update the keyboard DnD in the Navigation Menu Editor. There are still many things to polish, but I wanted to share this as an initial working draft to gather some feedback :smile: 

As this is hidden behind a feature flag (`Liferay.FeatureFlags['LPS-134527']`) it can be safely sent to master if everything is ok.

This is the current result:
![Screencast from 2023-03-28 17-39-32.webm](https://user-images.githubusercontent.com/800645/228292300-2886373b-e96d-40e7-b8ee-464777b00eec.webm).

As you might see, the "target selection" right now is a bit erratic. Sometimes it skips menu items, and moving upwards/downwards do not always produce the same result. I am trying to reuse existing behavior as much as possible, but this needs to be updated to be more user-friendly.

I've tried to follow existing DnD conventions by providing an API that is similar to `react-dnd` and just adding some extra keyboard-* state where needed.