### PR TITLE
[TS] [Urgent] LPS-180106 Fix regression that causes Site Navigation Menu Editor to be unavailable on LXC environments.

### DIFF
--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminDisplayContext.java
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/java/com/liferay/site/navigation/admin/web/internal/display/context/SiteNavigationAdminDisplayContext.java
@@ -109,6 +109,16 @@ public class SiteNavigationAdminDisplayContext {
 			_siteNavigationMenuItemTypeRegistry.
 				getSiteNavigationMenuItemTypes();
 
+		SiteNavigationMenuItemTypeContext siteNavigationMenuItemTypeContext =
+			new DefaultSiteNavigationMenuItemTypeContext(
+				_themeDisplay.getScopeGroup());
+
+		siteNavigationMenuItemTypes = ListUtil.filter(
+			siteNavigationMenuItemTypes,
+			siteNavigationMenuItemType ->
+				siteNavigationMenuItemType.isAvailable(
+					siteNavigationMenuItemTypeContext));
+
 		ListUtil.sort(
 			siteNavigationMenuItemTypes,
 			Comparator.comparing(
@@ -116,23 +126,11 @@ public class SiteNavigationAdminDisplayContext {
 					siteNavigationMenuItemType.getLabel(
 						_themeDisplay.getLocale())));
 
-		SiteNavigationMenuItemTypeContext siteNavigationMenuItemTypeContext =
-			new DefaultSiteNavigationMenuItemTypeContext(
-				_themeDisplay.getScopeGroup());
-
 		return DropdownItemListBuilder.addAll(
 			TransformUtil.transform(
 				siteNavigationMenuItemTypes,
-				siteNavigationMenuItemType -> {
-					if (!siteNavigationMenuItemType.isAvailable(
-							siteNavigationMenuItemTypeContext)) {
-
-						return null;
-					}
-
-					return _getDropdownItem(
-						siteNavigationMenuItemType, _themeDisplay);
-				})
+				siteNavigationMenuItemType -> _getDropdownItem(
+					siteNavigationMenuItemType, _themeDisplay))
 		).build();
 	}
 


### PR DESCRIPTION
Motivation
=======
In [LPS-174414](https://issues.liferay.com/browse/LPS-174414), the Core Infra team exclusively made changes to the Site Navigation Menu Portlet that the Echo Team did not appear to be involved at all in at any point in the review process, despite the Echo Team owning this component. These changes caused a severe regression when database partitioning is enabled, meaning that all our LXC customers will be affected by this regression. The regression is that, if any virtual instance has a custom Object, it will be impossible to access the Site Navigation Menu Editor from any other instance.

This occurs because in [LPS-174414](https://issues.liferay.com/browse/LPS-174414), we reordered the logic of filtering out the SiteNavigationMenuItemTypes that are not available and the logic of sorting the Site Navigation Menu Item Types. Prior to [LPS-174414](https://issues.liferay.com/browse/LPS-174414), we filtered out the unavailable SiteNavigationMenuItemTypes first, and then we sorted them after the filter. After [LPS-174414](https://issues.liferay.com/browse/LPS-174414), we instead sorted them first, and then filtered them out. This was a mistake, because attempting to invoke the Comparator on an unavailable SiteNavigationMenuItemType can cause a NullPointerException, which gets propagated all the way back up to Liferay and causes the page to fail to load.

Proposed Solution
========
Reorder the filter and the sort logic to be in the same order as they were prior to [LPS-174414](https://issues.liferay.com/browse/LPS-174414).

Steps to Verify
========
Please see [LPS-180106](https://issues.liferay.com/browse/LPS-180106) for detailed steps.