### PR TITLE
LPS-182220 | Test Fix | Master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/outoftheboxfragments/formcomponents/FileUpload.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/outoftheboxfragments/formcomponents/FileUpload.testcase
@@ -422,25 +422,20 @@ definition {
 	test ViewErrorMessageWhenSubmitFormWithAttachedFileSizeLargerThanAllowedMaximumUploadSize {
 		task ("Given a user has a content page where a File Upload and Submit Button fragments are inside a Form Container") {
 			task ("Add an Attachment field to object") {
-				ObjectAdmin.addObjectFieldViaAPI(
-					fieldBusinessType = "Attachment",
-					fieldLabelName = "Custom Attachment From Computer",
-					fieldName = "customAttachmentFromComputer",
-					fieldType = "Long",
-					fileSource = "userComputer",
-					isRequired = "false",
-					objectName = "UploadObject");
-
-				ObjectAdmin.publishObjectViaAPI(objectName = "UploadObject");
-			}
-
-			task ("Change the Maximum File Size to 2 MB") {
 				ObjectAdmin.openObjectAdmin();
 
 				ObjectPortlet.selectCustomObject(label = "Upload Object");
 
 				ObjectAdmin.goToFieldsTab();
 
+				ObjectAdmin.addObjectFieldViaUI(
+					enableShowFiles = "true",
+					fieldAttachment = "Upload Directly from the User's Computer",
+					fieldLabel = "Custom Attachment From Computer",
+					fieldType = "Attachment");
+			}
+
+			task ("Change the Maximum File Size to 2 MB") {
 				ObjectAdmin.goToFieldsDetails(label = "Custom Attachment From Computer");
 
 				Type(
@@ -449,6 +444,8 @@ definition {
 					value1 = 2);
 
 				ObjectField.save();
+
+				ObjectAdmin.publishObjectViaAPI(objectName = "UploadObject");
 			}
 
 			task ("Add a Form Container framgment to content page") {


### PR DESCRIPTION
# Element is not present at FileUpload#ViewErrorMessageWhenSubmitFormWithAttachedFileSizeLargerThanAllowedMaximumUploadSize

Hi! :)
This pr is corresponding to this ticket: [LPS-182220](https://issues.liferay.com/browse/LPS-182220)

**Problem:**
The test aims to verify that the Form Container fragment mapped to an object with an Attatchemnt field and a document size limitation is working correctly, preventing the document from being sent. However, according to the log of the test rounds, the document was being sent.

**Fix:**
The failure occurs because when creating the attachment field by API the required Storage Folder field is not filled in, so the document size limitation change is not saved correctly.