### PR TITLE
LPS-181405 | master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Upgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Upgrade.macro
@@ -1630,21 +1630,21 @@ definition {
 		WebContentNavigator.openWebContentAdmin(siteURLKey = "guest");
 
 		WebContent.viewWithStructureCP(
-			webContentText = "This is a Text field Edit",
+			webContentText = "This is a Text field",
 			webContentTextFieldLabel = "Text Edit",
-			webContentTitle = "Web Content Title Edit");
+			webContentTitle = "Web Content Title");
 
 		Navigator.gotoPage(pageName = "Web Content Display");
 
 		WebContentDisplayPortlet.viewContent(
-			webContentContent = "This is a Text field Edit",
-			webContentTitle = "Web Content Title Edit");
+			webContentContent = "This is a Text field",
+			webContentTitle = "Web Content Title");
 
 		Navigator.gotoPage(pageName = "Asset Publisher");
 
 		AssetPublisherPortlet.viewAssetDetailsPG(
-			assetContent = "This is a Text field Edit",
-			assetTitle = "Web Content Title Edit");
+			assetContent = "This is a Text field",
+			assetTitle = "Web Content Title");
 	}
 
 	macro EditWebContentAndViewInWCDandAssetPublisher {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/Upgrade.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Upgrade.macro
@@ -1642,9 +1642,11 @@ definition {
 
 		Navigator.gotoPage(pageName = "Asset Publisher");
 
-		AssetPublisherPortlet.viewAssetDetailsPG(
-			assetContent = "This is a Text field",
-			assetTitle = "Web Content Title");
+		AssetPublisherPortlet.clickAssetTitle(assetTitle = "Web Content Title");
+
+		WebContentDisplayPortlet.viewContent(
+			webContentContent = "This is a Text field",
+			webContentTitle = "Web Content Title");
 	}
 
 	macro EditWebContentAndViewInWCDandAssetPublisher {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgrade.testcase
@@ -924,6 +924,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.0.4";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher704";
 
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher(webContentColor = "false");
 	}
@@ -934,6 +935,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.1.3";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher713";
 
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
 	}
@@ -944,6 +946,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.2.1";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher721";
 
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
 	}
@@ -954,6 +957,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.3.5";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher735";
 
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
 	}
@@ -964,6 +968,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
 		property portal.version = "7.3.10";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher7310";
 
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
 	}
@@ -974,6 +979,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
 		property portal.version = "7.1.10.3";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher71103";
 
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
 	}
@@ -984,6 +990,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.2.10.1";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher72101";
 
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
 	}
@@ -994,6 +1001,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
 		property portal.version = "7.0.10.14";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher701014";
 
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher(webContentColor = "false");
 	}
@@ -1004,6 +1012,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.0.4";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWebContentAndViewInWCDAndAssetPublisher704";
 
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
@@ -1014,6 +1023,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.1.3";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWebContentAndViewInWCDAndAssetPublisher713";
 
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
@@ -1024,6 +1034,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.2.1";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWebContentAndViewInWCDAndAssetPublisher721";
 
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
@@ -1034,6 +1045,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.3.5";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWebContentAndViewInWCDAndAssetPublisher735";
 
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
@@ -1044,6 +1056,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
 		property portal.version = "7.3.10";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWebContentAndViewInWCDAndAssetPublisher7310";
 
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
@@ -1054,6 +1067,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
 		property portal.version = "7.1.10.3";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWebContentAndViewInWCDAndAssetPublisher71103";
 
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
@@ -1064,6 +1078,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.2.10.1";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWebContentAndViewInWCDAndAssetPublisher72101";
 
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
@@ -1074,6 +1089,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
 		property portal.version = "7.0.10.14";
+		property test.name.skip.portal.instance = "WebContentUpgrade#EditWebContentAndViewInWCDAndAssetPublisher701014";
 
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
@@ -1137,6 +1153,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.0.4";
+		property test.name.skip.portal.instance = "WebContentUpgrade#ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher704";
 
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher(webContentColor = "false");
 	}
@@ -1147,6 +1164,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.1.3";
+		property test.name.skip.portal.instance = "WebContentUpgrade#ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher713";
 
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
 	}
@@ -1157,6 +1175,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.2.1";
+		property test.name.skip.portal.instance = "WebContentUpgrade#ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher721";
 
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
 	}
@@ -1167,6 +1186,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.3.5";
+		property test.name.skip.portal.instance = "WebContentUpgrade#ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher735";
 
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
 	}
@@ -1177,6 +1197,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
 		property portal.version = "7.3.10";
+		property test.name.skip.portal.instance = "WebContentUpgrade#ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher7310";
 
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
 	}
@@ -1187,6 +1208,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
 		property portal.version = "7.1.10.3";
+		property test.name.skip.portal.instance = "WebContentUpgrade#ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher71103";
 
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
 	}
@@ -1197,6 +1219,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "mariadb,mysql,postgresql";
 		property portal.version = "7.2.10.1";
+		property test.name.skip.portal.instance = "WebContentUpgrade#ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher72101";
 
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
 	}
@@ -1207,6 +1230,7 @@ definition {
 		property data.archive.type = "data-archive-web-content-with-fields";
 		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
 		property portal.version = "7.0.10.14";
+		property test.name.skip.portal.instance = "WebContentUpgrade#ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher701014";
 
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher(webContentColor = "false");
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgrade.testcase
@@ -918,6 +918,166 @@ definition {
 		}
 	}
 
+	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher704 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.0.4";
+
+		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher(webContentColor = "false");
+	}
+
+	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher713 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.1.3";
+
+		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher721 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.2.1";
+
+		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher735 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.3.5";
+
+		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher7310 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
+		property portal.version = "7.3.10";
+
+		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher71103 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
+		property portal.version = "7.1.10.3";
+
+		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher72101 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.2.10.1";
+
+		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher701014 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
+		property portal.version = "7.0.10.14";
+
+		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher(webContentColor = "false");
+	}
+
+	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWebContentAndViewInWCDAndAssetPublisher704 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.0.4";
+
+		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWebContentAndViewInWCDAndAssetPublisher713 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.1.3";
+
+		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWebContentAndViewInWCDAndAssetPublisher721 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.2.1";
+
+		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWebContentAndViewInWCDAndAssetPublisher735 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.3.5";
+
+		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWebContentAndViewInWCDAndAssetPublisher7310 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
+		property portal.version = "7.3.10";
+
+		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWebContentAndViewInWCDAndAssetPublisher71103 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
+		property portal.version = "7.1.10.3";
+
+		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWebContentAndViewInWCDAndAssetPublisher72101 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.2.10.1";
+
+		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test EditWebContentAndViewInWCDAndAssetPublisher701014 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
+		property portal.version = "7.0.10.14";
+
+		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
+	}
+
 	@priority = 5
 	test PublishDraftWebContentAfterUpgrade625 {
 		property data.archive.type = "data-archive-web-content-draft";
@@ -951,118 +1111,6 @@ definition {
 		Upgrade.publishWCDraft();
 	}
 
-	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
-	@priority = 5
-	test ViewAndEditWebContentWCStructureWCTemplateWCDAndAssetPublisher704 {
-		property data.archive.type = "data-archive-web-content-with-fields";
-		property database.types = "mariadb,mysql,postgresql";
-		property portal.version = "7.0.4";
-
-		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher(webContentColor = "false");
-
-		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
-
-		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher(webContentColor = "false");
-	}
-
-	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
-	@priority = 5
-	test ViewAndEditWebContentWCStructureWCTemplateWCDAndAssetPublisher713 {
-		property data.archive.type = "data-archive-web-content-with-fields";
-		property database.types = "mariadb,mysql,postgresql";
-		property portal.version = "7.1.3";
-
-		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
-
-		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
-
-		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
-	}
-
-	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
-	@priority = 5
-	test ViewAndEditWebContentWCStructureWCTemplateWCDAndAssetPublisher721 {
-		property data.archive.type = "data-archive-web-content-with-fields";
-		property database.types = "mariadb,mysql,postgresql";
-		property portal.version = "7.2.1";
-
-		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
-
-		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
-
-		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
-	}
-
-	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
-	@priority = 5
-	test ViewAndEditWebContentWCStructureWCTemplateWCDAndAssetPublisher735 {
-		property data.archive.type = "data-archive-web-content-with-fields";
-		property database.types = "mariadb,mysql,postgresql";
-		property portal.version = "7.3.5";
-
-		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
-
-		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
-
-		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
-	}
-
-	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
-	@priority = 5
-	test ViewAndEditWebContentWCStructureWCTemplateWCDAndAssetPublisher7310 {
-		property data.archive.type = "data-archive-web-content-with-fields";
-		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
-		property portal.version = "7.3.10";
-
-		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
-
-		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
-
-		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
-	}
-
-	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
-	@priority = 5
-	test ViewAndEditWebContentWCStructureWCTemplateWCDAndAssetPublisher71103 {
-		property data.archive.type = "data-archive-web-content-with-fields";
-		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
-		property portal.version = "7.1.10.3";
-
-		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
-
-		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
-
-		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
-	}
-
-	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
-	@priority = 5
-	test ViewAndEditWebContentWCStructureWCTemplateWCDAndAssetPublisher72101 {
-		property data.archive.type = "data-archive-web-content-with-fields";
-		property database.types = "mariadb,mysql,postgresql";
-		property portal.version = "7.2.10.1";
-
-		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
-
-		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
-
-		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
-	}
-
-	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
-	@priority = 5
-	test ViewAndEditWebContentWCStructureWCTemplateWCDAndAssetPublisher701014 {
-		property data.archive.type = "data-archive-web-content-with-fields";
-		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
-		property portal.version = "7.0.10.14";
-
-		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher(webContentColor = "false");
-
-		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
-
-		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher(webContentColor = "false");
-	}
-
 	@description = "This is a use case for LPS-123590."
 	@priority = 4
 	test ViewSpecificDisplayPageTemplateArchive721 {
@@ -1081,6 +1129,86 @@ definition {
 		property portal.version = "7.2.10.4";
 
 		Upgrade.viewSpecificDisplayPageTemplateViaAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher704 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.0.4";
+
+		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher(webContentColor = "false");
+	}
+
+	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher713 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.1.3";
+
+		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher721 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.2.1";
+
+		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher735 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.3.5";
+
+		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher7310 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
+		property portal.version = "7.3.10";
+
+		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher71103 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
+		property portal.version = "7.1.10.3";
+
+		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher72101 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "mariadb,mysql,postgresql";
+		property portal.version = "7.2.10.1";
+
+		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
+	}
+
+	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@priority = 5
+	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher701014 {
+		property data.archive.type = "data-archive-web-content-with-fields";
+		property database.types = "db2,mariadb,mysql,oracle,postgresql,sybase";
+		property portal.version = "7.0.10.14";
+
+		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher(webContentColor = "false");
 	}
 
 	@description = "This is a use case for LRQA-62720. View web content with all fields and value after upgrade from 6.2."

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgrade.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/upgrades/webcontent/WebContentUpgrade.testcase
@@ -918,7 +918,7 @@ definition {
 		}
 	}
 
-	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126653. Upgrade 7.0.4 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher704 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -929,7 +929,7 @@ definition {
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher(webContentColor = "false");
 	}
 
-	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126654. Upgrade 7.1.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher713 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -940,7 +940,7 @@ definition {
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126655. Upgrade 7.2.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher721 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -951,7 +951,7 @@ definition {
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126656. Upgrade 7.3.5 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher735 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -962,7 +962,7 @@ definition {
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126656. Upgrade 7.3.10 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher7310 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -973,7 +973,7 @@ definition {
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126654. Upgrade 7.1.10.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher71103 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -984,7 +984,7 @@ definition {
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126655. Upgrade 7.2.10.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher72101 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -995,7 +995,7 @@ definition {
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126653. Upgrade 7.0.10.14 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWCStructureWCTemplateAndViewInWCDAndAssetPublisher701014 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1006,7 +1006,7 @@ definition {
 		Upgrade.EditWCStructureAndTemplateAndViewInWCDandAssetPublisher(webContentColor = "false");
 	}
 
-	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126653. Upgrade 7.0.4 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWebContentAndViewInWCDAndAssetPublisher704 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1017,7 +1017,7 @@ definition {
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126654. Upgrade 7.1.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWebContentAndViewInWCDAndAssetPublisher713 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1028,7 +1028,7 @@ definition {
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126655. Upgrade 7.2.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWebContentAndViewInWCDAndAssetPublisher721 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1039,7 +1039,7 @@ definition {
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126656. Upgrade 7.3.5 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWebContentAndViewInWCDAndAssetPublisher735 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1050,7 +1050,7 @@ definition {
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126656. Upgrade 7.3.10 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWebContentAndViewInWCDAndAssetPublisher7310 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1061,7 +1061,7 @@ definition {
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126654. Upgrade 7.1.10.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWebContentAndViewInWCDAndAssetPublisher71103 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1072,7 +1072,7 @@ definition {
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126655. Upgrade 7.2.10.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWebContentAndViewInWCDAndAssetPublisher72101 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1083,7 +1083,7 @@ definition {
 		Upgrade.EditWebContentAndViewInWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126653. Upgrade 7.0.10.14 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test EditWebContentAndViewInWCDAndAssetPublisher701014 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1147,7 +1147,7 @@ definition {
 		Upgrade.viewSpecificDisplayPageTemplateViaAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126653. Upgrade 7.0.4 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher704 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1158,7 +1158,7 @@ definition {
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher(webContentColor = "false");
 	}
 
-	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126654. Upgrade 7.1.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher713 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1169,7 +1169,7 @@ definition {
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126655. Upgrade 7.2.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher721 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1180,7 +1180,7 @@ definition {
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126656. Upgrade 7.3.5 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher735 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1191,7 +1191,7 @@ definition {
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126656. Upgrade 7.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126656. Upgrade 7.3.10 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher7310 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1202,7 +1202,7 @@ definition {
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126654. Upgrade 7.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126654. Upgrade 7.1.10.3 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher71103 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1213,7 +1213,7 @@ definition {
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126655. Upgrade 7.2 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126655. Upgrade 7.2.10.1 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher72101 {
 		property data.archive.type = "data-archive-web-content-with-fields";
@@ -1224,7 +1224,7 @@ definition {
 		Upgrade.ViewWebContentWCStructureWCTemplateWCDandAssetPublisher();
 	}
 
-	@description = "This is a test for LPS-126653. Upgrade 7.0 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
+	@description = "This is a test for LPS-126653. Upgrade 7.0.10.14 to Master with a Web Content, a Structure, a WC Template and a page with Web Content Display and Asset Publisher"
 	@priority = 5
 	test ViewWebContentWCStructureWCTemplateWCDAndAssetPublisher701014 {
 		property data.archive.type = "data-archive-web-content-with-fields";


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-181405

This is only for master.

@david-gutierrez-mesa

The reason to allocate smaller cases to dedicated jenkins nodes is ci will group upgrade cases with same dump without rebuild database. That will cause them failed by wrong data.

**Before break down**, the ci duration info is
```
Build Time: 2 hours 5 minutes

Total CPU Usage Time: 2 days 2 hours 53 minutes

Total number of Jenkins slaves used: 144
```

**After break down**, the ci duration info is
```
Build Time: 2 hours 22 minutes

Total CPU Usage Time: 2 days 1 hour 55 minutes

Total number of Jenkins slaves used: 160
```