### PR TITLE
LPS-180181 Style Book and Master Pages panels have wrong padding

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_design_options/components/PageDesignOptionsSidebar.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_design_options/components/PageDesignOptionsSidebar.js
@@ -175,6 +175,7 @@ export default function PageDesignOptionsSidebar() {
 							Liferay.Language.get('select-x'),
 							label
 						)}
+						className="p-0"
 						id={getTabPanelId(index)}
 						key={index}
 					>


### PR DESCRIPTION
Motivation
=======
The card of the tabs within Page Design Options don't correspond with the desired design since they're not filling the space correctly.
[LPS-180181](https://issues.liferay.com/browse/LPS-180181)

Proposed Solution
========
Changing the padding of the tab panel.

Steps to Verify
========
1. Create a content page and edit it
2. Go to Page Design Options sidebar panel
3. Look at Style Book and Master Page cards and check that the card are filling the space correctly

How it looked before:
![before](https://user-images.githubusercontent.com/91207948/228535578-812a07e3-c43b-43a6-a12c-8bae503c90e5.png)


How it should look:
<img width="677" alt="Screenshot 2023-03-29 at 14 27 21" src="https://user-images.githubusercontent.com/91207948/228535091-616070a3-5564-45de-9aad-c4e35699edae.png">

<img width="514" alt="Screenshot 2023-03-29 at 14 27 49" src="https://user-images.githubusercontent.com/91207948/228535215-15d8b5ab-a7ad-4cb3-a5d2-b1e62b3db0d9.png">

