### PR TITLE
LPS-180293 - Test Scenarios Coverage | Backend

### DIFF
--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/DuplicateGroupExceptionMapper.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/DuplicateGroupExceptionMapper.java
@@ -45,7 +45,7 @@ public class DuplicateGroupExceptionMapper
 
 		return new Problem(
 			Response.Status.CONFLICT,
-			"There is already a site with the same key");
+			"A site with the same key already exists");
 	}
 
 }

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/DuplicateGroupExceptionMapper.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/DuplicateGroupExceptionMapper.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.site.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.kernel.exception.DuplicateGroupException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Converts any {@code DuplicateGroupException} to a {@code 409} error.
+ *
+ * @author Rubén Pulido
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Site)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Site.DuplicateGroupExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class DuplicateGroupExceptionMapper
+	extends BaseExceptionMapper<DuplicateGroupException> {
+
+	@Override
+	protected Problem getProblem(
+		DuplicateGroupException duplicateGroupException) {
+
+		return new Problem(
+			Response.Status.CONFLICT,
+			"There is already a site with the same key");
+	}
+
+}

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/GroupKeyExceptionMapper.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/GroupKeyExceptionMapper.java
@@ -41,7 +41,7 @@ public class GroupKeyExceptionMapper
 
 	@Override
 	protected Problem getProblem(GroupKeyException groupKeyException) {
-		return new Problem(Response.Status.BAD_REQUEST, "Invalid site key");
+		return new Problem(Response.Status.BAD_REQUEST, "Site key is invalid");
 	}
 
 }

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/GroupKeyExceptionMapper.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/GroupKeyExceptionMapper.java
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.site.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.kernel.exception.GroupKeyException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Converts any {@code GroupKeyExceptionMapper} to a {@code 400} error.
+ *
+ * @author Rubén Pulido
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Site)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Site.GroupKeyExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class GroupKeyExceptionMapper
+	extends BaseExceptionMapper<GroupKeyException> {
+
+	@Override
+	protected Problem getProblem(GroupKeyException groupKeyException) {
+		return new Problem(Response.Status.BAD_REQUEST, "Invalid site key");
+	}
+
+}

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/IllegalArgumentExceptionMapper.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/IllegalArgumentExceptionMapper.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.site.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Converts any {@code IllegalArgumentExceptionMapper} to a {@code 400} error.
+ *
+ * @author Rubén Pulido
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Site)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Site.IllegalArgumentExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class IllegalArgumentExceptionMapper
+	extends BaseExceptionMapper<IllegalArgumentException> {
+
+	@Override
+	protected Problem getProblem(
+		IllegalArgumentException illegalArgumentException) {
+
+		return new Problem(
+			Response.Status.BAD_REQUEST, illegalArgumentException.getMessage());
+	}
+
+}

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/NoSuchGroupExceptionMapper.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/NoSuchGroupExceptionMapper.java
@@ -15,8 +15,12 @@
 package com.liferay.headless.site.internal.jaxrs.exception.mapper;
 
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
@@ -42,7 +46,31 @@ public class NoSuchGroupExceptionMapper
 	@Override
 	protected Problem getProblem(NoSuchGroupException noSuchGroupException) {
 		return new Problem(
-			Response.Status.NOT_FOUND, "Could not find parent site");
+			Response.Status.NOT_FOUND, _getTitle(noSuchGroupException));
 	}
+
+	private String _getTitle(NoSuchGroupException noSuchGroupException) {
+		String title = "No site exists";
+
+		if (noSuchGroupException.getMessage() == null) {
+			return title;
+		}
+
+		Matcher matcher = _pattern.matcher(noSuchGroupException.getMessage());
+
+		if (!matcher.matches()) {
+			return title;
+		}
+
+		String siteKey = matcher.group(1);
+
+		if (Validator.isNotNull(siteKey)) {
+			title = title + " for site key " + siteKey;
+		}
+
+		return title;
+	}
+
+	private static final Pattern _pattern = Pattern.compile(".+groupKey=(.+)}");
 
 }

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/NoSuchGroupExceptionMapper.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/NoSuchGroupExceptionMapper.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.site.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.kernel.exception.NoSuchGroupException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Converts any {@code NoSuchGroupExceptionMapper} to a {@code 404} error.
+ *
+ * @author Rubén Pulido
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Site)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Site.NoSuchGroupExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class NoSuchGroupExceptionMapper
+	extends BaseExceptionMapper<NoSuchGroupException> {
+
+	@Override
+	protected Problem getProblem(NoSuchGroupException noSuchGroupException) {
+		return new Problem(
+			Response.Status.NOT_FOUND, "Could not find parent site");
+	}
+
+}

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -118,7 +118,7 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 
 			if (layoutSetPrototype == null) {
 				throw new IllegalArgumentException(
-					"No site template found for site template key " +
+					"No site template was found for site template key " +
 						site.getTemplateKey());
 			}
 

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -83,6 +83,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		_testPostSiteFailureParentSiteNotFound();
 		_testPostSiteFailureSiteInitializerNotFound();
 		_testPostSiteFailureSiteTemplateInactive();
+		_testPostSiteFailureSiteTemplateNotFound();
 		_testPostSiteSuccessChild();
 		_testPostSiteSuccessMembershipTypePrivate();
 		_testPostSiteSuccessSiteInitializer();
@@ -255,6 +256,29 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			Assert.assertEquals(
 				"Site template with site template key " +
 					randomSite.getTemplateKey() + " is inactive",
+				problem.getTitle());
+		}
+	}
+
+	private void _testPostSiteFailureSiteTemplateNotFound() throws Exception {
+		Site randomSite = randomSite();
+
+		randomSite.setTemplateKey(String.valueOf(RandomTestUtil.randomLong()));
+		randomSite.setTemplateType(Site.TemplateType.SITE_TEMPLATE);
+
+		try {
+			testPostSite_addSite(randomSite);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
+
+			Assert.assertEquals(
+				"No site template was found for site template key " +
+					randomSite.getTemplateKey(),
 				problem.getTitle());
 		}
 	}

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -80,6 +80,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		_testPostSiteFailureDuplicateName();
 		_testPostSiteFailureInvalidKey();
 		_testPostSiteFailureNoName();
+		_testPostSiteFailureParentSiteNotFound();
 		_testPostSiteFailureSiteTemplateInactive();
 		_testPostSiteSuccessChild();
 		_testPostSiteSuccessMembershipTypePrivate();
@@ -169,6 +170,27 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			String title = problem.getTitle();
 
 			Assert.assertTrue(title.contains("name must not be empty"));
+		}
+	}
+
+	private void _testPostSiteFailureParentSiteNotFound() throws Exception {
+		Site randomSite = randomSite();
+
+		randomSite.setParentSiteKey(
+			StringUtil.toLowerCase(RandomTestUtil.randomString()));
+
+		try {
+			testPostSite_addSite(randomSite);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+
+			Assert.assertEquals(
+				"Could not find parent site", problem.getTitle());
 		}
 	}
 

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -179,7 +179,12 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
-			Assert.assertEquals("INTERNAL_SERVER_ERROR", problem.getStatus());
+			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
+
+			Assert.assertEquals(
+				"Site template with site template key " +
+					randomSite.getTemplateKey() + " is inactive",
+				problem.getTitle());
 		}
 	}
 

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -85,6 +85,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		_testPostSiteFailureSiteTemplateInactive();
 		_testPostSiteFailureSiteTemplateNotFound();
 		_testPostSiteFailureTemplateKeyNoTemplateType();
+		_testPostSiteFailureTemplateTypeNoTemplateKey();
 		_testPostSiteSuccessChild();
 		_testPostSiteSuccessMembershipTypePrivate();
 		_testPostSiteSuccessSiteInitializer();
@@ -304,6 +305,29 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 			Assert.assertEquals(
 				"Template type cannot be empty if template key is specified",
+				problem.getTitle());
+		}
+	}
+
+	private void _testPostSiteFailureTemplateTypeNoTemplateKey()
+		throws Exception {
+
+		Site randomSite = randomSite();
+
+		randomSite.setTemplateType(Site.TemplateType.SITE_INITIALIZER);
+
+		try {
+			testPostSite_addSite(randomSite);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
+
+			Assert.assertEquals(
+				"Template key cannot be empty if template type is specified",
 				problem.getTitle());
 		}
 	}

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -84,6 +84,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		_testPostSiteFailureSiteInitializerNotFound();
 		_testPostSiteFailureSiteTemplateInactive();
 		_testPostSiteFailureSiteTemplateNotFound();
+		_testPostSiteFailureTemplateKeyNoTemplateType();
 		_testPostSiteSuccessChild();
 		_testPostSiteSuccessMembershipTypePrivate();
 		_testPostSiteSuccessSiteInitializer();
@@ -279,6 +280,30 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			Assert.assertEquals(
 				"No site template was found for site template key " +
 					randomSite.getTemplateKey(),
+				problem.getTitle());
+		}
+	}
+
+	private void _testPostSiteFailureTemplateKeyNoTemplateType()
+		throws Exception {
+
+		Site randomSite = randomSite();
+
+		randomSite.setTemplateKey(
+			StringUtil.toLowerCase(RandomTestUtil.randomString()));
+
+		try {
+			testPostSite_addSite(randomSite);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
+
+			Assert.assertEquals(
+				"Template type cannot be empty if template key is specified",
 				problem.getTitle());
 		}
 	}

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -78,6 +78,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		super.testPostSite();
 
 		_testPostSiteFailureDuplicateName();
+		_testPostSiteFailureInvalidKey();
 		_testPostSiteFailureNoName();
 		_testPostSiteFailureSiteTemplateInactive();
 		_testPostSiteSuccessChild();
@@ -126,6 +127,27 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			Assert.assertEquals(
 				"There is already a site with the same key",
 				problem.getTitle());
+		}
+	}
+
+	private void _testPostSiteFailureInvalidKey() throws Exception {
+		Site randomSite = randomSite();
+
+		randomSite.setName("*");
+
+		try {
+			testPostSite_addSite(randomSite);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
+
+			String title = problem.getTitle();
+
+			Assert.assertTrue(title.contains("Invalid site key"));
 		}
 	}
 

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -130,8 +130,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			Assert.assertEquals("CONFLICT", problem.getStatus());
 
 			Assert.assertEquals(
-				"There is already a site with the same key",
-				problem.getTitle());
+				"A site with the same key already exists", problem.getTitle());
 		}
 	}
 
@@ -150,9 +149,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
 
-			String title = problem.getTitle();
-
-			Assert.assertTrue(title.contains("Invalid site key"));
+			Assert.assertEquals("Site key is invalid", problem.getTitle());
 		}
 	}
 
@@ -194,7 +191,8 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			Assert.assertEquals("NOT_FOUND", problem.getStatus());
 
 			Assert.assertEquals(
-				"Could not find parent site", problem.getTitle());
+				"No site exists for site key " + randomSite.getParentSiteKey(),
+				problem.getTitle());
 		}
 	}
 

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -121,7 +121,11 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		catch (Problem.ProblemException problemException) {
 			Problem problem = problemException.getProblem();
 
-			Assert.assertEquals("INTERNAL_SERVER_ERROR", problem.getStatus());
+			Assert.assertEquals("CONFLICT", problem.getStatus());
+
+			Assert.assertEquals(
+				"There is already a site with the same key",
+				problem.getTitle());
 		}
 	}
 

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -81,6 +81,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		_testPostSiteFailureInvalidKey();
 		_testPostSiteFailureNoName();
 		_testPostSiteFailureParentSiteNotFound();
+		_testPostSiteFailureSiteInitializerNotFound();
 		_testPostSiteFailureSiteTemplateInactive();
 		_testPostSiteSuccessChild();
 		_testPostSiteSuccessMembershipTypePrivate();
@@ -191,6 +192,32 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 
 			Assert.assertEquals(
 				"Could not find parent site", problem.getTitle());
+		}
+	}
+
+	private void _testPostSiteFailureSiteInitializerNotFound()
+		throws Exception {
+
+		Site randomSite = randomSite();
+
+		randomSite.setTemplateKey(
+			StringUtil.toLowerCase(RandomTestUtil.randomString()));
+		randomSite.setTemplateType(Site.TemplateType.SITE_INITIALIZER);
+
+		try {
+			testPostSite_addSite(randomSite);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("BAD_REQUEST", problem.getStatus());
+
+			Assert.assertEquals(
+				"No site initializer was found for site template key " +
+					randomSite.getTemplateKey(),
+				problem.getTitle());
 		}
 	}
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/IllegalArgumentExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/IllegalArgumentExceptionMapper.java
@@ -12,29 +12,18 @@
  * details.
  */
 
-package com.liferay.headless.site.internal.jaxrs.exception.mapper;
+package com.liferay.portal.vulcan.internal.jaxrs.exception.mapper;
 
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
 
 import javax.ws.rs.core.Response;
-import javax.ws.rs.ext.ExceptionMapper;
-
-import org.osgi.service.component.annotations.Component;
 
 /**
  * Converts any {@code IllegalArgumentExceptionMapper} to a {@code 400} error.
  *
  * @author Rubén Pulido
  */
-@Component(
-	property = {
-		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Site)",
-		"osgi.jaxrs.extension=true",
-		"osgi.jaxrs.name=Liferay.Headless.Site.IllegalArgumentExceptionMapper"
-	},
-	service = ExceptionMapper.class
-)
 public class IllegalArgumentExceptionMapper
 	extends BaseExceptionMapper<IllegalArgumentException> {
 

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/IllegalArgumentExceptionMapper.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/exception/mapper/IllegalArgumentExceptionMapper.java
@@ -17,8 +17,6 @@ package com.liferay.portal.vulcan.internal.jaxrs.exception.mapper;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
 import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
 
-import javax.ws.rs.core.Response;
-
 /**
  * Converts any {@code IllegalArgumentExceptionMapper} to a {@code 400} error.
  *
@@ -31,8 +29,7 @@ public class IllegalArgumentExceptionMapper
 	protected Problem getProblem(
 		IllegalArgumentException illegalArgumentException) {
 
-		return new Problem(
-			Response.Status.BAD_REQUEST, illegalArgumentException.getMessage());
+		return new Problem(illegalArgumentException);
 	}
 
 }

--- a/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
+++ b/modules/apps/portal-vulcan/portal-vulcan-impl/src/main/java/com/liferay/portal/vulcan/internal/jaxrs/feature/VulcanFeature.java
@@ -53,6 +53,7 @@ import com.liferay.portal.vulcan.internal.jaxrs.context.resolver.ObjectMapperCon
 import com.liferay.portal.vulcan.internal.jaxrs.context.resolver.XmlMapperContextResolver;
 import com.liferay.portal.vulcan.internal.jaxrs.dynamic.feature.StatusDynamicFeature;
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.ExceptionMapper;
+import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.IllegalArgumentExceptionMapper;
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.InvalidFilterExceptionMapper;
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.InvalidFormatExceptionMapper;
 import com.liferay.portal.vulcan.internal.jaxrs.exception.mapper.JsonMappingExceptionMapper;
@@ -116,6 +117,7 @@ public class VulcanFeature implements Feature {
 		featureContext.register(EntityExtensionWriterInterceptor.class);
 		featureContext.register(ExceptionMapper.class);
 		featureContext.register(FieldsQueryParamContextProvider.class);
+		featureContext.register(IllegalArgumentExceptionMapper.class);
 		featureContext.register(InvalidFilterExceptionMapper.class);
 		featureContext.register(InvalidFormatExceptionMapper.class);
 		featureContext.register(JSONMessageBodyReader.class);


### PR DESCRIPTION
Incorporates feedback from https://github.com/brianchandotcom/liferay-portal/pull/133654#issuecomment-1515981961

- modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/jaxrs/exception/mapper/NoSuchGroupExceptionMapper.java is necessary, since it makes sure that the message returned uses the terms "site" and "site key" instead of "group" and "groupKey". It also hides companyId value which is otherwise returned by the Vulcan NoSuchModelExceptionMapper

- IllegalArgumentExceptionMapper has been moved to Vulcan.
@4lejandrito Can you review this [commit](https://github.com/liferay-echo/liferay-portal/pull/11842/commits/766d78befab27b2eeff226bc73ace0e43b8b72fc)?
 

//cc @ealonso @jkappler 