### PR TITLE
LPS-180303 Fix horizontal scroll in Browser Tree

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTreeNode.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTreeNode.js
@@ -452,7 +452,7 @@ function StructureTreeNodeContent({
 
 			{!editingName && (
 				<div
-					className={classNames('flex-shrink-0', {
+					className={classNames({
 						'page-editor__page-structure__tree-node__buttons--hidden':
 							node.hidden || node.hiddenAncestor,
 					})}
@@ -522,12 +522,7 @@ const NameLabel = React.forwardRef(
 				)}
 				ref={ref}
 			>
-				{icon && (
-					<ClayIcon
-						className="flex-shrink-0 mt-0"
-						symbol={icon || ''}
-					/>
-				)}
+				{icon && <ClayIcon className="mt-0" symbol={icon || ''} />}
 
 				{editingName ? (
 					<input
@@ -558,9 +553,7 @@ const NameLabel = React.forwardRef(
 						value={name}
 					/>
 				) : (
-					<span className="text-truncate">
-						{name || defaultName || Liferay.Language.get('element')}
-					</span>
+					name || defaultName || Liferay.Language.get('element')
 				)}
 
 				{!editingName && nameInfo && (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTreeNode.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTreeNode.scss
@@ -4,10 +4,6 @@ $treeNodeNameMappedColor: #954cff;
 
 html#{$cadmin-selector} {
 	.cadmin {
-		.lfr-treeview-node-list-item__node {
-			max-width: 100%;
-		}
-
 		.page-editor__page-structure__tree-node {
 			align-items: center;
 			display: flex;


### PR DESCRIPTION
Motivation
=======
The user should be able to read the node names using the horizontal scroll.
[Link to story or ticket](https://issues.liferay.com/browse/LPS-180303)

Proposed Solution
========
Reverts commit 5b2df08510d69c26b32e5dac6056ba4f07eb4580 in which the bug was introduced.

Steps to Verify:
----------------

1. Go to Home page and click Edit
2. Add some fragments inside other fragments (for example, a grid inside a container and a heading inside the grid)
3. In the left side bar click on Browser option
4. Open all the nodes in the tree

Screenshots (optional):
-----------------------
The bug:

![Captura de pantalla 2023-03-30 a las 13 26 38](https://user-images.githubusercontent.com/3276218/228880882-9f926818-acdf-41fe-a209-49e6da5f34a2.png)

Fixed:
![Captura de pantalla 2023-03-30 a las 17 07 10](https://user-images.githubusercontent.com/3276218/228880914-5ddb5c17-1c38-4ea4-bc0e-5f6c00279d08.png)
