### PR TITLE
LPS-183338

### DIFF
--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
@@ -951,12 +951,8 @@ public class PortletPreferencesFactoryImpl
 			hasMasterLayoutPreferences = true;
 		}
 
-		if (hasMasterLayoutPreferences) {
-			ownerType = PortletKeys.PREFS_OWNER_TYPE_LAYOUT;
-			plid = masterLayoutPlid;
-		}
-		else if (PortletIdCodec.hasUserId(originalPortletId) &&
-				 (PortletIdCodec.decodeUserId(originalPortletId) == userId)) {
+		if (PortletIdCodec.hasUserId(originalPortletId) &&
+			(PortletIdCodec.decodeUserId(originalPortletId) == userId)) {
 
 			ownerId = userId;
 			ownerType = PortletKeys.PREFS_OWNER_TYPE_USER;
@@ -971,7 +967,13 @@ public class PortletPreferencesFactoryImpl
 		else {
 			if (portlet.isPreferencesUniquePerLayout()) {
 				ownerId = PortletKeys.PREFS_OWNER_ID_DEFAULT;
-				plid = layout.getPlid();
+
+				if (hasMasterLayoutPreferences) {
+					plid = masterLayoutPlid;
+				}
+				else {
+					plid = layout.getPlid();
+				}
 
 				if (themeDisplay != null) {
 					if (themeDisplay.isPortletEmbedded(

--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
@@ -938,19 +938,6 @@ public class PortletPreferencesFactoryImpl
 		int ownerType = 0;
 		long plid = 0;
 
-		long masterLayoutPlid = layout.getMasterLayoutPlid();
-
-		boolean hasMasterLayoutPreferences = false;
-
-		long portletPreferencesCount =
-			PortletPreferencesLocalServiceUtil.getPortletPreferencesCount(
-				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, masterLayoutPlid,
-				portletId);
-
-		if ((masterLayoutPlid > 0) && (portletPreferencesCount > 0)) {
-			hasMasterLayoutPreferences = true;
-		}
-
 		if (PortletIdCodec.hasUserId(originalPortletId) &&
 			(PortletIdCodec.decodeUserId(originalPortletId) == userId)) {
 
@@ -967,6 +954,20 @@ public class PortletPreferencesFactoryImpl
 		else {
 			if (portlet.isPreferencesUniquePerLayout()) {
 				ownerId = PortletKeys.PREFS_OWNER_ID_DEFAULT;
+
+				long masterLayoutPlid = layout.getMasterLayoutPlid();
+
+				boolean hasMasterLayoutPreferences = false;
+
+				long portletPreferencesCount =
+					PortletPreferencesLocalServiceUtil.
+						getPortletPreferencesCount(
+							PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+							masterLayoutPlid, portletId);
+
+				if ((masterLayoutPlid > 0) && (portletPreferencesCount > 0)) {
+					hasMasterLayoutPreferences = true;
+				}
 
 				if (hasMasterLayoutPreferences) {
 					plid = masterLayoutPlid;

--- a/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
+++ b/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java
@@ -957,8 +957,6 @@ public class PortletPreferencesFactoryImpl
 
 				long masterLayoutPlid = layout.getMasterLayoutPlid();
 
-				boolean hasMasterLayoutPreferences = false;
-
 				long portletPreferencesCount =
 					PortletPreferencesLocalServiceUtil.
 						getPortletPreferencesCount(
@@ -966,10 +964,6 @@ public class PortletPreferencesFactoryImpl
 							masterLayoutPlid, portletId);
 
 				if ((masterLayoutPlid > 0) && (portletPreferencesCount > 0)) {
-					hasMasterLayoutPreferences = true;
-				}
-
-				if (hasMasterLayoutPreferences) {
 					plid = masterLayoutPlid;
 				}
 				else {


### PR DESCRIPTION
Motivation
=======
When loading the `portletPreferences` of a portlet to be used as a global variable in a FreeMarker template, sometimes the wrong `portletPreferences` gets loaded. This happens because we have logic to always load the portlet preferences by the plid of the Master Page, which is not always correct. In some cases, the portlet preferences for the Master Page are stored using the shared plid (0) rather than the plid of the Master Page. We should take that into account when we load the portlet preferences.

Proposed Solution
========
Edit the logic for looking up the plid with which to search for the PortletPreferences when the page is linked to a master page. It should only use the plid of the master page if the portlet would normally use its layout's plid (as opposed to the shared plid).

Steps to Verify
========
1. Start up Liferay and log in as the admin user.
2. Navigate to Site Builder > Navigation Menus > Add Menu > Name it "Test Navigation Menu".
3. Navigate to Design > Templates > Widget Templates > New > More > Menu Display Template
4. Name it "Test Menu Display Template" and give it the following content and then save:
```
${getterUtil.getLong(portletPreferences.siteNavigationMenuId[0])}
```

5. Navigate to Design > Page Templates
6. Add Master Page > name it as "Test Page Template" > Publish Master
7. Navigate to localhost:8080/home and click the Edit icon.
8. Under Page Design Options > select "Test Page Template" and publish
9. Navigate to Design > Page Templates > Test Page Template
10. Under Fragments and Widgets > Widgets > Add two Menu Displays (print-2)
11. For the top Menu Display > Click on three dots Menu > Configuration and configure it as follows:
* Choose Menu > Select > Test Navigation Menu
* Display Template > Test Menu Display Template
* Save

12. Leave the bottom Menu Display as is for now (do not edit its configuration)
13. Publish Master > click "OK" to accept the propagation.
14. Navigate to localhost:8080/home and verify that the top Menu Display widget is now displaying the ID of the "Test Navigation Menu".
15. Navigate to Design > Page Templates > Test Page Template
16. Edit the bottom Menu Display using the same configuration from step 11.
17. Publish Master > click "OK" to accept the propagation.
18. Navigate to localhost:8080/home.

**Expected Result:** Both Menu Display widgets would be displaying the ID of the "Test Navigation Menu"
**Actual Result:** The top Menu Display widget displays the ID of the "Test Navigation Menu", but the bottom one displays an error message as follows:
```
An error occurred while processing the template.

The following has evaluated to null or missing:
==> portletPreferences.siteNavigationMenuId  [in template "20096#20121#43709" at line 1, column 22]

----
Tip: It's the step after the last dot that caused this error, not those before it.
----
Tip: If the failing expression is known to legally refer to something that's sometimes null or missing, either specify a default value like myOptionalVar!myDefault, or use <#if myOptionalVar??>when-present<#else>when-missing</#if>. (These only cover the last step of the expression; to cover the whole expression, use parenthesis: (myOptionalVar.foo)!myDefault, (myOptionalVar.foo)??
----

----
FTL stack trace ("~" means nesting-related):
	- Failed at: ${getterUtil.getLong(portletPreferenc...  [in template "20096#20121#43709" at line 1, column 1]
----

1${getterUtil.getLong(portletPreferences.siteNavigationMenuId[0])} 
```