### PR TITLE
LPS-180475 Adapt headers of SEO, Open Graph and Custom Meta Tags views

### DIFF
--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/custom_meta_tags.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/custom_meta_tags.jsp
@@ -38,39 +38,43 @@ if (Validator.isNull(backURL)) {
 	<clay:sheet>
 		<clay:sheet-header>
 			<h2 class="sheet-title"><liferay-ui:message key="custom-meta-tags" /></h2>
+		</clay:sheet-header>
+
+		<clay:sheet-section>
+			<h3 class="sheet-title"><liferay-ui:message key="settings" /></h3>
 
 			<p class="text-secondary">
 				<liferay-ui:message key="custom-meta-tags-description" />
 			</p>
-		</clay:sheet-header>
 
-		<liferay-ui:error exception="<%= DDMFormValuesValidationException.class %>" message="field-validation-failed" />
+			<liferay-ui:error exception="<%= DDMFormValuesValidationException.class %>" message="field-validation-failed" />
 
-		<liferay-ui:error exception="<%= DDMFormValuesValidationException.RequiredValue.class %>">
+			<liferay-ui:error exception="<%= DDMFormValuesValidationException.RequiredValue.class %>">
 
-			<%
-			DDMFormValuesValidationException.RequiredValue rv = (DDMFormValuesValidationException.RequiredValue)errorException;
+				<%
+				DDMFormValuesValidationException.RequiredValue rv = (DDMFormValuesValidationException.RequiredValue)errorException;
 
-			String fieldLabelValue = rv.getFieldLabelValue(themeDisplay.getLocale());
+				String fieldLabelValue = rv.getFieldLabelValue(themeDisplay.getLocale());
 
-			if (Validator.isNull(fieldLabelValue)) {
-				fieldLabelValue = rv.getFieldName();
-			}
-			%>
+				if (Validator.isNull(fieldLabelValue)) {
+					fieldLabelValue = rv.getFieldName();
+				}
+				%>
 
-			<liferay-ui:message arguments="<%= HtmlUtil.escape(fieldLabelValue) %>" key="no-value-is-defined-for-field-x" translateArguments="<%= false %>" />
-		</liferay-ui:error>
+				<liferay-ui:message arguments="<%= HtmlUtil.escape(fieldLabelValue) %>" key="no-value-is-defined-for-field-x" translateArguments="<%= false %>" />
+			</liferay-ui:error>
 
-		<liferay-ddm:html
-			classNameId="<%= PortalUtil.getClassNameId(com.liferay.dynamic.data.mapping.model.DDMStructure.class) %>"
-			classPK="<%= layoutsSEODisplayContext.getDDMStructurePrimaryKey() %>"
-			ddmFormValues="<%= layoutsSEODisplayContext.getDDMFormValues() %>"
-			defaultEditLocale="<%= PortalUtil.getSiteDefaultLocale(layoutsSEODisplayContext.getGroupId()) %>"
-			defaultLocale="<%= PortalUtil.getSiteDefaultLocale(layoutsSEODisplayContext.getGroupId()) %>"
-			fieldsNamespace="<%= String.valueOf(layoutsSEODisplayContext.getDDMStructurePrimaryKey()) %>"
-			groupId="<%= layoutsSEODisplayContext.getGroupId() %>"
-			requestedLocale="<%= locale %>"
-		/>
+			<liferay-ddm:html
+				classNameId="<%= PortalUtil.getClassNameId(com.liferay.dynamic.data.mapping.model.DDMStructure.class) %>"
+				classPK="<%= layoutsSEODisplayContext.getDDMStructurePrimaryKey() %>"
+				ddmFormValues="<%= layoutsSEODisplayContext.getDDMFormValues() %>"
+				defaultEditLocale="<%= PortalUtil.getSiteDefaultLocale(layoutsSEODisplayContext.getGroupId()) %>"
+				defaultLocale="<%= PortalUtil.getSiteDefaultLocale(layoutsSEODisplayContext.getGroupId()) %>"
+				fieldsNamespace="<%= String.valueOf(layoutsSEODisplayContext.getDDMStructurePrimaryKey()) %>"
+				groupId="<%= layoutsSEODisplayContext.getGroupId() %>"
+				requestedLocale="<%= locale %>"
+			/>
+		</clay:sheet-section>
 
 		<clay:sheet-footer>
 			<clay:button

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/open_graph.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/open_graph.jsp
@@ -54,6 +54,8 @@ Layout selLayout = layoutsSEODisplayContext.getSelLayout();
 				value="open-graph"
 			/>
 
+			<h3 class="sheet-title"><liferay-ui:message key="settings" /></h3>
+
 			<p class="text-secondary">
 				<liferay-ui:message key="open-graph-description" />
 			</p>

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
@@ -57,7 +57,7 @@ UnicodeProperties layoutTypeSettingsUnicodeProperties = selLayout.getTypeSetting
 				value="seo"
 			/>
 
-			<h3 class="sheet-subtitle"><liferay-ui:message key="general-settings" /></h3>
+			<h3 class="sheet-title"><liferay-ui:message key="settings" /></h3>
 
 			<clay:alert
 				cssClass="mb-4"
@@ -196,7 +196,9 @@ UnicodeProperties layoutTypeSettingsUnicodeProperties = selLayout.getTypeSetting
 			<aui:input name="robots" placeholder="robots" />
 
 			<c:if test="<%= PortalUtil.isLayoutSitemapable(selLayout) %>">
-				<h3 class="sheet-subtitle"><liferay-ui:message key="sitemap" /></h3>
+				<hr class="mt-4 separator" />
+
+				<h3 class="sheet-title"><liferay-ui:message key="sitemap" /></h3>
 
 				<div class="alert alert-warning layout-prototype-info-message <%= selLayout.isLayoutPrototypeLinkActive() ? StringPool.BLANK : "hide" %>">
 					<liferay-ui:message arguments='<%= new String[] {"inherit-changes", "general"} %>' key="some-page-settings-are-unavailable-because-x-is-enabled" />


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to update the headers in the Configuration part of the Widget Pages according to the new designs established.
[LPS-180475](https://issues.liferay.com/browse/LPS-180475)
[LPS-153953](https://issues.liferay.com/browse/LPS-153953)

Proposed Solution
========
The solution consists in changing the class attribute from sheet-subtitle to sheet-title for the headers they are displayed as the desired design and adding separators when there are more than one section.

Steps to Verify
========
1. Go to Site Builder -> Pages
2. Add a Widget Page
3. Click on the dropdown button for the created widget page -> Click on Configure
4. Go through  the views of Seo, Open Graph and Custom Meta Tags
5. Check that the headers of the sections are displayed according to the designs.

Screenshots (if applies)
========
<img width="1792" alt="Screenshot 2023-04-05 at 11 38 09" src="https://user-images.githubusercontent.com/91207948/230043400-c7702ea7-9afe-4a9c-a789-9f8fb1285d20.png">

<img width="1120" alt="Screenshot 2023-04-05 at 11 38 40" src="https://user-images.githubusercontent.com/91207948/230043425-c5ca20ea-29cc-4710-805f-42543dfd4ea6.png">



