### PR TITLE
LPS-181870 - Take into account parent page of a published page when exporting and importing it

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Delivery API
 Bundle-SymbolicName: com.liferay.headless.delivery.api
-Bundle-Version: 47.1.1
+Bundle-Version: 47.2.0
 Export-Package:\
 	com.liferay.headless.delivery.dto.v1_0,\
 	com.liferay.headless.delivery.dto.v1_0.util,\

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/OpenGraphSettings.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/OpenGraphSettings.java
@@ -148,6 +148,64 @@ public class OpenGraphSettings implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected ContentDocument image;
 
+	@Schema(description = "The Open Graph's image alt.")
+	public String getImageAlt() {
+		return imageAlt;
+	}
+
+	public void setImageAlt(String imageAlt) {
+		this.imageAlt = imageAlt;
+	}
+
+	@JsonIgnore
+	public void setImageAlt(
+		UnsafeSupplier<String, Exception> imageAltUnsafeSupplier) {
+
+		try {
+			imageAlt = imageAltUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The Open Graph's image alt.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String imageAlt;
+
+	@Schema(description = "The localized Open Graph's image alts.")
+	@Valid
+	public Map<String, String> getImageAlt_i18n() {
+		return imageAlt_i18n;
+	}
+
+	public void setImageAlt_i18n(Map<String, String> imageAlt_i18n) {
+		this.imageAlt_i18n = imageAlt_i18n;
+	}
+
+	@JsonIgnore
+	public void setImageAlt_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			imageAlt_i18nUnsafeSupplier) {
+
+		try {
+			imageAlt_i18n = imageAlt_i18nUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The localized Open Graph's image alts.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Map<String, String> imageAlt_i18n;
+
 	@Schema(description = "The Open Graph's title.")
 	public String getTitle() {
 		return title;
@@ -265,6 +323,30 @@ public class OpenGraphSettings implements Serializable {
 			sb.append("\"image\": ");
 
 			sb.append(String.valueOf(image));
+		}
+
+		if (imageAlt != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"imageAlt\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(imageAlt));
+
+			sb.append("\"");
+		}
+
+		if (imageAlt_i18n != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"imageAlt_i18n\": ");
+
+			sb.append(_toJSON(imageAlt_i18n));
 		}
 
 		if (title != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ParentSitePage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/ParentSitePage.java
@@ -1,0 +1,226 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.delivery.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "The parent page or null if it is a top level page.",
+	value = "ParentSitePage"
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "ParentSitePage")
+public class ParentSitePage implements Serializable {
+
+	public static ParentSitePage toDTO(String json) {
+		return ObjectMapperUtil.readValue(ParentSitePage.class, json);
+	}
+
+	public static ParentSitePage unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(ParentSitePage.class, json);
+	}
+
+	@Schema(description = "The relative URL of the parent page.")
+	public String getFriendlyUrlPath() {
+		return friendlyUrlPath;
+	}
+
+	public void setFriendlyUrlPath(String friendlyUrlPath) {
+		this.friendlyUrlPath = friendlyUrlPath;
+	}
+
+	@JsonIgnore
+	public void setFriendlyUrlPath(
+		UnsafeSupplier<String, Exception> friendlyUrlPathUnsafeSupplier) {
+
+		try {
+			friendlyUrlPath = friendlyUrlPathUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The relative URL of the parent page.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String friendlyUrlPath;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ParentSitePage)) {
+			return false;
+		}
+
+		ParentSitePage parentSitePage = (ParentSitePage)object;
+
+		return Objects.equals(toString(), parentSitePage.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		if (friendlyUrlPath != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"friendlyUrlPath\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(friendlyUrlPath));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.delivery.dto.v1_0.ParentSitePage",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/SitePage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/SitePage.java
@@ -556,6 +556,38 @@ public class SitePage implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String pageType;
 
+	@Schema(description = "The parent page or null if it is a top level page.")
+	@Valid
+	public ParentSitePage getParentSitePage() {
+		return parentSitePage;
+	}
+
+	public void setParentSitePage(ParentSitePage parentSitePage) {
+		this.parentSitePage = parentSitePage;
+	}
+
+	@JsonIgnore
+	public void setParentSitePage(
+		UnsafeSupplier<ParentSitePage, Exception>
+			parentSitePageUnsafeSupplier) {
+
+		try {
+			parentSitePage = parentSitePageUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "The parent page or null if it is a top level page."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected ParentSitePage parentSitePage;
+
 	@Schema(
 		description = "Metadata of the page such as it's master page and template."
 	)
@@ -1054,6 +1086,16 @@ public class SitePage implements Serializable {
 			sb.append(_escape(pageType));
 
 			sb.append("\"");
+		}
+
+		if (parentSitePage != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"parentSitePage\": ");
+
+			sb.append(String.valueOf(parentSitePage));
 		}
 
 		if (renderedPage != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/resources/com/liferay/headless/delivery/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 31.7.0
+version 31.8.0

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/OpenGraphSettings.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/OpenGraphSettings.java
@@ -99,6 +99,49 @@ public class OpenGraphSettings implements Cloneable, Serializable {
 
 	protected ContentDocument image;
 
+	public String getImageAlt() {
+		return imageAlt;
+	}
+
+	public void setImageAlt(String imageAlt) {
+		this.imageAlt = imageAlt;
+	}
+
+	public void setImageAlt(
+		UnsafeSupplier<String, Exception> imageAltUnsafeSupplier) {
+
+		try {
+			imageAlt = imageAltUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String imageAlt;
+
+	public Map<String, String> getImageAlt_i18n() {
+		return imageAlt_i18n;
+	}
+
+	public void setImageAlt_i18n(Map<String, String> imageAlt_i18n) {
+		this.imageAlt_i18n = imageAlt_i18n;
+	}
+
+	public void setImageAlt_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			imageAlt_i18nUnsafeSupplier) {
+
+		try {
+			imageAlt_i18n = imageAlt_i18nUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, String> imageAlt_i18n;
+
 	public String getTitle() {
 		return title;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/ParentSitePage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/ParentSitePage.java
@@ -1,0 +1,89 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.delivery.client.dto.v1_0;
+
+import com.liferay.headless.delivery.client.function.UnsafeSupplier;
+import com.liferay.headless.delivery.client.serdes.v1_0.ParentSitePageSerDes;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class ParentSitePage implements Cloneable, Serializable {
+
+	public static ParentSitePage toDTO(String json) {
+		return ParentSitePageSerDes.toDTO(json);
+	}
+
+	public String getFriendlyUrlPath() {
+		return friendlyUrlPath;
+	}
+
+	public void setFriendlyUrlPath(String friendlyUrlPath) {
+		this.friendlyUrlPath = friendlyUrlPath;
+	}
+
+	public void setFriendlyUrlPath(
+		UnsafeSupplier<String, Exception> friendlyUrlPathUnsafeSupplier) {
+
+		try {
+			friendlyUrlPath = friendlyUrlPathUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String friendlyUrlPath;
+
+	@Override
+	public ParentSitePage clone() throws CloneNotSupportedException {
+		return (ParentSitePage)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof ParentSitePage)) {
+			return false;
+		}
+
+		ParentSitePage parentSitePage = (ParentSitePage)object;
+
+		return Objects.equals(toString(), parentSitePage.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return ParentSitePageSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/SitePage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/SitePage.java
@@ -376,6 +376,28 @@ public class SitePage implements Cloneable, Serializable {
 
 	protected String pageType;
 
+	public ParentSitePage getParentSitePage() {
+		return parentSitePage;
+	}
+
+	public void setParentSitePage(ParentSitePage parentSitePage) {
+		this.parentSitePage = parentSitePage;
+	}
+
+	public void setParentSitePage(
+		UnsafeSupplier<ParentSitePage, Exception>
+			parentSitePageUnsafeSupplier) {
+
+		try {
+			parentSitePage = parentSitePageUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected ParentSitePage parentSitePage;
+
 	public RenderedPage getRenderedPage() {
 		return renderedPage;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/OpenGraphSettingsSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/OpenGraphSettingsSerDes.java
@@ -89,6 +89,30 @@ public class OpenGraphSettingsSerDes {
 			sb.append(String.valueOf(openGraphSettings.getImage()));
 		}
 
+		if (openGraphSettings.getImageAlt() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"imageAlt\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(openGraphSettings.getImageAlt()));
+
+			sb.append("\"");
+		}
+
+		if (openGraphSettings.getImageAlt_i18n() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"imageAlt_i18n\": ");
+
+			sb.append(_toJSON(openGraphSettings.getImageAlt_i18n()));
+		}
+
 		if (openGraphSettings.getTitle() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -159,6 +183,23 @@ public class OpenGraphSettingsSerDes {
 			map.put("image", String.valueOf(openGraphSettings.getImage()));
 		}
 
+		if (openGraphSettings.getImageAlt() == null) {
+			map.put("imageAlt", null);
+		}
+		else {
+			map.put(
+				"imageAlt", String.valueOf(openGraphSettings.getImageAlt()));
+		}
+
+		if (openGraphSettings.getImageAlt_i18n() == null) {
+			map.put("imageAlt_i18n", null);
+		}
+		else {
+			map.put(
+				"imageAlt_i18n",
+				String.valueOf(openGraphSettings.getImageAlt_i18n()));
+		}
+
 		if (openGraphSettings.getTitle() == null) {
 			map.put("title", null);
 		}
@@ -213,6 +254,18 @@ public class OpenGraphSettingsSerDes {
 				if (jsonParserFieldValue != null) {
 					openGraphSettings.setImage(
 						ContentDocumentSerDes.toDTO(
+							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "imageAlt")) {
+				if (jsonParserFieldValue != null) {
+					openGraphSettings.setImageAlt((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "imageAlt_i18n")) {
+				if (jsonParserFieldValue != null) {
+					openGraphSettings.setImageAlt_i18n(
+						(Map)OpenGraphSettingsSerDes.toMap(
 							(String)jsonParserFieldValue));
 				}
 			}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ParentSitePageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/ParentSitePageSerDes.java
@@ -1,0 +1,200 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.delivery.client.serdes.v1_0;
+
+import com.liferay.headless.delivery.client.dto.v1_0.ParentSitePage;
+import com.liferay.headless.delivery.client.json.BaseJSONParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class ParentSitePageSerDes {
+
+	public static ParentSitePage toDTO(String json) {
+		ParentSitePageJSONParser parentSitePageJSONParser =
+			new ParentSitePageJSONParser();
+
+		return parentSitePageJSONParser.parseToDTO(json);
+	}
+
+	public static ParentSitePage[] toDTOs(String json) {
+		ParentSitePageJSONParser parentSitePageJSONParser =
+			new ParentSitePageJSONParser();
+
+		return parentSitePageJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(ParentSitePage parentSitePage) {
+		if (parentSitePage == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (parentSitePage.getFriendlyUrlPath() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"friendlyUrlPath\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(parentSitePage.getFriendlyUrlPath()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		ParentSitePageJSONParser parentSitePageJSONParser =
+			new ParentSitePageJSONParser();
+
+		return parentSitePageJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(ParentSitePage parentSitePage) {
+		if (parentSitePage == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (parentSitePage.getFriendlyUrlPath() == null) {
+			map.put("friendlyUrlPath", null);
+		}
+		else {
+			map.put(
+				"friendlyUrlPath",
+				String.valueOf(parentSitePage.getFriendlyUrlPath()));
+		}
+
+		return map;
+	}
+
+	public static class ParentSitePageJSONParser
+		extends BaseJSONParser<ParentSitePage> {
+
+		@Override
+		protected ParentSitePage createDTO() {
+			return new ParentSitePage();
+		}
+
+		@Override
+		protected ParentSitePage[] createDTOArray(int size) {
+			return new ParentSitePage[size];
+		}
+
+		@Override
+		protected void setField(
+			ParentSitePage parentSitePage, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "friendlyUrlPath")) {
+				if (jsonParserFieldValue != null) {
+					parentSitePage.setFriendlyUrlPath(
+						(String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			Class<?> valueClass = value.getClass();
+
+			if (value instanceof Map) {
+				sb.append(_toJSON((Map)value));
+			}
+			else if (valueClass.isArray()) {
+				Object[] values = (Object[])value;
+
+				sb.append("[");
+
+				for (int i = 0; i < values.length; i++) {
+					sb.append("\"");
+					sb.append(_escape(values[i]));
+					sb.append("\"");
+
+					if ((i + 1) < values.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(entry.getValue()));
+				sb.append("\"");
+			}
+			else {
+				sb.append(String.valueOf(entry.getValue()));
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/SitePageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/SitePageSerDes.java
@@ -282,6 +282,16 @@ public class SitePageSerDes {
 			sb.append("\"");
 		}
 
+		if (sitePage.getParentSitePage() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"parentSitePage\": ");
+
+			sb.append(String.valueOf(sitePage.getParentSitePage()));
+		}
+
 		if (sitePage.getRenderedPage() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -545,6 +555,14 @@ public class SitePageSerDes {
 			map.put("pageType", String.valueOf(sitePage.getPageType()));
 		}
 
+		if (sitePage.getParentSitePage() == null) {
+			map.put("parentSitePage", null);
+		}
+		else {
+			map.put(
+				"parentSitePage", String.valueOf(sitePage.getParentSitePage()));
+		}
+
 		if (sitePage.getRenderedPage() == null) {
 			map.put("renderedPage", null);
 		}
@@ -734,6 +752,13 @@ public class SitePageSerDes {
 			else if (Objects.equals(jsonParserFieldName, "pageType")) {
 				if (jsonParserFieldValue != null) {
 					sitePage.setPageType((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "parentSitePage")) {
+				if (jsonParserFieldValue != null) {
+					sitePage.setParentSitePage(
+						ParentSitePageSerDes.toDTO(
+							(String)jsonParserFieldValue));
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "renderedPage")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -4656,6 +4656,17 @@ components:
                     description:
                         The type of the page.
                     type: string
+                parentSitePage:
+                    # @review
+                    description:
+                        The parent page or null if it is a top level page.
+                    properties:
+                        friendlyUrlPath:
+                            # @review
+                            description:
+                                The relative URL of the parent page.
+                            type: string
+                    type: object
                 renderedPage:
                     allOf:
                         - $ref: "#/components/schemas/RenderedPage"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -3258,6 +3258,18 @@ components:
                     # @review
                     description:
                         The Open Graph's image.
+                imageAlt:
+                    # @review
+                    description:
+                        The Open Graph's image alt.
+                    type: string
+                imageAlt_i18n:
+                    additionalProperties:
+                        type: string
+                    # @review
+                    description:
+                        The localized Open Graph's image alts.
+                    type: object
                 title:
                     # @review
                     description:
@@ -5409,7 +5421,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.53'."
+        'com.liferay.headless.delivery.client', and version '4.0.54'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/SitePageDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/SitePageDTOConverter.java
@@ -22,6 +22,7 @@ import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.dynamic.data.mapping.kernel.StorageEngineManager;
 import com.liferay.headless.delivery.dto.v1_0.Experience;
 import com.liferay.headless.delivery.dto.v1_0.PageDefinition;
+import com.liferay.headless.delivery.dto.v1_0.ParentSitePage;
 import com.liferay.headless.delivery.dto.v1_0.SitePage;
 import com.liferay.headless.delivery.dto.v1_0.TaxonomyCategoryBrief;
 import com.liferay.headless.delivery.dto.v1_0.util.CreatorUtil;
@@ -38,7 +39,9 @@ import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypeController;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -199,6 +202,23 @@ public class SitePageDTOConverter implements DTOConverter<Layout, SitePage> {
 								layoutTypeController.getClass()),
 							"layout.types." + layout.getType());
 					});
+				setParentSitePage(
+					() -> {
+						if (layout.getParentLayoutId() ==
+								LayoutConstants.DEFAULT_PARENT_LAYOUT_ID) {
+
+							return null;
+						}
+
+						Layout parentLayout = _layoutLocalService.fetchLayout(
+							layout.getParentPlid());
+
+						return new ParentSitePage() {
+							{
+								friendlyUrlPath = parentLayout.getFriendlyURL();
+							}
+						};
+					});
 			}
 		};
 	}
@@ -223,6 +243,9 @@ public class SitePageDTOConverter implements DTOConverter<Layout, SitePage> {
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private LayoutPageTemplateEntryLocalService

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/OpenGraphSettingsUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/util/OpenGraphSettingsUtil.java
@@ -51,6 +51,11 @@ public class OpenGraphSettingsUtil {
 				description_i18n = LocalizedMapUtil.getI18nMap(
 					dtoConverterContext.isAcceptAllLanguages(),
 					layoutSEOEntry.getOpenGraphDescriptionMap());
+				imageAlt = layoutSEOEntry.getOpenGraphImageAlt(
+					dtoConverterContext.getLocale());
+				imageAlt_i18n = LocalizedMapUtil.getI18nMap(
+					dtoConverterContext.isAcceptAllLanguages(),
+					layoutSEOEntry.getOpenGraphImageAltMap());
 				title = layoutSEOEntry.getOpenGraphTitle(
 					dtoConverterContext.getLocale());
 				title_i18n = LocalizedMapUtil.getI18nMap(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -2862,7 +2862,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sitePage(friendlyUrlPath: ___, siteKey: ___){actions, aggregateRating, availableLanguages, creator, customFields, dateCreated, dateModified, datePublished, experience, friendlyUrlPath, friendlyUrlPath_i18n, id, keywords, pageDefinition, pageSettings, pageType, renderedPage, siteId, taxonomyCategoryBriefs, taxonomyCategoryIds, title, title_i18n, uuid, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sitePage(friendlyUrlPath: ___, siteKey: ___){actions, aggregateRating, availableLanguages, creator, customFields, dateCreated, dateModified, datePublished, experience, friendlyUrlPath, friendlyUrlPath_i18n, id, keywords, pageDefinition, pageSettings, pageType, parentSitePage, renderedPage, siteId, taxonomyCategoryBriefs, taxonomyCategoryIds, title, title_i18n, uuid, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves a specific public page of a site")
 	public SitePage sitePage(
@@ -2899,7 +2899,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sitePageExperienceExperienceKey(experienceKey: ___, friendlyUrlPath: ___, siteKey: ___){actions, aggregateRating, availableLanguages, creator, customFields, dateCreated, dateModified, datePublished, experience, friendlyUrlPath, friendlyUrlPath_i18n, id, keywords, pageDefinition, pageSettings, pageType, renderedPage, siteId, taxonomyCategoryBriefs, taxonomyCategoryIds, title, title_i18n, uuid, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sitePageExperienceExperienceKey(experienceKey: ___, friendlyUrlPath: ___, siteKey: ___){actions, aggregateRating, availableLanguages, creator, customFields, dateCreated, dateModified, datePublished, experience, friendlyUrlPath, friendlyUrlPath_i18n, id, keywords, pageDefinition, pageSettings, pageType, parentSitePage, renderedPage, siteId, taxonomyCategoryBriefs, taxonomyCategoryIds, title, title_i18n, uuid, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves a specific public page of a site for a given experience"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -245,7 +245,7 @@ public abstract class BaseSitePageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/site-pages' -d $'{"customFields": ___, "datePublished": ___, "experience": ___, "friendlyUrlPath": ___, "friendlyUrlPath_i18n": ___, "keywords": ___, "pageDefinition": ___, "pageSettings": ___, "pageType": ___, "renderedPage": ___, "taxonomyCategoryIds": ___, "title": ___, "title_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/site-pages' -d $'{"customFields": ___, "datePublished": ___, "experience": ___, "friendlyUrlPath": ___, "friendlyUrlPath_i18n": ___, "keywords": ___, "pageDefinition": ___, "pageSettings": ___, "pageType": ___, "parentSitePage": ___, "renderedPage": ___, "taxonomyCategoryIds": ___, "title": ___, "title_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new site page"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.53'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.54'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.headless.common.spi.service.context.ServiceContextRequestUtil
 import com.liferay.headless.delivery.dto.v1_0.ContentDocument;
 import com.liferay.headless.delivery.dto.v1_0.OpenGraphSettings;
 import com.liferay.headless.delivery.dto.v1_0.PageSettings;
+import com.liferay.headless.delivery.dto.v1_0.ParentSitePage;
 import com.liferay.headless.delivery.dto.v1_0.SEOSettings;
 import com.liferay.headless.delivery.dto.v1_0.SitePage;
 import com.liferay.headless.delivery.internal.odata.entity.v1_0.SitePageEntityModel;
@@ -261,6 +262,24 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 			Map<Locale, String> nameMap)
 		throws Exception {
 
+		long parentLayoutId = 0;
+
+		ParentSitePage parentSitePage = sitePage.getParentSitePage();
+
+		if (parentSitePage != null) {
+			Layout layout = _layoutLocalService.fetchLayoutByFriendlyURL(
+				siteId, false, parentSitePage.getFriendlyUrlPath());
+
+			if (layout == null) {
+				if (_log.isWarnEnabled()) {
+					_log.warn("Could not find parent site page");
+				}
+			}
+			else {
+				parentLayoutId = layout.getLayoutId();
+			}
+		}
+
 		Map<Locale, String> descriptionMap = new HashMap<>();
 		Map<Locale, String> keywordsMap = new HashMap<>();
 		Map<Locale, String> robotsMap = new HashMap<>();
@@ -291,8 +310,8 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 		}
 
 		Layout layout = _layoutService.addLayout(
-			siteId, false, 0, nameMap, titleMap, descriptionMap, keywordsMap,
-			robotsMap, LayoutConstants.TYPE_CONTENT, null, false,
+			siteId, false, parentLayoutId, nameMap, titleMap, descriptionMap,
+			keywordsMap, robotsMap, LayoutConstants.TYPE_CONTENT, null, false,
 			friendlyUrlMap, 0, _createServiceContext(siteId, sitePage));
 
 		layout.setStatus(WorkflowConstants.STATUS_APPROVED);

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -40,6 +40,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutService;
+import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
 import com.liferay.portal.kernel.servlet.DynamicServletRequest;
 import com.liferay.portal.kernel.servlet.ServletContextPool;
@@ -231,7 +232,7 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 			sitePage.getFriendlyUrlPath(), sitePage.getFriendlyUrlPath_i18n(),
 			titleMap);
 
-		Layout layout = _addLayout(siteId, friendlyUrlMap, titleMap);
+		Layout layout = _addLayout(siteId, sitePage, friendlyUrlMap, titleMap);
 
 		DefaultDTOConverterContext dtoConverterContext =
 			new DefaultDTOConverterContext(
@@ -245,7 +246,7 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 	}
 
 	private Layout _addLayout(
-			Long siteId, Map<Locale, String> friendlyUrlMap,
+			Long siteId, SitePage sitePage, Map<Locale, String> friendlyUrlMap,
 			Map<Locale, String> titleMap)
 		throws Exception {
 
@@ -253,8 +254,7 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 			siteId, false, 0, titleMap, new HashMap<>(), new HashMap<>(),
 			new HashMap<>(), new HashMap<>(), LayoutConstants.TYPE_CONTENT,
 			null, false, friendlyUrlMap, 0,
-			ServiceContextRequestUtil.createServiceContext(
-				siteId, contextHttpServletRequest, null));
+			_createServiceContext(siteId, sitePage));
 
 		layout.setStatus(WorkflowConstants.STATUS_APPROVED);
 
@@ -271,6 +271,26 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 
 		return _layoutLocalService.updateLayout(
 			siteId, false, layout.getLayoutId(), draftLayout.getModifiedDate());
+	}
+
+	private ServiceContext _createServiceContext(
+		long groupId, SitePage sitePage) {
+
+		Long[] assetCategoryIds = {};
+
+		if (sitePage.getTaxonomyCategoryIds() != null) {
+			assetCategoryIds = sitePage.getTaxonomyCategoryIds();
+		}
+
+		String[] assetTagNames = new String[0];
+
+		if (sitePage.getKeywords() != null) {
+			assetTagNames = sitePage.getKeywords();
+		}
+
+		return ServiceContextRequestUtil.createServiceContext(
+			assetCategoryIds, assetTagNames, null, groupId,
+			contextHttpServletRequest, null);
 	}
 
 	private Map<String, Map<String, String>> _getBasicActions(Layout layout) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -311,7 +311,8 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 
 		Layout layout = _layoutService.addLayout(
 			siteId, false, parentLayoutId, nameMap, titleMap, descriptionMap,
-			keywordsMap, robotsMap, LayoutConstants.TYPE_CONTENT, null, false,
+			keywordsMap, robotsMap, LayoutConstants.TYPE_CONTENT, null,
+			GetterUtil.getBoolean(pageSettings.getHiddenFromNavigation()),
 			friendlyUrlMap, 0, _createServiceContext(siteId, sitePage));
 
 		layout.setStatus(WorkflowConstants.STATUS_APPROVED);

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -1239,6 +1239,14 @@ public abstract class BaseSitePageResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("parentSitePage", additionalAssertFieldName)) {
+				if (sitePage.getParentSitePage() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("renderedPage", additionalAssertFieldName)) {
 				if (sitePage.getRenderedPage() == null) {
 					valid = false;
@@ -1581,6 +1589,17 @@ public abstract class BaseSitePageResourceTestCase {
 			if (Objects.equals("pageType", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						sitePage1.getPageType(), sitePage2.getPageType())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("parentSitePage", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sitePage1.getParentSitePage(),
+						sitePage2.getParentSitePage())) {
 
 					return false;
 				}
@@ -1931,6 +1950,11 @@ public abstract class BaseSitePageResourceTestCase {
 			sb.append("'");
 
 			return sb.toString();
+		}
+
+		if (entityFieldName.equals("parentSitePage")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
 		}
 
 		if (entityFieldName.equals("renderedPage")) {


### PR DESCRIPTION
## Motivation

Link to ticket
[LPS-181451](https://issues.liferay.com/browse/LPS-181451)
[LPS-181870](https://issues.liferay.com/browse/LPS-181870)
[LPS-181930](https://issues.liferay.com/browse/LPS-181930)

Continuing with basic import of configuration for a content page, we added support for some properties with this PR

## Change summary:

* Take into account categories, tags, SEO Settings and OpenGraph settings when posting a page
* Take into account parent site page when posting a page
* Take into hiddenFromNavigationMenu when posting a page

## TODO:

* Integrations tests
* Exception mappers


//cc @ruben-pulido