### PR TITLE
LPS-181692 Update mouse DND

### DIFF
--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
@@ -46,7 +46,6 @@ export function MenuItem({item, onMenuItemRemoved}) {
 	const setSidebarPanelId = useSetSidebarPanelId();
 	const {
 		editSiteNavigationMenuItemParentURL,
-		languageId,
 		portletNamespace,
 	} = useConstants();
 
@@ -112,7 +111,7 @@ export function MenuItem({item, onMenuItemRemoved}) {
 	const keyboardDragLayer = useDragLayer();
 	const setKeyboardDragLayer = useSetDragLayer();
 	const {handlerRef, isDragging} = useDragItem(item, updateMenuItemParent);
-	const {targetRef} = useDropTarget(item);
+	const {isOver, nestingLevel, targetRef} = useDropTarget(item);
 
 	const isKeyboardDragging = useMemo(
 		() =>
@@ -128,10 +127,11 @@ export function MenuItem({item, onMenuItemRemoved}) {
 		]
 	);
 
-	const rtl = Liferay.Language.direction[languageId] === 'rtl';
-	const itemStyle = rtl
-		? {paddingRight: (itemPath.length - 1) * NESTING_MARGIN}
-		: {paddingLeft: (itemPath.length - 1) * NESTING_MARGIN};
+	const itemStyle = {
+		'--nesting-level': itemPath.length,
+		'--nesting-margin': NESTING_MARGIN,
+		'--over-nesting-level': nestingLevel,
+	};
 
 	const parentItemId =
 		itemPath.length > 1 ? itemPath[itemPath.length - 2] : '0';
@@ -272,11 +272,13 @@ export function MenuItem({item, onMenuItemRemoved}) {
 				className={classNames(
 					'focusable-menu-item site_navigation_menu_editor_MenuItem',
 					{
-						active: selected,
-						dragging: isDragging || isKeyboardDragging,
+						'active': selected,
+						'dragging': isDragging || isKeyboardDragging,
+						'is-over': isOver,
 					}
 				)}
 				data-item-id={item.siteNavigationMenuItemId}
+				data-nesting-level={nestingLevel}
 				data-parent-item-id={parentItemId}
 				onBlur={onBlur}
 				onClick={(event) => {

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
@@ -75,17 +75,24 @@ export function MenuItem({item, onMenuItemRemoved}) {
 		[items, item]
 	);
 
-	const updateMenuItemParent = (itemId, parentId) => {
-		const order = getOrder({
-			items,
-			parentSiteNavigationMenuItemId: parentId,
-			siteNavigationMenuItemId: itemId,
-		});
+	const updateMenuItemParent = (itemId, parentId, order) => {
+		let computedOrder;
+
+		if (Liferay.FeatureFlags['LPS-134527']) {
+			computedOrder = order;
+		}
+		else {
+			computedOrder = getOrder({
+				items,
+				parentSiteNavigationMenuItemId: parentId,
+				siteNavigationMenuItemId: itemId,
+			});
+		}
 
 		updateMenuItem({
 			editSiteNavigationMenuItemParentURL,
 			itemId,
-			order,
+			order: computedOrder,
 			parentId,
 			portletNamespace,
 		})

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/MenuItem.js
@@ -130,8 +130,8 @@ export function MenuItem({item, onMenuItemRemoved}) {
 
 	const rtl = Liferay.Language.direction[languageId] === 'rtl';
 	const itemStyle = rtl
-		? {marginRight: (itemPath.length - 1) * NESTING_MARGIN}
-		: {marginLeft: (itemPath.length - 1) * NESTING_MARGIN};
+		? {paddingRight: (itemPath.length - 1) * NESTING_MARGIN}
+		: {paddingLeft: (itemPath.length - 1) * NESTING_MARGIN};
 
 	const parentItemId =
 		itemPath.length > 1 ? itemPath[itemPath.length - 2] : '0';

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/_MenuItem.scss
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/_MenuItem.scss
@@ -1,6 +1,7 @@
 @import 'atlas-variables';
 
 .site_navigation_menu_editor_MenuItem {
+	box-sizing: content-box;
 	width: 40ch;
 
 	&:focus,

--- a/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/_MenuItem.scss
+++ b/modules/apps/site-navigation/site-navigation-admin-web/src/main/resources/META-INF/resources/site_navigation_menu_editor/components/_MenuItem.scss
@@ -2,6 +2,9 @@
 
 .site_navigation_menu_editor_MenuItem {
 	box-sizing: content-box;
+	padding-left: calc(
+		var(--nesting-margin) * (var(--nesting-level) - 1) * 1px
+	);
 	width: 40ch;
 
 	&:focus,
@@ -69,6 +72,34 @@
 
 	&.dragging {
 		opacity: 0.4;
+	}
+
+	&.is-over {
+		&::after {
+			border-top: 4px solid $primary-l1;
+			content: '';
+			display: block;
+			margin-top: 8px;
+			padding-bottom: 16px;
+			transform: translateX(
+				calc(
+					var(--nesting-margin) *
+						(var(--nesting-level) - var(--over-nesting-level)) *
+						-1px
+				)
+			);
+			width: 100%;
+
+			[dir='rtl'] & {
+				transform: translateX(
+					calc(
+						var(--nesting-margin) *
+							(var(--nesting-level) - var(--over-nesting-level)) *
+							1px
+					)
+				);
+			}
+		}
 	}
 
 	.card-row {


### PR DESCRIPTION
Hey there!

I have updated the DND feedback in Navigation Menus. Now the feedback does not modify the tree at all, and the backend request is only made once some item is dropped. I have been able to simplify the code a lot, and a lot of it will be removed with the feature flag :smile:

Now there are only two things that need to be taken into account when looking at the DND context:

1. The `targetId` is just the `itemId` of the navigation menu item that is being dragged over. A simple `targetId === siteNavigationMenuItemId` check means "*something* is being dragged over this item".
2. The `nestingLevel` represents "how much nested" is the dragged item, meaning how much distance is there from the left side of the page (in LTR languages).

The tricky part here is how this `nestingLevel` value is clamped, using the following formula, which allows discarding invalid nesting levels: 

```js
nextItemNesting <= nesting <= (targetItemNesting + 1)
```

To see how it works, let's check the following "invalid" example of DND:

![canvas](https://user-images.githubusercontent.com/800645/232796911-872afa35-7e61-4bab-8b3d-64eb83fe5044.png)

In this case, we are trying to move "E" as a sibling of "B", placing the item right before "C". This is not valid because "C" is a child of "B", and adding "E" there with a nesting of 1 would break this relationship. But if we apply the formula:

```js
nextItemNesting <= nesting <= (targetItemNesting + 1)
      2         <=    1    <=          2
```

We see that the only possible nesting here is "2", because it is being limited by the nodes that follow "B". Note that when we say "next" here, we mean the "next" existing now following the tree as a flat-list in top-down order, ignoring all parent/child relationships.

## Caveats

There is a big lag when hovering/dropping elements, and I think it is because all `MenuItems` are being rendered at the same time. I tried to add a quick `React.memo`, but it won't work because all the internal state they have. I would like to improve this in another PR to give a better DND experience.

---

[Screencast from 2023-04-18 15-28-58.webm](https://user-images.githubusercontent.com/800645/232792499-f4503d74-da80-4637-8df4-23982d9e9512.webm)
