### PR TITLE
LPS-152257 Adapt import so it does not fail when a widget is not available

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/WidgetLayoutStructureItemImporter.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/structure/util/WidgetLayoutStructureItemImporter.java
@@ -175,6 +175,13 @@ public class WidgetLayoutStructureItemImporter
 			return null;
 		}
 
+		Portlet portlet = _portletLocalService.fetchPortletById(
+			layout.getCompanyId(), widgetName);
+
+		if (portlet == null) {
+			return null;
+		}
+
 		String widgetInstanceId = (String)widgetInstance.get(
 			"widgetInstanceId");
 
@@ -187,7 +194,7 @@ public class WidgetLayoutStructureItemImporter
 		}
 
 		widgetInstanceId = _getPortletInstanceId(
-			layout, widgetInstanceId, widgetName);
+			layout, portlet, widgetInstanceId);
 
 		editableValueJSONObject.put(
 			"instanceId", widgetInstanceId
@@ -223,22 +230,16 @@ public class WidgetLayoutStructureItemImporter
 	}
 
 	private String _getPortletInstanceId(
-			Layout layout, String portletInstanceId, String portletId)
+			Layout layout, Portlet portlet, String portletInstanceId)
 		throws Exception {
-
-		Portlet portlet = _portletLocalService.fetchPortletById(
-			layout.getCompanyId(), portletId);
-
-		if (portlet == null) {
-			throw new PortletIdException();
-		}
 
 		if (portlet.isInstanceable()) {
 			return portletInstanceId;
 		}
 
 		long count = _portletPreferencesLocalService.getPortletPreferencesCount(
-			PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(), portletId);
+			PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
+			portlet.getPortletId());
 
 		if (count > 0) {
 			throw new PortletIdException(

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/PageTemplatesImporterTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/PageTemplatesImporterTest.java
@@ -499,6 +499,37 @@ public class PageTemplatesImporterTest {
 	}
 
 	@Test
+	public void testImportEmptyLayoutPageTemplateEntryWithInvalidWidget()
+		throws Exception {
+
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_getImportLayoutPageTemplateEntry(
+				"widget",
+				HashMapBuilder.put(
+					"WIDGET_NAME", RandomTestUtil.randomString()
+				).build());
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(
+					_group.getGroupId(), layoutPageTemplateEntry.getPlid());
+
+		Assert.assertNotNull(layoutPageTemplateStructure);
+
+		LayoutStructure layoutStructure = LayoutStructure.of(
+			layoutPageTemplateStructure.getDefaultSegmentsExperienceData());
+
+		LayoutStructureItem mainLayoutStructureItem =
+			layoutStructure.getMainLayoutStructureItem();
+
+		List<String> childrenItemIds =
+			mainLayoutStructureItem.getChildrenItemIds();
+
+		Assert.assertEquals(
+			childrenItemIds.toString(), 0, childrenItemIds.size());
+	}
+
+	@Test
 	public void testImportLayoutPageTemplateEntryDropZoneFragment()
 		throws Exception {
 


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-152257)

When a page definition contains a widget that does not exist, the import fails, not as with fragments where they are ignored. So this PR deals with it, standardizing the cases

## Change summary:

- Instead of throwing an exception, ignore widgets that don't exist
- Adds test


## Test Scenario (ideal case)

- Deploy a widget to a portal instance
- Create a new page template and add the widget to the page
- Export the page template
- Delete the page template
- Undleploy the widget
- Import the page page
- It should succeed

## Test Scenario (medium case)

- Create a new page template and add any widget to the page
- Export the page template
- Delete the page template
- Blacklist the widget
- Import the page page
- It should succeed

## Test Scenario (non optimal case)

- Just run the integration test
