### PR TITLE
[TS] LPS-182522 Web Contents are not creating new copies when importing them

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -965,6 +965,11 @@ public class JournalArticleStagedModelDataHandler
 				}
 			}
 			else {
+				if (Validator.isNull(newArticleId)) {
+					articleId = StringPool.BLANK;
+					autoArticleId = true;
+				}
+
 				JournalArticle existingArticle =
 					_journalArticleLocalService.fetchArticle(
 						portletDataContext.getScopeGroupId(), articleId,


### PR DESCRIPTION
Motivation
=======
Importing journalArticles with "Copy as new" strategy will not create new articles if an articleId match exists in the importing site.
[LPS-182522](https://issues.liferay.com/browse/LPS-182522)

Proposed Solution
========
Create the new articles with different articleIds in order to "branch off" from the original journalArticle

Steps to Verify
========
1. Go to Content & Data > Web Content
2. Create a Basic Web Content
3. Go to the home page
4. Add a Web Content Display widget to the page and select the created Basic Web Content for it
5. Export the Web Content Display widget as a .LAR file
6. Import the .LAR file to the Web Content Display widget
7. Under "UPDATE DATA" select "Copy as New"
8. Go to Content & Data > Web Content

**Expected behviour:** There are 2 Web Contents
**Actual behaviour:** There is only 1 Web Content

cc @vendeltoreki