### PR TITLE
LPS-180185 Remove asset category properties value's validation

### DIFF
--- a/modules/apps/asset/asset-category-property-service/src/main/java/com/liferay/asset/category/property/service/impl/AssetCategoryPropertyLocalServiceImpl.java
+++ b/modules/apps/asset/asset-category-property-service/src/main/java/com/liferay/asset/category/property/service/impl/AssetCategoryPropertyLocalServiceImpl.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
 
@@ -205,8 +206,9 @@ public class AssetCategoryPropertyLocalServiceImpl
 				"Maximum length of key exceeded");
 		}
 
-		if (!_assetHelper.isValidWord(value)) {
-			throw new CategoryPropertyValueException("Invalid value " + value);
+		if (Validator.isBlank(value)) {
+			throw new CategoryPropertyValueException(
+				"Property value cannot be an empty string");
 		}
 
 		int valueMaxLength = ModelHintsUtil.getMaxLength(

--- a/modules/apps/asset/asset-category-property-test/build.gradle
+++ b/modules/apps/asset/asset-category-property-test/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+	testIntegrationCompile project(":apps:asset:asset-api")
 	testIntegrationCompile project(":apps:asset:asset-category-property-api")
 	testIntegrationCompile project(":apps:asset:asset-test-util")
 	testIntegrationCompile project(":apps:change-tracking:change-tracking-test-util")

--- a/modules/apps/asset/asset-category-property-test/src/testIntegration/java/com/liferay/asset/category/property/service/test/AssetCategoryPropertyLocalServiceTest.java
+++ b/modules/apps/asset/asset-category-property-test/src/testIntegration/java/com/liferay/asset/category/property/service/test/AssetCategoryPropertyLocalServiceTest.java
@@ -23,6 +23,8 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
+import com.liferay.asset.util.AssetHelper;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -40,6 +42,7 @@ import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import java.util.Locale;
 import java.util.Map;
 
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -60,6 +63,39 @@ public class AssetCategoryPropertyLocalServiceTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testCanAddCategoryPropertyValueWithSpecialCharacters()
+		throws Exception {
+
+		Map<Locale, String> titleMap = HashMapBuilder.put(
+			LocaleUtil.US, RandomTestUtil.randomString()
+		).build();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), titleMap, null, null,
+				serviceContext);
+
+		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			RandomTestUtil.randomString(), assetVocabulary.getVocabularyId(),
+			serviceContext);
+
+		AssetCategoryProperty result =
+			_assetCategoryPropertyLocalService.addCategoryProperty(
+				TestPropsValues.getUserId(), assetCategory.getCategoryId(),
+				RandomTestUtil.randomString(),
+				String.valueOf(AssetHelper.INVALID_CHARACTERS));
+
+		Assert.assertEquals(
+			String.valueOf(AssetHelper.INVALID_CHARACTERS), result.getValue());
 	}
 
 	@Test(expected = CategoryPropertyKeyException.class)
@@ -124,6 +160,32 @@ public class AssetCategoryPropertyLocalServiceTest {
 			TestPropsValues.getUserId(), assetCategory.getCategoryId(),
 			RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(keyMaxLength + 1));
+	}
+
+	@Test(expected = CategoryPropertyValueException.class)
+	public void testCannotAddEmptyCategoryPropertyValue() throws Exception {
+		Map<Locale, String> titleMap = HashMapBuilder.put(
+			LocaleUtil.US, RandomTestUtil.randomString()
+		).build();
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		AssetVocabulary assetVocabulary =
+			_assetVocabularyLocalService.addVocabulary(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(), titleMap, null, null,
+				serviceContext);
+
+		AssetCategory assetCategory = _assetCategoryLocalService.addCategory(
+			TestPropsValues.getUserId(), _group.getGroupId(),
+			RandomTestUtil.randomString(), assetVocabulary.getVocabularyId(),
+			serviceContext);
+
+		_assetCategoryPropertyLocalService.addCategoryProperty(
+			TestPropsValues.getUserId(), assetCategory.getCategoryId(),
+			RandomTestUtil.randomString(), StringPool.BLANK);
 	}
 
 	@Inject


### PR DESCRIPTION
Motivation
=======
[Link to ticket](https://issues.liferay.com/browse/LPS-180171)

Bug fixing: Currently, when you try to save an asset property with a value containing special character you get an error.

Proposed Solution
========
Remove the asset category properties value's validations to allow our clients to use the special characters there (you can see a list of those special characters in  AssetHelper file)

Steps to Verify
========

1) Create a category
2) Add a property to the category:

**Key**: URL
**Value**: https://someurl.com/

**Expected result:** The category is saved
**Actual result:** "Error: Please enter a valid property value. "

Commits
========
- LPS-180185 Remove asset category properties value's validation
- LPS-180185 Adding test for asset category properties value validation's removal

**Note:** No changes are needed in the frontend side as the tag used already scapes the special characters
