### PR TITLE
[TS] LPS-179558 | It is not possible to display web content on the live site when web contents are unstaged

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/action/AssetPublisherConfigurationAction.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/portlet/action/AssetPublisherConfigurationAction.java
@@ -17,7 +17,9 @@ package com.liferay.asset.publisher.web.internal.portlet.action;
 import com.liferay.asset.kernel.AssetRendererFactoryRegistryUtil;
 import com.liferay.asset.kernel.exception.AssetTagException;
 import com.liferay.asset.kernel.exception.DuplicateQueryRuleException;
+import com.liferay.asset.kernel.model.AssetEntry;
 import com.liferay.asset.kernel.model.AssetRendererFactory;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
 import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.asset.list.asset.entry.provider.AssetListAssetEntryProvider;
 import com.liferay.asset.list.service.AssetListEntrySegmentsEntryRelLocalService;
@@ -337,6 +339,9 @@ public class AssetPublisherConfigurationAction
 	protected AssetEntryActionRegistry assetEntryActionRegistry;
 
 	@Reference
+	protected AssetEntryLocalService assetEntryLocalService;
+
+	@Reference
 	protected AssetHelper assetHelper;
 
 	@Reference
@@ -430,6 +435,13 @@ public class AssetPublisherConfigurationAction
 			actionRequest, "assetEntryType");
 
 		for (long assetEntryId : assetEntryIds) {
+			if (assetEntryType.equals(StringPool.BLANK)) {
+				AssetEntry assetEntry = assetEntryLocalService.getAssetEntry(
+					assetEntryId);
+
+				assetEntryType = assetEntry.getClassName();
+			}
+
 			assetPublisherWebHelper.addSelection(
 				preferences, assetEntryId, assetEntryOrder, assetEntryType);
 		}


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-179558
Thank you!

-------

**Steps to reproduce:**

1. Go to Publishing --> Staging --> enable local staging and uncheck "Web Content" from the Staged Content.
2. Go to the Live Site --> Content & Data --> Web Content and add basic web content.
3. On Staging Site go to Site Builder --> Pages and add a widget page.
4. Add an Asset Publisher to the page and configure it by Going to Asset Selection and check "Manual"
5. At the "Asset Entries" click on "Select" and choose "Basic Web Content"
6. On the Select Basic Web Content popup, select the web content and click on "Add".
**Expected Result:**  The web content should be added and displayed on the Asset Publisher.
**Actual Result:** the following message appears on the UI:
"The selected asset(s) have been removed from the list because they do not belong in the scope of this widget."
and the web content is not added and not displayed on AP.

The root cause of the issue is that when the selection is added under [addSelection ](https://github.com/liferay/liferay-portal/blob/master/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/helper/AssetPublisherWebHelper.java#L187-L200)the assetEntryType is not specified. I think the reason for this is that the selection can hold any kind of asset in this use case so the selector can't identify the selection type. To solve this get the assetEntryType through the localService just to be safe I added the condition when the assetEntryType is blank. The assetEntryType is needed for the staging environment to decide whether or not the given type is staged.

Note: The customer has a go-live, so if my solution is insufficient and requires additional work, I would like to know whether or not it is sufficient as an SDH.
