### PR TITLE
LPS 182526

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/notifications/AssetPublisherNotificationHandler.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/notifications/AssetPublisherNotificationHandler.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.publisher.web.internal.notifications;
+
+import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.UserNotificationEvent;
+import com.liferay.portal.kernel.notifications.BaseModelUserNotificationHandler;
+import com.liferay.portal.kernel.notifications.UserNotificationHandler;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.util.HtmlUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.util.Map;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Roberto Díaz
+ */
+@Component(
+	property = "javax.portlet.name=" + AssetPublisherPortletKeys.ASSET_PUBLISHER,
+	service = UserNotificationHandler.class
+)
+public class AssetPublisherNotificationHandler
+	extends BaseModelUserNotificationHandler {
+
+	public AssetPublisherNotificationHandler() {
+		setPortletId(AssetPublisherPortletKeys.ASSET_PUBLISHER);
+	}
+
+	@Override
+	protected String getBody(
+			UserNotificationEvent userNotificationEvent,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		return StringUtil.replace(
+			getBodyTemplate(), new String[] {"[$BODY$]", "[$TITLE$]"},
+			new String[] {
+				getBodyContent(
+					_jsonFactory.createJSONObject(
+						userNotificationEvent.getPayload())),
+				getTitle(userNotificationEvent, serviceContext)
+			});
+	}
+
+	@Override
+	protected String getBodyContent(JSONObject jsonObject) {
+		JSONObject contextJSONObject = jsonObject.getJSONObject("context");
+
+		JSONObject assetEntriesJSONObject = contextJSONObject.getJSONObject(
+			"[$ASSET_ENTRIES$]");
+
+		return assetEntriesJSONObject.getString("originalValue");
+	}
+
+	protected String getTitle(
+			UserNotificationEvent userNotificationEvent,
+			ServiceContext serviceContext)
+		throws Exception {
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject(
+			userNotificationEvent.getPayload());
+
+		Map<String, String> localizedJsonSubjectMap =
+			(Map)_jsonFactory.looseDeserialize(
+				String.valueOf(jsonObject.get("localizedSubjectMap")));
+
+		String subject = localizedJsonSubjectMap.get(
+			serviceContext.getLanguageId());
+
+		return StringUtil.replace(
+			subject, new String[] {"[$PORTLET_TITLE$]"},
+			new String[] {
+				HtmlUtil.escape(
+					_portal.getPortletTitle(
+						AssetPublisherPortletKeys.ASSET_PUBLISHER,
+						serviceContext.getLanguageId()))
+			});
+	}
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/notifications/AssetPublisherUserNotificationDefinition.java
+++ b/modules/apps/asset/asset-publisher-web/src/main/java/com/liferay/asset/publisher/web/internal/notifications/AssetPublisherUserNotificationDefinition.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.asset.publisher.web.internal.notifications;
+
+import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
+import com.liferay.portal.kernel.model.UserNotificationDeliveryConstants;
+import com.liferay.portal.kernel.notifications.UserNotificationDefinition;
+import com.liferay.portal.kernel.notifications.UserNotificationDeliveryType;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Roberto Díaz
+ */
+@Component(
+	property = "javax.portlet.name=" + AssetPublisherPortletKeys.ASSET_PUBLISHER,
+	service = UserNotificationDefinition.class
+)
+public class AssetPublisherUserNotificationDefinition
+	extends UserNotificationDefinition {
+
+	public AssetPublisherUserNotificationDefinition() {
+		super(
+			AssetPublisherPortletKeys.ASSET_PUBLISHER, 0,
+			UserNotificationDefinition.NOTIFICATION_TYPE_ADD_ENTRY,
+			"receive-a-notification-when-someone-adds-a-new-asset-entry-in-" +
+				"an-asset-publisher-you-are-subscribed-to");
+
+		addUserNotificationDeliveryType(
+			new UserNotificationDeliveryType(
+				"email", UserNotificationDeliveryConstants.TYPE_EMAIL, true,
+				true));
+		addUserNotificationDeliveryType(
+			new UserNotificationDeliveryType(
+				"website", UserNotificationDeliveryConstants.TYPE_WEBSITE, true,
+				true));
+	}
+
+}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -13453,6 +13453,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to.
 receive-a-notification-when-someone=Receive a notification when someone:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to.
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adds a new bookmark in a folder you are subscribed to.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adds a comment to comments you are subscribed to.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=يحدِّث مقالة قاعدة المعارف في التي اشتركت فيها.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=مراجعة مستند في المجلد الذي تشترك به.
 receive-a-notification-when-someone=تلقي إعلام عندما يقوم شخص بما يلي:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=يضيف إدخال مدونة جديد في مدونة أنت مشترك فيها.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=يضيف إشارة مرجعية جديدة في مجلد قمت بالاشتراك فيه.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=تضيف تعليقًا على التعليقات التي اشتركت فيها.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Прегледайте документ в папка, за която сте абонирани. (Automatic Translation)
 receive-a-notification-when-someone=Получаване на известие, когато някой: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Добавя нов блог запис в блог, за който сте абонирани. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Добавя нов показалец в папка, за която сте абонирани. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Добавя коментар към коментарите, за които сте абонирани. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -13449,6 +13449,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Reviseu un article de la base de coneixement a què esteu subscrit.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revisar un document en una carpeta a què esteu subscrit.
 receive-a-notification-when-someone=Rebre una notificació quan algú...
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=afegeix una entrada de blog nova a un blog al qual esteu subscrits.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Afegeix un marcador nou en una carpeta a la qual esteu subscrits.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Afegeix un comentari als comentaris als que esteu subscrit.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Zkontrolujte dokument ve složce, ke které jste přihlášeni. (Automatic Translation)
 receive-a-notification-when-someone=Obdržíte oznámení, když někdo: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Přidá novou položku blogu do blogu, ke které jste přihlášeni. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Přidá novou záložku do složky, ke které jste přihlášeni. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Přidá komentář k komentářům, ke které jste přihlášeni. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=Modtag en notifikation, når en person: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Tilføjer en ny blog-indtastning i en blog, du abonnerer på. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Tilføjer et nyt bogmærke i en mappe, du abonnerer på. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Føjer en kommentar til de kommentarer, du abonnerer på. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -13449,6 +13449,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Überprüfen Sie einen Wissensdatenbank-Artikel, den Sie abonniert haben.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Überprüfen Sie ein Dokument in einem Ordner, den Sie abonniert haben.
 receive-a-notification-when-someone=Erhalten Sie eine Benachrichtigung, wenn jemand:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Erhalten Sie eine Benachrichtigung, wenn ein neuer Blogeintrag in einem von Ihnen abonnierten Blog veröffentlicht wird.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Erhalten Sie eine Benachrichtigung, wenn jemand ein neues Lesezeichen in einen von Ihnen abonnierten Ordner einfügt.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Erhalten Sie eine Benachrichtigung, wenn jemand einen neuen Kommentar zu einem Kommentar, den Sie abonniert haben, hinzufügt.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Εξετάστε ένα έγγραφο σε ένα φάκελο στον οποίο είστε εγγεγραμμένοι. (Automatic Translation)
 receive-a-notification-when-someone=Λάβετε μια ειδοποίηση όταν κάποιος: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Προσθέτει μια νέα καταχώρηση ιστολογίου σε ένα ιστολόγιο στο οποίο είστε εγγεγραμμένοι. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Προσθέτει έναν νέο σελιδοδείκτη σε ένα φάκελο στον οποίο έχετε εγγραφεί. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Προσθέτει ένα σχόλιο σε σχόλια στα οποία έχετε εγγραφεί. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -13453,6 +13453,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to.
 receive-a-notification-when-someone=Receive a notification when someone:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to.
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adds a new bookmark in a folder you are subscribed to.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adds a comment to comments you are subscribed to.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adds a new bookmark in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adds a comment to comments you are subscribed to. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adds a new bookmark in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adds a comment to comments you are subscribed to. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -13449,6 +13449,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Revise un artículo de la base de conocimiento a la que esté suscrito.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revise un documento en una carpeta a la que esté suscrito.
 receive-a-notification-when-someone=Recibir una notificación cuando alguien:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Añade una nueva entrada en un blog al que me he suscrito.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Añade un nuevo enlace en una carpeta a la que me he suscrito.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Añade un comentario a comentarios a los que me he suscrito.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -13449,6 +13449,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revise un documento en una carpeta a la que esté suscrito.
 receive-a-notification-when-someone=Recibir una notificación cuando alguien:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Añade una nueva entrada en un blog al que me he suscrito.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Añade un nuevo enlace en una carpeta a la que me he suscrito.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Añade un comentario a comentarios a los que me he suscrito.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -13449,6 +13449,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revise un documento en una carpeta a la que esté suscrito.
 receive-a-notification-when-someone=Recibir una notificación cuando alguien:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Añade una nueva entrada en un blog al que me he suscrito.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Añade un nuevo enlace en una carpeta a la que me he suscrito.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Añade un comentario a comentarios a los que me he suscrito.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -13449,6 +13449,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revise un documento en una carpeta a la que esté suscrito.
 receive-a-notification-when-someone=Recibir una notificación cuando alguien:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Añade una nueva entrada en un blog al que me he suscrito.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Añade un nuevo enlace en una carpeta a la que me he suscrito.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Añade un comentario a comentarios a los que me he suscrito.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Vaadake üle dokument, mis asub teie tellitud kaustas. (Automatic Translation)
 receive-a-notification-when-someone=Saate teatise, kui keegi: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Lisab uue ajaveebikirje ajaveebis, mille olete tellinud. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Lisab uue järjehoidja kausta, mille olete tellinud. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Lisab kommentaari kommentaaridele, mida olete tellinud. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adds a new bookmark in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adds a comment to comments you are subscribed to. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=یک سند را در پوشه ای که مشترک آن هستید مرور کنید. (Automatic Translation)
 receive-a-notification-when-someone=وقتی کسی اعلان دریافت می کند: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=یک وبلاگ جدید در یک بلاگ که شما اشتراک دارید، اضافه می کند.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=یک بوک مارک جدید در یک پوشه که شما در آن مشترک هستید، اضافه می کند.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=یک نظر به نظرهایی که به اشتراک گذاشته اید، اضافه می شود.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -13446,6 +13446,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Tarkista tietämyskannan artikkeli, jonka olet tilannut.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Tarkasta asiakirja kansiossa, jonka olet tilannut.
 receive-a-notification-when-someone=Saa ilmoitus, kun joku:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Lisää uuden blogin tilaamaasi blogiin.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Lisää uuden kirjanmerkin tilaamaasi kansioon.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Lisää kommentin kommentteihin mitkä olet tilannut.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -13449,6 +13449,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Passez en revue un article de la base de connaissances auquel vous êtes abonné.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Révisez un document dans un dossier auquel vous êtes abonné.
 receive-a-notification-when-someone=Recevoir une notification quand quelqu'un :
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Ajouter une nouvelle entrée de blog dans le blog où vous êtes abonné.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Ajouter un signet auquel vous êtes abonné.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Recevoir une notification lorsque quelqu'un ajoute un nouveau commentaire aux commentaires auxquels vous êtes abonné.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Révisez un document dans un dossier auquel vous êtes abonné.
 receive-a-notification-when-someone=Recevoir une notification quand quelqu'un :
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Ajouter une nouvelle entrée de blog dans le blog où vous êtes abonné.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Ajouter un signet auquel vous êtes abonné.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Recevoir une notification lorsque quelqu'un ajoute un nouveau commentaire aux commentaires auxquels vous êtes abonné.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=Recibir unha notificación cando alguén:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Engada unha nova entrada de blog a un blog ao que está suscrito.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Engade un novo marcador a un cartafol ao que está subscrito.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Engade un comentario aos comentarios que está subscrito.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=किसी फ़ोल्डर में दस्तावेज़ की समीक्षा करें जिससे आप सब्सक्राइब होते हैं. (Automatic Translation)
 receive-a-notification-when-someone=जब कोई व्यक्ति सूचना प्राप्त करता है: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=आपके द्वारा सदस्यता ली गई ब्लॉग में एक नया ब्लॉग प्रविष्टि जोड़ता है।
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=आपके द्वारा सदस्यता लिए गए फ़ोल्डर में एक नया बुकमार्क जोड़ता है।
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=आप टिप्पणी करने के लिए एक टिप्पणी dds की सदस्यता ली है।

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adds a new bookmark in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adds a comment to comments you are subscribed to. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -13450,6 +13450,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Nézzen át egy tudásbázis-cikket, amire fel van iratkozva.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Ellenőrizze a dokumentumot a mappában, amelyre előfizetett.
 receive-a-notification-when-someone=Értesítés megjelenítése amikor valaki...
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Hozzáad egy új blogbejegyzést egy blogban, amire feliratkoztál.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Hozzáad egy új könyvjelzőt egy mappához, amire fel vagy iratkozva.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Hozzáad egy hozzászólást a hozzászólásokhoz, amikre fel vagy iratkozva.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Tinjau dokumen dalam folder tempat Anda berlangganan. (Automatic Translation)
 receive-a-notification-when-someone=Menerima pemberitahuan saat seseorang: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Menambahkan entri blog baru di blog tempat Anda berlangganan. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Menambahkan bookmark baru di folder tempat Anda berlangganan. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Menambahkan komentar ke komentar langganan Anda. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -13448,6 +13448,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Esaminare un documento in una cartella sottoscritta. (Automatic Translation)
 receive-a-notification-when-someone=Ricevi una notifica quando qualcuno:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Aggiunge un nuovo articolo blog in un blog che hai sottoscritto
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Aggiunge un segnalibro in una cartella che hai sottoscritto
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Aggiunge un commento a commenti in cui sei sottoscritto

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=סקור מסמך בתיקיה שאליה נרשמת כמנוי. (Automatic Translation)
 receive-a-notification-when-someone=קבל הודעה כאשר מישהו:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=הוסף רשומת בלוג חדשה בבלוג שבו יש לך מנוי.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=הוסף סימניה חדשה בתיקייה שאליה יש לך מנוי.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=מוסיף תגובה לתגובות שאליהן אתה רשום כמנוי.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -13449,6 +13449,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=購読先のナレッジベース記事をレビューします。
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=購読先のフォルダ内のドキュメントをレビューしてください。
 receive-a-notification-when-someone=以下からの通知を受け取る :
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=購読済みのブログに、新規ブログ記事を追加する
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=購読しているフォルダーに新しいブックマークを追加
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=購読済みのコメントに、コメントを追加する

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adds a new bookmark in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adds a comment to comments you are subscribed to. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -13453,6 +13453,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to.
 receive-a-notification-when-someone=Receive a notification when someone:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adds a new bookmark in a folder you are subscribed to.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adds a comment to comments you are subscribed to.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=구독 중인 폴더의 문서를 검토합니다.
 receive-a-notification-when-someone=다음과 같은 경우 알림을 받습니다.
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=구독 중인 블로그에 새 블로그 항목을 추가합니다.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=구독 중인 폴더에 새 책갈피를 추가합니다.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=구독 중인 댓글에 댓글을 추가합니다.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adds a new bookmark in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adds a comment to comments you are subscribed to. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Peržiūrėkite dokumentą aplanke, kuriame esate užsiprenumeravę. (Automatic Translation)
 receive-a-notification-when-someone=Gauti pranešimą, kai kas nors: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Įtraukia naują internetinio dienoraščio įrašą į tinklaraštį, užsiprenumeravote. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Įtraukia naują žymelę į aplanką, kuriame esate užsiprenumeravę. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Prideda komentarą prie komentarų, kuriuos prenumeruojate. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Semak dokumen dalam folder yang anda langgani. (Automatic Translation)
 receive-a-notification-when-someone=Terima pemberitahuan apabila seseorang: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Menambah entri blog baru dalam blog yang anda langgan. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Menambah penanda buku baru dalam folder yang anda langgan. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Menambah komen pada komen yang anda langgani. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Se gjennom et dokument i en mappe du abonnerer på. (Automatic Translation)
 receive-a-notification-when-someone=Motta en melding når noen:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Legger til et nytt blogginnlegg i en blogg du abonnerer på.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Legger til et nytt bokmerke i en mappe du abonnerer på.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Legger til en kommentar til en kommentar du abonnerer på.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -13450,6 +13450,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Geef een beoordeling over een kennisbankartikel waarop u bent geabonneerd.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Controleer een document in een map waarop u bent geabonneerd.
 receive-a-notification-when-someone=Ontvangt een melding wanneer iemand:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Voegt een nieuw blogbericht toe in een blog waarop u bent geabonneerd.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Voegt een nieuwe bladwijzer toe in een map waarop u bent geabonneerd.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Voegt een reactie toe aan reacties waarop u geabonneerd bent.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -13450,6 +13450,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adds a new bookmark in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adds a comment to comments you are subscribed to. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Przejrzyj dokument w folderze, do którego jesteś subskrybentem. (Automatic Translation)
 receive-a-notification-when-someone=Otrzymuj powiadomienie, gdy ktoś: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Dodaje nowy wpis blogu w blogu, do którego jesteś subskrybentem. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Dodaje nową zakładkę do folderu, do którego jesteś subskrybentem. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Dodaje komentarz do komentarzy, które są subskrybowane. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Revisar um artigo da base de conhecimento que você assina.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Revise um documento em uma pasta que você esteja inscrito.
 receive-a-notification-when-someone=Receber uma notificação quando alguém:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=adiciona um novo post a um blog que você acompanha.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adiciona um novo favorito a uma pasta que você assina.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=adiciona um comentário aos comentários que você acompanha.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -13449,6 +13449,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=Receber uma notificação quando alguém...
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adiciona uma nova entrada no blog em um blog que você está inscrito. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adiciona um novo marcador em uma pasta a que você está inscrito. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adiciona um comentário aos comentários que você está inscrito. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Examinați un document dintr-un folder la care sunteți abonat. (Automatic Translation)
 receive-a-notification-when-someone=Primiți o notificare atunci când cineva: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adaugă o nouă intrare de blog într-un blog la care sunteți abonat. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adaugă un marcaj în document nou într-un folder la care sunteți abonat. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adaugă un comentariu la comentariile la care sunteți abonat. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Просмотрите документ в папке, на которую вы подписаны. (Automatic Translation)
 receive-a-notification-when-someone=Получаем уведомление, когда кто-то: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Добавляет новую запись в блоге вы подписались. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Добавляет новую закладку в папку, на которую вы подписаны. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Добавляет комментарий к комментариям, на которые вы подписаны. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Skontrolujte dokument v priečinku, na odber ktorý ste prihlásení. (Automatic Translation)
 receive-a-notification-when-someone=Upozornenie, keď niekto: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Pridá nový záznam blogu do blogu, na odber ktorom ste prihlásení. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Pridá novú záložku do priečinka, na odber ktorý ste prihlásení. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Pridá komentár k komentárom, ktoré odoberáte. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Preglejte dokument v mapi, na kar ste naročeni. (Automatic Translation)
 receive-a-notification-when-someone=Prejmite obvestilo, ko nekdo: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Doda nov vnos v spletni dnevnik v spletnem dnevniku, na ki ste nanje naročeni. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Doda nov zaznamek v mapo, na kar ste naročeni. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Komentarje, na ki ste naročeni, doda komentar. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adds a new bookmark in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adds a comment to comments you are subscribed to. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=Receive a notification when someone: (Automatic Copy)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Adds a new blog entry in a blog you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Adds a new bookmark in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Adds a comment to comments you are subscribed to. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Recensera en artikel i kunskapsbasen som du prenumererar på.
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Granska ett dokument i en mapp som du prenumererar på.
 receive-a-notification-when-someone=Ta emot en avisering när någon:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Lägger till ett nytt blogginlägg i en blogg som du prenumererar på.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Lägger till ett nytt bokmärke i en mapp som du prenumererar på.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Lägger till en kommentar i kommentarer som du prenumererar på.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Review a document in a folder you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone=யாரேனும் இவற்றைச் செய்யும்போது அறிவிப்பைப் பெறவும்:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=நீங்கள் பதிவு செய்துள்ள பதிவில் புதிய பதிவை இணைக்க.
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=நீங்கள் இணைந்துள்ள ஃபோல்டரில் புதிய புக்மார்க்குகள் உள்ளன.
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=நீங்கள் குழுசேர்ந்த கருத்துக்களுக்கு கருத்தைச் சேர்க்கிறது.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=ตรวจดูเอกสารในโฟลเดอร์ที่คุณสมัครไว้
 receive-a-notification-when-someone=รับการแจ้งเตือนเมื่อมีคน:
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=เพิ่มรายการบล็อกใหม่ในบล็อกที่คุณสมัคร
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=เพิ่มบุ๊กมาร์กใหม่ในโฟลเดอร์ที่คุณสมัคร
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=เพิ่มความคิดเห็นในความคิดเห็นที่คุณสมัครเป็นสมาชิก

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Abone olduğunuz klasördeki bir belgeyi gözden geçirin. (Automatic Translation)
 receive-a-notification-when-someone=Birisi: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Abone olduğunuz bir bloga yeni bir blog girdisi ekler. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Abone olduğunuz klasöre yeni bir yer işareti ekler. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Abone olduğunuz açıklamalara bir açıklama ekler. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Перегляньте документ у папці, на яку ви підписані. (Automatic Translation)
 receive-a-notification-when-someone=Отримуйте сповіщення, коли хтось: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Додавання нового запису блогу в блозі, на який ви підписані. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Додає нову закладку до папки, на яку ви підписані. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Додає коментар до коментарів, на які ви підписані. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -13447,6 +13447,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=Xem lại tài liệu trong thư mục bạn đã đăng ký. (Automatic Translation)
 receive-a-notification-when-someone=Nhận thông báo khi có người: (Automatic Translation)
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=Thêm một mục blog mới trong blog mà bạn đã đăng ký. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=Thêm dấu trang mới vào thư mục bạn đã đăng ký. (Automatic Translation)
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=Thêm nhận xét vào nhận xét mà bạn đã đăng ký. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -13449,6 +13449,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=审阅您订阅的知识库文章。
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=审核您订阅的文件夹中的文档。
 receive-a-notification-when-someone=当有人……时收到通知
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=在您订阅的博客中添加一个新的博文。
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=在您订阅的文件夹中添加一个新的书签。
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=为您订阅的评论添加评论。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -13448,6 +13448,7 @@ receive-a-notification-when-document-has-expired-in-a-folder-you-are-subscribed-
 receive-a-notification-when-review-is-needed-on-a-knowledge-base-article-you-are-subscribed-to=Review a knowledge base article you are subscribed to. (Automatic Copy)
 receive-a-notification-when-review-is-needed-on-document-in-a-folder-you-are-subscribed-to=檢視您訂閱的資料夾裡的文件。
 receive-a-notification-when-someone=收到一個通知，當有人...
+receive-a-notification-when-someone-adds-a-new-asset-entry-in-an-asset-publisher-you-are-subscribed-to=Adds a new asset entry in an asset publisher you are subscribed to. (Automatic Copy)
 receive-a-notification-when-someone-adds-a-new-blog-entry-in-a-blog-you-are-subscribed-to=在您訂閱的部落格上增加新的部落格條目。
 receive-a-notification-when-someone-adds-a-new-bookmark-in-a-folder-you-are-subscribed-to=在您訂閱的資料夾中添加一個新的書籤。
 receive-a-notification-when-someone-adds-a-new-comment-to-comments-you-are-subscribed-to=在您訂閱的評論中添加評論。


### PR DESCRIPTION
I've added this new option in notifications in order o avoid customers perceive it as a bug.
Right now, it isnot possible to see the new added elements of asset publisher in the notifications portlet.

Most of portlets use thjis option, so it seem reasonable to have this web notification also in this portlet.

It is triggered as current emails (once a day by default) so the configuration is the same.

![Captura de pantalla 2023-04-24 a las 13 39 51](https://user-images.githubusercontent.com/2728470/233985870-93556d33-b1a1-4324-a6f2-a1037c0136aa.png)

![Captura de pantalla 2023-04-24 a las 13 40 31](https://user-images.githubusercontent.com/2728470/233985993-5aa76c85-512c-4c48-bcd4-e88f53b1bb21.png)

I've also add a link to browse to the page containing the asset publisher.

cc: @ealonso , @jkappler , @dacoulsalr

https://issues.liferay.com/browse/LPS-182526