### PR TITLE
LPS-180856 Fix TreeView styles

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureClayTreeNode.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureClayTreeNode.js
@@ -347,9 +347,6 @@ function StructureTreeNodeContent({
 				'dragged': isDraggingSource,
 				'font-weight-semi-bold':
 					node.activable && node.itemType !== ITEM_TYPES.editable,
-				'page-editor__page-structure__tree-node--mapped': isMapped,
-				'page-editor__page-structure__tree-node--master-item':
-					node.isMasterItem,
 			})}
 			ref={targetRef}
 		>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureClayTreeNode.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureClayTreeNode.js
@@ -454,7 +454,6 @@ const NameLabel = React.forwardRef(
 						'page-editor__page-structure__tree-node__name--hidden': hidden,
 						'page-editor__page-structure__tree-node__name--mapped': isMapped,
 						'page-editor__page-structure__tree-node__name--master-item': isMasterItem,
-						'w-100': editingName,
 					}
 				)}
 				ref={ref}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureClayTreeNodeActions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureClayTreeNodeActions.js
@@ -75,7 +75,7 @@ export default function StructureClayTreeNodeActions({
 				aria-haspopup="true"
 				aria-label={Liferay.Language.get('options')}
 				className={classNames(
-					'page-editor__page-structure__tree-node__actions-button',
+					'ml-0 page-editor__page-structure__tree-node__actions-button',
 					{
 						'page-editor__page-structure__tree-node__actions-button--visible': visible,
 					}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
@@ -224,7 +224,7 @@ export default function PageStructureSidebar() {
 
 		return (
 			<div
-				className={classNames('flex-shrink-0', {
+				className={classNames('autofit-row', {
 					'page-editor__page-structure__tree-node__buttons--hidden':
 						item.hidden || item.hiddenAncestor,
 				})}
@@ -233,6 +233,7 @@ export default function PageStructureSidebar() {
 			>
 				{(item.hidable || item.hidden) && (
 					<VisibilityButton
+						className="ml-0"
 						dispatch={dispatch}
 						node={item}
 						selectedViewportSize={selectedViewportSize}
@@ -291,6 +292,7 @@ export default function PageStructureSidebar() {
 									actions={<ItemActions item={item} />}
 								>
 									<ClayTreeView.ItemStack
+										className="page-editor__page-structure__structure-tree-node"
 										data-title={
 											item.isMasterItem || !item.activable
 												? ''

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
@@ -144,6 +144,7 @@ export default function PageStructureSidebar() {
 				dragAndDropHoveredItemId,
 				editingNodeId,
 				fragmentEntryLinks,
+				hoveredItemId,
 				isMasterPage,
 				keyboardMovementTargetId,
 				layoutData,
@@ -163,6 +164,7 @@ export default function PageStructureSidebar() {
 			dragAndDropHoveredItemId,
 			editingNodeId,
 			fragmentEntryLinks,
+			hoveredItemId,
 			isMasterPage,
 			keyboardMovementTargetId,
 			layoutData,
@@ -292,7 +294,20 @@ export default function PageStructureSidebar() {
 									actions={<ItemActions item={item} />}
 								>
 									<ClayTreeView.ItemStack
-										className="page-editor__page-structure__structure-tree-node"
+										className={classNames(
+											'page-editor__page-structure__clay-tree-node',
+											{
+												'page-editor__page-structure__clay-tree-node--active':
+													item.active &&
+													item.activable,
+												'page-editor__page-structure__clay-tree-node--hovered':
+													item.hovered,
+												'page-editor__page-structure__clay-tree-node--mapped':
+													item.mapped,
+												'page-editor__page-structure__clay-tree-node--master-item':
+													item.isMasterItem,
+											}
+										)}
 										data-title={
 											item.isMasterItem || !item.activable
 												? ''
@@ -533,6 +548,7 @@ function visit(
 		editingNodeId,
 		fragmentEntryLinks,
 		hasHiddenAncestor,
+		hoveredItemId,
 		isMasterPage,
 		keyboardMovementTargetId,
 		layoutData,
@@ -641,6 +657,7 @@ function visit(
 						editingNodeId,
 						fragmentEntryLinks,
 						hasHiddenAncestor: hasHiddenAncestor || hidden,
+						hoveredItemId,
 						isMasterPage,
 						layoutData,
 						layoutDataRef,
@@ -689,6 +706,7 @@ function visit(
 						editingNodeId,
 						fragmentEntryLinks,
 						hasHiddenAncestor: hasHiddenAncestor || hidden,
+						hoveredItemId,
 						isMasterPage,
 						keyboardMovementTargetId,
 						layoutData,
@@ -712,6 +730,7 @@ function visit(
 					editingNodeId,
 					fragmentEntryLinks,
 					hasHiddenAncestor: hasHiddenAncestor || hidden,
+					hoveredItemId,
 					isMasterPage,
 					keyboardMovementTargetId,
 					layoutData,
@@ -734,6 +753,7 @@ function visit(
 			item.type !== LAYOUT_DATA_ITEM_TYPES.collectionItem &&
 			item.type !== LAYOUT_DATA_ITEM_TYPES.fragmentDropZone &&
 			canUpdateItemConfiguration,
+		active: item.itemId === activeItemId,
 		children,
 		config: layoutDataRef.current.items[item.itemId]?.config,
 		draggable: true,
@@ -747,6 +767,7 @@ function visit(
 			isHidable(item, fragmentEntryLinks, layoutData),
 		hidden,
 		hiddenAncestor: hasHiddenAncestor,
+		hovered: item.itemId === hoveredItemId,
 		icon,
 		id: item.itemId,
 		isMasterItem: !isMasterPage && itemInMasterLayout,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
@@ -224,7 +224,7 @@ export default function PageStructureSidebar() {
 
 		return (
 			<div
-				className={classNames('autofit-row', {
+				className={classNames('autofit-row w-auto', {
 					'page-editor__page-structure__tree-node__buttons--hidden':
 						item.hidden || item.hiddenAncestor,
 				})}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/VisibilityButton.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/VisibilityButton.js
@@ -27,6 +27,7 @@ import updateItemStyle from '../../../../../app/utils/updateItemStyle';
 import useHasRequiredChild from '../../../../../app/utils/useHasRequiredChild';
 
 export default function VisibilityButton({
+	className,
 	dispatch,
 	node,
 	selectedViewportSize,
@@ -43,7 +44,8 @@ export default function VisibilityButton({
 				[node.name]
 			)}
 			className={classNames(
-				'page-editor__page-structure__tree-node__visibility-button',
+				'page-editor__page-structure__tree-node__visibility-button ' +
+					className,
 				{
 					'page-editor__page-structure__tree-node__visibility-button--visible': visible,
 				}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTree.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTree.scss
@@ -3,7 +3,21 @@
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__page-structure__structure-tree {
+			min-height: 100%;
 			padding: 0 16px;
+
+			&-node {
+				width: initial;
+				min-width: initial;
+
+				&.treeview-link {
+					width: fit-content;
+				}
+
+				& > .autofit-col-expand {
+					flex-shrink: 0;
+				}
+			}
 
 			.lfr-treeview-node-list {
 				border-left: none;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTree.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTree.scss
@@ -6,23 +6,6 @@ html#{$cadmin-selector} {
 			min-height: 100%;
 			padding: 0 16px;
 
-			&-node {
-				width: initial;
-				min-width: 100%;
-
-				&.treeview-link {
-					width: fit-content;
-				}
-
-				.c-inner {
-					width: auto;
-				}
-
-				& > .autofit-col-expand {
-					flex-shrink: 0;
-				}
-			}
-
 			.lfr-treeview-node-list {
 				border-left: none;
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTree.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTree.scss
@@ -8,10 +8,14 @@ html#{$cadmin-selector} {
 
 			&-node {
 				width: initial;
-				min-width: initial;
+				min-width: 100%;
 
 				&.treeview-link {
 					width: fit-content;
+				}
+
+				.c-inner {
+					width: auto;
 				}
 
 				& > .autofit-col-expand {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTreeNode.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTreeNode.scss
@@ -5,8 +5,8 @@ $treeNodeNameMappedColor: #954cff;
 html#{$cadmin-selector} {
 	.cadmin {
 		.page-editor__page-structure__clay-tree-node {
-			width: initial;
 			min-width: 100%;
+			width: initial;
 
 			&.treeview-link {
 				width: fit-content;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTreeNode.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTreeNode.scss
@@ -47,8 +47,6 @@ html#{$cadmin-selector} {
 			.page-editor__page-structure__tree-node__actions-button,
 			.page-editor__page-structure__tree-node__visibility-button {
 				color: $cadmin-secondary;
-				margin-left: 0;
-				transform: translateY(1px);
 				visibility: hidden;
 
 				&--visible {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTreeNode.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTreeNode.scss
@@ -43,6 +43,18 @@ html#{$cadmin-selector} {
 			&--master-item.treeview-link {
 				background-color: $cadmin-light-l1;
 			}
+
+			.page-editor__page-structure__tree-node__actions-button,
+			.page-editor__page-structure__tree-node__visibility-button {
+				color: $cadmin-secondary;
+				margin-left: 0;
+				transform: translateY(1px);
+				visibility: hidden;
+
+				&--visible {
+					visibility: visible;
+				}
+			}
 		}
 
 		.page-editor__page-structure__tree-node {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTreeNode.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/_StructureTreeNode.scss
@@ -4,6 +4,47 @@ $treeNodeNameMappedColor: #954cff;
 
 html#{$cadmin-selector} {
 	.cadmin {
+		.page-editor__page-structure__clay-tree-node {
+			width: initial;
+			min-width: 100%;
+
+			&.treeview-link {
+				width: fit-content;
+			}
+
+			.c-inner {
+				width: auto;
+			}
+
+			& > .autofit-col-expand {
+				flex-shrink: 0;
+			}
+
+			&--active.treeview-link {
+				background-color: $cadmin-primary-l3;
+				border-radius: 4px;
+				box-shadow: inset 0 0 0 1px $cadmin-primary-l1;
+				font-weight: 600;
+			}
+
+			&--hovered.treeview-link {
+				background-color: $cadmin-primary-l3;
+				border-radius: 4px;
+			}
+			&--mapped#{&}--active.treeview-link,
+			&--mapped#{&}--hovered.treeview-link {
+				background-color: fade_out($cadmin-purple, 0.92);
+			}
+
+			&--mapped#{&}--active.treeview-link {
+				box-shadow: inset 0 0 0 1px $cadmin-purple;
+			}
+
+			&--master-item.treeview-link {
+				background-color: $cadmin-light-l1;
+			}
+		}
+
 		.page-editor__page-structure__tree-node {
 			align-items: center;
 			display: flex;


### PR DESCRIPTION
Motivation
=======
This is a follow-up of https://github.com/liferay-echo/liferay-portal/pull/11636
It fixes the styles of the tree so that actions do not overlap with the node name and the horizontal scroll is applied correctly.
[Link to task](https://issues.liferay.com/browse/LPS-151678)
[Link to subtask](https://issues.liferay.com/browse/LPS-180856)

Proposed Solution
========
We have changed the CSS

Steps to Verify:
----------------

1. Set feature.flag.LPS-151678=true
2. Go to home page and click on edit
3. In the left sidebar click on Browser section
4. Open the tree nodes and check that the styles are good
5. Set feature.flag.LPS-151678=false, restart the server and check the everything works as before


Screenshots ():
-----------------------

![Captura de pantalla 2023-04-12 a las 11 27 52](https://user-images.githubusercontent.com/3276218/231415925-98f55190-c8e3-48ee-870a-b32d015900f0.png)

