### PR TITLE
LPS-184017 Adds exception mappers for layout title and friendly URLs

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/SitePageFriendlyURLsExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/SitePageFriendlyURLsExceptionMapper.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.delivery.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.kernel.exception.LayoutFriendlyURLsException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Converts any {@code LayoutFriendlyURLsException} to a {@code 400} error.
+ *
+ * @author Jürgen Kappler
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Delivery.SitePageFriendlyURLsExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class SitePageFriendlyURLsExceptionMapper
+	extends BaseExceptionMapper<LayoutFriendlyURLsException> {
+
+	@Override
+	protected Problem getProblem(
+		LayoutFriendlyURLsException layoutFriendlyURLsException) {
+
+		return new Problem(layoutFriendlyURLsException);
+	}
+
+}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/SitePageTitleExceptionMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/jaxrs/exception/mapper/SitePageTitleExceptionMapper.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.headless.delivery.internal.jaxrs.exception.mapper;
+
+import com.liferay.portal.kernel.exception.LayoutNameException;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.BaseExceptionMapper;
+import com.liferay.portal.vulcan.jaxrs.exception.mapper.Problem;
+
+import javax.ws.rs.ext.ExceptionMapper;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * Converts any {@code LayoutNameException} to a {@code 400} error.
+ *
+ * @author Jürgen Kappler
+ */
+@Component(
+	property = {
+		"osgi.jaxrs.application.select=(osgi.jaxrs.name=Liferay.Headless.Delivery)",
+		"osgi.jaxrs.extension=true",
+		"osgi.jaxrs.name=Liferay.Headless.Delivery.SitePageTitleExceptionMapper"
+	},
+	service = ExceptionMapper.class
+)
+public class SitePageTitleExceptionMapper
+	extends BaseExceptionMapper<LayoutNameException> {
+
+	@Override
+	protected Problem getProblem(LayoutNameException layoutNameException) {
+		return new Problem(layoutNameException);
+	}
+
+}


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-184017)

Adds exception mappers for bad title and friendly URLs for layout

## Change summary:

* Just add both mappers


## Test Scenario

* Enable FF for the endpoint: LPS-178052
* Try to create a page through with a bad title or friendlyURL (examples can be: title longer than 255 chars, friendlyURL with less than 2 chars, friendlyURL with invalid chars)
* Instead of an ugly exception thrown in the logs, a "nice" error is returned


## Notes

* If the typeSettings for sitemap are incorrect, an error (or several) is (are) thrown at service layer. But since we already capture the errors in the schema, there's no need to add mappers for it