### PR TITLE
[TS] LPS-184429 | Saving a web content as a draft with the preview button does not generate DDMfieldAttributes for the content translation

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -41,6 +41,9 @@ export default function _JournalPortlet({
 	const actionInput = document.getElementById(
 		`${namespace}javax-portlet-action`
 	);
+	const availableLocalesInput = document.getElementById(
+		`${namespace}availableLocales`
+	);
 	const contextualSidebarButton = document.getElementById(
 		`${namespace}contextualSidebarButton`
 	);
@@ -59,6 +62,8 @@ export default function _JournalPortlet({
 		...initialAvailableLocales,
 		initialDefaultLanguageId,
 	];
+
+	availableLocalesInput.value = availableLocales;
 
 	let articleId = initialArticleId;
 	let defaultLanguageId = initialDefaultLanguageId;
@@ -196,10 +201,6 @@ export default function _JournalPortlet({
 			);
 
 			articleIdInput.value = articleId;
-
-			const availableLocalesInput = document.getElementById(
-				`${namespace}availableLocales`
-			);
 
 			availableLocalesInput.value = availableLocales;
 
@@ -398,6 +399,7 @@ export default function _JournalPortlet({
 			onLocaleChangedCallback: (_context, languageId) => {
 				if (!availableLocales.includes(languageId)) {
 					availableLocales.push(languageId);
+					availableLocalesInput.value = availableLocales;
 				}
 
 				selectedLanguageId = languageId;


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-184429
Thank you!

-----

**Reproduction Steps**

1. Create a Display Page Template for basic web content
     1. add a Language selector on the page
     2. add a heading and map the title on it
     3. add a Display Page Content fragment to the page
     4. click on Publish
2. For the DPT, click on ⋮ → Mark as default
3. Start creating a Basic Web Content article
    1. set the title and content for the English translation
    2. click on Save as Draft
    3. change the language to another one, e.g. French
    4. change the translation for the title and content field
    5. click on Save as Draft
4. Click on the Preview button on the right bar under Display Page section
5. Use the selector to change the language to French

 **Expected Behavior:** The correct translation is displayed.
 **Actual Behavior:**The content field language does not change on the display page only the title does.
 
The root cause of the issue is that the availableLocales is not stored in the input field but handled inside the journalPortlet.es.js. The availableLocales are only stored in the input field when the publish or save as draft button is clicked. My solution for the issue is to store the value in the input field after the initialization and also update the input field value with the availableLocales whenever it is changed.
