### PR TITLE
LPS-181157 Modifiying ContentDashboardAdminPortletTest to avoid falkiness when running in the CI 

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletTest.java
@@ -67,10 +67,12 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
@@ -499,8 +501,14 @@ public class ContentDashboardAdminPortletTest {
 
 		JournalArticle journalArticle1 = JournalTestUtil.addArticle(
 			_user.getUserId(), _group.getGroupId(), 0);
+
 		JournalArticle journalArticle2 = JournalTestUtil.addArticle(
 			_user.getUserId(), _group.getGroupId(), 0);
+
+		journalArticle2.setModifiedDate(
+			DateUtil.newDate(System.currentTimeMillis() + Time.SECOND));
+
+		_journalArticleLocalService.updateJournalArticle(journalArticle2);
 
 		searchContainer = _getSearchContainer(
 			_getMockLiferayPortletRenderRequest());


### PR DESCRIPTION
Motivation
=======
Flacky test failing in the CI located in class ContentDashboardAdminPortletTest
[ticket](https://issues.liferay.com/browse/LPS-181157)
[TestRay](https://testray.liferay.com/home/-/testray/cases/1518348776/view?p_p_state=normal&orderByCol=createDate_sortable&orderByType=desc&statuses=3)

Proposed Solution
========
Manually set the modifiedDate so the defatlt order works as expected
Steps to Verify

========
1. Run the test located in ContentDashboardAdminPortletTest