### PR TITLE
LPS-177303 Replace clay:navigation-bar with clay:tabs in site-memberships-web

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SiteMembershipsDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SiteMembershipsDisplayContext.java
@@ -79,16 +79,6 @@ public class SiteMembershipsDisplayContext {
 		return group.getGroupId();
 	}
 
-	public List<NavigationItem> getInfoPanelNavigationItems() {
-		return NavigationItemListBuilder.add(
-			navigationItem -> {
-				navigationItem.setActive(true);
-				navigationItem.setLabel(
-					LanguageUtil.get(_httpServletRequest, "details"));
-			}
-		).build();
-	}
-
 	public PortletURL getPortletURL() {
 		return PortletURLBuilder.createRenderURL(
 			_liferayPortletResponse

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SiteMembershipsDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SiteMembershipsDisplayContext.java
@@ -16,6 +16,8 @@ package com.liferay.site.memberships.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItemListBuilder;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.TabsItemListBuilder;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.model.Group;
@@ -133,6 +135,16 @@ public class SiteMembershipsDisplayContext {
 		_tabs1 = ParamUtil.getString(_httpServletRequest, "tabs1", "users");
 
 		return _tabs1;
+	}
+
+	public List<TabsItem> getTabsItems() {
+		return TabsItemListBuilder.add(
+			tabsItem -> {
+				tabsItem.setActive(true);
+				tabsItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "details"));
+			}
+		).build();
 	}
 
 	public long getUserGroupId() {

--- a/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SiteMembershipsDisplayContext.java
+++ b/modules/apps/site/site-memberships-web/src/main/java/com/liferay/site/memberships/web/internal/display/context/SiteMembershipsDisplayContext.java
@@ -28,7 +28,6 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
-import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.List;
@@ -91,22 +90,6 @@ public class SiteMembershipsDisplayContext {
 		).buildPortletURL();
 	}
 
-	public String getRedirect() {
-		if (_redirect != null) {
-			return _redirect;
-		}
-
-		_redirect = ParamUtil.getString(_httpServletRequest, "redirect");
-
-		if (Validator.isNull(_redirect)) {
-			PortletURL portletURL = _liferayPortletResponse.createRenderURL();
-
-			_redirect = portletURL.toString();
-		}
-
-		return _redirect;
-	}
-
 	public User getSelUser() throws PortalException {
 		if (_selUser != null) {
 			return _selUser;
@@ -135,16 +118,6 @@ public class SiteMembershipsDisplayContext {
 					LanguageUtil.get(_httpServletRequest, "details"));
 			}
 		).build();
-	}
-
-	public long getUserGroupId() {
-		if (_userGroupId != null) {
-			return _userGroupId;
-		}
-
-		_userGroupId = ParamUtil.getLong(_httpServletRequest, "userGroupId");
-
-		return _userGroupId;
 	}
 
 	public long getUserId() throws PortalException {
@@ -188,9 +161,7 @@ public class SiteMembershipsDisplayContext {
 	private Group _group;
 	private final HttpServletRequest _httpServletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;
-	private String _redirect;
 	private User _selUser;
 	private String _tabs1;
-	private Long _userGroupId;
 
 }

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organization_info_panel.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/organization_info_panel.jsp
@@ -26,25 +26,27 @@ List<Organization> organizations = (List<Organization>)request.getAttribute(Site
 			<h4><liferay-ui:message key="organizations" /></h4>
 		</div>
 
-		<clay:navigation-bar
-			navigationItems="<%= siteMembershipsDisplayContext.getInfoPanelNavigationItems() %>"
-		/>
+		<div class="sheet-row">
+			<clay:tabs
+				tabsItems="<%= siteMembershipsDisplayContext.getTabsItems() %>"
+			>
+				<div class="sidebar-body">
+					<h5><liferay-ui:message key="num-of-organizations" /></h5>
 
-		<div class="sidebar-body">
-			<h5><liferay-ui:message key="num-of-organizations" /></h5>
+					<p>
+						<%=
+						OrganizationLocalServiceUtil.searchCount(
+							company.getCompanyId(), OrganizationConstants.ANY_PARENT_ORGANIZATION_ID, StringPool.BLANK, StringPool.BLANK, null, null,
+							LinkedHashMapBuilder.<String, Object>put(
+								"groupOrganization", Long.valueOf(siteMembershipsDisplayContext.getGroupId())
+							).put(
+								"organizationsGroups", Long.valueOf(siteMembershipsDisplayContext.getGroupId())
+							).build())
+						%>
 
-			<p>
-				<%=
-				OrganizationLocalServiceUtil.searchCount(
-					company.getCompanyId(), OrganizationConstants.ANY_PARENT_ORGANIZATION_ID, StringPool.BLANK, StringPool.BLANK, null, null,
-					LinkedHashMapBuilder.<String, Object>put(
-						"groupOrganization", Long.valueOf(siteMembershipsDisplayContext.getGroupId())
-					).put(
-						"organizationsGroups", Long.valueOf(siteMembershipsDisplayContext.getGroupId())
-					).build())
-				%>
-
-			</p>
+					</p>
+				</div>
+			</clay:tabs>
 		</div>
 	</c:when>
 	<c:when test="<%= ListUtil.isNotEmpty(organizations) && (organizations.size() == 1) %>">
@@ -77,54 +79,56 @@ List<Organization> organizations = (List<Organization>)request.getAttribute(Site
 			</c:if>
 		</div>
 
-		<clay:navigation-bar
-			navigationItems="<%= siteMembershipsDisplayContext.getInfoPanelNavigationItems() %>"
-		/>
+		<div class="sheet-row">
+			<clay:tabs
+				tabsItems="<%= siteMembershipsDisplayContext.getTabsItems() %>"
+			>
+				<div class="sidebar-body">
+					<h5><liferay-ui:message key="num-of-users" /></h5>
 
-		<div class="sidebar-body">
-			<h5><liferay-ui:message key="num-of-users" /></h5>
+					<p>
+						<%= UserLocalServiceUtil.getOrganizationUsersCount(organization.getOrganizationId(), WorkflowConstants.STATUS_APPROVED) %>
+					</p>
 
-			<p>
-				<%= UserLocalServiceUtil.getOrganizationUsersCount(organization.getOrganizationId(), WorkflowConstants.STATUS_APPROVED) %>
-			</p>
+					<%
+					Address address = organization.getAddress();
 
-			<%
-			Address address = organization.getAddress();
+					String city = address.getCity();
+					%>
 
-			String city = address.getCity();
-			%>
+					<c:if test="<%= Validator.isNotNull(city) %>">
+						<h5><liferay-ui:message key="city" /></h5>
 
-			<c:if test="<%= Validator.isNotNull(city) %>">
-				<h5><liferay-ui:message key="city" /></h5>
+						<p>
+							<%= HtmlUtil.escape(city) %>
+						</p>
+					</c:if>
 
-				<p>
-					<%= HtmlUtil.escape(city) %>
-				</p>
-			</c:if>
+					<%
+					String region = UsersAdmin.ORGANIZATION_REGION_NAME_ACCESSOR.get(organization);
+					%>
 
-			<%
-			String region = UsersAdmin.ORGANIZATION_REGION_NAME_ACCESSOR.get(organization);
-			%>
+					<c:if test="<%= Validator.isNotNull(region) %>">
+						<h5><liferay-ui:message key="region" /></h5>
 
-			<c:if test="<%= Validator.isNotNull(region) %>">
-				<h5><liferay-ui:message key="region" /></h5>
+						<p>
+							<%= region %>
+						</p>
+					</c:if>
 
-				<p>
-					<%= region %>
-				</p>
-			</c:if>
+					<%
+					String country = UsersAdmin.ORGANIZATION_COUNTRY_NAME_ACCESSOR.get(organization);
+					%>
 
-			<%
-			String country = UsersAdmin.ORGANIZATION_COUNTRY_NAME_ACCESSOR.get(organization);
-			%>
+					<c:if test="<%= Validator.isNotNull(country) %>">
+						<h5><liferay-ui:message key="country" /></h5>
 
-			<c:if test="<%= Validator.isNotNull(country) %>">
-				<h5><liferay-ui:message key="country" /></h5>
-
-				<p>
-					<%= country %>
-				</p>
-			</c:if>
+						<p>
+							<%= country %>
+						</p>
+					</c:if>
+				</div>
+			</clay:tabs>
 		</div>
 	</c:when>
 	<c:when test="<%= ListUtil.isNotEmpty(organizations) && (organizations.size() > 1) %>">
@@ -132,12 +136,14 @@ List<Organization> organizations = (List<Organization>)request.getAttribute(Site
 			<h4><liferay-ui:message arguments="<%= organizations.size() %>" key="x-items-are-selected" /></h4>
 		</div>
 
-		<clay:navigation-bar
-			navigationItems="<%= siteMembershipsDisplayContext.getInfoPanelNavigationItems() %>"
-		/>
-
-		<div class="sidebar-body">
-			<h5><liferay-ui:message arguments="<%= organizations.size() %>" key="x-items-are-selected" /></h5>
+		<div class="sheet-row">
+			<clay:tabs
+				tabsItems="<%= siteMembershipsDisplayContext.getTabsItems() %>"
+			>
+				<div class="sidebar-body">
+					<h5><liferay-ui:message arguments="<%= organizations.size() %>" key="x-items-are-selected" /></h5>
+				</div>
+			</clay:tabs>
 		</div>
 	</c:when>
 </c:choose>

--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_info_panel.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/user_info_panel.jsp
@@ -51,24 +51,26 @@ Group group = siteMembershipsDisplayContext.getGroup();
 			</h6>
 		</div>
 
-		<clay:navigation-bar
-			navigationItems="<%= siteMembershipsDisplayContext.getInfoPanelNavigationItems() %>"
-		/>
+		<div class="sheet-row">
+			<clay:tabs
+				tabsItems="<%= siteMembershipsDisplayContext.getTabsItems() %>"
+			>
+				<div class="sidebar-body">
+					<h5><liferay-ui:message key="num-of-users" /></h5>
 
-		<div class="sidebar-body">
-			<h5><liferay-ui:message key="num-of-users" /></h5>
+					<%
+					LinkedHashMap<String, Object> userParams = LinkedHashMapBuilder.<String, Object>put(
+						"inherit", Boolean.TRUE
+					).put(
+						"usersGroups", Long.valueOf(siteMembershipsDisplayContext.getGroupId())
+					).build();
+					%>
 
-			<%
-			LinkedHashMap<String, Object> userParams = LinkedHashMapBuilder.<String, Object>put(
-				"inherit", Boolean.TRUE
-			).put(
-				"usersGroups", Long.valueOf(siteMembershipsDisplayContext.getGroupId())
-			).build();
-			%>
-
-			<p>
-				<%= UserLocalServiceUtil.searchCount(company.getCompanyId(), StringPool.BLANK, WorkflowConstants.STATUS_APPROVED, userParams) %>
-			</p>
+					<p>
+						<%= UserLocalServiceUtil.searchCount(company.getCompanyId(), StringPool.BLANK, WorkflowConstants.STATUS_APPROVED, userParams) %>
+					</p>
+				</div>
+			</clay:tabs>
 		</div>
 	</c:when>
 	<c:when test="<%= ListUtil.isNotEmpty(users) && (users.size() == 1) %>">
@@ -87,62 +89,64 @@ Group group = siteMembershipsDisplayContext.getGroup();
 			</h6>
 		</div>
 
-		<clay:navigation-bar
-			navigationItems="<%= siteMembershipsDisplayContext.getInfoPanelNavigationItems() %>"
-		/>
+		<div class="sheet-row">
+			<clay:tabs
+				tabsItems="<%= siteMembershipsDisplayContext.getTabsItems() %>"
+			>
+				<div class="sidebar-body">
 
-		<div class="sidebar-body">
+					<%
+					List<String> names = new ArrayList<String>();
 
-			<%
-			List<String> names = new ArrayList<String>();
+					names.addAll(SitesUtil.getOrganizationNames(group, curUser));
 
-			names.addAll(SitesUtil.getOrganizationNames(group, curUser));
+					names.addAll(SitesUtil.getUserGroupNames(group, curUser));
+					%>
 
-			names.addAll(SitesUtil.getUserGroupNames(group, curUser));
-			%>
+					<c:if test="<%= ListUtil.isNotEmpty(names) %>">
+						<p>
+							<c:choose>
+								<c:when test="<%= names.size() == 1 %>">
+									<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(group.getDescriptiveName(locale)), HtmlUtil.escape(names.get(0))} %>" key="this-user-is-a-member-of-x-because-he-belongs-to-x" translateArguments="<%= false %>" />
+								</c:when>
+								<c:otherwise>
+									<liferay-ui:message arguments='<%= new Object[] {HtmlUtil.escape(group.getDescriptiveName(locale)), HtmlUtil.escape(StringUtil.merge(names.subList(0, names.size() - 1).toArray(new String[names.size() - 1]), ", ")), HtmlUtil.escape(names.get(names.size() - 1))} %>' key="this-user-is-a-member-of-x-because-he-belongs-to-x-and-x" translateArguments="<%= false %>" />
+								</c:otherwise>
+							</c:choose>
+						</p>
+					</c:if>
 
-			<c:if test="<%= ListUtil.isNotEmpty(names) %>">
-				<p>
-					<c:choose>
-						<c:when test="<%= names.size() == 1 %>">
-							<liferay-ui:message arguments="<%= new Object[] {HtmlUtil.escape(group.getDescriptiveName(locale)), HtmlUtil.escape(names.get(0))} %>" key="this-user-is-a-member-of-x-because-he-belongs-to-x" translateArguments="<%= false %>" />
-						</c:when>
-						<c:otherwise>
-							<liferay-ui:message arguments='<%= new Object[] {HtmlUtil.escape(group.getDescriptiveName(locale)), HtmlUtil.escape(StringUtil.merge(names.subList(0, names.size() - 1).toArray(new String[names.size() - 1]), ", ")), HtmlUtil.escape(names.get(names.size() - 1))} %>' key="this-user-is-a-member-of-x-because-he-belongs-to-x-and-x" translateArguments="<%= false %>" />
-						</c:otherwise>
-					</c:choose>
-				</p>
-			</c:if>
+					<%
+					String portraitURL = curUser.getPortraitURL(themeDisplay);
+					%>
 
-			<%
-			String portraitURL = curUser.getPortraitURL(themeDisplay);
-			%>
+					<c:if test="<%= Validator.isNotNull(portraitURL) %>">
+						<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="thumbnail" />" class="crop-img rounded" src="<%= portraitURL %>" />
+					</c:if>
 
-			<c:if test="<%= Validator.isNotNull(portraitURL) %>">
-				<img alt="<liferay-ui:message escapeAttribute="<%= true %>" key="thumbnail" />" class="crop-img rounded" src="<%= portraitURL %>" />
-			</c:if>
+					<h5><liferay-ui:message key="email" /></h5>
 
-			<h5><liferay-ui:message key="email" /></h5>
+					<p>
+						<%= curUser.getEmailAddress() %>
+					</p>
 
-			<p>
-				<%= curUser.getEmailAddress() %>
-			</p>
+					<%
+					List<Team> teams = TeamLocalServiceUtil.getUserOrUserGroupTeams(siteMembershipsDisplayContext.getGroupId(), curUser.getUserId());
 
-			<%
-			List<Team> teams = TeamLocalServiceUtil.getUserOrUserGroupTeams(siteMembershipsDisplayContext.getGroupId(), curUser.getUserId());
+					List<String> rolesAndTeamsNames = ListUtil.toList(UserGroupRoleLocalServiceUtil.getUserGroupRoles(curUser.getUserId(), siteMembershipsDisplayContext.getGroupId()), UsersAdmin.USER_GROUP_ROLE_TITLE_ACCESSOR);
 
-			List<String> rolesAndTeamsNames = ListUtil.toList(UserGroupRoleLocalServiceUtil.getUserGroupRoles(curUser.getUserId(), siteMembershipsDisplayContext.getGroupId()), UsersAdmin.USER_GROUP_ROLE_TITLE_ACCESSOR);
+					rolesAndTeamsNames.addAll(ListUtil.toList(teams, Team.NAME_ACCESSOR));
+					%>
 
-			rolesAndTeamsNames.addAll(ListUtil.toList(teams, Team.NAME_ACCESSOR));
-			%>
+					<c:if test="<%= !ListUtil.isEmpty(rolesAndTeamsNames) %>">
+						<h5><liferay-ui:message key="roles-and-teams" /></h5>
 
-			<c:if test="<%= !ListUtil.isEmpty(rolesAndTeamsNames) %>">
-				<h5><liferay-ui:message key="roles-and-teams" /></h5>
-
-				<p>
-					<%= HtmlUtil.escape(StringUtil.merge(rolesAndTeamsNames, StringPool.COMMA_AND_SPACE)) %>
-				</p>
-			</c:if>
+						<p>
+							<%= HtmlUtil.escape(StringUtil.merge(rolesAndTeamsNames, StringPool.COMMA_AND_SPACE)) %>
+						</p>
+					</c:if>
+				</div>
+			</clay:tabs>
 		</div>
 	</c:when>
 	<c:when test="<%= ListUtil.isNotEmpty(users) && (users.size() > 1) %>">
@@ -150,12 +154,14 @@ Group group = siteMembershipsDisplayContext.getGroup();
 			<h4><liferay-ui:message arguments="<%= users.size() %>" key="x-items-are-selected" /></h4>
 		</div>
 
-		<clay:navigation-bar
-			navigationItems="<%= siteMembershipsDisplayContext.getInfoPanelNavigationItems() %>"
-		/>
-
-		<div class="sidebar-body">
-			<h5><liferay-ui:message arguments="<%= users.size() %>" key="x-items-are-selected" /></h5>
+		<div class="sheet-row">
+			<clay:tabs
+				tabsItems="<%= siteMembershipsDisplayContext.getTabsItems() %>"
+			>
+				<div class="sidebar-body">
+					<h5><liferay-ui:message arguments="<%= users.size() %>" key="x-items-are-selected" /></h5>
+				</div>
+			</clay:tabs>
 		</div>
 	</c:when>
 </c:choose>


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/LPS-177303)

## Steps 

1. Go to Control Menu > Control Panel > Users and organisations
2. Create 2 users and 2 organisations
3. Go to Product Menu > People > memberships 
4. Click on the info icon in both users and organisations sections
<img width="972" alt="Screenshot 2023-05-12 at 11 45 24" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/d67fc317-53dd-408e-8945-4369ff1735f8">
<img width="979" alt="Screenshot 2023-05-12 at 11 45 34" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/7dff2575-2db0-49d4-b944-19f4d2bc0da2">
<img width="973" alt="Screenshot 2023-05-12 at 11 45 53" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/48fa3ed7-9111-409d-a7de-5d3444993775">
