### PR TITLE
[TS] LPS-182423 Keep the parentGroupId parameter

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SelectSiteInitializerDisplayContext.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SelectSiteInitializerDisplayContext.java
@@ -127,6 +127,8 @@ public class SelectSiteInitializerDisplayContext {
 			"/site_admin/select_site_initializer"
 		).setRedirect(
 			getBackURL()
+		).setParameter(
+			"parentGroupId", getParentGroupId()
 		).buildPortletURL();
 	}
 


### PR DESCRIPTION
Motivation
=======
Site initialization does not keep the parentGroupId param from the initial request, so a Custom Site Template can't be used to create a child site.
https://issues.liferay.com/browse/LPS-182423

Proposed Solution
========
SelectSiteInitializerDisplayContext must keep the parentGroupId  for its portletURL, like how [SiteAdminManagementToolbarDisplayContext](https://github.com/liferay/liferay-portal/blob/master/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminManagementToolbarDisplayContext.java#L125) defines it

Steps to Verify
========
1. Go to Control Panel > Sites > Site Templates
2. Create a Site Template
3. Go to Control Panel > Sites > Sites
4. Create a child site for the Liferay DXP site using the Site Template
5. Go to Control Panel > Sites > Sites

**Expected behavior:** Child site should be created as a child site for the Liferay DXP site
**Actual behavior:** Child site gets created on the same level as the Liferay DXP site