### PR TITLE
[TS] LPS-182033

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java
@@ -43,6 +43,9 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
@@ -551,6 +554,16 @@ public class FragmentEntryProcessorHelperImpl
 
 			if (infoField.getInfoFieldType() instanceof DateInfoFieldType) {
 				Locale dateLocale = locale;
+
+				ServiceContext serviceContext =
+					ServiceContextThreadLocal.getServiceContext();
+
+				if (serviceContext != null) {
+					ThemeDisplay themeDisplay =
+						serviceContext.getThemeDisplay();
+
+					dateLocale = themeDisplay.getSiteDefaultLocale();
+				}
 
 				if (infoField.isLocalizable()) {
 					InfoLocalizedValue<String> infoLocalizedValue =

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java
@@ -30,6 +30,7 @@ import com.liferay.info.item.InfoItemReference;
 import com.liferay.info.item.InfoItemServiceRegistry;
 import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.item.provider.InfoItemObjectProvider;
+import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.info.search.InfoSearchClassMapperRegistry;
 import com.liferay.info.type.Labeled;
 import com.liferay.info.type.WebImage;
@@ -65,6 +66,7 @@ import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -548,10 +550,24 @@ public class FragmentEntryProcessorHelperImpl
 			InfoField infoField = infoFieldValue.getInfoField();
 
 			if (infoField.getInfoFieldType() instanceof DateInfoFieldType) {
+				Locale dateLocale = locale;
+
+				if (infoField.isLocalizable()) {
+					InfoLocalizedValue<String> infoLocalizedValue =
+						(InfoLocalizedValue<String>)infoFieldValue.getValue();
+
+					Set<Locale> availableLocales =
+						infoLocalizedValue.getAvailableLocales();
+
+					if (!availableLocales.contains(locale)) {
+						dateLocale = infoLocalizedValue.getDefaultLocale();
+					}
+				}
+
 				try {
 					DateFormat dateFormat =
 						DateFormatFactoryUtil.getSimpleDateFormat(
-							_getShortTimeStylePattern(locale), locale);
+							_getShortTimeStylePattern(dateLocale), dateLocale);
 
 					Date date = dateFormat.parse(value.toString());
 
@@ -567,7 +583,7 @@ public class FragmentEntryProcessorHelperImpl
 					try {
 						DateFormat dateFormat =
 							DateFormatFactoryUtil.getSimpleDateFormat(
-								_getDefaultPattern(locale), locale);
+								_getDefaultPattern(dateLocale), dateLocale);
 
 						return _getDateValue(
 							editableValueJSONObject,

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-impl/src/main/java/com/liferay/fragment/entry/processor/internal/util/FragmentEntryProcessorHelperImpl.java
@@ -551,7 +551,7 @@ public class FragmentEntryProcessorHelperImpl
 				try {
 					DateFormat dateFormat =
 						DateFormatFactoryUtil.getSimpleDateFormat(
-							"MM/dd/yy hh:mm a", locale);
+							_getShortTimeStylePattern(locale), locale);
 
 					Date date = dateFormat.parse(value.toString());
 
@@ -567,7 +567,7 @@ public class FragmentEntryProcessorHelperImpl
 					try {
 						DateFormat dateFormat =
 							DateFormatFactoryUtil.getSimpleDateFormat(
-								"MM/dd/yy", locale);
+								_getDefaultPattern(locale), locale);
 
 						return _getDateValue(
 							editableValueJSONObject,


### PR DESCRIPTION
Motivation
=======
When a site's default language uses a different date format than American English a structure's date field is not correctly mapped to content pages.

Proposed Solution
========
Replaced the hardcoded en_us date parse patterns with a locale appropriate one

Steps to Verify
========
1. Create a site, set French as its default language
2. Create a structure with a date field
3. Create a web content from the structure, select the a date where the day number is higher than 12
4. Create a content page, put a paragraph fragment in it
5. Map the web content's date field into the paragraph's text
6. Publish the page

**Expected behaviour:** Displayed date should look like: "17/04/2023"
**Actual behavior:** "Displayed date gets rolled over to the next year and looks like "04/05/24"
