### PR TITLE
LPS-177888 NullPointerExeption when importing lar file

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/util/configuration/FragmentEntryConfigurationParserImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/util/configuration/FragmentEntryConfigurationParserImpl.java
@@ -392,6 +392,10 @@ public class FragmentEntryConfigurationParserImpl
 
 		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
 
+		if (themeDisplay == null) {
+			return fieldValue;
+		}
+
 		Group group = themeDisplay.getScopeGroup();
 
 		LayoutSet layoutSet = _layoutSetLocalService.fetchLayoutSet(


### PR DESCRIPTION
Motivation
=======
This PR contains the solution to [LPS-177888](https://issues.liferay.com/browse/LPS-177888) which fixes [LPP-48180](https://issues.liferay.com/browse/LPP-48180). I was not able to reproduce this error on master because it is only reproducible with the customer database. But I noticed that there is no check to see if the themeDisplay variable is null in the master, so probably this error can happen in another situation.

Proposed Solution
========
I added one check to returns the fieldValue variable before use the themeDisplay variable if themeDisplay is null.

Steps to Verify
========
1. Setup Liferay DXP 7.4 Update 52.
2. Connect the portal with the customer database (I can share it to you)
3. Go to Publishing > Import > Import the Lar ([download here](https://drive.google.com/file/d/1Upt4o8xz436P5RPZr9_T6DgOGU1aRUpN/view?usp=sharing)).

 ## Expected Behavior
We can import the LAR.
 ## Actual Behavior
The import failed with the erros

I wasn't able to upgrade the client's database to master, so we can only test it in this update.