### PR TITLE
Accessibility: LPS-183087 Allow user to remove toast when ready

### DIFF
--- a/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/js/undo.js
+++ b/modules/apps/trash/trash-taglib/src/main/resources/META-INF/resources/js/undo.js
@@ -18,7 +18,7 @@ export default function ({alertMessage, namespace}) {
 	const componentId = `${namespace}recycleBinAlert`;
 
 	openToast({
-		autoClose: 15000,
+		autoClose: false,
 		message: alertMessage,
 		renderData: {
 			componentId,


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-183087

The toast should remain open until a user decides to close it, interact with it, or go to a different page. 
This is for accessibility purposes for users that use Screen Readers or have disabilities that makes it difficult to react to the toast.
https://www.w3.org/TR/UNDERSTANDING-WCAG20/time-limits-no-exceptions.html

If there are any questions or comments please let me know.
Thank you!
