### PR TITLE
LPS-181930 Take into account custom fields, meta tags and page definition when creating a page

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PagePermission.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/PagePermission.java
@@ -1,0 +1,279 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.delivery.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+@GraphQLName(description = "The page's permissions.", value = "PagePermission")
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "PagePermission")
+public class PagePermission implements Serializable {
+
+	public static PagePermission toDTO(String json) {
+		return ObjectMapperUtil.readValue(PagePermission.class, json);
+	}
+
+	public static PagePermission unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(PagePermission.class, json);
+	}
+
+	@Schema(
+		description = "The keys of the actions the role has permission for."
+	)
+	public String[] getActionKeys() {
+		return actionKeys;
+	}
+
+	public void setActionKeys(String[] actionKeys) {
+		this.actionKeys = actionKeys;
+	}
+
+	@JsonIgnore
+	public void setActionKeys(
+		UnsafeSupplier<String[], Exception> actionKeysUnsafeSupplier) {
+
+		try {
+			actionKeys = actionKeysUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "The keys of the actions the role has permission for."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String[] actionKeys;
+
+	@Schema(description = "The role's key.")
+	public String getRoleKey() {
+		return roleKey;
+	}
+
+	public void setRoleKey(String roleKey) {
+		this.roleKey = roleKey;
+	}
+
+	@JsonIgnore
+	public void setRoleKey(
+		UnsafeSupplier<String, Exception> roleKeyUnsafeSupplier) {
+
+		try {
+			roleKey = roleKeyUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The role's key.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String roleKey;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PagePermission)) {
+			return false;
+		}
+
+		PagePermission pagePermission = (PagePermission)object;
+
+		return Objects.equals(toString(), pagePermission.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		if (actionKeys != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actionKeys\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < actionKeys.length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(actionKeys[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < actionKeys.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (roleKey != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"roleKey\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(roleKey));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.delivery.dto.v1_0.PagePermission",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/SitePage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/SitePage.java
@@ -497,6 +497,36 @@ public class SitePage implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected PageDefinition pageDefinition;
 
+	@Schema(description = "The page's permissions.")
+	@Valid
+	public PagePermission[] getPagePermissions() {
+		return pagePermissions;
+	}
+
+	public void setPagePermissions(PagePermission[] pagePermissions) {
+		this.pagePermissions = pagePermissions;
+	}
+
+	@JsonIgnore
+	public void setPagePermissions(
+		UnsafeSupplier<PagePermission[], Exception>
+			pagePermissionsUnsafeSupplier) {
+
+		try {
+			pagePermissions = pagePermissionsUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The page's permissions.")
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected PagePermission[] pagePermissions;
+
 	@Schema(description = "Settings of the page, such as SEO or OpenGraph.")
 	@Valid
 	public PageSettings getPageSettings() {
@@ -1062,6 +1092,26 @@ public class SitePage implements Serializable {
 			sb.append("\"pageDefinition\": ");
 
 			sb.append(String.valueOf(pageDefinition));
+		}
+
+		if (pagePermissions != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"pagePermissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < pagePermissions.length; i++) {
+				sb.append(String.valueOf(pagePermissions[i]));
+
+				if ((i + 1) < pagePermissions.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		if (pageSettings != null) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PagePermission.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/PagePermission.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.delivery.client.dto.v1_0;
+
+import com.liferay.headless.delivery.client.function.UnsafeSupplier;
+import com.liferay.headless.delivery.client.serdes.v1_0.PagePermissionSerDes;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class PagePermission implements Cloneable, Serializable {
+
+	public static PagePermission toDTO(String json) {
+		return PagePermissionSerDes.toDTO(json);
+	}
+
+	public String[] getActionKeys() {
+		return actionKeys;
+	}
+
+	public void setActionKeys(String[] actionKeys) {
+		this.actionKeys = actionKeys;
+	}
+
+	public void setActionKeys(
+		UnsafeSupplier<String[], Exception> actionKeysUnsafeSupplier) {
+
+		try {
+			actionKeys = actionKeysUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String[] actionKeys;
+
+	public String getRoleKey() {
+		return roleKey;
+	}
+
+	public void setRoleKey(String roleKey) {
+		this.roleKey = roleKey;
+	}
+
+	public void setRoleKey(
+		UnsafeSupplier<String, Exception> roleKeyUnsafeSupplier) {
+
+		try {
+			roleKey = roleKeyUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String roleKey;
+
+	@Override
+	public PagePermission clone() throws CloneNotSupportedException {
+		return (PagePermission)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof PagePermission)) {
+			return false;
+		}
+
+		PagePermission pagePermission = (PagePermission)object;
+
+		return Objects.equals(toString(), pagePermission.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return PagePermissionSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/SitePage.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/dto/v1_0/SitePage.java
@@ -334,6 +334,28 @@ public class SitePage implements Cloneable, Serializable {
 
 	protected PageDefinition pageDefinition;
 
+	public PagePermission[] getPagePermissions() {
+		return pagePermissions;
+	}
+
+	public void setPagePermissions(PagePermission[] pagePermissions) {
+		this.pagePermissions = pagePermissions;
+	}
+
+	public void setPagePermissions(
+		UnsafeSupplier<PagePermission[], Exception>
+			pagePermissionsUnsafeSupplier) {
+
+		try {
+			pagePermissions = pagePermissionsUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected PagePermission[] pagePermissions;
+
 	public PageSettings getPageSettings() {
 		return pageSettings;
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PagePermissionSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/PagePermissionSerDes.java
@@ -1,0 +1,235 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.delivery.client.serdes.v1_0;
+
+import com.liferay.headless.delivery.client.dto.v1_0.PagePermission;
+import com.liferay.headless.delivery.client.json.BaseJSONParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Javier Gamarra
+ * @generated
+ */
+@Generated("")
+public class PagePermissionSerDes {
+
+	public static PagePermission toDTO(String json) {
+		PagePermissionJSONParser pagePermissionJSONParser =
+			new PagePermissionJSONParser();
+
+		return pagePermissionJSONParser.parseToDTO(json);
+	}
+
+	public static PagePermission[] toDTOs(String json) {
+		PagePermissionJSONParser pagePermissionJSONParser =
+			new PagePermissionJSONParser();
+
+		return pagePermissionJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(PagePermission pagePermission) {
+		if (pagePermission == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (pagePermission.getActionKeys() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"actionKeys\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < pagePermission.getActionKeys().length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(pagePermission.getActionKeys()[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < pagePermission.getActionKeys().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (pagePermission.getRoleKey() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"roleKey\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(pagePermission.getRoleKey()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		PagePermissionJSONParser pagePermissionJSONParser =
+			new PagePermissionJSONParser();
+
+		return pagePermissionJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(PagePermission pagePermission) {
+		if (pagePermission == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (pagePermission.getActionKeys() == null) {
+			map.put("actionKeys", null);
+		}
+		else {
+			map.put(
+				"actionKeys", String.valueOf(pagePermission.getActionKeys()));
+		}
+
+		if (pagePermission.getRoleKey() == null) {
+			map.put("roleKey", null);
+		}
+		else {
+			map.put("roleKey", String.valueOf(pagePermission.getRoleKey()));
+		}
+
+		return map;
+	}
+
+	public static class PagePermissionJSONParser
+		extends BaseJSONParser<PagePermission> {
+
+		@Override
+		protected PagePermission createDTO() {
+			return new PagePermission();
+		}
+
+		@Override
+		protected PagePermission[] createDTOArray(int size) {
+			return new PagePermission[size];
+		}
+
+		@Override
+		protected void setField(
+			PagePermission pagePermission, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "actionKeys")) {
+				if (jsonParserFieldValue != null) {
+					pagePermission.setActionKeys(
+						toStrings((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "roleKey")) {
+				if (jsonParserFieldValue != null) {
+					pagePermission.setRoleKey((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			Class<?> valueClass = value.getClass();
+
+			if (value instanceof Map) {
+				sb.append(_toJSON((Map)value));
+			}
+			else if (valueClass.isArray()) {
+				Object[] values = (Object[])value;
+
+				sb.append("[");
+
+				for (int i = 0; i < values.length; i++) {
+					sb.append("\"");
+					sb.append(_escape(values[i]));
+					sb.append("\"");
+
+					if ((i + 1) < values.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(entry.getValue()));
+				sb.append("\"");
+			}
+			else {
+				sb.append(String.valueOf(entry.getValue()));
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/SitePageSerDes.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-client/src/main/java/com/liferay/headless/delivery/client/serdes/v1_0/SitePageSerDes.java
@@ -15,6 +15,7 @@
 package com.liferay.headless.delivery.client.serdes.v1_0;
 
 import com.liferay.headless.delivery.client.dto.v1_0.CustomField;
+import com.liferay.headless.delivery.client.dto.v1_0.PagePermission;
 import com.liferay.headless.delivery.client.dto.v1_0.SitePage;
 import com.liferay.headless.delivery.client.dto.v1_0.TaxonomyCategoryBrief;
 import com.liferay.headless.delivery.client.json.BaseJSONParser;
@@ -256,6 +257,26 @@ public class SitePageSerDes {
 			sb.append("\"pageDefinition\": ");
 
 			sb.append(String.valueOf(sitePage.getPageDefinition()));
+		}
+
+		if (sitePage.getPagePermissions() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"pagePermissions\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < sitePage.getPagePermissions().length; i++) {
+				sb.append(String.valueOf(sitePage.getPagePermissions()[i]));
+
+				if ((i + 1) < sitePage.getPagePermissions().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		if (sitePage.getPageSettings() != null) {
@@ -541,6 +562,15 @@ public class SitePageSerDes {
 				"pageDefinition", String.valueOf(sitePage.getPageDefinition()));
 		}
 
+		if (sitePage.getPagePermissions() == null) {
+			map.put("pagePermissions", null);
+		}
+		else {
+			map.put(
+				"pagePermissions",
+				String.valueOf(sitePage.getPagePermissions()));
+		}
+
 		if (sitePage.getPageSettings() == null) {
 			map.put("pageSettings", null);
 		}
@@ -741,6 +771,22 @@ public class SitePageSerDes {
 					sitePage.setPageDefinition(
 						PageDefinitionSerDes.toDTO(
 							(String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "pagePermissions")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					PagePermission[] pagePermissionsArray =
+						new PagePermission[jsonParserFieldValues.length];
+
+					for (int i = 0; i < pagePermissionsArray.length; i++) {
+						pagePermissionsArray[i] = PagePermissionSerDes.toDTO(
+							(String)jsonParserFieldValues[i]);
+					}
+
+					sitePage.setPagePermissions(pagePermissionsArray);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "pageSettings")) {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -4645,6 +4645,26 @@ components:
                         Optional field with the structure of all the elements of the page. Can be embedded with
                         nestedFields when retrieving the collection of site pages. When retrieving a single site page,
                         it will automatically be included.
+                pagePermissions:
+                    # @review
+                    description:
+                        The page's permissions.
+                    items:
+                        properties:
+                            actionKeys:
+                                # @review
+                                description:
+                                    The keys of the actions the role has permission for.
+                                items:
+                                    type: string
+                                type: array
+                            roleKey:
+                                # @review
+                                description:
+                                    The role's key.
+                                type: string
+                        type: object
+                    type: array
                 pageSettings:
                     allOf:
                         - $ref: "#/components/schemas/PageSettings"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/SitePageDTOConverter.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/converter/SitePageDTOConverter.java
@@ -22,6 +22,7 @@ import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.dynamic.data.mapping.kernel.StorageEngineManager;
 import com.liferay.headless.delivery.dto.v1_0.Experience;
 import com.liferay.headless.delivery.dto.v1_0.PageDefinition;
+import com.liferay.headless.delivery.dto.v1_0.PagePermission;
 import com.liferay.headless.delivery.dto.v1_0.ParentSitePage;
 import com.liferay.headless.delivery.dto.v1_0.SitePage;
 import com.liferay.headless.delivery.dto.v1_0.TaxonomyCategoryBrief;
@@ -38,10 +39,21 @@ import com.liferay.layout.seo.service.LayoutSEOEntryLocalService;
 import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypeController;
+import com.liferay.portal.kernel.model.ResourceAction;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.ResourcePermission;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.Team;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ResourceActionLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.TeamLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -55,6 +67,11 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.ratings.kernel.service.RatingsStatsLocalService;
 import com.liferay.segments.constants.SegmentsExperienceConstants;
 import com.liferay.segments.model.SegmentsExperience;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -188,6 +205,96 @@ public class SitePageDTOConverter implements DTOConverter<Layout, SitePage> {
 						return _pageDefinitionDTOConverter.toDTO(
 							dtoConverterContext, layoutStructure);
 					});
+				setPagePermissions(
+					() -> {
+						List<ResourcePermission> resourcePermissions =
+							_resourcePermissionLocalService.
+								getResourcePermissions(
+									layout.getCompanyId(),
+									Layout.class.getName(),
+									ResourceConstants.SCOPE_INDIVIDUAL,
+									String.valueOf(layout.getPlid()));
+
+						if (ListUtil.isEmpty(resourcePermissions)) {
+							return null;
+						}
+
+						List<ResourceAction> resourceActions =
+							_resourceActionLocalService.getResourceActions(
+								Layout.class.getName());
+
+						if (ListUtil.isEmpty(resourceActions)) {
+							return null;
+						}
+
+						ArrayList<PagePermission> pagePermissions =
+							new ArrayList<>();
+
+						for (ResourcePermission resourcePermission :
+								resourcePermissions) {
+
+							Role role = _roleLocalService.fetchRole(
+								resourcePermission.getRoleId());
+
+							if (role == null) {
+								if (_log.isWarnEnabled()) {
+									_log.warn(
+										String.format(
+											"Resource permission %s will not " +
+												"be included since no role " +
+													"was found with role ID %s",
+											resourcePermission.getName(),
+											resourcePermission.getRoleId()));
+								}
+
+								continue;
+							}
+
+							Set<String> actionIdsSet = new HashSet<>();
+
+							long actionIds = resourcePermission.getActionIds();
+
+							for (ResourceAction resourceAction :
+									resourceActions) {
+
+								long bitwiseValue =
+									resourceAction.getBitwiseValue();
+
+								if ((actionIds & bitwiseValue) ==
+										bitwiseValue) {
+
+									actionIdsSet.add(
+										resourceAction.getActionId());
+								}
+							}
+
+							String roleKey = role.getName();
+
+							if (role.getClassNameId() == _portal.getClassNameId(
+									Team.class)) {
+
+								Team team = _teamLocalService.fetchTeam(
+									role.getClassPK());
+
+								if (team != null) {
+									roleKey = team.getName();
+								}
+							}
+
+							String finalRoleKey = roleKey;
+
+							pagePermissions.add(
+								new PagePermission() {
+									{
+										actionKeys = actionIdsSet.toArray(
+											new String[0]);
+										roleKey = finalRoleKey;
+									}
+								});
+						}
+
+						return pagePermissions.toArray(new PagePermission[0]);
+					});
 				setPageType(
 					() -> {
 						LayoutTypeController layoutTypeController =
@@ -222,6 +329,9 @@ public class SitePageDTOConverter implements DTOConverter<Layout, SitePage> {
 			}
 		};
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SitePageDTOConverter.class);
 
 	@Reference
 	private AssetCategoryLocalService _assetCategoryLocalService;
@@ -271,7 +381,19 @@ public class SitePageDTOConverter implements DTOConverter<Layout, SitePage> {
 	private RatingsStatsLocalService _ratingsStatsLocalService;
 
 	@Reference
+	private ResourceActionLocalService _resourceActionLocalService;
+
+	@Reference
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Reference
+	private RoleLocalService _roleLocalService;
+
+	@Reference
 	private StorageEngineManager _storageEngineManager;
+
+	@Reference
+	private TeamLocalService _teamLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/graphql/query/v1_0/Query.java
@@ -2862,7 +2862,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sitePage(friendlyUrlPath: ___, siteKey: ___){actions, aggregateRating, availableLanguages, creator, customFields, dateCreated, dateModified, datePublished, experience, friendlyUrlPath, friendlyUrlPath_i18n, id, keywords, pageDefinition, pageSettings, pageType, parentSitePage, renderedPage, siteId, taxonomyCategoryBriefs, taxonomyCategoryIds, title, title_i18n, uuid, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sitePage(friendlyUrlPath: ___, siteKey: ___){actions, aggregateRating, availableLanguages, creator, customFields, dateCreated, dateModified, datePublished, experience, friendlyUrlPath, friendlyUrlPath_i18n, id, keywords, pageDefinition, pagePermissions, pageSettings, pageType, parentSitePage, renderedPage, siteId, taxonomyCategoryBriefs, taxonomyCategoryIds, title, title_i18n, uuid, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(description = "Retrieves a specific public page of a site")
 	public SitePage sitePage(
@@ -2899,7 +2899,7 @@ public class Query {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sitePageExperienceExperienceKey(experienceKey: ___, friendlyUrlPath: ___, siteKey: ___){actions, aggregateRating, availableLanguages, creator, customFields, dateCreated, dateModified, datePublished, experience, friendlyUrlPath, friendlyUrlPath_i18n, id, keywords, pageDefinition, pageSettings, pageType, parentSitePage, renderedPage, siteId, taxonomyCategoryBriefs, taxonomyCategoryIds, title, title_i18n, uuid, viewableBy}}"}' -u 'test@liferay.com:test'
+	 * curl -H 'Content-Type: text/plain; charset=utf-8' -X 'POST' 'http://localhost:8080/o/graphql' -d $'{"query": "query {sitePageExperienceExperienceKey(experienceKey: ___, friendlyUrlPath: ___, siteKey: ___){actions, aggregateRating, availableLanguages, creator, customFields, dateCreated, dateModified, datePublished, experience, friendlyUrlPath, friendlyUrlPath_i18n, id, keywords, pageDefinition, pagePermissions, pageSettings, pageType, parentSitePage, renderedPage, siteId, taxonomyCategoryBriefs, taxonomyCategoryIds, title, title_i18n, uuid, viewableBy}}"}' -u 'test@liferay.com:test'
 	 */
 	@GraphQLField(
 		description = "Retrieves a specific public page of a site for a given experience"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BaseSitePageResourceImpl.java
@@ -245,7 +245,7 @@ public abstract class BaseSitePageResourceImpl
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/site-pages' -d $'{"customFields": ___, "datePublished": ___, "experience": ___, "friendlyUrlPath": ___, "friendlyUrlPath_i18n": ___, "keywords": ___, "pageDefinition": ___, "pageSettings": ___, "pageType": ___, "parentSitePage": ___, "renderedPage": ___, "taxonomyCategoryIds": ___, "title": ___, "title_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-delivery/v1.0/sites/{siteId}/site-pages' -d $'{"customFields": ___, "datePublished": ___, "experience": ___, "friendlyUrlPath": ___, "friendlyUrlPath_i18n": ___, "keywords": ___, "pageDefinition": ___, "pagePermissions": ___, "pageSettings": ___, "pageType": ___, "parentSitePage": ___, "renderedPage": ___, "taxonomyCategoryIds": ___, "title": ___, "title_i18n": ___, "viewableBy": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new site page"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -28,6 +28,7 @@ import com.liferay.headless.delivery.dto.v1_0.PageSettings;
 import com.liferay.headless.delivery.dto.v1_0.ParentSitePage;
 import com.liferay.headless.delivery.dto.v1_0.SEOSettings;
 import com.liferay.headless.delivery.dto.v1_0.SitePage;
+import com.liferay.headless.delivery.dto.v1_0.util.CustomFieldsUtil;
 import com.liferay.headless.delivery.internal.odata.entity.v1_0.SitePageEntityModel;
 import com.liferay.headless.delivery.resource.v1_0.SitePageResource;
 import com.liferay.layout.seo.model.LayoutSEOEntry;
@@ -103,6 +104,8 @@ import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.processor.SegmentsExperienceRequestProcessorRegistry;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.segments.service.SegmentsExperienceService;
+
+import java.io.Serializable;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -406,7 +409,8 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 		}
 
 		return ServiceContextRequestUtil.createServiceContext(
-			assetCategoryIds, assetTagNames, null, groupId,
+			assetCategoryIds, assetTagNames,
+			_getExpandoBridgeAttributes(sitePage), groupId,
 			contextHttpServletRequest, null);
 	}
 
@@ -516,6 +520,15 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 			"custom-meta-tags");
 
 		return ddmStructure.getPrimaryKey();
+	}
+
+	private Map<String, Serializable> _getExpandoBridgeAttributes(
+		SitePage sitePage) {
+
+		return CustomFieldsUtil.toMap(
+			Layout.class.getName(), contextCompany.getCompanyId(),
+			sitePage.getCustomFields(),
+			contextAcceptLanguage.getPreferredLocale());
 	}
 
 	private Map<String, Map<String, String>> _getExperienceActions(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -344,6 +344,11 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 			ModelPermissions modelPermissions = ModelPermissionsFactory.create(
 				modelPermissionsParameterMap, null);
 
+			_resourcePermissionLocalService.deleteResourcePermissions(
+				layout.getCompanyId(), Layout.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(layout.getPlid()));
+
 			_resourcePermissionLocalService.addModelResourcePermissions(
 				layout.getCompanyId(), siteId, contextUser.getUserId(),
 				Layout.class.getName(), String.valueOf(layout.getPlid()),

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutSet;
 import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Team;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
@@ -55,6 +56,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.TeamLocalService;
 import com.liferay.portal.kernel.service.permission.ModelPermissions;
 import com.liferay.portal.kernel.service.permission.ModelPermissionsFactory;
 import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
@@ -336,9 +338,16 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 				new HashMap<>(pagePermissions.length);
 
 			for (PagePermission pagePermission : pagePermissions) {
+				String roleKey = pagePermission.getRoleKey();
+
+				Team team = _teamLocalService.fetchTeam(siteId, roleKey);
+
+				if (team != null) {
+					roleKey = String.valueOf(team.getTeamId());
+				}
+
 				modelPermissionsParameterMap.put(
-					pagePermission.getRoleKey(),
-					pagePermission.getActionKeys());
+					roleKey, pagePermission.getActionKeys());
 			}
 
 			ModelPermissions modelPermissions = ModelPermissionsFactory.create(
@@ -773,5 +782,8 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 		target = "(component.name=com.liferay.headless.delivery.internal.dto.v1_0.converter.SitePageDTOConverter)"
 	)
 	private DTOConverter<Layout, SitePage> _sitePageDTOConverter;
+
+	@Reference
+	private TeamLocalService _teamLocalService;
 
 }

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -39,6 +39,7 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.seo.model.LayoutSEOEntry;
 import com.liferay.layout.seo.service.LayoutSEOEntryService;
+import com.liferay.layout.util.LayoutCopyHelper;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.events.ServicePreAction;
@@ -359,40 +360,9 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 
 		layout = _updateLayoutSettings(layout, sitePage.getPageDefinition());
 
+		_updateLayoutPermissions(siteId, sitePage, layout);
+
 		_updateSEOEntry(layout, sitePage);
-
-		PagePermission[] pagePermissions = sitePage.getPagePermissions();
-
-		if (pagePermissions != null) {
-			HashMap<String, String[]> modelPermissionsParameterMap =
-				new HashMap<>(pagePermissions.length);
-
-			for (PagePermission pagePermission : pagePermissions) {
-				String roleKey = pagePermission.getRoleKey();
-
-				Team team = _teamLocalService.fetchTeam(siteId, roleKey);
-
-				if (team != null) {
-					roleKey = String.valueOf(team.getTeamId());
-				}
-
-				modelPermissionsParameterMap.put(
-					roleKey, pagePermission.getActionKeys());
-			}
-
-			ModelPermissions modelPermissions = ModelPermissionsFactory.create(
-				modelPermissionsParameterMap, null);
-
-			_resourcePermissionLocalService.deleteResourcePermissions(
-				layout.getCompanyId(), Layout.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(layout.getPlid()));
-
-			_resourcePermissionLocalService.addModelResourcePermissions(
-				layout.getCompanyId(), siteId, contextUser.getUserId(),
-				Layout.class.getName(), String.valueOf(layout.getPlid()),
-				modelPermissions);
-		}
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
@@ -804,6 +774,44 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 		}
 
 		return _sitePageDTOConverter.toDTO(dtoConverterContext, layout);
+	}
+
+	private void _updateLayoutPermissions(
+			Long siteId, SitePage sitePage, Layout layout)
+		throws Exception {
+
+		PagePermission[] pagePermissions = sitePage.getPagePermissions();
+
+		if (pagePermissions != null) {
+			HashMap<String, String[]> modelPermissionsParameterMap =
+				new HashMap<>(pagePermissions.length);
+
+			for (PagePermission pagePermission : pagePermissions) {
+				String roleKey = pagePermission.getRoleKey();
+
+				Team team = _teamLocalService.fetchTeam(siteId, roleKey);
+
+				if (team != null) {
+					roleKey = String.valueOf(team.getTeamId());
+				}
+
+				modelPermissionsParameterMap.put(
+					roleKey, pagePermission.getActionKeys());
+			}
+
+			ModelPermissions modelPermissions = ModelPermissionsFactory.create(
+				modelPermissionsParameterMap, null);
+
+			_resourcePermissionLocalService.deleteResourcePermissions(
+				layout.getCompanyId(), Layout.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(layout.getPlid()));
+
+			_resourcePermissionLocalService.addModelResourcePermissions(
+				layout.getCompanyId(), siteId, contextUser.getUserId(),
+				Layout.class.getName(), String.valueOf(layout.getPlid()),
+				modelPermissions);
+		}
 	}
 
 	private Layout _updateLayoutSettings(

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/SitePageResourceImpl.java
@@ -354,33 +354,23 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 			keywordsMap, robotsMap, LayoutConstants.TYPE_CONTENT, null, hidden,
 			friendlyUrlMap, 0, _createServiceContext(siteId, sitePage));
 
+		layout = _updateLayoutSettings(layout, sitePage.getPageDefinition());
+
+		Layout draftLayout = _updateDraftLayout(layout);
+
+		layout.setModifiedDate(draftLayout.getModifiedDate());
+
 		layout.setStatus(WorkflowConstants.STATUS_APPROVED);
 
 		layout = _layoutLocalService.updateLayout(layout);
 
-		layout = _updateLayoutSettings(layout, sitePage.getPageDefinition());
+		_updateModelResourcePermissions(
+			layout.getCompanyId(), siteId, layout.getPlid(), sitePage);
 
-		_updateLayoutPermissions(siteId, sitePage, layout);
+		_updateSEOEntry(
+			layout.getCompanyId(), siteId, layout.getLayoutId(), sitePage);
 
-		_updateSEOEntry(layout, sitePage);
-
-		Layout draftLayout = layout.fetchDraftLayout();
-
-		draftLayout = _layoutCopyHelper.copyLayoutContent(layout, draftLayout);
-
-		draftLayout.setStatus(WorkflowConstants.STATUS_APPROVED);
-
-		UnicodeProperties typeSettingsUnicodeProperties =
-			draftLayout.getTypeSettingsProperties();
-
-		typeSettingsUnicodeProperties.put("published", Boolean.TRUE.toString());
-
-		draftLayout.setTypeSettingsProperties(typeSettingsUnicodeProperties);
-
-		draftLayout = _layoutLocalService.updateLayout(draftLayout);
-
-		return _layoutLocalService.updateLayout(
-			siteId, false, layout.getLayoutId(), draftLayout.getModifiedDate());
+		return layout;
 	}
 
 	private ServiceContext _createServiceContext(
@@ -500,9 +490,8 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 		return ddmFormValuesJSONObject.toString();
 	}
 
-	private long _getDDMStructurePrimaryKey(Layout layout) throws Exception {
-		Company company = _companyLocalService.getCompany(
-			layout.getCompanyId());
+	private long _getDDMStructurePrimaryKey(long companyId) throws Exception {
+		Company company = _companyLocalService.getCompany(companyId);
 
 		DDMStructure ddmStructure = _ddmStructureService.getStructure(
 			company.getGroupId(),
@@ -776,60 +765,37 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 		return _sitePageDTOConverter.toDTO(dtoConverterContext, layout);
 	}
 
-	private void _updateLayoutPermissions(
-			Long siteId, SitePage sitePage, Layout layout)
-		throws Exception {
+	private Layout _updateDraftLayout(Layout layout) throws Exception {
+		Layout draftLayout = layout.fetchDraftLayout();
 
-		PagePermission[] pagePermissions = sitePage.getPagePermissions();
+		draftLayout = _layoutCopyHelper.copyLayoutContent(layout, draftLayout);
 
-		if (pagePermissions != null) {
-			HashMap<String, String[]> modelPermissionsParameterMap =
-				new HashMap<>(pagePermissions.length);
+		draftLayout.setStatus(WorkflowConstants.STATUS_APPROVED);
 
-			for (PagePermission pagePermission : pagePermissions) {
-				String roleKey = pagePermission.getRoleKey();
+		UnicodeProperties typeSettingsUnicodeProperties =
+			draftLayout.getTypeSettingsProperties();
 
-				Team team = _teamLocalService.fetchTeam(siteId, roleKey);
+		typeSettingsUnicodeProperties.put("published", Boolean.TRUE.toString());
 
-				if (team != null) {
-					roleKey = String.valueOf(team.getTeamId());
-				}
+		draftLayout.setTypeSettingsProperties(typeSettingsUnicodeProperties);
 
-				modelPermissionsParameterMap.put(
-					roleKey, pagePermission.getActionKeys());
-			}
-
-			ModelPermissions modelPermissions = ModelPermissionsFactory.create(
-				modelPermissionsParameterMap, null);
-
-			_resourcePermissionLocalService.deleteResourcePermissions(
-				layout.getCompanyId(), Layout.class.getName(),
-				ResourceConstants.SCOPE_INDIVIDUAL,
-				String.valueOf(layout.getPlid()));
-
-			_resourcePermissionLocalService.addModelResourcePermissions(
-				layout.getCompanyId(), siteId, contextUser.getUserId(),
-				Layout.class.getName(), String.valueOf(layout.getPlid()),
-				modelPermissions);
-		}
+		return _layoutLocalService.updateLayout(draftLayout);
 	}
 
 	private Layout _updateLayoutSettings(
 		Layout layout, PageDefinition pageDefinition) {
 
-		if (pageDefinition == null) {
-			return layout;
-		}
+		if ((pageDefinition == null) ||
+			(pageDefinition.getSettings() == null)) {
 
-		Settings settings = pageDefinition.getSettings();
-
-		if (settings == null) {
 			layout.setThemeId(null);
 
 			layout.setColorSchemeId(null);
 
 			return _layoutLocalService.updateLayout(layout);
 		}
+
+		Settings settings = pageDefinition.getSettings();
 
 		UnicodeProperties unicodeProperties =
 			layout.getTypeSettingsProperties();
@@ -899,7 +865,44 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 		return _layoutLocalService.updateLayout(layout);
 	}
 
-	private void _updateSEOEntry(Layout layout, SitePage sitePage)
+	private void _updateModelResourcePermissions(
+			long companyId, long groupId, long plid, SitePage sitePage)
+		throws Exception {
+
+		PagePermission[] pagePermissions = sitePage.getPagePermissions();
+
+		if (pagePermissions != null) {
+			HashMap<String, String[]> modelPermissionsParameterMap =
+				new HashMap<>(pagePermissions.length);
+
+			for (PagePermission pagePermission : pagePermissions) {
+				String roleKey = pagePermission.getRoleKey();
+
+				Team team = _teamLocalService.fetchTeam(groupId, roleKey);
+
+				if (team != null) {
+					roleKey = String.valueOf(team.getTeamId());
+				}
+
+				modelPermissionsParameterMap.put(
+					roleKey, pagePermission.getActionKeys());
+			}
+
+			ModelPermissions modelPermissions = ModelPermissionsFactory.create(
+				modelPermissionsParameterMap, null);
+
+			_resourcePermissionLocalService.deleteResourcePermissions(
+				companyId, Layout.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL, String.valueOf(plid));
+
+			_resourcePermissionLocalService.addModelResourcePermissions(
+				companyId, groupId, contextUser.getUserId(),
+				Layout.class.getName(), String.valueOf(plid), modelPermissions);
+		}
+	}
+
+	private void _updateSEOEntry(
+			long companyId, long groupId, long layoutId, SitePage sitePage)
 		throws Exception {
 
 		PageSettings pageSettings = sitePage.getPageSettings();
@@ -960,23 +963,22 @@ public class SitePageResourceImpl extends BaseSitePageResourceImpl {
 
 		ServiceContext serviceContext =
 			ServiceContextRequestUtil.createServiceContext(
-				null, layout.getGroupId(), contextHttpServletRequest, null);
+				null, groupId, contextHttpServletRequest, null);
 
 		String ddmFormValues = _getDDMFormValues(pageSettings);
 
 		if (Validator.isNotNull(ddmFormValues)) {
-			long ddmStructurePrimaryKey = _getDDMStructurePrimaryKey(layout);
+			long ddmStructurePrimaryKey = _getDDMStructurePrimaryKey(companyId);
 
 			serviceContext.setAttribute(
 				ddmStructurePrimaryKey + "ddmFormValues", ddmFormValues);
 		}
 
 		_layoutSEOEntryService.updateLayoutSEOEntry(
-			layout.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),
-			canonicalURLEnabled, canonicalURLMap, openGraphDescriptionEnabled,
-			openGraphDescriptionMap, openImageAltMap,
-			_getFileEntryId(openGraphSettings), openGraphTitleEnabled,
-			openGraphTitleMap, serviceContext);
+			groupId, false, layoutId, canonicalURLEnabled, canonicalURLMap,
+			openGraphDescriptionEnabled, openGraphDescriptionMap,
+			openImageAltMap, _getFileEntryId(openGraphSettings),
+			openGraphTitleEnabled, openGraphTitleMap, serviceContext);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/BaseSitePageResourceTestCase.java
@@ -1223,6 +1223,14 @@ public abstract class BaseSitePageResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("pagePermissions", additionalAssertFieldName)) {
+				if (sitePage.getPagePermissions() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("pageSettings", additionalAssertFieldName)) {
 				if (sitePage.getPageSettings() == null) {
 					valid = false;
@@ -1568,6 +1576,17 @@ public abstract class BaseSitePageResourceTestCase {
 				if (!Objects.deepEquals(
 						sitePage1.getPageDefinition(),
 						sitePage2.getPageDefinition())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("pagePermissions", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						sitePage1.getPagePermissions(),
+						sitePage2.getPagePermissions())) {
 
 					return false;
 				}
@@ -1935,6 +1954,11 @@ public abstract class BaseSitePageResourceTestCase {
 		}
 
 		if (entityFieldName.equals("pageDefinition")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("pagePermissions")) {
 			throw new IllegalArgumentException(
 				"Invalid entity field " + entityFieldName);
 		}


### PR DESCRIPTION
- LPS-181930 Add pagePermissions to SitePage following format used by widgetPermissions in WidgetInstance
- LPS-181930 buildREST
- LPS-181930 Set page permissions in SitePageDTOConverter following pattern in WidgetInstanceMapper._getWidgetPermissions
- LPS-181930 Add specified model resource permissions if page permissions are available in the request
- LPS-181930 If page permissions are available in the request, delete existing (default) permissions
- LPS-181930 Take into account that roleKey may refer to the name of the team. In this case replace roleKey with teamId in modelPermissionsParameterMap
- LPS-181450 Take into account custom metatags when importing a page
- LPS-181450 Take into account custom fields when importing a page
- LPS-181450 For now, copy logic from importer dealing with the page definition. We deal with theme, stylebooks and more. We don't deal with actual content for this story
- LPS-181450 Extract method
- LPS-181450 Reorganize code
