### PR TITLE
LPS-184250 Can't save API Key in site settings > pages > Google PageSpeed Insights in new site

### DIFF
--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/product/navigation/control/menu/LayoutReportsProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/product/navigation/control/menu/LayoutReportsProductNavigationControlMenuEntry.java
@@ -211,7 +211,7 @@ public class LayoutReportsProductNavigationControlMenuEntry
 		return HttpComponentsUtil.addParameters(
 			themeDisplay.getPortalURL() + themeDisplay.getPathMain() +
 				"/layout_reports/get_layout_reports_data",
-			"plid", themeDisplay.getPlid());
+			"p_l_id", themeDisplay.getPlid());
 	}
 
 	private boolean _hasEditPermission(

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportsDataStrutsAction.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportsDataStrutsAction.java
@@ -85,7 +85,7 @@ public class GetLayoutReportsDataStrutsAction implements StrutsAction {
 		throws Exception {
 
 		Layout layout = _layoutLocalService.fetchLayout(
-			ParamUtil.getLong(httpServletRequest, "plid"));
+			ParamUtil.getLong(httpServletRequest, "p_l_id"));
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)httpServletRequest.getAttribute(

--- a/modules/dxp/apps/osb/osb-faro/.gitrepo
+++ b/modules/dxp/apps/osb/osb-faro/.gitrepo
@@ -4,8 +4,8 @@
 [subrepo]
 	autopull = false
 	cmdver = liferay
-	commit = 64b4f23cdd7b9366ba9d9ceac9288357dac22242
+	commit = b7e75403a63fc13607fe826922be9e3d1aacb1e4
 	mergebuttonmergecommits = false
 	mode = push
-	parent = bdbb33483cea0274fcbed348e38a85b1f80b0802
+	parent = 8329c91078d2a38871b5b24e463d9a506efbf806
 	remote = git@github.com:liferay/com-liferay-osb-faro-private.git

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3597,6 +3597,9 @@
         /image_gallery_display/find_folder,\
         /image_gallery_display/find_image,\
         \
+        /layout_reports/get_layout_reports_data,\
+        /layout_reports/get_layout_reports_issues,\
+        \
         /login/facebook_connect_oauth,\
         \
         /message_boards/find_category,\


### PR DESCRIPTION
Motivation
=======
This ticket solves the next bug: [LPS-184250](https://issues.liferay.com/browse/LPS-184250)

Proposed Solution
========
What we did to solve the problem is to fix the p_l_id name attribute so the correct configuration for the site is obtained. Also we added the paths used for Struts to portal.properties to fix the error thrown by the server.

Steps to Verify
========
1. Add a site and add a content page in it
2. Go to created site's site settings > pages > Google PageSpeed Insights
3. Add an API Key
4. Save and go to view the content page
5. Go to Page Audit and Check that the button that appears is "Launch Page Audit" button.

