### PR TITLE
[TS] LPS-181614 Replace custom ae_autolink plugin with ootb autolink plugin in FragmentEntryLinkEditor

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
@@ -90,7 +90,7 @@ public class FragmentEntryLinkEditorConfigContributor
 	}
 
 	protected String getExtraPluginsLists() {
-		return "ae_autolink,ae_dragresize,ae_addimages,ae_imagealignment," +
+		return "autolink,ae_dragresize,ae_addimages,ae_imagealignment," +
 			"ae_placeholder,ae_selectionregion,ae_tableresize," +
 				"ae_tabletools,ae_uicore,itemselector,media,adaptivemedia";
 	}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkRichTextEditorConfigContributor.java
@@ -97,7 +97,7 @@ public class FragmentEntryLinkRichTextEditorConfigContributor
 	}
 
 	protected String getExtraPluginsLists() {
-		return "ae_autolink,ae_dragresize,ae_addimages,ae_imagealignment," +
+		return "autolink,ae_dragresize,ae_addimages,ae_imagealignment," +
 			"ae_placeholder,ae_selectionregion,ae_tableresize," +
 				"ae_tabletools,ae_uicore,itemselector,media,adaptivemedia";
 	}


### PR DESCRIPTION
Hi Team,

Could you please review this pull request?
https://issues.liferay.com/browse/LPS-181614
Thank you!

----
**Reproduction Steps:**


1. Go to Site Builder --> Pages and add a content page
2. From the Basic Section add to the Page a Banner fragment (in 7.4 from the featured content).
3. Copy a very long text, for example, **hhsdhetzwujkasjiwiuzruusjdjhasdjhjkhdfuwuzuweuusduhushsls** or **Lieferkettensorgfaltspflichtengesetz**, and try to paste it into the banner's title or content.

**Expected Result:** The text is pasted successfully with no issues.
**Actual Result:** The page freezes, and a popup appears that the page is unresponsive. If we exit the page, it crashes and loads back without the pasted text.

The issue is reproduced on Chrome and Edge, with the page crashing. The text on Firefox should be very long to reproduce the case. The page freezes and a JS browser error appears, Uncaught InternalError: too much recursion.

With Chrome and Edge, text longer than 35 characters makes the page crash. With Firefox, the text should be longer than 35 chars in order to reproduce the issue.


**Solution:**
FragmentEntryLinkEditorConfigContributor and FragmentEntryLinkRichTextEditorConfigContributor included ae_autolink as a plugin, which has a bad performance when it comes to alphanumeric strings. We don't even use this ae plugin within our BaseAlloyEditorConfigContributor since [LPS-119875](https://issues.liferay.com/browse/LPS-119875), so I replaced ae_autolink with autolink plugin.