### PR TITLE
LPS-181486 Avoid NPE when the configured layout was deleted

### DIFF
--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/NavItemUtil.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/internal/util/NavItemUtil.java
@@ -202,8 +202,10 @@ public class NavItemUtil {
 							rootLayoutUuid, layout.getGroupId(), true);
 				}
 
-				rootNavItem = new NavItem(
-					httpServletRequest, themeDisplay, rootLayout);
+				if (rootLayout != null) {
+					rootNavItem = new NavItem(
+						httpServletRequest, themeDisplay, rootLayout);
+				}
 			}
 			else {
 				navItems = _fromLayouts(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-181486

'Menu Display is temporarily unavailable' error when configuration points to a deleted page because the code doesn't check the fetchLayoutByUuidAndGroupId call can return a null value.

This was reproduced by a 7.2.x customer when a site indexation is triggered. In this situation, there is a content page with this problem that throws a NPE and the site indexation operation is aborted.

In 7.2.x and 7.3.x the, the code throws an NoSuchLayoutException exception instead of the NPE because in master this commit https://github.com/liferay/liferay-portal/commit/0ab83d395cf26bf0df8861b243b6d1d66292c4ac replaced the getLayoutByUuidAndGroupId call with fetchLayoutByUuidAndGroupId, so that commit should be also backported to that versions.

Let me know if you have any question