### PR TITLE
LPS 180710

### DIFF
--- a/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/scheduler/helper/test/AssetEntriesCheckerHelperTest.java
+++ b/modules/apps/asset/asset-publisher-test/src/testIntegration/java/com/liferay/asset/publisher/web/internal/scheduler/helper/test/AssetEntriesCheckerHelperTest.java
@@ -17,6 +17,11 @@ package com.liferay.asset.publisher.web.internal.scheduler.helper.test;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.asset.list.asset.entry.provider.AssetListAssetEntryProvider;
+import com.liferay.asset.list.constants.AssetListEntryTypeConstants;
+import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.asset.list.service.AssetListEntryLocalService;
+import com.liferay.asset.list.service.AssetListEntrySegmentsEntryRelLocalService;
 import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
 import com.liferay.asset.publisher.test.util.AssetPublisherTestUtil;
 import com.liferay.asset.publisher.util.AssetPublisherHelper;
@@ -29,6 +34,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
@@ -41,6 +47,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.segments.configuration.provider.SegmentsConfigurationProvider;
 
 import java.lang.reflect.Constructor;
 
@@ -64,6 +71,7 @@ import org.osgi.framework.FrameworkUtil;
 
 /**
  * @author István András Dézsi
+ * @author Roberto Díaz
  */
 @RunWith(Arquillian.class)
 public class AssetEntriesCheckerHelperTest {
@@ -81,37 +89,63 @@ public class AssetEntriesCheckerHelperTest {
 
 		_layout = LayoutTestUtil.addTypePortletLayout(_group.getGroupId());
 
+		_portletId = LayoutTestUtil.addPortletToLayout(
+			_layout, AssetPublisherPortletKeys.ASSET_PUBLISHER);
+
 		_setUpAssetEntriesCheckerHelper();
 	}
 
 	@Test
-	public void testGetAssetEntries() throws Exception {
-		String portletId = LayoutTestUtil.addPortletToLayout(
-			_layout, AssetPublisherPortletKeys.ASSET_PUBLISHER);
+	public void testGetAssetEntriesFromAssetListSelectionAssetPublisher()
+		throws Exception {
+
 		AssetEntry assetEntry1 = _addAssetEntry();
 		AssetEntry assetEntry2 = _addAssetEntry();
 
-		_setPortletManualSelectionStylePreference(
-			portletId, assetEntry1, assetEntry2);
-
-		_assertAssetEntries(
-			Arrays.asList(
-				_addAssetEntry(), _addAssetEntry(), assetEntry1, assetEntry2),
-			ReflectionTestUtil.invoke(
-				_assetEntriesCheckerHelper, "_getAssetEntries",
-				new Class<?>[] {PortletPreferences.class, Layout.class},
-				LayoutTestUtil.getPortletPreferences(
-					_layout,
-					LayoutTestUtil.addPortletToLayout(
-						_layout, AssetPublisherPortletKeys.ASSET_PUBLISHER)),
-				_layout));
+		_setAssetListSelectionStylePreference(assetEntry1, assetEntry2);
 
 		_assertAssetEntries(
 			Arrays.asList(assetEntry1, assetEntry2),
 			ReflectionTestUtil.invoke(
 				_assetEntriesCheckerHelper, "_getAssetEntries",
 				new Class<?>[] {PortletPreferences.class, Layout.class},
-				LayoutTestUtil.getPortletPreferences(_layout, portletId),
+				LayoutTestUtil.getPortletPreferences(_layout, _portletId),
+				_layout));
+	}
+
+	@Test
+	public void testGetAssetEntriesFromDynamicSelectionAssetPublisher()
+		throws Exception {
+
+		_setDynamicSelectionStylePreference();
+
+		_assertAssetEntries(
+			Arrays.asList(_addAssetEntry(), _addAssetEntry(), _addAssetEntry()),
+			ReflectionTestUtil.invoke(
+				_assetEntriesCheckerHelper, "_getAssetEntries",
+				new Class<?>[] {PortletPreferences.class, Layout.class},
+				LayoutTestUtil.getPortletPreferences(_layout, _portletId),
+				_layout));
+	}
+
+	@Test
+	public void testGetAssetEntriesFromManualSelectionAssetPublisher()
+		throws Exception {
+
+		AssetEntry assetEntry1 = _addAssetEntry();
+		AssetEntry assetEntry2 = _addAssetEntry();
+		AssetEntry assetEntry3 = _addAssetEntry();
+		AssetEntry assetEntry4 = _addAssetEntry();
+
+		_setPortletManualSelectionStylePreference(
+			assetEntry1, assetEntry2, assetEntry3, assetEntry4);
+
+		_assertAssetEntries(
+			Arrays.asList(assetEntry1, assetEntry2, assetEntry3, assetEntry4),
+			ReflectionTestUtil.invoke(
+				_assetEntriesCheckerHelper, "_getAssetEntries",
+				new Class<?>[] {PortletPreferences.class, Layout.class},
+				LayoutTestUtil.getPortletPreferences(_layout, _portletId),
 				_layout));
 	}
 
@@ -153,12 +187,52 @@ public class AssetEntriesCheckerHelperTest {
 		}
 	}
 
-	private void _setPortletManualSelectionStylePreference(
-			String portletId, AssetEntry... assetEntries)
+	private void _setAssetListSelectionStylePreference(
+			AssetEntry... assetEntries)
 		throws Exception {
 
 		PortletPreferences portletPreferences =
-			LayoutTestUtil.getPortletPreferences(_layout, portletId);
+			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group.getGroupId(), TestPropsValues.getUserId());
+
+		AssetListEntry assetListEntry =
+			_assetListEntryLocalService.addAssetListEntry(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				RandomTestUtil.randomString(),
+				AssetListEntryTypeConstants.TYPE_MANUAL, serviceContext);
+
+		for (AssetEntry assetEntry : assetEntries) {
+			_assetListEntryLocalService.addAssetEntrySelection(
+				assetListEntry.getAssetListEntryId(), assetEntry.getEntryId(),
+				0, serviceContext);
+		}
+
+		portletPreferences.setValue("selectionStyle", "asset-list");
+		portletPreferences.setValue(
+			"assetListEntryId",
+			String.valueOf(assetListEntry.getAssetListEntryId()));
+
+		portletPreferences.store();
+	}
+
+	private void _setDynamicSelectionStylePreference() throws Exception {
+		PortletPreferences portletPreferences =
+			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
+
+		portletPreferences.setValue("selectionStyle", "dynamic");
+
+		portletPreferences.store();
+	}
+
+	private void _setPortletManualSelectionStylePreference(
+			AssetEntry... assetEntries)
+		throws Exception {
+
+		PortletPreferences portletPreferences =
+			LayoutTestUtil.getPortletPreferences(_layout, _portletId);
 
 		portletPreferences.setValue("selectionStyle", "manual");
 
@@ -217,6 +291,16 @@ public class AssetEntriesCheckerHelperTest {
 		ReflectionTestUtil.setFieldValue(
 			_assetEntriesCheckerHelper, "_assetHelper", _assetHelper);
 		ReflectionTestUtil.setFieldValue(
+			_assetEntriesCheckerHelper, "_assetListAssetEntryProvider",
+			_assetListAssetEntryProvider);
+		ReflectionTestUtil.setFieldValue(
+			_assetEntriesCheckerHelper, "_assetListEntryLocalService",
+			_assetListEntryLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_assetEntriesCheckerHelper,
+			"_assetListEntrySegmentsEntryRelLocalService",
+			_assetListEntrySegmentsEntryRelLocalService);
+		ReflectionTestUtil.setFieldValue(
 			_assetEntriesCheckerHelper, "_assetPublisherHelper",
 			_assetPublisherHelper);
 		ReflectionTestUtil.setFieldValue(
@@ -225,6 +309,9 @@ public class AssetEntriesCheckerHelperTest {
 		ReflectionTestUtil.setFieldValue(
 			_assetEntriesCheckerHelper, "_groupLocalService",
 			_groupLocalService);
+		ReflectionTestUtil.setFieldValue(
+			_assetEntriesCheckerHelper, "_segmentsConfigurationProvider",
+			_segmentsConfigurationProvider);
 	}
 
 	private Object _assetEntriesCheckerHelper;
@@ -234,6 +321,16 @@ public class AssetEntriesCheckerHelperTest {
 
 	@Inject
 	private AssetHelper _assetHelper;
+
+	@Inject
+	private AssetListAssetEntryProvider _assetListAssetEntryProvider;
+
+	@Inject
+	private AssetListEntryLocalService _assetListEntryLocalService;
+
+	@Inject
+	private AssetListEntrySegmentsEntryRelLocalService
+		_assetListEntrySegmentsEntryRelLocalService;
 
 	@Inject
 	private AssetPublisherHelper _assetPublisherHelper;
@@ -251,5 +348,9 @@ public class AssetEntriesCheckerHelperTest {
 	private GroupLocalService _groupLocalService;
 
 	private Layout _layout;
+	private String _portletId;
+
+	@Inject
+	private SegmentsConfigurationProvider _segmentsConfigurationProvider;
 
 }

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/scheduler/helper/AssetEntriesCheckerHelper.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/scheduler/helper/AssetEntriesCheckerHelper.java
@@ -18,6 +18,10 @@ import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.persistence.AssetEntryQuery;
 import com.liferay.asset.kernel.util.NotifiedAssetEntryThreadLocal;
+import com.liferay.asset.list.asset.entry.provider.AssetListAssetEntryProvider;
+import com.liferay.asset.list.model.AssetListEntry;
+import com.liferay.asset.list.service.AssetListEntryLocalService;
+import com.liferay.asset.list.service.AssetListEntrySegmentsEntryRelLocalService;
 import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
 import com.liferay.asset.publisher.util.AssetPublisherHelper;
 import com.liferay.asset.publisher.web.internal.configuration.AssetPublisherSelectionStyleConfigurationUtil;
@@ -25,6 +29,7 @@ import com.liferay.asset.publisher.web.internal.configuration.AssetPublisherWebC
 import com.liferay.asset.publisher.web.internal.constants.AssetPublisherSelectionStyleConstants;
 import com.liferay.asset.publisher.web.internal.helper.AssetPublisherWebHelper;
 import com.liferay.asset.util.AssetHelper;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
 import com.liferay.portal.kernel.dao.orm.Property;
@@ -62,6 +67,9 @@ import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
 import com.liferay.portlet.asset.service.permission.AssetEntryPermission;
 import com.liferay.portlet.configuration.kernel.util.PortletConfigurationUtil;
+import com.liferay.segments.SegmentsEntryRetriever;
+import com.liferay.segments.configuration.provider.SegmentsConfigurationProvider;
+import com.liferay.segments.constants.SegmentsEntryConstants;
 import com.liferay.subscription.model.Subscription;
 import com.liferay.subscription.service.SubscriptionLocalService;
 
@@ -249,6 +257,13 @@ public class AssetEntriesCheckerHelper {
 			return _getManuallySelectedAssetEntries(
 				portletPreferences, layout.getGroupId());
 		}
+		else if (Objects.equals(
+					selectionStyle,
+					AssetPublisherSelectionStyleConstants.TYPE_ASSET_LIST)) {
+
+			return _getAssetListEntryAssetEntries(
+				layout.getGroupId(), portletPreferences);
+		}
 
 		AssetPublisherWebConfiguration assetPublisherWebConfiguration =
 			_configurationProvider.getCompanyConfiguration(
@@ -289,6 +304,69 @@ public class AssetEntriesCheckerHelper {
 
 			return Collections.emptyList();
 		}
+	}
+
+	private List<AssetEntry> _getAssetListEntryAssetEntries(
+		long groupId, PortletPreferences portletPreferences) {
+
+		long assetListEntryId = GetterUtil.getLong(
+			portletPreferences.getValue("assetListEntryId", null));
+
+		if (assetListEntryId <= 0) {
+			return Collections.emptyList();
+		}
+
+		List<AssetEntry> assetEntries = new ArrayList<>();
+
+		try {
+			AssetListEntry assetListEntry =
+				_assetListEntryLocalService.fetchAssetListEntry(
+					assetListEntryId);
+
+			if (assetListEntry == null) {
+				return Collections.emptyList();
+			}
+
+			long[] segmentsEntryIds = {SegmentsEntryConstants.ID_DEFAULT};
+
+			try {
+				if (_segmentsConfigurationProvider.isSegmentationEnabled(
+						groupId)) {
+
+					segmentsEntryIds = ArrayUtil.toLongArray(
+						TransformUtil.transform(
+							_assetListEntrySegmentsEntryRelLocalService.
+								getAssetListEntrySegmentsEntryRels(
+									assetListEntryId, QueryUtil.ALL_POS,
+									QueryUtil.ALL_POS),
+							assetListEntrySegmentsEntryRel ->
+								assetListEntrySegmentsEntryRel.
+									getSegmentsEntryId()));
+				}
+			}
+			catch (PortalException portalException) {
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Unable to retrieve segmentsEntryIds for " +
+							"assetListEntryId" + assetListEntryId);
+				}
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(portalException);
+				}
+			}
+
+			assetEntries = _assetListAssetEntryProvider.getAssetEntries(
+				assetListEntry, segmentsEntryIds, null, null, StringPool.BLANK,
+				StringPool.BLANK, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return assetEntries;
 	}
 
 	private List<AssetEntry> _getManuallySelectedAssetEntries(
@@ -447,6 +525,16 @@ public class AssetEntriesCheckerHelper {
 	private AssetHelper _assetHelper;
 
 	@Reference
+	private AssetListAssetEntryProvider _assetListAssetEntryProvider;
+
+	@Reference
+	private AssetListEntryLocalService _assetListEntryLocalService;
+
+	@Reference
+	private AssetListEntrySegmentsEntryRelLocalService
+		_assetListEntrySegmentsEntryRelLocalService;
+
+	@Reference
 	private AssetPublisherHelper _assetPublisherHelper;
 
 	@Reference
@@ -467,6 +555,12 @@ public class AssetEntriesCheckerHelper {
 	@Reference
 	private PortletPreferenceValueLocalService
 		_portletPreferenceValueLocalService;
+
+	@Reference
+	private SegmentsConfigurationProvider _segmentsConfigurationProvider;
+
+	@Reference
+	private SegmentsEntryRetriever _segmentsEntryRetriever;
 
 	@Reference
 	private SubscriptionLocalService _subscriptionLocalService;

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/scheduler/helper/AssetEntriesCheckerHelper.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/scheduler/helper/AssetEntriesCheckerHelper.java
@@ -252,62 +252,24 @@ public class AssetEntriesCheckerHelper {
 
 		if (Objects.equals(
 				selectionStyle,
-				AssetPublisherSelectionStyleConstants.TYPE_MANUAL)) {
+				AssetPublisherSelectionStyleConstants.TYPE_ASSET_LIST)) {
 
-			return _getManuallySelectedAssetEntries(
+			return _getAssetListEntrySelectedAssetEntries(
 				portletPreferences, layout.getGroupId());
 		}
 		else if (Objects.equals(
 					selectionStyle,
-					AssetPublisherSelectionStyleConstants.TYPE_ASSET_LIST)) {
+					AssetPublisherSelectionStyleConstants.TYPE_DYNAMIC)) {
 
-			return _getAssetListEntryAssetEntries(
-				layout.getGroupId(), portletPreferences);
+			return _getDynamicSelectedAssetEntries(portletPreferences, layout);
 		}
 
-		AssetPublisherWebConfiguration assetPublisherWebConfiguration =
-			_configurationProvider.getCompanyConfiguration(
-				AssetPublisherWebConfiguration.class, layout.getCompanyId());
-
-		AssetEntryQuery assetEntryQuery =
-			_assetPublisherHelper.getAssetEntryQuery(
-				portletPreferences, layout.getGroupId(), layout, null, null);
-
-		int end = assetPublisherWebConfiguration.dynamicSubscriptionLimit();
-		int start = 0;
-
-		if (end == 0) {
-			end = QueryUtil.ALL_POS;
-			start = QueryUtil.ALL_POS;
-		}
-
-		assetEntryQuery.setEnd(end);
-		assetEntryQuery.setStart(start);
-
-		try {
-			SearchContext searchContext = SearchContextFactory.getInstance(
-				new long[0], new String[0], null, layout.getCompanyId(),
-				StringPool.BLANK, layout,
-				LocaleThreadLocal.getSiteDefaultLocale(), layout.getGroupId(),
-				TimeZoneThreadLocal.getDefaultTimeZone(), 0);
-
-			BaseModelSearchResult<AssetEntry> baseModelSearchResult =
-				_assetHelper.searchAssetEntries(
-					searchContext, assetEntryQuery, start, end);
-
-			return baseModelSearchResult.getBaseModels();
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-
-			return Collections.emptyList();
-		}
+		return _getManuallySelectedAssetEntries(
+			portletPreferences, layout.getGroupId());
 	}
 
-	private List<AssetEntry> _getAssetListEntryAssetEntries(
-		long groupId, PortletPreferences portletPreferences) {
+	private List<AssetEntry> _getAssetListEntrySelectedAssetEntries(
+		PortletPreferences portletPreferences, long groupId) {
 
 		long assetListEntryId = GetterUtil.getLong(
 			portletPreferences.getValue("assetListEntryId", null));
@@ -367,6 +329,51 @@ public class AssetEntriesCheckerHelper {
 		}
 
 		return assetEntries;
+	}
+
+	private List<AssetEntry> _getDynamicSelectedAssetEntries(
+			PortletPreferences portletPreferences, Layout layout)
+		throws PortalException {
+
+		AssetPublisherWebConfiguration assetPublisherWebConfiguration =
+			_configurationProvider.getCompanyConfiguration(
+				AssetPublisherWebConfiguration.class, layout.getCompanyId());
+
+		AssetEntryQuery assetEntryQuery =
+			_assetPublisherHelper.getAssetEntryQuery(
+				portletPreferences, layout.getGroupId(), layout, null, null);
+
+		int end = assetPublisherWebConfiguration.dynamicSubscriptionLimit();
+		int start = 0;
+
+		if (end == 0) {
+			end = QueryUtil.ALL_POS;
+			start = QueryUtil.ALL_POS;
+		}
+
+		assetEntryQuery.setEnd(end);
+		assetEntryQuery.setStart(start);
+
+		try {
+			SearchContext searchContext = SearchContextFactory.getInstance(
+				new long[0], new String[0], null, layout.getCompanyId(),
+				StringPool.BLANK, layout,
+				LocaleThreadLocal.getSiteDefaultLocale(), layout.getGroupId(),
+				TimeZoneThreadLocal.getDefaultTimeZone(), 0);
+
+			BaseModelSearchResult<AssetEntry> baseModelSearchResult =
+				_assetHelper.searchAssetEntries(
+					searchContext, assetEntryQuery, start, end);
+
+			return baseModelSearchResult.getBaseModels();
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return Collections.emptyList();
+		}
 	}
 
 	private List<AssetEntry> _getManuallySelectedAssetEntries(


### PR DESCRIPTION
See the reproduction steps in https://issues.liferay.com/browse/LPS-180710

It seems that retrieving the asset entires from collections was missing, so the asset publisher didn't notify to subscribers.

I've created a new method, _getAssetListEntryAssetEntries and its logic is partially based in the code used to retrieve the elements in asset publisher by calling _com.liferay.asset.publisher.web.internal.display.context.AssetPublisherDisplayContext#getAssetEntryQuery_.

 I simplify the use and call _assetListAssetEntryProvider.getAssetEntries directly instead of creating a new asset entry query.

If you prefer to use the asset entry query, please tell me and I'll reformat it


**Suggestions for testing:**  modify this line: com/liferay/asset/publisher/web/internal/scheduler/CheckAssetEntrySchedulerJobConfiguration.java:77 to 

`return TriggerConfiguration.createTriggerConfiguration(1, TimeUnit.MINUTE);
`

So the cron is executed more often (default value is 24 hours) :D

If you need more context, please tell me!

Thank you in advance!


