### PR TITLE
LPS-182556 | Test Fix | Master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/segmentation/Segmentation.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/segmentation/Segmentation.path
@@ -157,7 +157,7 @@
 </tr>
 <tr>
 	<td>TRANSLATION_STATUS_TITLE</td>
-	<td>//ul[contains(@class, 'dropdown-menu')]/li[contains(@role, 'presentation')]/descendant::span[contains(text(), '${key_locale}')]/span</td>
+	<td>//div[contains(@class, 'dropdown-menu')]//li[contains(@role, 'presentation')]//span[contains(text(), '${key_locale}')]</td>
 	<td></td>
 </tr>
 </tbody>


### PR DESCRIPTION
# Element is not present at SegmentationCreateSegment#CheckEditableTranslatedInputTitle

Hi! :)
This pr is corresponding to this ticket: [LPS-182556](https://issues.liferay.com/browse/LPS-182556)

**Problem:**
The path was not being found on the page.

**Fix:**
Refactoring the path.