### PR TITLE
LPS-183054 Fix menu right position

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/dropdown/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/dropdown/index.js
@@ -55,6 +55,10 @@ function alignMenu() {
 	else if (configuration.panelType === 'full-width') {
 		menu.style.width = `${fragmentElement.getBoundingClientRect().width}px`;
 	}
+
+	if (toggleRect.right === window.innerWidth) {
+		menu.style.right = '0px';
+	}
 }
 
 function toggleMenu() {


### PR DESCRIPTION
Hi Team,

could you please check my fix?

**Steps to reproduce:**

1. Start the bundle and log in as admin
2. Edit the Home page and create a composition as follows
3. Add a Container Fragment to the page
4. In the Container add a Dropdown fragment
5. In the drop zone of the Dropdown fragment add a Paragraph fragment
6. At the Advanced tab of the Container add the CSS classes: "d-flex" and "justify-content-end"
7. Click on the Dropdown

**Expected result**: paragraph content is fully visible

**Fix**: Set the menu.style.right to 0px in case the toggleRect.right is equals with the window.innerWidth

Thanks, Roland