### PR TITLE
LPS-180427 Style changes to modified paddings for the Add Panel for Widget Pages

### DIFF
--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/AddPanel.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/AddPanel.js
@@ -199,11 +199,7 @@ const AddPanel = ({
 	);
 
 	return (
-		<div
-			className={classNames('sidebar-body__add-panel', {
-				rtl,
-			})}
-		>
+		<div className={classNames('sidebar-body__add-panel p-0', {rtl})}>
 			<AddPanelContextProvider
 				value={{
 					addContentsURLs,

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabsPanel.js
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/js/TabsPanel.js
@@ -33,7 +33,7 @@ const TabsPanel = ({tabs}) => {
 
 	return (
 		<>
-			<ClayTabs className="sidebar-body__add-panel__tabs">
+			<ClayTabs className="mb-0 pl-3 sidebar-body__add-panel__tabs">
 				{tabs.map((tab, index) => (
 					<ClayTabs.Item
 						active={activeTabId === index}
@@ -56,6 +56,7 @@ const TabsPanel = ({tabs}) => {
 				{tabs.map((tab, index) => (
 					<ClayTabs.TabPane
 						aria-labelledby={getTabId(index)}
+						className="p-3"
 						id={getTabPanelId(index)}
 						key={index}
 					>


### PR DESCRIPTION
Motivation
=======
Problem this work solves are the styles of the Add Panel for Widget Pages.

Proposed Solution
========
What we did to solve this problem is modify the padding of the by removing the padding for the panel and adding the correct one for the TabPane outside of the panel. Also we modified the padding of the tabs.

Steps to Verify
========
1. Create a Widget Page and edit it
2. Click over the  button on the Control Menu navigation bar to open the add panel
3. Check that the view of the panel is the correct one (look added screenshot)

Screenshots 
========
![Screenshot 2023-03-31 at 11 49 26](https://user-images.githubusercontent.com/91207948/229087326-5c15fd3f-6d68-43ad-9b3a-386f38efc09c.png)
