### PR TITLE
[TS] LPS-183515 Apply also to background images since it can contain references to classNameId

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesMappingExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesMappingExportImportContentProcessor.java
@@ -67,6 +67,12 @@ public class EditableValuesMappingExportImportContentProcessor
 		_replaceAllEditableExportContentReferences(
 			editableValuesJSONObject.getJSONObject(
 				FragmentEntryProcessorConstants.
+					KEY_BACKGROUND_IMAGE_FRAGMENT_ENTRY_PROCESSOR),
+			exportReferencedContent, portletDataContext, stagedModel);
+
+		_replaceAllEditableExportContentReferences(
+			editableValuesJSONObject.getJSONObject(
+				FragmentEntryProcessorConstants.
 					KEY_EDITABLE_FRAGMENT_ENTRY_PROCESSOR),
 			exportReferencedContent, portletDataContext, stagedModel);
 
@@ -84,6 +90,12 @@ public class EditableValuesMappingExportImportContentProcessor
 			PortletDataContext portletDataContext, StagedModel stagedModel,
 			JSONObject editableValuesJSONObject)
 		throws Exception {
+
+		_replaceAllEditableImportContentReferences(
+			editableValuesJSONObject.getJSONObject(
+				FragmentEntryProcessorConstants.
+					KEY_BACKGROUND_IMAGE_FRAGMENT_ENTRY_PROCESSOR),
+			portletDataContext);
 
 		_replaceAllEditableImportContentReferences(
 			editableValuesJSONObject.getJSONObject(


### PR DESCRIPTION
Motivation
=======
Exporting and Importing a fragment with an editable background image can result in a "Unable to get class name" error.
[LPS-183515](https://issues.liferay.com/browse/LPS-183515)

Proposed Solution
========
Append the className belonging to the classNameId to the exported fragmentEntryLink for background images, like how [LPS-169440](https://issues.liferay.com/browse/LPS-169440) did it for Freemarker

Steps to Verify
========
1. Create a new fragment, the HTML field should look like this:
```
<div class="fragment_1">
	<div data-lfr-background-image-id="unique-id">
		<lfr-editable id="unique-id" type="image">
			<img src="...">
		</lfr-editable>
	</div>
</div>
```
(Copied from: https://help.liferay.com/hc/en-us/articles/360029147771-Fragment-Specific-Tags#making-images-editable)
2. Add this fragment to a page
3. Click on it and select a background image from the right side menu (upload one if necessary)
4. Publish the page
5. Export the whole site (Exclude Pages 1 Items - Utility Pages from the Content section)
6. Create a new environment, this is necessary because the two environments should have different classnameids for com.liferay.portal.kernel.repository.model.FileEntry
7. Try to import the lar to the new environment

**Expected behaviour:** Import is successful
**Actual behaviour:** Import fails with message: The model.resource.com.liferay.fragment.model.FragmentEntryLink 4adb09c8-354b-21ad-53df-65d9279a0760 could not be imported because of the following error: Unable to get class name from id 28602.

Cheers,
Balázs