### PR TITLE
LPS-180874 Asset Publisher loses configuration when creating A/B test variant in nondefault language

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/segments/SegmentsExperienceUtil.java
@@ -382,14 +382,6 @@ public class SegmentsExperienceUtil {
 
 			String newNamespace = StringUtil.randomId();
 
-			if (SegmentsExperimentLocalServiceUtil.hasSegmentsExperiment(
-					sourceSegmentsExperienceId,
-					PortalUtil.getClassNameId(Layout.class.getName()), plid,
-					null)) {
-
-				newNamespace = fragmentEntryLink.getNamespace();
-			}
-
 			newFragmentEntryLink.setEditableValues(
 				_getNewEditableValues(
 					fragmentEntryLink.getEditableValues(),


### PR DESCRIPTION
Bug : https://issues.liferay.com/browse/LPS-180874

This bug is related to this another one: [LPS-178900](https://issues.liferay.com/browse/LPS-178900). We are keeping the same namespace as the source segment experience from we are creating the variant (Default segments experience or Control variant). So for that reason is causing that wrong portlet preferences are being created. So to fix it, we have to generate a new namespace also for the new variant because they are like a segments experience and a variant is totally independent of another but associated to a A/B test .