### PR TITLE
LPS-181056 add treepath to retrieve values from children folders

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleFinderImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleFinderImpl.java
@@ -810,7 +810,6 @@ public class JournalArticleFinderImpl
 
 			if (folderIds.isEmpty()) {
 				sql = StringUtil.removeSubstring(sql, "([$FOLDER_ID$]) AND");
-				sql = StringUtil.removeSubstring(sql, "([$TREE_PATH$]) AND");
 			}
 			else {
 				sql = StringUtil.replace(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleFinderImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/persistence/impl/JournalArticleFinderImpl.java
@@ -526,7 +526,8 @@ public class JournalArticleFinderImpl
 			else {
 				sql = StringUtil.replace(
 					sql, "[$FOLDER_ID$]",
-					getFolderIds(folderIds, JournalArticleImpl.TABLE_NAME));
+					getFolderIdsAndTreePath(
+						folderIds, JournalArticleImpl.TABLE_NAME));
 			}
 
 			if (ddmStructureId <= 0) {
@@ -554,6 +555,10 @@ public class JournalArticleFinderImpl
 
 			for (Long folderId : folderIds) {
 				queryPos.add(folderId);
+			}
+
+			if (!folderIds.isEmpty()) {
+				queryPos.add(getTreePathArrayIds(folderIds));
 			}
 
 			if (ddmStructureId > 0) {
@@ -805,11 +810,13 @@ public class JournalArticleFinderImpl
 
 			if (folderIds.isEmpty()) {
 				sql = StringUtil.removeSubstring(sql, "([$FOLDER_ID$]) AND");
+				sql = StringUtil.removeSubstring(sql, "([$TREE_PATH$]) AND");
 			}
 			else {
 				sql = StringUtil.replace(
 					sql, "[$FOLDER_ID$]",
-					getFolderIds(folderIds, JournalArticleImpl.TABLE_NAME));
+					getFolderIdsAndTreePath(
+						folderIds, JournalArticleImpl.TABLE_NAME));
 			}
 
 			if (ddmStructureId <= 0) {
@@ -845,6 +852,10 @@ public class JournalArticleFinderImpl
 
 			for (Long folderId : folderIds) {
 				queryPos.add(folderId);
+			}
+
+			if (!folderIds.isEmpty()) {
+				queryPos.add(getTreePathArrayIds(folderIds));
 			}
 
 			if (ddmStructureId > 0) {
@@ -989,6 +1000,55 @@ public class JournalArticleFinderImpl
 		sb.append(StringPool.CLOSE_PARENTHESIS);
 
 		return sb.toString();
+	}
+
+	protected String getFolderIdsAndTreePath(
+		List<Long> folderIds, String tableName) {
+
+		if (folderIds.isEmpty()) {
+			return StringPool.BLANK;
+		}
+
+		StringBundler sb = new StringBundler((folderIds.size() * 6) + 1);
+
+		sb.append(StringPool.OPEN_PARENTHESIS);
+
+		for (int i = 0; i < folderIds.size(); i++) {
+			sb.append(tableName);
+			sb.append(".folderId = ? OR ");
+			sb.append(tableName);
+			sb.append(".treePath LIKE ? ");
+
+			if ((i + 1) != folderIds.size()) {
+				sb.append(WHERE_OR);
+			}
+		}
+
+		sb.append(StringPool.CLOSE_PARENTHESIS);
+
+		return sb.toString();
+	}
+
+	protected String[] getTreePathArrayIds(List<Long> folderIds) {
+		String[] folderIdsArray = new String[folderIds.size()];
+
+		for (int i = 0; i < folderIds.size(); i++) {
+			StringBundler sb = new StringBundler(5);
+
+			sb.append(StringPool.PERCENT);
+			sb.append(StringPool.SLASH);
+
+			if (folderIds.get(i) != 0) {
+				sb.append(String.valueOf(folderIds.get(i)));
+				sb.append(StringPool.SLASH);
+			}
+
+			sb.append(StringPool.PERCENT);
+
+			folderIdsArray[i] = sb.toString();
+		}
+
+		return folderIdsArray;
 	}
 
 	protected String replaceStatusJoin(


### PR DESCRIPTION
Motivation
=======
This PR aims to solve the case where filtering by structureId from the web content administration only search in the current folder, instead of this folders and their children, [LPS-181056](https://issues.liferay.com/browse/LPS-181056)

Proposed Solution
========
Modify the methods in the finder to take into account the treepath and the folderId instead of only using the folderId.
The new aproximation uses 
`folderId = X or treepath like %/folderId/% `
instead of just 
`folderId = X`
If folderId = 0, treepath is /, as currently stored in the database

Steps to Verify
========

1. Start master
2. Go to Web Content
3. Create a Basic Web Content named "Outer Content" in Home level directory
4. Create a folder named "Subfolder 1"
5. Open "Subfolder 1", create Basic Web Content named "Inner Content Depth 1" AND create folder named "Subfolder 2"
6. Open "Subfolder 2", create Basic Web Content named "Inner Content Depth 2"
7. Go to Home (top level directory in Web Content)
8. Filter by Structure and select Basic Web Content

Expected Results :
    Show Basic Web Content in Home folder, Subfolder 1, and Subfolder 2 ("Outer Content", "Inner Content Depth 1", and "Inner Content Depth 2")

Actual Results :
    Only shows Basic Web Content in Home folder "Outer Content" 