### PR TITLE
LPS-184545 The Load More Result button is not present under childpages

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.SessionClicks;
+import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
@@ -204,7 +205,8 @@ public class LayoutsTreeImpl implements LayoutsTree {
 			JSONArray childLayoutsJSONArray = null;
 
 			if (ancestorLayouts.contains(layout) ||
-				expandedLayoutIds.contains(layout.getLayoutId())) {
+				(SetUtil.isNotEmpty(expandedLayoutIds) &&
+				 expandedLayoutIds.contains(layout.getLayoutId()))) {
 
 				if (layout instanceof VirtualLayout) {
 					VirtualLayout virtualLayout = (VirtualLayout)layout;

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutsTreeImpl.java
@@ -201,7 +201,6 @@ public class LayoutsTreeImpl implements LayoutsTree {
 		}
 
 		for (Layout layout : layouts) {
-			int childLayoutsCount = 0;
 			JSONArray childLayoutsJSONArray = null;
 
 			if (ancestorLayouts.contains(layout) ||
@@ -226,13 +225,8 @@ public class LayoutsTreeImpl implements LayoutsTree {
 						layout.getLayoutId(), layout.isPrivateLayout(),
 						themeDisplay);
 				}
-
-				childLayoutsCount = childLayoutsJSONArray.length();
 			}
 			else {
-				childLayoutsCount = _layoutService.getLayoutsCount(
-					groupId, privateLayout, layout.getLayoutId());
-
 				childLayoutsJSONArray = _jsonFactory.createJSONArray();
 			}
 
@@ -252,7 +246,9 @@ public class LayoutsTreeImpl implements LayoutsTree {
 
 			layoutsJSONArray.put(
 				_toJSONObject(
-					afterDeleteSelectedLayout, childLayoutsCount,
+					afterDeleteSelectedLayout,
+					_layoutService.getLayoutsCount(
+						groupId, privateLayout, layout.getLayoutId()),
 					childLayoutsJSONArray, httpServletRequest, includeActions,
 					layout, themeDisplay));
 

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/portlet/action/GetLayoutsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/portlet/action/GetLayoutsMVCResourceCommand.java
@@ -15,7 +15,10 @@
 package com.liferay.product.navigation.product.menu.web.internal.portlet.action;
 
 import com.liferay.layout.util.LayoutsTree;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
@@ -25,6 +28,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.SessionClicks;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.product.navigation.product.menu.constants.ProductNavigationProductMenuPortletKeys;
@@ -85,8 +89,26 @@ public class GetLayoutsMVCResourceCommand extends BaseMVCResourceCommand {
 					int pageSize = GetterUtil.getInteger(
 						PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN);
 
+					String key = StringBundler.concat(
+						"productMenuPagesTree:", themeDisplay.getScopeGroupId(),
+						StringPool.COLON, privateLayout, ":Pagination");
+
+					String paginationJSON = SessionClicks.get(
+						httpServletRequest.getSession(), key,
+						_jsonFactory.getNullJSON());
+
+					JSONObject paginationJSONObject =
+						_jsonFactory.createJSONObject(paginationJSON);
+
+					int loadedLayoutsCount = paginationJSONObject.getInt(
+						String.valueOf(parentLayoutId), 0);
+
 					int end = ParamUtil.getInteger(
 						httpServletRequest, "end", start + pageSize);
+
+					if (loadedLayoutsCount > end) {
+						end = loadedLayoutsCount;
+					}
 
 					end = Math.max(start, end);
 


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-184545)

Fix two scenarios, the first one is that the load more button doesn't appear during staging process, the other is that the button didn't have a correct behaviour in product menu

## Change summary:

* Change so that the total layout count is used when calculating is we want to show the load more button in the publish process
* Take into account the session key when calculating how to show the load more button in product menu


## Test Scenario No. 1

* Follow the steps in the ticket to reproduce
* At the end, the load more elements is displayed and upon clicking, the tree is expanded

## Test Scenario No. 2

* Start portal with layout.manage.pages.initial.children=5 as explained in the ticket
* Create a new Site
* Add a Home page
* Add several child pages to the home page (one more than the property at least)
* Go to the home page and open the product menu
* Click on Page Tree and expand home page (notice that only 5 childs are shown and a load more button is present)
* Click on load more, and the rest of the child pages are shown
* Click on the cog in pages tree to "configure pages"
* The tree should be expanded and load more button is not shown



