### PR TITLE
Lps 184344

### DIFF
--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/model/listener/LayoutModelListener.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/model/listener/LayoutModelListener.java
@@ -51,7 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 public class LayoutModelListener extends BaseModelListener<Layout> {
 
 	@Override
-	public void onBeforeUpdate(Layout originalLayout, Layout layout)
+	public void onAfterUpdate(Layout originalLayout, Layout layout)
 		throws ModelListenerException {
 
 		try {

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/model/listener/LayoutModelListener.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/model/listener/LayoutModelListener.java
@@ -55,7 +55,7 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 		throws ModelListenerException {
 
 		try {
-			if (_isSkipEvent(layout)) {
+			if (_isSkipEvent(originalLayout, layout)) {
 				return;
 			}
 
@@ -96,7 +96,9 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 		_asahSegmentsExperimentProcessor = null;
 	}
 
-	private boolean _isSkipEvent(Layout layout) throws Exception {
+	private boolean _isSkipEvent(Layout originalLayout, Layout layout)
+		throws Exception {
+
 		if (AsahUtil.isSkipAsahEvent(
 				_analyticsSettingsManager, layout.getCompanyId(),
 				layout.getGroupId())) {
@@ -104,11 +106,9 @@ public class LayoutModelListener extends BaseModelListener<Layout> {
 			return true;
 		}
 
-		Layout oldLayout = _layoutLocalService.fetchLayout(layout.getPlid());
-
 		if (!Objects.equals(
-				oldLayout.getFriendlyURL(), layout.getFriendlyURL()) ||
-			!Objects.equals(oldLayout.getTitle(), layout.getTitle())) {
+				originalLayout.getFriendlyURL(), layout.getFriendlyURL()) ||
+			!Objects.equals(originalLayout.getTitle(), layout.getTitle())) {
 
 			return false;
 		}


### PR DESCRIPTION
Motivation
=======
https://issues.liferay.com/browse/LPS-184344
This issue occurs when publications is enabled and the portlet configurations are updated. When an entity is updated in a publication, a new entry is added to the database. Therefore, a new entry to PortletPreferences is added to the transaction. When this LayoutModelListener is executed, a fetch to PortletPreferences is made when AsahUtil.isSkipAsahEvent i called. This causes the transaction to flush which will also flush the update layout action and lead to a StaleStateException

See more details in [PTR-3902](https://issues.liferay.com/browse/PTR-3902)

Proposed Solution
========
I fixed this issue by changing the LayoutModelListener action from onBefore to onAfter

Steps to Verify
========

1. Open the main menu --> Applications --> Publications and enable Publications
2. On the default Site go to Site Builder --> Pages
         2.1. Create two widget pages and add to each page an Asset Publisher.
3. Create a new Publication by clicking the Production menu at the top of the page.
4. Go to Site Builder --> Pages and try to configure the Asset Publisher of one of the Pages.
         Checkpoint: The configuration is saved with no issues.
5. Try to configure the Asset Publisher of the other Page.