### PR TITLE
LPS-181468 Expand nodes when they are active

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureClayTreeNode.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureClayTreeNode.js
@@ -32,7 +32,6 @@ import {
 } from '../../../../../app/config/constants/keyboardCodes';
 import {LAYOUT_DATA_ITEM_TYPES} from '../../../../../app/config/constants/layoutDataItemTypes';
 import {VIEWPORT_SIZES} from '../../../../../app/config/constants/viewportSizes';
-import {config} from '../../../../../app/config/index';
 import {
 	useActivationOrigin,
 	useActiveItemId,
@@ -194,6 +193,7 @@ function StructureTreeNodeContent({
 	const canUpdatePageStructure = useSelector(selectCanUpdatePageStructure);
 	const dispatch = useDispatch();
 	const nodeRef = useRef();
+	const restrictedItemIds = useSelector((state) => state.restrictedItemIds);
 	const selectedViewportSize = useSelector(
 		(state) => state.selectedViewportSize
 	);
@@ -405,7 +405,7 @@ function StructureTreeNodeContent({
 				showPermissionRestriction={isRestricted(
 					item,
 					node,
-					config.restrictedItemIds
+					restrictedItemIds
 				)}
 				showUnavailableWarning={
 					Liferay.FeatureFlags['LPS-169923'] &&

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
@@ -147,7 +147,6 @@ export default function PageStructureSidebar() {
 				dragAndDropHoveredItemId,
 				editingNodeId,
 				fragmentEntryLinks,
-				hoveredItemId,
 				isMasterPage,
 				keyboardMovementTargetId,
 				layoutData,
@@ -169,7 +168,6 @@ export default function PageStructureSidebar() {
 			dragAndDropHoveredItemId,
 			editingNodeId,
 			fragmentEntryLinks,
-			hoveredItemId,
 			isMasterPage,
 			keyboardMovementTargetId,
 			layoutData,
@@ -342,7 +340,8 @@ export default function PageStructureSidebar() {
 													item.active &&
 													item.activable,
 												'page-editor__page-structure__clay-tree-node--hovered':
-													item.hovered,
+													item.itemId ===
+													hoveredItemId,
 												'page-editor__page-structure__clay-tree-node--mapped':
 													item.mapped,
 												'page-editor__page-structure__clay-tree-node--master-item':
@@ -589,7 +588,6 @@ function visit(
 		editingNodeId,
 		fragmentEntryLinks,
 		hasHiddenAncestor,
-		hoveredItemId,
 		isMasterPage,
 		keyboardMovementTargetId,
 		layoutData,
@@ -700,7 +698,6 @@ function visit(
 						editingNodeId,
 						fragmentEntryLinks,
 						hasHiddenAncestor: hasHiddenAncestor || hidden,
-						hoveredItemId,
 						isMasterPage,
 						layoutData,
 						layoutDataRef,
@@ -750,7 +747,6 @@ function visit(
 						editingNodeId,
 						fragmentEntryLinks,
 						hasHiddenAncestor: hasHiddenAncestor || hidden,
-						hoveredItemId,
 						isMasterPage,
 						keyboardMovementTargetId,
 						layoutData,
@@ -775,7 +771,6 @@ function visit(
 					editingNodeId,
 					fragmentEntryLinks,
 					hasHiddenAncestor: hasHiddenAncestor || hidden,
-					hoveredItemId,
 					isMasterPage,
 					keyboardMovementTargetId,
 					layoutData,
@@ -813,7 +808,6 @@ function visit(
 			isHidable(item, fragmentEntryLinks, layoutData),
 		hidden,
 		hiddenAncestor: hasHiddenAncestor,
-		hovered: item.itemId === hoveredItemId,
 		icon,
 		id: item.itemId,
 		isMasterItem: !isMasterPage && itemInMasterLayout,


### PR DESCRIPTION
Motivation
=======
This is a follow-up of https://github.com/liferay-echo/liferay-portal/pull/11712
When the user select a node in the page editor and activate it, the node should expand in the structure tree to that it is visible.
[Link to task](https://issues.liferay.com/browse/LPS-151678)
[Link to subtask](https://issues.liferay.com/browse/LPS-181468)

Proposed Solution
========
We control what nodes are expanded by passing the props expandedKeys and onExpandedChange and keeping the nodes currently expended in the component state.

Steps to Verify:
----------------

1. Set feature.flag.LPS-151678=true
2. Go to home page and click on edit
3. Click on any element of the page layout and check the the structure tree appears with the node element selected expanded.
4. Try expanding and closing other nodes and clicking in the page editor and check that everything works fine.
5. Set feature.flag.LPS-151678=false, restart the server and check the everything works as before