### PR TITLE
LPS-183042 Clean the context path form url so it could be processed as it should

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
+++ b/portal-impl/src/com/liferay/portal/action/UpdateLanguageAction.java
@@ -128,6 +128,14 @@ public class UpdateLanguageAction implements Action {
 			throw new IllegalArgumentException();
 		}
 
+		String contextPath = httpServletRequest.getContextPath();
+
+		if (Validator.isNotNull(contextPath) &&
+			!contextPath.equals(StringPool.SLASH)) {
+
+			redirect = redirect.substring(contextPath.length());
+		}
+
 		String layoutURL = redirect;
 
 		String friendlyURLSeparatorPart = StringPool.BLANK;


### PR DESCRIPTION
Hi guys!  

Following this document it seems that language widget belongs to your team (https://airtable.com/shrQ35YwWwHLRvhZ9/tbl66zH9L32CxqoNu). If I'm wrong, please tell me.

## Motivation: ##

The error here is that using the languages widget in a display page with a custom context path doesn't work.

For example, this is a valid url for an article:

http://roberto:8080/mysite/w/seasfdadsdf?redirect=%2Fmysite%2Fadmin

where /mysite/ is a custom context path.

What happens here is that com.liferay.portal.action.UpdateLanguageAction#getRedirect method is not handing it, and when it is called with urls like this: 

http://roberto:8080/myportal/c/portal/update_language?p_l_id=14&redirect=%2Fmyportal%2Fw%2Feng-2%3Fredirect%3D%252Fmyportal%252Fasset-publisher&languageId=es_ES

uses the redirect parameter (%2Fmyportal%2Fw%2Feng-2%3Fredirect%3D%252Fmyportal%252Fasset-publisher) 

in this case it redirects to 

http://roberto:8080/mysite/cb7e029d-d898-6420-997b-9d5cfe556f72/w/seasfdadsdf?redirect=%2Fmysite%2Fadmin

Instead of the valid url listed before (http://roberto:8080/mysite/w/seasfdadsdf?redirect=%2Fmysite%2Fadmin) because UpdateLanguageAction is not stripping the context path from the url (so it gets the friendlyURL from the display page and appends it to the url producing the 404)

## Solution ##

Clean the url removing the context path so the redirection urls are generated the same way

See https://issues.liferay.com/browse/LPS-183042 for more details or contact with me if you have any questions.

Regards




