### PR TITLE
LPS-176836 | Test Fix | Master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentperformance/ContentPerformance.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/contentperformance/ContentPerformance.testcase
@@ -1276,7 +1276,7 @@ definition {
 		task ("Check the value of engagement data") {
 			for (var channel : list "Referral,Social,Paid,Direct,Organic") {
 				ContentPerformance.viewTrafficViews(
-					key_numberViews = 0,
+					key_numberViews = "-",
 					trafficChannel = ${channel});
 			}
 		}


### PR DESCRIPTION
# Element is not present at ContentPerformance#NoNavigationWithoutIncomingTraffic

Hi! :)
This pr is corresponding to this ticket: [LPS-176836](https://issues.liferay.com/browse/LPS-176836)

**Problem:**
Data does not arrive in time for checking on the Content Performance page.

**Fix:**
Substitution of values for "-" because we understand that If the value is -, it also means no incoming traffic. The - and 0 are the same for our case