### PR TITLE
LPS 180374 Flaky Test: UpdateSegmentsEntryMVCCommandTest

### DIFF
--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/web/internal/portlet/action/test/UpdateSegmentsEntryMVCCommandTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/web/internal/portlet/action/test/UpdateSegmentsEntryMVCCommandTest.java
@@ -39,6 +39,9 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
@@ -49,6 +52,8 @@ import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.service.SegmentsEntryLocalService;
 import com.liferay.segments.test.util.SegmentsTestUtil;
+
+import java.util.List;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -103,8 +108,19 @@ public class UpdateSegmentsEntryMVCCommandTest {
 		mockLiferayPortletActionRequest.setParameter(
 			"segmentsEntryKey", "key12345");
 
-		_mvcActionCommand.processAction(
-			mockLiferayPortletActionRequest, mockLiferayPortletActionResponse);
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.segments.web.internal.portlet.action." +
+					"UpdateSegmentsEntryMVCActionCommand",
+				LoggerTestUtil.WARN)) {
+
+			_mvcActionCommand.processAction(
+				mockLiferayPortletActionRequest,
+				mockLiferayPortletActionResponse);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 0, logEntries.size());
+		}
 
 		SegmentsEntry segmentsEntry =
 			_segmentsEntryLocalService.fetchSegmentsEntry(
@@ -159,8 +175,19 @@ public class UpdateSegmentsEntryMVCCommandTest {
 		mockLiferayPortletActionRequest.setParameter(
 			"saveAndContinue", StringPool.TRUE);
 
-		_mvcActionCommand.processAction(
-			mockLiferayPortletActionRequest, mockLiferayPortletActionResponse);
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.segments.web.internal.portlet.action." +
+					"UpdateSegmentsEntryMVCActionCommand",
+				LoggerTestUtil.WARN)) {
+
+			_mvcActionCommand.processAction(
+				mockLiferayPortletActionRequest,
+				mockLiferayPortletActionResponse);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			Assert.assertEquals(logEntries.toString(), 0, logEntries.size());
+		}
 
 		SegmentsEntry finalSegmentsEntry =
 			_segmentsEntryLocalService.getSegmentsEntry(

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/portlet/action/UpdateSegmentsEntryMVCActionCommand.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/portlet/action/UpdateSegmentsEntryMVCActionCommand.java
@@ -16,6 +16,8 @@ package com.liferay.segments.web.internal.portlet.action;
 
 import com.liferay.portal.kernel.exception.NestableRuntimeException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactory;
@@ -137,6 +139,10 @@ public class UpdateSegmentsEntryMVCActionCommand extends BaseMVCActionCommand {
 			sendRedirect(actionRequest, actionResponse, redirect);
 		}
 		catch (Exception exception) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(exception);
+			}
+
 			if (exception instanceof NoSuchEntryException ||
 				exception instanceof PrincipalException) {
 
@@ -215,6 +221,9 @@ public class UpdateSegmentsEntryMVCActionCommand extends BaseMVCActionCommand {
 			throw new SegmentsEntryCriteriaException();
 		}
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpdateSegmentsEntryMVCActionCommand.class);
 
 	@Reference
 	private CompanyLocalService _companyLocalService;


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-180374)

UpdateSegmentsEntryMVCCommandTest has a flaky test that fails from time to time according to test runs. Since we don't know the real cause, we add a warning when an exception happens. 

Since it's a flaky test, it won't fail all the time, but at least next time it does, we will know the real cause. 

We also add the warning, since it's the proper thing to do.

 
## Change summary:

* Log exception as warn in the action command
* Check in the tests that no errors are thrown
