### PR TITLE
LPS-182721 Replace usages of old liferay-ui:logo-selector taglib

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/display_data.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/account_entry/display_data.jsp
@@ -27,61 +27,46 @@ String[] types = GetterUtil.getStringValues(request.getAttribute(AccountWebKeys.
 		<liferay-ui:message key="account-display-data" />
 	</h3>
 
-	<clay:row>
-		<clay:col
-			md="6"
-		>
-			<aui:input bean="<%= accountEntryDisplay %>" label="account-name" model="<%= AccountEntry.class %>" name="name" />
+	<liferay-frontend:logo-selector
+		currentLogoURL="<%= accountEntryDisplay.getLogoURL() %>"
+		defaultLogoURL="<%= accountEntryDisplay.getDefaultLogoURL() %>"
+		label='<%= LanguageUtil.get(request, "image") %>'
+	/>
 
-			<c:choose>
-				<c:when test="<%= accountEntryDisplay.getAccountEntryId() > 0 %>">
-					<aui:input disabled="<%= true %>" label="type" name="type" value="<%= LanguageUtil.get(request, accountEntryDisplay.getType()) %>" />
-				</c:when>
-				<c:otherwise>
-					<aui:select label="type" name="type">
+	<aui:input bean="<%= accountEntryDisplay %>" label="account-name" model="<%= AccountEntry.class %>" name="name" />
 
-						<%
-						for (String type : types) {
-						%>
+	<c:choose>
+		<c:when test="<%= accountEntryDisplay.getAccountEntryId() > 0 %>">
+			<aui:input disabled="<%= true %>" label="type" name="type" value="<%= LanguageUtil.get(request, accountEntryDisplay.getType()) %>" />
+		</c:when>
+		<c:otherwise>
+			<aui:select label="type" name="type">
 
-							<aui:option label="<%= LanguageUtil.get(request, type) %>" value="<%= type %>" />
+				<%
+				for (String type : types) {
+				%>
 
-						<%
-						}
-						%>
+					<aui:option label="<%= LanguageUtil.get(request, type) %>" value="<%= type %>" />
 
-					</aui:select>
-				</c:otherwise>
-			</c:choose>
+				<%
+				}
+				%>
 
-			<aui:input helpMessage="tax-id-help" label="tax-id" name="taxIdNumber" type="text" value="<%= accountEntryDisplay.getTaxIdNumber() %>">
-				<aui:validator name="maxLength"><%= ModelHintsUtil.getMaxLength(AccountEntry.class.getName(), "taxIdNumber") %></aui:validator>
-			</aui:input>
+			</aui:select>
+		</c:otherwise>
+	</c:choose>
 
-			<liferay-ui:error embed="<%= false %>" key="<%= DuplicateAccountEntryExternalReferenceCodeException.class.getName() %>" message="the-given-external-reference-code-belongs-to-another-account" />
+	<aui:input helpMessage="tax-id-help" label="tax-id" name="taxIdNumber" type="text" value="<%= accountEntryDisplay.getTaxIdNumber() %>">
+		<aui:validator name="maxLength"><%= ModelHintsUtil.getMaxLength(AccountEntry.class.getName(), "taxIdNumber") %></aui:validator>
+	</aui:input>
 
-			<aui:input bean="<%= accountEntryDisplay %>" label="external-reference-code" model="<%= AccountEntry.class %>" name="externalReferenceCode" />
+	<liferay-ui:error embed="<%= false %>" key="<%= DuplicateAccountEntryExternalReferenceCodeException.class.getName() %>" message="the-given-external-reference-code-belongs-to-another-account" />
 
-			<c:if test="<%= accountEntryDisplay.getAccountEntryId() > 0 %>">
-				<aui:input cssClass="disabled" label="account-id" name="accountEntryId" readonly="true" type="text" value="<%= String.valueOf(accountEntryDisplay.getAccountEntryId()) %>" />
-			</c:if>
-		</clay:col>
+	<aui:input bean="<%= accountEntryDisplay %>" label="external-reference-code" model="<%= AccountEntry.class %>" name="externalReferenceCode" />
 
-		<clay:col
-			md="5"
-		>
-			<div align="middle">
-				<label class="control-label"></label>
-
-				<liferay-ui:logo-selector
-					currentLogoURL="<%= accountEntryDisplay.getLogoURL() %>"
-					defaultLogo="<%= accountEntryDisplay.getLogoId() == 0 %>"
-					defaultLogoURL="<%= accountEntryDisplay.getDefaultLogoURL() %>"
-					tempImageFileName="<%= String.valueOf(accountEntryDisplay.getAccountEntryId()) %>"
-				/>
-			</div>
-		</clay:col>
-	</clay:row>
+	<c:if test="<%= accountEntryDisplay.getAccountEntryId() > 0 %>">
+		<aui:input cssClass="disabled" label="account-id" name="accountEntryId" readonly="true" type="text" value="<%= String.valueOf(accountEntryDisplay.getAccountEntryId()) %>" />
+	</c:if>
 
 	<aui:field-wrapper cssClass="form-group lfr-input-text-container">
 		<aui:input name="description" type="textarea" value="<%= accountEntryDisplay.getDescription() %>" />

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/add_account_user.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_entries_admin/add_account_user.jsp
@@ -69,72 +69,58 @@ renderResponse.setTitle(LanguageUtil.format(request, "add-new-user-to-x", accoun
 				<liferay-ui:message key="user-display-data" />
 			</h3>
 
-			<clay:row>
-				<clay:col
-					md="6"
-				>
-					<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeDuplicate.class %>" focusField="screenName" message="the-screen-name-you-requested-is-already-taken" />
-					<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeNull.class %>" focusField="screenName" message="the-screen-name-cannot-be-blank" />
-					<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeNumeric.class %>" focusField="screenName" message="the-screen-name-cannot-contain-only-numeric-values" />
-					<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeReserved.class %>" focusField="screenName" message="the-screen-name-you-requested-is-reserved" />
-					<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeReservedForAnonymous.class %>" focusField="screenName" message="the-screen-name-you-requested-is-reserved-for-the-anonymous-user" />
-					<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeUsedByGroup.class %>" focusField="screenName" message="the-screen-name-you-requested-is-already-taken-by-a-site" />
-					<liferay-ui:error exception="<%= UserScreenNameException.MustProduceValidFriendlyURL.class %>" focusField="screenName" message="the-screen-name-you-requested-must-produce-a-valid-friendly-url" />
+			<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeDuplicate.class %>" focusField="screenName" message="the-screen-name-you-requested-is-already-taken" />
+			<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeNull.class %>" focusField="screenName" message="the-screen-name-cannot-be-blank" />
+			<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeNumeric.class %>" focusField="screenName" message="the-screen-name-cannot-contain-only-numeric-values" />
+			<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeReserved.class %>" focusField="screenName" message="the-screen-name-you-requested-is-reserved" />
+			<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeReservedForAnonymous.class %>" focusField="screenName" message="the-screen-name-you-requested-is-reserved-for-the-anonymous-user" />
+			<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeUsedByGroup.class %>" focusField="screenName" message="the-screen-name-you-requested-is-already-taken-by-a-site" />
+			<liferay-ui:error exception="<%= UserScreenNameException.MustProduceValidFriendlyURL.class %>" focusField="screenName" message="the-screen-name-you-requested-must-produce-a-valid-friendly-url" />
 
-					<liferay-ui:error exception="<%= UserScreenNameException.MustValidate.class %>" focusField="screenName">
+			<liferay-ui:error exception="<%= UserScreenNameException.MustValidate.class %>" focusField="screenName">
 
-						<%
-						UserScreenNameException.MustValidate usne = (UserScreenNameException.MustValidate)errorException;
-						%>
+				<%
+				UserScreenNameException.MustValidate usne = (UserScreenNameException.MustValidate)errorException;
+				%>
 
-						<liferay-ui:message key="<%= usne.screenNameValidator.getDescription(locale) %>" />
-					</liferay-ui:error>
+				<liferay-ui:message key="<%= usne.screenNameValidator.getDescription(locale) %>" />
+			</liferay-ui:error>
 
-					<aui:model-context model="<%= User.class %>" />
+			<aui:model-context model="<%= User.class %>" />
 
-					<aui:input name="screenName">
+			<liferay-frontend:logo-selector
+				currentLogoURL='<%= themeDisplay.getPathImage() + "/user_portrait?img_id=0" %>'
+				defaultLogoURL='<%= themeDisplay.getPathImage() + "/user_portrait?img_id=0" %>'
+				label='<%= LanguageUtil.get(request, "image") %>'
+			/>
 
-						<%
-						ScreenNameValidator screenNameValidator = ScreenNameValidatorFactory.getInstance();
-						%>
+			<aui:input label="job-title" maxlength='<%= ModelHintsUtil.getMaxLength(Contact.class.getName(), "jobTitle") %>' name="jobTitle" type="text" />
 
-						<c:if test="<%= Validator.isNotNull(screenNameValidator.getAUIValidatorJS()) %>">
-							<aui:validator errorMessage="<%= screenNameValidator.getDescription(locale) %>" name="custom">
-								<%= screenNameValidator.getAUIValidatorJS() %>
-							</aui:validator>
-						</c:if>
-					</aui:input>
+			<aui:input name="screenName">
 
-					<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeDuplicate.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-already-taken" />
-					<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeNull.class %>" focusField="emailAddress" message="please-enter-an-email-address" />
-					<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBePOP3User.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-reserved" />
-					<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeReserved.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-reserved" />
-					<liferay-ui:error exception="<%= UserEmailAddressException.MustNotUseCompanyMx.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-not-valid-because-its-domain-is-reserved" />
-					<liferay-ui:error exception="<%= UserEmailAddressException.MustValidate.class %>" focusField="emailAddress" message="please-enter-a-valid-email-address" />
+				<%
+				ScreenNameValidator screenNameValidator = ScreenNameValidatorFactory.getInstance();
+				%>
 
-					<aui:input label="email-address" name="emailAddress" required="<%= true %>" type="text">
-						<aui:validator name="email" />
-					</aui:input>
+				<c:if test="<%= Validator.isNotNull(screenNameValidator.getAUIValidatorJS()) %>">
+					<aui:validator errorMessage="<%= screenNameValidator.getDescription(locale) %>" name="custom">
+						<%= screenNameValidator.getAUIValidatorJS() %>
+					</aui:validator>
+				</c:if>
+			</aui:input>
 
-					<liferay-ui:user-name-fields />
-				</clay:col>
+			<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeDuplicate.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-already-taken" />
+			<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeNull.class %>" focusField="emailAddress" message="please-enter-an-email-address" />
+			<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBePOP3User.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-reserved" />
+			<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeReserved.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-reserved" />
+			<liferay-ui:error exception="<%= UserEmailAddressException.MustNotUseCompanyMx.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-not-valid-because-its-domain-is-reserved" />
+			<liferay-ui:error exception="<%= UserEmailAddressException.MustValidate.class %>" focusField="emailAddress" message="please-enter-a-valid-email-address" />
 
-				<clay:col
-					md="6"
-				>
-					<div class="text-center">
-						<liferay-ui:logo-selector
-							currentLogoURL='<%= themeDisplay.getPathImage() + "/user_portrait?img_id=0" %>'
-							defaultLogo="<%= true %>"
-							defaultLogoURL='<%= themeDisplay.getPathImage() + "/user_portrait?img_id=0" %>'
-							tempImageFileName="0"
-						/>
-					</div>
+			<aui:input label="email-address" name="emailAddress" required="<%= true %>" type="text">
+				<aui:validator name="email" />
+			</aui:input>
 
-					<aui:input label="job-title" maxlength='<%= ModelHintsUtil.getMaxLength(Contact.class.getName(), "jobTitle") %>' name="jobTitle" type="text">
-					</aui:input>
-				</clay:col>
-			</clay:row>
+			<liferay-ui:user-name-fields />
 		</clay:sheet-section>
 	</liferay-frontend:edit-form-body>
 

--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_user_registration/create_account_user.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_user_registration/create_account_user.jsp
@@ -66,73 +66,60 @@ portletDisplay.setURLBack(backURL);
 					<liferay-ui:message key="user-display-data" />
 				</h3>
 
-				<clay:row>
-					<clay:col
-						md="6"
-					>
-						<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeDuplicate.class %>" focusField="screenName" message="the-screen-name-you-requested-is-already-taken" />
-						<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeNull.class %>" focusField="screenName" message="the-screen-name-cannot-be-blank" />
-						<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeNumeric.class %>" focusField="screenName" message="the-screen-name-cannot-contain-only-numeric-values" />
-						<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeReserved.class %>" focusField="screenName" message="the-screen-name-you-requested-is-reserved" />
-						<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeReservedForAnonymous.class %>" focusField="screenName" message="the-screen-name-you-requested-is-reserved-for-the-anonymous-user" />
-						<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeUsedByGroup.class %>" focusField="screenName" message="the-screen-name-you-requested-is-already-taken-by-a-site" />
-						<liferay-ui:error exception="<%= UserScreenNameException.MustProduceValidFriendlyURL.class %>" focusField="screenName" message="the-screen-name-you-requested-must-produce-a-valid-friendly-url" />
+				<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeDuplicate.class %>" focusField="screenName" message="the-screen-name-you-requested-is-already-taken" />
+				<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeNull.class %>" focusField="screenName" message="the-screen-name-cannot-be-blank" />
+				<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeNumeric.class %>" focusField="screenName" message="the-screen-name-cannot-contain-only-numeric-values" />
+				<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeReserved.class %>" focusField="screenName" message="the-screen-name-you-requested-is-reserved" />
+				<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeReservedForAnonymous.class %>" focusField="screenName" message="the-screen-name-you-requested-is-reserved-for-the-anonymous-user" />
+				<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeUsedByGroup.class %>" focusField="screenName" message="the-screen-name-you-requested-is-already-taken-by-a-site" />
+				<liferay-ui:error exception="<%= UserScreenNameException.MustProduceValidFriendlyURL.class %>" focusField="screenName" message="the-screen-name-you-requested-must-produce-a-valid-friendly-url" />
 
-						<liferay-ui:error exception="<%= UserScreenNameException.MustValidate.class %>" focusField="screenName">
+				<liferay-ui:error exception="<%= UserScreenNameException.MustValidate.class %>" focusField="screenName">
 
-							<%
-							UserScreenNameException.MustValidate usne = (UserScreenNameException.MustValidate)errorException;
-							%>
+					<%
+					UserScreenNameException.MustValidate usne = (UserScreenNameException.MustValidate)errorException;
+					%>
 
-							<liferay-ui:message key="<%= usne.screenNameValidator.getDescription(locale) %>" />
-						</liferay-ui:error>
+					<liferay-ui:message key="<%= usne.screenNameValidator.getDescription(locale) %>" />
+				</liferay-ui:error>
 
-						<aui:model-context model="<%= User.class %>" />
+				<aui:model-context model="<%= User.class %>" />
 
-						<aui:input name="screenName">
+				<liferay-frontend:logo-selector
+					currentLogoURL='<%= themeDisplay.getPathImage() + "/user_portrait?img_id=0" %>'
+					defaultLogoURL='<%= themeDisplay.getPathImage() + "/user_portrait?img_id=0" %>'
+					label='<%= LanguageUtil.get(request, "image") %>'
+				/>
 
-							<%
-							ScreenNameValidator screenNameValidator = ScreenNameValidatorFactory.getInstance();
-							%>
+				<aui:input name="screenName">
 
-							<c:if test="<%= Validator.isNotNull(screenNameValidator.getAUIValidatorJS()) %>">
-								<aui:validator errorMessage="<%= screenNameValidator.getDescription(locale) %>" name="custom">
-									<%= screenNameValidator.getAUIValidatorJS() %>
-								</aui:validator>
-							</c:if>
-						</aui:input>
+					<%
+					ScreenNameValidator screenNameValidator = ScreenNameValidatorFactory.getInstance();
+					%>
 
-						<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeDuplicate.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-already-taken" />
-						<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeNull.class %>" focusField="emailAddress" message="please-enter-an-email-address" />
-						<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBePOP3User.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-reserved" />
-						<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeReserved.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-reserved" />
-						<liferay-ui:error exception="<%= UserEmailAddressException.MustNotUseCompanyMx.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-not-valid-because-its-domain-is-reserved" />
-						<liferay-ui:error exception="<%= UserEmailAddressException.MustValidate.class %>" focusField="emailAddress" message="please-enter-a-valid-email-address" />
+					<c:if test="<%= Validator.isNotNull(screenNameValidator.getAUIValidatorJS()) %>">
+						<aui:validator errorMessage="<%= screenNameValidator.getDescription(locale) %>" name="custom">
+							<%= screenNameValidator.getAUIValidatorJS() %>
+						</aui:validator>
+					</c:if>
+				</aui:input>
 
-						<div class="form-group">
-							<label>
-								<liferay-ui:message key="email-address" />
-							</label>
+				<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeDuplicate.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-already-taken" />
+				<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeNull.class %>" focusField="emailAddress" message="please-enter-an-email-address" />
+				<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBePOP3User.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-reserved" />
+				<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeReserved.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-reserved" />
+				<liferay-ui:error exception="<%= UserEmailAddressException.MustNotUseCompanyMx.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-not-valid-because-its-domain-is-reserved" />
+				<liferay-ui:error exception="<%= UserEmailAddressException.MustValidate.class %>" focusField="emailAddress" message="please-enter-a-valid-email-address" />
 
-							<div class="form-control-plaintext">
-								<%= invitedAccountUserDisplayContext.getEmailAddress() %>
-							</div>
-						</div>
-					</clay:col>
+				<div class="form-group">
+					<label>
+						<liferay-ui:message key="email-address" />
+					</label>
 
-					<clay:col
-						md="6"
-					>
-						<div class="text-center">
-							<liferay-ui:logo-selector
-								currentLogoURL='<%= themeDisplay.getPathImage() + "/user_portrait?img_id=0" %>'
-								defaultLogo="<%= true %>"
-								defaultLogoURL='<%= themeDisplay.getPathImage() + "/user_portrait?img_id=0" %>'
-								tempImageFileName="0"
-							/>
-						</div>
-					</clay:col>
-				</clay:row>
+					<div class="form-control-plaintext">
+						<%= invitedAccountUserDisplayContext.getEmailAddress() %>
+					</div>
+				</div>
 			</div>
 
 			<div class="form-group">

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/css/logo_selector.scss
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/css/logo_selector.scss
@@ -1,0 +1,3 @@
+.logo-selector-img {
+	max-width: 200px;
+}

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/logo_selector/LogoSelector.js
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/logo_selector/LogoSelector.js
@@ -113,7 +113,7 @@ export default function LogoSelector({
 			{logoURL ? (
 				<img
 					alt={sub(Liferay.Language.get('current-x'), label)}
-					className="avatar img-fluid mb-3 mw-100"
+					className="logo-selector-img mb-3"
 					src={logoURL}
 				/>
 			) : (

--- a/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/logo_selector/page.jsp
+++ b/modules/apps/frontend-taglib/frontend-taglib/src/main/resources/META-INF/resources/logo_selector/page.jsp
@@ -24,6 +24,10 @@ String logoURL = (String)request.getAttribute("liferay-frontend:logo-selector:lo
 String selectLogoURL = (String)request.getAttribute("liferay-frontend:logo-selector:selectLogoURL");
 %>
 
+<liferay-util:html-top>
+	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/logo_selector.css") %>" rel="stylesheet" type="text/css" />
+</liferay-util:html-top>
+
 <div>
 	<react:component
 		module="logo_selector/LogoSelector"

--- a/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/monitoring/monitoring-web/src/main/resources/META-INF/resources/css/main.scss
@@ -95,12 +95,6 @@
 	.form-navigator {
 		.user-info,
 		.organization-info {
-			.user-logo,
-			.organization-logo {
-				margin-right: 5px;
-				width: 35px;
-			}
-
 			.user-name {
 				word-wrap: break-word;
 			}

--- a/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
+++ b/modules/apps/oauth2-provider/oauth2-provider-web/src/main/resources/META-INF/resources/admin/edit_application_credentials.jsp
@@ -125,8 +125,10 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 						</clay:col>
 
 						<clay:col
+							cssClass="pt-4"
 							lg="3"
 						>
+
 							<h3 class="sheet-subtitle"><liferay-ui:message key="icon" /></h3>
 
 							<%
@@ -135,11 +137,10 @@ String clientSecret = (oAuth2Application == null) ? "" : oAuth2Application.getCl
 
 							<c:choose>
 								<c:when test="<%= oAuth2AdminPortletDisplayContext.hasUpdatePermission(oAuth2Application) %>">
-									<liferay-ui:logo-selector
+									<liferay-frontend:logo-selector
 										currentLogoURL="<%= thumbnailURL %>"
-										defaultLogo="<%= oAuth2Application.getIconFileEntryId() == 0 %>"
 										defaultLogoURL="<%= oAuth2AdminPortletDisplayContext.getDefaultIconURL() %>"
-										tempImageFileName="<%= String.valueOf(oAuth2Application.getClientId()) %>"
+										label='<%= LanguageUtil.get(request, "icon") %>'
 									/>
 								</c:when>
 								<c:otherwise>

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/look_and_feel.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/look_and_feel.jsp
@@ -23,12 +23,9 @@
 <aui:fieldset>
 	<aui:input label="allow-site-administrators-to-use-their-own-logo" name='<%= "settings--" + PropsKeys.COMPANY_SECURITY_SITE_LOGO + "--" %>' type="checkbox" value="<%= company.isSiteLogo() %>" />
 
-	<liferay-ui:logo-selector
+	<liferay-frontend:logo-selector
 		currentLogoURL='<%= themeDisplay.getPathImage() + "/company_logo?img_id=" + company.getLogoId() + "&t=" + WebServerServletTokenUtil.getToken(company.getLogoId()) %>'
-		defaultLogo="<%= company.getLogoId() == 0 %>"
 		defaultLogoURL='<%= themeDisplay.getPathImage() + "/company_logo?img_id=0" %>'
-		logoDisplaySelector=".company-logo"
-		tempImageFileName="<%= String.valueOf(themeDisplay.getCompanyId()) %>"
 	/>
 </aui:fieldset>
 

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/look_and_feel.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/look_and_feel.jsp
@@ -24,7 +24,7 @@
 	<aui:input label="allow-site-administrators-to-use-their-own-logo" name='<%= "settings--" + PropsKeys.COMPANY_SECURITY_SITE_LOGO + "--" %>' type="checkbox" value="<%= company.isSiteLogo() %>" />
 
 	<liferay-frontend:logo-selector
-		currentLogoURL='<%= themeDisplay.getPathImage() + "/company_logo?img_id=" + company.getLogoId() + "&t=" + WebServerServletTokenUtil.getToken(company.getLogoId()) %>'
+		currentLogoURL='<%= themeDisplay.getPathImage() + "/company_logo?img_id=" + company.getLogoId() %>'
 		defaultLogoURL='<%= themeDisplay.getPathImage() + "/company_logo?img_id=0" %>'
 	/>
 </aui:fieldset>

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/users_admin/css/main.scss
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/users_admin/css/main.scss
@@ -95,12 +95,6 @@
 	.form-navigator {
 		.user-info,
 		.organization-info {
-			.user-logo,
-			.organization-logo {
-				margin-right: 5px;
-				width: 35px;
-			}
-
 			.user-name {
 				word-wrap: break-word;
 			}

--- a/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/portal-workflow/portal-workflow-task-web/src/main/resources/META-INF/resources/css/main.scss
@@ -95,12 +95,6 @@
 	.form-navigator {
 		.user-info,
 		.organization-info {
-			.user-logo,
-			.organization-logo {
-				margin-right: 5px;
-				width: 35px;
-			}
-
 			.user-name {
 				word-wrap: break-word;
 			}

--- a/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/css/main.scss
@@ -100,12 +100,6 @@
 	.form-navigator {
 		.user-info,
 		.organization-info {
-			.user-logo,
-			.organization-logo {
-				margin-right: 5px;
-				width: 35px;
-			}
-
 			.user-name {
 				word-wrap: break-word;
 			}

--- a/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/user-groups-admin/user-groups-admin-web/src/main/resources/META-INF/resources/css/main.scss
@@ -95,12 +95,6 @@
 	.form-navigator {
 		.user-info,
 		.organization-info {
-			.user-logo,
-			.organization-logo {
-				margin-right: 5px;
-				width: 35px;
-			}
-
 			.user-name {
 				word-wrap: break-word;
 			}

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/css/main.scss
@@ -100,12 +100,6 @@
 	.form-navigator {
 		.user-info,
 		.organization-info {
-			.user-logo,
-			.organization-logo {
-				margin-right: 5px;
-				width: 35px;
-			}
-
 			.user-name {
 				word-wrap: break-word;
 			}

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/details.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/organization/details.jsp
@@ -37,93 +37,64 @@ if (organization != null) {
 
 <aui:model-context bean="<%= organization %>" model="<%= Organization.class %>" />
 
-<clay:row>
-	<clay:col
-		md="7"
-	>
-		<liferay-ui:error exception="<%= DuplicateOrganizationException.class %>" message="the-organization-name-is-already-taken" />
+<liferay-ui:error exception="<%= DuplicateOrganizationException.class %>" message="the-organization-name-is-already-taken" />
 
-		<liferay-ui:error exception="<%= OrganizationNameException.class %>">
-			<liferay-ui:message arguments="<%= new String[] {OrganizationConstants.NAME_LABEL, OrganizationConstants.NAME_GENERAL_RESTRICTIONS, OrganizationConstants.NAME_RESERVED_WORDS} %>" key="the-x-cannot-be-x-or-a-reserved-word-such-as-x" />
-		</liferay-ui:error>
+<liferay-ui:error exception="<%= OrganizationNameException.class %>">
+	<liferay-ui:message arguments="<%= new String[] {OrganizationConstants.NAME_LABEL, OrganizationConstants.NAME_GENERAL_RESTRICTIONS, OrganizationConstants.NAME_RESERVED_WORDS} %>" key="the-x-cannot-be-x-or-a-reserved-word-such-as-x" />
+</liferay-ui:error>
 
-		<aui:input name="name" />
+<liferay-frontend:logo-selector
+	currentLogoURL='<%= (organization != null) ? organization.getLogoURL() : themeDisplay.getPathImage() + "/organization_logo?img_id=0" %>'
+	defaultLogoURL='<%= themeDisplay.getPathImage() + "/organization_logo?img_id=0" %>'
+	label='<%= LanguageUtil.get(request, "image") %>'
+/>
 
-		<c:choose>
-			<c:when test="<%= PropsValues.FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS %>">
-				<liferay-ui:error key="<%= NoSuchListTypeException.class.getName() + Organization.class.getName() + ListTypeConstants.ORGANIZATION_STATUS %>" message="please-select-a-type" />
+<aui:input name="name" />
 
-				<aui:select label="status" listType="<%= ListTypeConstants.ORGANIZATION_STATUS %>" listTypeFieldName="statusListTypeId" name="statusListTypeId" showEmptyOption="<%= true %>" />
-			</c:when>
-			<c:otherwise>
-				<aui:input name="statusId" type="hidden" value="<%= (organization != null) ? organization.getStatusListTypeId() : ListTypeConstants.ORGANIZATION_STATUS_DEFAULT %>" />
-			</c:otherwise>
-		</c:choose>
+<c:choose>
+	<c:when test="<%= PropsValues.FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_ORGANIZATION_STATUS %>">
+		<liferay-ui:error key="<%= NoSuchListTypeException.class.getName() + Organization.class.getName() + ListTypeConstants.ORGANIZATION_STATUS %>" message="please-select-a-type" />
 
-		<c:choose>
-			<c:when test="<%= (organization == null) && (organizationsTypes.length > 1) %>">
-				<aui:select name="type">
+		<aui:select label="status" listType="<%= ListTypeConstants.ORGANIZATION_STATUS %>" listTypeFieldName="statusListTypeId" name="statusListTypeId" showEmptyOption="<%= true %>" />
+	</c:when>
+	<c:otherwise>
+		<aui:input name="statusId" type="hidden" value="<%= (organization != null) ? organization.getStatusListTypeId() : ListTypeConstants.ORGANIZATION_STATUS_DEFAULT %>" />
+	</c:otherwise>
+</c:choose>
 
-					<%
-					for (String curType : organizationsTypes) {
-					%>
+<c:choose>
+	<c:when test="<%= (organization == null) && (organizationsTypes.length > 1) %>">
+		<aui:select name="type">
 
-						<aui:option label="<%= curType %>" selected="<%= type.equals(curType) %>" />
+			<%
+			for (String curType : organizationsTypes) {
+			%>
 
-					<%
-					}
-					%>
+				<aui:option label="<%= curType %>" selected="<%= type.equals(curType) %>" />
 
-				</aui:select>
-			</c:when>
-			<c:when test="<%= organization == null %>">
-				<aui:input name="type" type="hidden" value="<%= organizationsTypes[0] %>" />
-			</c:when>
-			<c:otherwise>
-				<aui:input name="typeLabel" type="resource" value="<%= LanguageUtil.get(request, organization.getType()) %>" />
+			<%
+			}
+			%>
 
-				<aui:input name="type" type="hidden" value="<%= organization.getType() %>" />
-			</c:otherwise>
-		</c:choose>
+		</aui:select>
+	</c:when>
+	<c:when test="<%= organization == null %>">
+		<aui:input name="type" type="hidden" value="<%= organizationsTypes[0] %>" />
+	</c:when>
+	<c:otherwise>
+		<aui:input name="typeLabel" type="resource" value="<%= LanguageUtil.get(request, organization.getType()) %>" />
 
-		<liferay-ui:error exception="<%= NoSuchCountryException.class %>" message="please-select-a-country" />
+		<aui:input name="type" type="hidden" value="<%= organization.getType() %>" />
+	</c:otherwise>
+</c:choose>
 
-		<div class="<%= OrganizationLocalServiceUtil.isCountryEnabled(type) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />countryDiv">
-			<aui:select label="country" name="countryId" />
+<liferay-ui:error exception="<%= NoSuchCountryException.class %>" message="please-select-a-country" />
 
-			<aui:select label="region" name="regionId" />
-		</div>
-	</clay:col>
+<div class="<%= OrganizationLocalServiceUtil.isCountryEnabled(type) ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />countryDiv">
+	<aui:select label="country" name="countryId" />
 
-	<clay:col
-		md="5"
-	>
-		<div align="middle">
-			<c:choose>
-				<c:when test="<%= organization != null %>">
-					<label class="control-label"></label>
-
-					<liferay-ui:logo-selector
-						currentLogoURL="<%= organization.getLogoURL() %>"
-						defaultLogo="<%= organization.getLogoId() == 0 %>"
-						defaultLogoURL='<%= themeDisplay.getPathImage() + "/organization_logo?img_id=0" %>'
-						logoDisplaySelector=".organization-logo"
-						tempImageFileName="<%= String.valueOf(groupId) %>"
-					/>
-				</c:when>
-				<c:otherwise>
-					<liferay-ui:logo-selector
-						currentLogoURL='<%= themeDisplay.getPathImage() + "/organization_logo?img_id=0" %>'
-						defaultLogo="<%= true %>"
-						defaultLogoURL='<%= themeDisplay.getPathImage() + "/organization_logo?img_id=0" %>'
-						logoDisplaySelector=".organization-logo"
-						tempImageFileName="0"
-					/>
-				</c:otherwise>
-			</c:choose>
-		</div>
-	</clay:col>
-</clay:row>
+	<aui:select label="region" name="regionId" />
+</div>
 
 <liferay-frontend:component
 	componentId="CountryRegionDynamicSelect"

--- a/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_display_data.jsp
+++ b/modules/apps/users-admin/users-admin-web/src/main/resources/META-INF/resources/user/user_display_data.jsp
@@ -22,166 +22,148 @@ User selUser = (User)request.getAttribute(UsersAdminWebKeys.SELECTED_USER);
 
 <aui:model-context bean="<%= selUser %>" model="<%= User.class %>" />
 
-<clay:row>
-	<clay:col
-		md="6"
-	>
-		<liferay-ui:success key="verificationEmailSent" message="your-email-verification-code-has-been-sent-and-the-new-email-address-will-be-applied-to-your-account-once-it-has-been-verified" />
+<liferay-ui:success key="verificationEmailSent" message="your-email-verification-code-has-been-sent-and-the-new-email-address-will-be-applied-to-your-account-once-it-has-been-verified" />
 
-		<liferay-ui:error exception="<%= CompanyMaxUsersException.class %>" message="unable-to-create-user-account-because-the-maximum-number-of-users-has-been-reached" />
+<liferay-ui:error exception="<%= CompanyMaxUsersException.class %>" message="unable-to-create-user-account-because-the-maximum-number-of-users-has-been-reached" />
 
-		<liferay-ui:error exception="<%= GroupFriendlyURLException.class %>" focusField="screenName">
+<liferay-ui:error exception="<%= GroupFriendlyURLException.class %>" focusField="screenName">
 
-			<%
-			GroupFriendlyURLException gfurle = (GroupFriendlyURLException)errorException;
-			%>
+	<%
+	GroupFriendlyURLException gfurle = (GroupFriendlyURLException)errorException;
+	%>
 
-			<c:if test="<%= gfurle.getType() == GroupFriendlyURLException.DUPLICATE %>">
-				<liferay-ui:message key="the-screen-name-you-requested-is-associated-with-an-existing-friendly-url" />
-			</c:if>
-		</liferay-ui:error>
+	<c:if test="<%= gfurle.getType() == GroupFriendlyURLException.DUPLICATE %>">
+		<liferay-ui:message key="the-screen-name-you-requested-is-associated-with-an-existing-friendly-url" />
+	</c:if>
+</liferay-ui:error>
 
-		<liferay-ui:error exception="<%= UserFieldException.class %>">
+<liferay-ui:error exception="<%= UserFieldException.class %>">
 
-			<%
-			UserFieldException ufe = (UserFieldException)errorException;
+	<%
+	UserFieldException ufe = (UserFieldException)errorException;
 
-			List<String> fields = ufe.getFields();
+	List<String> fields = ufe.getFields();
 
-			StringBundler sb = new StringBundler((2 * fields.size()) - 1);
+	StringBundler sb = new StringBundler((2 * fields.size()) - 1);
 
-			for (int i = 0; i < fields.size(); i++) {
-				String field = fields.get(i);
+	for (int i = 0; i < fields.size(); i++) {
+		String field = fields.get(i);
 
-				sb.append(LanguageUtil.get(request, TextFormatter.format(field, TextFormatter.K)));
+		sb.append(LanguageUtil.get(request, TextFormatter.format(field, TextFormatter.K)));
 
-				if ((i + 1) < fields.size()) {
-					sb.append(StringPool.COMMA_AND_SPACE);
-				}
-			}
-			%>
+		if ((i + 1) < fields.size()) {
+			sb.append(StringPool.COMMA_AND_SPACE);
+		}
+	}
+	%>
 
-			<liferay-ui:message arguments="<%= sb.toString() %>" key="your-portal-administrator-has-disabled-the-ability-to-modify-the-following-fields" translateArguments="<%= false %>" />
-		</liferay-ui:error>
+	<liferay-ui:message arguments="<%= sb.toString() %>" key="your-portal-administrator-has-disabled-the-ability-to-modify-the-following-fields" translateArguments="<%= false %>" />
+</liferay-ui:error>
 
-		<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeDuplicate.class %>" focusField="screenName" message="the-screen-name-you-requested-is-already-taken" />
-		<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeNull.class %>" focusField="screenName" message="the-screen-name-cannot-be-blank" />
-		<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeNumeric.class %>" focusField="screenName" message="the-screen-name-cannot-contain-only-numeric-values" />
-		<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeReserved.class %>" focusField="screenName" message="the-screen-name-you-requested-is-reserved" />
-		<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeReservedForAnonymous.class %>" focusField="screenName" message="the-screen-name-you-requested-is-reserved-for-the-anonymous-user" />
-		<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeUsedByGroup.class %>" focusField="screenName" message="the-screen-name-you-requested-is-already-taken-by-a-site" />
-		<liferay-ui:error exception="<%= UserScreenNameException.MustProduceValidFriendlyURL.class %>" focusField="screenName" message="the-screen-name-you-requested-must-produce-a-valid-friendly-url" />
+<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeDuplicate.class %>" focusField="screenName" message="the-screen-name-you-requested-is-already-taken" />
+<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeNull.class %>" focusField="screenName" message="the-screen-name-cannot-be-blank" />
+<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeNumeric.class %>" focusField="screenName" message="the-screen-name-cannot-contain-only-numeric-values" />
+<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeReserved.class %>" focusField="screenName" message="the-screen-name-you-requested-is-reserved" />
+<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeReservedForAnonymous.class %>" focusField="screenName" message="the-screen-name-you-requested-is-reserved-for-the-anonymous-user" />
+<liferay-ui:error exception="<%= UserScreenNameException.MustNotBeUsedByGroup.class %>" focusField="screenName" message="the-screen-name-you-requested-is-already-taken-by-a-site" />
+<liferay-ui:error exception="<%= UserScreenNameException.MustProduceValidFriendlyURL.class %>" focusField="screenName" message="the-screen-name-you-requested-must-produce-a-valid-friendly-url" />
 
-		<liferay-ui:error exception="<%= UserScreenNameException.MustValidate.class %>" focusField="screenName">
+<liferay-ui:error exception="<%= UserScreenNameException.MustValidate.class %>" focusField="screenName">
 
-			<%
-			UserScreenNameException.MustValidate usne = (UserScreenNameException.MustValidate)errorException;
-			%>
+	<%
+	UserScreenNameException.MustValidate usne = (UserScreenNameException.MustValidate)errorException;
+	%>
 
-			<liferay-ui:message key="<%= usne.screenNameValidator.getDescription(locale) %>" />
-		</liferay-ui:error>
+	<liferay-ui:message key="<%= usne.screenNameValidator.getDescription(locale) %>" />
+</liferay-ui:error>
 
-		<c:if test="<%= !PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_SCREEN_NAME_ALWAYS_AUTOGENERATE) || (selUser != null) %>">
-			<c:choose>
-				<c:when test='<%= PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_SCREEN_NAME_ALWAYS_AUTOGENERATE) || !UsersAdminUtil.hasUpdateFieldPermission(permissionChecker, user, selUser, "screenName") || ((selUser != null) && (selUser.getType() == UserConstants.TYPE_DEFAULT_SERVICE_ACCOUNT)) %>'>
-					<aui:input disabled="<%= true %>" name="screenName" />
-				</c:when>
-				<c:otherwise>
-					<aui:input name="screenName">
-
-						<%
-						ScreenNameValidator screenNameValidator = ScreenNameValidatorFactory.getInstance();
-						%>
-
-						<c:if test="<%= Validator.isNotNull(screenNameValidator.getAUIValidatorJS()) %>">
-							<aui:validator errorMessage="<%= screenNameValidator.getDescription(locale) %>" name="custom">
-								<%= screenNameValidator.getAUIValidatorJS() %>
-							</aui:validator>
-						</c:if>
-					</aui:input>
-				</c:otherwise>
-			</c:choose>
-		</c:if>
-
-		<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeDuplicate.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-already-taken" />
-		<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeNull.class %>" focusField="emailAddress" message="please-enter-an-email-address" />
-		<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBePOP3User.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-reserved" />
-		<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeReserved.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-reserved" />
-		<liferay-ui:error exception="<%= UserEmailAddressException.MustNotUseCompanyMx.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-not-valid-because-its-domain-is-reserved" />
-		<liferay-ui:error exception="<%= UserEmailAddressException.MustValidate.class %>" focusField="emailAddress" message="please-enter-a-valid-email-address" />
-
+<c:choose>
+	<c:when test="<%= selUser != null %>">
 		<c:choose>
-			<c:when test='<%= !UsersAdminUtil.hasUpdateFieldPermission(permissionChecker, user, selUser, "emailAddress") %>'>
-				<aui:input disabled="<%= true %>" name="emailAddress" />
+			<c:when test='<%= UsersAdminUtil.hasUpdateFieldPermission(permissionChecker, user, selUser, "portrait") %>'>
+				<liferay-frontend:logo-selector
+					aspectRatio="<%= 1 %>"
+					currentLogoURL="<%= selUser.getPortraitURL(themeDisplay) %>"
+					defaultLogoURL="<%= UserConstants.getPortraitURL(themeDisplay.getPathImage(), selUser.isMale(), 0, null) %>"
+					label='<%= LanguageUtil.get(request, "image") %>'
+					preserveRatio="<%= true %>"
+				/>
 			</c:when>
 			<c:otherwise>
-
-				<%
-				User displayEmailAddressUser = null;
-
-				if (selUser != null) {
-					displayEmailAddressUser = (User)selUser.clone();
-
-					displayEmailAddressUser.setEmailAddress(displayEmailAddressUser.getDisplayEmailAddress());
-				}
-				%>
-
-				<aui:input bean="<%= displayEmailAddressUser %>" model="<%= User.class %>" name="emailAddress">
-					<c:if test="<%= PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_EMAIL_ADDRESS_REQUIRED) %>">
-						<aui:validator name="required" />
-					</c:if>
-				</aui:input>
+				<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="portrait" />" src="<%= selUser.getPortraitURL(themeDisplay) %>" />
 			</c:otherwise>
 		</c:choose>
+	</c:when>
+	<c:otherwise>
+		<liferay-frontend:logo-selector
+			aspectRatio="<%= 1 %>"
+			currentLogoURL='<%= themeDisplay.getPathImage() + "/user_portrait?img_id=0" %>'
+			defaultLogoURL='<%= themeDisplay.getPathImage() + "/user_portrait?img_id=0" %>'
+			label='<%= LanguageUtil.get(request, "image") %>'
+			preserveRatio="<%= true %>"
+		/>
+	</c:otherwise>
+</c:choose>
 
-		<c:if test="<%= selUser != null %>">
-			<liferay-ui:error exception="<%= UserIdException.MustNotBeNull.class %>" message="please-enter-a-user-id" />
-			<liferay-ui:error exception="<%= UserIdException.MustNotBeReserved.class %>" message="the-user-id-you-requested-is-reserved" />
+<c:if test="<%= !PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_SCREEN_NAME_ALWAYS_AUTOGENERATE) || (selUser != null) %>">
+	<c:choose>
+		<c:when test='<%= PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_SCREEN_NAME_ALWAYS_AUTOGENERATE) || !UsersAdminUtil.hasUpdateFieldPermission(permissionChecker, user, selUser, "screenName") || ((selUser != null) && (selUser.getType() == UserConstants.TYPE_DEFAULT_SERVICE_ACCOUNT)) %>'>
+			<aui:input disabled="<%= true %>" name="screenName" />
+		</c:when>
+		<c:otherwise>
+			<aui:input name="screenName">
 
-			<aui:input cssClass="disabled" name="userId" readonly="true" type="text" value="<%= String.valueOf(selUser.getUserId()) %>" />
-		</c:if>
-	</clay:col>
+				<%
+				ScreenNameValidator screenNameValidator = ScreenNameValidatorFactory.getInstance();
+				%>
 
-	<clay:col
-		md="5"
-	>
-		<div align="middle">
-			<c:choose>
-				<c:when test="<%= selUser != null %>">
-					<c:choose>
-						<c:when test='<%= UsersAdminUtil.hasUpdateFieldPermission(permissionChecker, user, selUser, "portrait") %>'>
-							<label class="control-label"></label>
+				<c:if test="<%= Validator.isNotNull(screenNameValidator.getAUIValidatorJS()) %>">
+					<aui:validator errorMessage="<%= screenNameValidator.getDescription(locale) %>" name="custom">
+						<%= screenNameValidator.getAUIValidatorJS() %>
+					</aui:validator>
+				</c:if>
+			</aui:input>
+		</c:otherwise>
+	</c:choose>
+</c:if>
 
-							<liferay-ui:logo-selector
-								aspectRatio="<%= 1 %>"
-								currentLogoURL="<%= selUser.getPortraitURL(themeDisplay) %>"
-								defaultLogo="<%= selUser.getPortraitId() == 0 %>"
-								defaultLogoURL="<%= UserConstants.getPortraitURL(themeDisplay.getPathImage(), selUser.isMale(), 0, null) %>"
-								logoDisplaySelector=".user-logo"
-								preserveRatio="<%= true %>"
-								tempImageFileName="<%= String.valueOf(selUser.getUserId()) %>"
-							/>
-						</c:when>
-						<c:otherwise>
-							<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="portrait" />" src="<%= selUser.getPortraitURL(themeDisplay) %>" />
-						</c:otherwise>
-					</c:choose>
-				</c:when>
-				<c:otherwise>
-					<liferay-ui:logo-selector
-						aspectRatio="<%= 1 %>"
-						currentLogoURL='<%= themeDisplay.getPathImage() + "/user_portrait?img_id=0" %>'
-						defaultLogo="<%= true %>"
-						defaultLogoURL='<%= themeDisplay.getPathImage() + "/user_portrait?img_id=0" %>'
-						logoDisplaySelector=".user-logo"
-						preserveRatio="<%= true %>"
-						tempImageFileName="0"
-					/>
-				</c:otherwise>
-			</c:choose>
-		</div>
-	</clay:col>
-</clay:row>
+<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeDuplicate.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-already-taken" />
+<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeNull.class %>" focusField="emailAddress" message="please-enter-an-email-address" />
+<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBePOP3User.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-reserved" />
+<liferay-ui:error exception="<%= UserEmailAddressException.MustNotBeReserved.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-reserved" />
+<liferay-ui:error exception="<%= UserEmailAddressException.MustNotUseCompanyMx.class %>" focusField="emailAddress" message="the-email-address-you-requested-is-not-valid-because-its-domain-is-reserved" />
+<liferay-ui:error exception="<%= UserEmailAddressException.MustValidate.class %>" focusField="emailAddress" message="please-enter-a-valid-email-address" />
+
+<c:choose>
+	<c:when test='<%= !UsersAdminUtil.hasUpdateFieldPermission(permissionChecker, user, selUser, "emailAddress") %>'>
+		<aui:input disabled="<%= true %>" name="emailAddress" />
+	</c:when>
+	<c:otherwise>
+
+		<%
+		User displayEmailAddressUser = null;
+
+		if (selUser != null) {
+			displayEmailAddressUser = (User)selUser.clone();
+
+			displayEmailAddressUser.setEmailAddress(displayEmailAddressUser.getDisplayEmailAddress());
+		}
+		%>
+
+		<aui:input bean="<%= displayEmailAddressUser %>" model="<%= User.class %>" name="emailAddress">
+			<c:if test="<%= PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_EMAIL_ADDRESS_REQUIRED) %>">
+				<aui:validator name="required" />
+			</c:if>
+		</aui:input>
+	</c:otherwise>
+</c:choose>
+
+<c:if test="<%= selUser != null %>">
+	<liferay-ui:error exception="<%= UserIdException.MustNotBeNull.class %>" message="please-enter-a-user-id" />
+	<liferay-ui:error exception="<%= UserIdException.MustNotBeReserved.class %>" message="the-user-id-you-requested-is-reserved" />
+
+	<aui:input cssClass="disabled" name="userId" readonly="true" type="text" value="<%= String.valueOf(selUser.getUserId()) %>" />
+</c:if>
 
 <portlet:renderURL var="verifyPasswordURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
 	<portlet:param name="mvcPath" value="/user/password_verification.jsp" />


### PR DESCRIPTION
## Motivation
This PR replaces usages of `liferay-ui:logo-selector` taglib with the new `liferay-frontend:logo-selector` one.

**Only LPS-182721 commits need to be reviewed.**

## How to reproduce
I'm leaving the steps to reach the views:
### `account-admin-web`
- Apps Menu > Control Panel > Accounts > Create an account
- Apps Menu > Control Panel > Account Users > Create an account user

**Note**: For these views, I have changed the view from 2 columns to 1 so it looks better, according to our designers.

### `users-admin-web`
- Apps Menu > Control Panel > Users and Organizations > Create/edit a user
- Apps Menu > Control Panel > Users and Organizations > Create/edit an organization

**Note**: For these views, I have changed the view from 2 columns to 1 so it looks better, according to our designers.

### `oauth2-provider-web`
- Apps Menu > Control Panel > OAuth 2 Administration > Edit one of them

### `portal-settings-web`
- Apps Menu > Control Panel > Instance Settings > Instance Configuration > Appearance
