### PR TITLE
LPS-184146 Replace clay:navigation-bar with clay:tabs in trash-web

### DIFF
--- a/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashDisplayContext.java
+++ b/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashDisplayContext.java
@@ -17,6 +17,8 @@ package com.liferay.trash.web.internal.display.context;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItemListBuilder;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
@@ -416,6 +418,16 @@ public class TrashDisplayContext {
 		}
 
 		return portletURL;
+	}
+
+	public List<TabsItem> getTabsItems() {
+		return TabsItemListBuilder.add(
+			tabsItem -> {
+				tabsItem.setActive(true);
+				tabsItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "details"));
+			}
+		).build();
 	}
 
 	public SearchContainer<TrashedModel> getTrashContainerSearchContainer()

--- a/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashDisplayContext.java
+++ b/modules/apps/trash/trash-web/src/main/java/com/liferay/trash/web/internal/display/context/TrashDisplayContext.java
@@ -15,8 +15,6 @@
 package com.liferay.trash.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
-import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItemListBuilder;
 import com.liferay.petra.string.StringPool;
@@ -317,16 +315,6 @@ public class TrashDisplayContext {
 		_entrySearch = entrySearch;
 
 		return _entrySearch;
-	}
-
-	public List<NavigationItem> getInfoPanelNavigationItems() {
-		return NavigationItemListBuilder.add(
-			navigationItem -> {
-				navigationItem.setActive(true);
-				navigationItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "details"));
-			}
-		).build();
 	}
 
 	public String getKeywords() {

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/info_panel.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/info_panel.jsp
@@ -82,23 +82,25 @@ List<TrashEntry> trashEntries = (List<TrashEntry>)request.getAttribute(TrashWebK
 					</clay:content-row>
 				</div>
 
-				<clay:navigation-bar
-					navigationItems="<%= trashDisplayContext.getInfoPanelNavigationItems() %>"
-				/>
+				<div class="sheet-row">
+					<clay:tabs
+						tabsItems="<%= trashDisplayContext.getTabsItems() %>"
+					>
+						<div class="sidebar-body">
+							<dl class="sidebar-dl sidebar-section">
+								<dt class="sidebar-dt"><liferay-ui:message key="removed-date" /></dt>
 
-				<div class="sidebar-body">
-					<dl class="sidebar-dl sidebar-section">
-						<dt class="sidebar-dt"><liferay-ui:message key="removed-date" /></dt>
+								<dd class="sidebar-dd">
+									<%= dateFormatDateTime.format(trashEntry.getCreateDate()) %>
+								</dd>
+								<dt class="sidebar-dt"><liferay-ui:message key="removed-by" /></dt>
 
-						<dd class="sidebar-dd">
-							<%= dateFormatDateTime.format(trashEntry.getCreateDate()) %>
-						</dd>
-						<dt class="sidebar-dt"><liferay-ui:message key="removed-by" /></dt>
-
-						<dd class="sidebar-dd">
-							<%= HtmlUtil.escape(trashEntry.getUserName()) %>
-						</dd>
-					</dl>
+								<dd class="sidebar-dd">
+									<%= HtmlUtil.escape(trashEntry.getUserName()) %>
+								</dd>
+							</dl>
+						</div>
+					</clay:tabs>
 				</div>
 			</c:when>
 			<c:otherwise>
@@ -121,18 +123,20 @@ List<TrashEntry> trashEntries = (List<TrashEntry>)request.getAttribute(TrashWebK
 					</clay:content-row>
 				</div>
 
-				<clay:navigation-bar
-					navigationItems="<%= trashDisplayContext.getInfoPanelNavigationItems() %>"
-				/>
+				<div class="sheet-row">
+					<clay:tabs
+						tabsItems="<%= trashDisplayContext.getTabsItems() %>"
+					>
+						<div class="sidebar-body">
+							<dl class="sidebar-dl sidebar-section">
+								<dt class="sidebar-dt"><liferay-ui:message key="num-of-items" /></dt>
 
-				<div class="sidebar-body">
-					<dl class="sidebar-dl sidebar-section">
-						<dt class="sidebar-dt"><liferay-ui:message key="num-of-items" /></dt>
-
-						<dd class="sidebar-dd">
-							<%= trashEntries.size() %>
-						</dd>
-					</dl>
+								<dd class="sidebar-dd">
+									<%= trashEntries.size() %>
+								</dd>
+							</dl>
+						</div>
+					</clay:tabs>
 				</div>
 			</c:otherwise>
 		</c:choose>
@@ -150,18 +154,20 @@ List<TrashEntry> trashEntries = (List<TrashEntry>)request.getAttribute(TrashWebK
 			</clay:content-row>
 		</div>
 
-		<clay:navigation-bar
-			navigationItems="<%= trashDisplayContext.getInfoPanelNavigationItems() %>"
-		/>
+		<div class="sheet-row">
+			<clay:tabs
+				tabsItems="<%= trashDisplayContext.getTabsItems() %>"
+			>
+				<div class="sidebar-body">
+					<dl class="sidebar-dl sidebar-section">
+						<dt class="sidebar-dt"><liferay-ui:message key="num-of-items" /></dt>
 
-		<div class="sidebar-body">
-			<dl class="sidebar-dl sidebar-section">
-				<dt class="sidebar-dt"><liferay-ui:message key="num-of-items" /></dt>
-
-				<dd class="sidebar-dd">
-					<%= TrashEntryLocalServiceUtil.getEntriesCount(themeDisplay.getScopeGroupId()) %>
-				</dd>
-			</dl>
+						<dd class="sidebar-dd">
+							<%= TrashEntryLocalServiceUtil.getEntriesCount(themeDisplay.getScopeGroupId()) %>
+						</dd>
+					</dl>
+				</div>
+			</clay:tabs>
 		</div>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content_info_panel.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content_info_panel.jsp
@@ -59,17 +59,19 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 		</clay:content-row>
 	</div>
 
-	<clay:navigation-bar
-		navigationItems="<%= trashDisplayContext.getInfoPanelNavigationItems() %>"
-	/>
+	<div class="sheet-row">
+		<clay:tabs
+			tabsItems="<%= trashDisplayContext.getTabsItems() %>"
+		>
+			<div class="sidebar-body">
+				<dl class="sidebar-dl sidebar-section">
+					<dt class="sidebar-dt"><liferay-ui:message key="num-of-items" /></dt>
 
-	<div class="sidebar-body">
-		<dl class="sidebar-dl sidebar-section">
-			<dt class="sidebar-dt"><liferay-ui:message key="num-of-items" /></dt>
-
-			<dd class="sidebar-dd">
-				<%= trashHandler.getTrashModelsCount(classPK) %>
-			</dd>
-		</dl>
+					<dd class="sidebar-dd">
+						<%= trashHandler.getTrashModelsCount(classPK) %>
+					</dd>
+				</dl>
+			</div>
+		</clay:tabs>
 	</div>
 </c:if>


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-184146)

## Steps

**Case 1**
1. Create a web content and remove it
2. Go to Product Menu > Recycle Bin 
3. Select the info icon upper right
<img width="388" alt="Screenshot 2023-05-11 at 12 52 56" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/5e738a45-e213-4684-aea1-4707818b5733">

**Case 2**
1. Create a web content and remove it
2. Go to Product Menu > Recycle Bin 
3. Select the web content removed
4. Select the info icon upper right
<img width="387" alt="Screenshot 2023-05-11 at 12 54 05" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/70346c11-dbc7-4cfd-a6aa-07c0ce78acce">
