### PR TITLE
[TS] LPS-180210 Do not override the styles of all elements of the Modal with the cadmin class

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/HTMLEditorModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/HTMLEditorModal.js
@@ -43,11 +43,7 @@ const HTMLEditorModal = ({
 
 	return (
 		visible && (
-			<ClayModal
-				containerProps={{className: 'cadmin'}}
-				observer={observer}
-				size="full-screen"
-			>
+			<ClayModal observer={observer} size="full-screen">
 				<ClayModal.Header>
 					{Liferay.Language.get('edit-content')}
 				</ClayModal.Header>
@@ -137,6 +133,7 @@ const HTMLEditorModal = ({
 				</ClayModal.Body>
 
 				<ClayModal.Footer
+					className="cadmin"
 					last={
 						<ClayButton.Group spaced>
 							<ClayButton


### PR DESCRIPTION
Hi Team,

LPS: https://issues.liferay.com/browse/LPS-180210
It is a regression fix caused by https://issues.liferay.com/browse/LPS-175642

I removed the _cadmin_ class from the ClayModal component and applied to the ClayModal.Footer only, because this solution applies the expected button style described in LPS-175642 as well as it is not going to override the whole Modal that causes the issue in LPS-180210.

Could you please review it?
Thanks
cc. @victorg1991 @pat270 