### PR TITLE
[TS] LPS-183967 NullPointerException when toggling segments in the Simulation view

### DIFF
--- a/modules/apps/segments/segments-simulation-web/src/main/java/com/liferay/segments/simulation/web/internal/portlet/SegmentsSimulationPortlet.java
+++ b/modules/apps/segments/segments-simulation-web/src/main/java/com/liferay/segments/simulation/web/internal/portlet/SegmentsSimulationPortlet.java
@@ -14,12 +14,24 @@
 
 package com.liferay.segments.simulation.web.internal.portlet;
 
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.segments.configuration.provider.SegmentsConfigurationProvider;
 import com.liferay.segments.constants.SegmentsPortletKeys;
+import com.liferay.segments.simulation.web.internal.display.context.SegmentsSimulationDisplayContext;
+
+import java.io.IOException;
 
 import javax.portlet.Portlet;
+import javax.portlet.PortletException;
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eduardo García
@@ -48,4 +60,36 @@ import org.osgi.service.component.annotations.Component;
 	service = Portlet.class
 )
 public class SegmentsSimulationPortlet extends MVCPortlet {
+
+	@Override
+	public void render(
+			RenderRequest renderRequest, RenderResponse renderResponse)
+		throws IOException, PortletException {
+
+		try {
+			SegmentsSimulationDisplayContext segmentsSimulationDisplayContext =
+				new SegmentsSimulationDisplayContext(
+					_portal.getHttpServletRequest(renderRequest),
+					_segmentsConfigurationProvider);
+
+			renderRequest.setAttribute(
+				WebKeys.PORTLET_DISPLAY_CONTEXT,
+				segmentsSimulationDisplayContext);
+		}
+		catch (Exception exception) {
+			_log.error(exception);
+		}
+
+		super.render(renderRequest, renderResponse);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SegmentsSimulationPortlet.class);
+
+	@Reference
+	private Portal _portal;
+
+	@Reference
+	private SegmentsConfigurationProvider _segmentsConfigurationProvider;
+
 }


### PR DESCRIPTION
Motivation
=======
When toggling segments in the Simulation view, a `NullPointerException` is thrown. This happens because we do not set the required `PORTLET_DISPLAY_CONTEXT` attribute when rendering the Segments Simulation's `view.jsp` file from the Portlet. We only set it when rendering the Segment Simulation's `view.jsp` from the Panel App, but not from the Portlet. We need to set it from the Portlet as well to prevent the `NullPointerException`.

Proposed Solution
========
Set the `PORTLET_DISPLAY_CONTEXT` attribute from the Portlet class to prevent the `NullPointerException` in the `view.jsp` file.

Steps to Verify
========
1. Start up Liferay and log in as the admin user.
2. Edit the 'Home' page.
3. Under the Experience selection drop-down, create a New Experience.
4. In the new window, title Experience as 'Admins Exp' and then create a 'New Segment'.
5. Create a new segment called 'Admins Segment' where the email address criteria contains "liferay".
6. Save the new segment.
7. Make sure the new experience has been selected in the drop down.
8. Change the Welcome to Liferay message in the portlet to 'Welcome to Liferay, Admins!'.
9. Reorder the 'Admins Exp' so that it comes before the Default experience.
10. Publish.
11. Open the Simulation Menu.
12. Toggle the created 'Admins Segment' on/off, and observe the Liferay logs when doing so.

*Expected Result:* The logs would be clean.
*Actual Behavior:* The logs contain the following NullPointerException:
```
2023-05-08 20:31:21.731 ERROR [http-nio-8080-exec-8][render_portlet_jsp:131] null
java.lang.NullPointerException: null
        at org.apache.jsp.view_jsp._jspService(view_jsp:213) ~[?:?]
        at org.apache.jasper.runtime.HttpJspBase.service(HttpJspBase.java:111) ~[jasper.jar:9.0.73]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:596) ~[servlet-api.jar:4.0.FR]
        at org.apache.jasper.servlet.JspServletWrapper.service(JspServletWrapper.java:411) ~[jasper.jar:9.0.73]
        at org.apache.jasper.servlet.JspServlet.serviceJspFile(JspServlet.java:473) ~[jasper.jar:9.0.73]
        at org.apache.jasper.servlet.JspServlet.service(JspServlet.java:377) ~[jasper.jar:9.0.73]
        at javax.servlet.http.HttpServlet.service(HttpServlet.java:596) ~[servlet-api.jar:4.0.FR]
        at com.liferay.portal.osgi.web.servlet.jsp.compiler.internal.JspServlet.service(JspServlet.java:328) ~[?:?]
        at com.liferay.portal.osgi.web.servlet.jsp.compiler.internal.JspServlet.service(JspServlet.java:340) ~[?:?]
        at org.eclipse.equinox.http.servlet.internal.registration.EndpointRegistration.service(EndpointRegistration.java:153) ~[?:?]
        at org.eclipse.equinox.http.servlet.internal.servlet.ResponseStateHandler.processRequest(ResponseStateHandler.java:63) ~[?:?]
        at org.eclipse.equinox.http.servlet.internal.context.DispatchTargets.doDispatch(DispatchTargets.java:120) ~[?:?]
        at org.eclipse.equinox.http.servlet.internal.servlet.RequestDispatcherAdaptor.include(RequestDispatcherAdaptor.java:48) ~[?:?]
        at com.liferay.portlet.internal.PortletRequestDispatcherImpl.dispatch(PortletRequestDispatcherImpl.java:291) ~[portal-impl.jar:?]
        at com.liferay.portlet.internal.PortletRequestDispatcherImpl.include(PortletRequestDispatcherImpl.java:123) ~[portal-impl.jar:?]
        at com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet.include(MVCPortlet.java:620) ~[portal-kernel.jar:?]
        at com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet.include(MVCPortlet.java:636) ~[portal-kernel.jar:?]
        at com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet.doView(MVCPortlet.java:181) ~[portal-kernel.jar:?]
        at com.liferay.portal.kernel.portlet.LiferayPortlet.doDispatch(LiferayPortlet.java:287) ~[portal-kernel.jar:?]
        at com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet.doDispatch(MVCPortlet.java:509) ~[portal-kernel.jar:?]
```