### PR TITLE
LPS-183503 Mapping Link to Page to Fragment

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-service/src/main/java/com/liferay/dynamic/data/mapping/internal/info/item/provider/DDMFormValuesInfoFieldValuesProviderImpl.java
@@ -42,9 +42,11 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.GroupedModel;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.sanitizer.Sanitizer;
 import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -82,11 +84,8 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 		for (DDMFormFieldValue ddmFormFieldValue :
 				ddmFormValues.getDDMFormFieldValues()) {
 
-			for (InfoFieldValue<InfoLocalizedValue<Object>> infoFieldValue :
-					_getInfoFieldValues(groupedModel, ddmFormFieldValue)) {
-
-				infoFieldValues.add(infoFieldValue);
-			}
+			infoFieldValues.addAll(
+				_getInfoFieldValues(groupedModel, ddmFormFieldValue));
 		}
 
 		return infoFieldValues;
@@ -323,6 +322,30 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 
 			if (Objects.equals(
 					ddmFormFieldValue.getType(),
+					DDMFormFieldTypeConstants.LINK_TO_LAYOUT)) {
+
+				if (Validator.isNull(valueString)) {
+					return StringPool.BLANK;
+				}
+
+				JSONObject jsonObject = _jsonFactory.createJSONObject(
+					valueString);
+
+				long layoutId = jsonObject.getLong("layoutId");
+
+				Layout layout = _layoutLocalService.fetchLayout(
+					jsonObject.getLong("groupId"),
+					jsonObject.getBoolean("privateLayout"), layoutId);
+
+				if (layout == null) {
+					return StringPool.BLANK;
+				}
+
+				return layout.getFriendlyURL(locale);
+			}
+
+			if (Objects.equals(
+					ddmFormFieldValue.getType(),
 					DDMFormFieldTypeConstants.RADIO)) {
 
 				if (Validator.isNull(valueString)) {
@@ -384,5 +407,8 @@ public class DDMFormValuesInfoFieldValuesProviderImpl
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 }

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/field/converter/DDMFormFieldInfoFieldConverterImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/field/converter/DDMFormFieldInfoFieldConverterImpl.java
@@ -30,6 +30,7 @@ import com.liferay.info.field.type.InfoFieldType;
 import com.liferay.info.field.type.NumberInfoFieldType;
 import com.liferay.info.field.type.SelectInfoFieldType;
 import com.liferay.info.field.type.TextInfoFieldType;
+import com.liferay.info.field.type.URLInfoFieldType;
 import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.info.localized.bundle.FunctionInfoLocalizedValue;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -188,6 +189,12 @@ public class DDMFormFieldInfoFieldConverterImpl
 					ddmFormFieldType, DDMFormFieldTypeConstants.IMAGE)) {
 
 			return ImageInfoFieldType.INSTANCE;
+		}
+		else if (Objects.equals(
+					ddmFormFieldType,
+					DDMFormFieldTypeConstants.LINK_TO_LAYOUT)) {
+
+			return URLInfoFieldType.INSTANCE;
 		}
 		else if (Objects.equals(
 					ddmFormFieldType, DDMFormFieldTypeConstants.NUMERIC)) {

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/item/provider/DDMStructureInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/info/item/provider/DDMStructureInfoItemFieldSetProviderImpl.java
@@ -101,6 +101,7 @@ public class DDMStructureInfoItemFieldSetProviderImpl
 		DDMFormFieldTypeConstants.CHECKBOX,
 		DDMFormFieldTypeConstants.CHECKBOX_MULTIPLE,
 		DDMFormFieldTypeConstants.DATE, DDMFormFieldTypeConstants.DATE_TIME,
+		DDMFormFieldTypeConstants.LINK_TO_LAYOUT,
 		DDMFormFieldTypeConstants.NUMERIC, DDMFormFieldTypeConstants.IMAGE,
 		DDMFormFieldTypeConstants.TEXT, DDMFormFieldTypeConstants.RADIO,
 		DDMFormFieldTypeConstants.RICH_TEXT, DDMFormFieldTypeConstants.SELECT


### PR DESCRIPTION
Motivation
=======
As a Customer, I want to map the Link to Page field in a fragment when I create a WebContent and try to map a fragment with a structure that contains a Link to Page field

Proposed Solution
========
Modify current code to allow that mapping

Steps to Verify
========

1. Go to Content & Data ->Structure and add a Link to Page field.
2. Create Web Content from the structure.
3. Go to Site Builder --> Pages and add a content (blank) page.
4. While editing the Page add a text fragment to it.
5. Click on the element of the fragment and on the Mapping/URL panel select the web content and as the Item and at the Field try to find the Content Structure.
6. The "link to Page" structure field should be available when mapping the fragment.


COMMITS:

- LPS-183503 Add link to layout to _SELECTABLE_DDM_STRUCTURE_FIELDS
- LPS-183503 Add LINK_TO_LAYOUT to getInfoType
- LPS-183503 Sanitize LINK_TO_LAYOUT value
- LPS-183503 Minor improvements to avoid nullPointerExceptions
