### PR TITLE
LPS-112937 - WCD portlet header overlaps over first line of content

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/css/main.scss
@@ -80,7 +80,7 @@
 
 	&.portlet-barebone .portlet .portlet-header {
 		margin-bottom: 0;
-		position: absolute;
+		position: relative;
 		right: 2px;
 		top: 2px;
 		z-index: 1;

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/css/main.scss
@@ -80,9 +80,10 @@
 
 	&.portlet-barebone .portlet .portlet-header {
 		margin-bottom: 0;
-		position: relative;
+		position: absolute;
 		right: 2px;
 		top: 2px;
+		width: auto;
 		z-index: 1;
 	}
 }


### PR DESCRIPTION
Hi @liferay-echo team!

This is addressing an apparently long-standing issue where the portlet header, when using the 'barebones' application decorator setting, will overlap over the first line of content. This prevents any admin user from interacting with the first line of content. I've switched the barebones portlet header positioning from absolute to relative to adjust for this while still hopefully maintaining usability across display resolutions, but please let me know if you have any concerns about this solution. Thanks!

As a note, I'm not sure why the LPS has the "7.2.x-ee only" tag -- this issue is still present and reproducible in Master.