### PR TITLE
[TS] LPS-184014 Take possible non ROOT context into account #11998

### DIFF
--- a/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
+++ b/modules/apps/translation/translation-web/src/main/java/com/liferay/translation/web/internal/display/context/TranslateDisplayContext.java
@@ -44,7 +44,6 @@ import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -114,7 +113,7 @@ public class TranslateDisplayContext {
 
 	public String getAutoTranslateURL() {
 		return PortalUtil.getPortalURL(_httpServletRequest) +
-			Portal.PATH_MODULE + "/translation/auto_translate";
+			PortalUtil.getPathModule() + "/translation/auto_translate";
 	}
 
 	public boolean getBooleanValue(


### PR DESCRIPTION
Hi @liferay-echo,

This issue ([LPS-184014](https://issues.liferay.com/browse/LPS-184014)) was reported by a customer. 

The Auto Translate button makes a request that doesn't consider a non-ROOT context in the application server. 

Instead of directly using `Portal.PATH_MODULE` (aka `/o`), we should use the auxiliary method `PortalUtil.getPathModule()` which will prepend the context if any. This method is used in multiple places throughout the portal.

Note that if you don't properly configure an external translation, you'll still get the expected error: "There is a problem with the translation service. Please contact your administrator."