### PR TITLE
[TS] LPS-180284 The validation message of some inputs doesn't mention the correct input name

### DIFF
--- a/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_user_registration/create_account_user.jsp
+++ b/modules/apps/account/account-admin-web/src/main/resources/META-INF/resources/account_user_registration/create_account_user.jsp
@@ -152,16 +152,12 @@ portletDisplay.setURLBack(backURL);
 						<clay:col
 							md="6"
 						>
-							<aui:input label="password" name="password1" size="30" type="password" value="">
-								<aui:validator name="required" />
-							</aui:input>
+							<aui:input label="password" name="password1" required="<%= true %>" size="30" type="password" value="" />
 
-							<aui:input label="enter-again" name="password2" size="30" type="password" value="">
+							<aui:input label="enter-again" name="password2" required="<%= true %>" size="30" type="password" value="">
 								<aui:validator name="equalTo">
 									'#<portlet:namespace />password1'
 								</aui:validator>
-
-								<aui:validator name="required" />
 							</aui:input>
 						</clay:col>
 					</clay:row>

--- a/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
+++ b/modules/apps/blogs/blogs-web/src/main/resources/META-INF/resources/blogs/edit_entry.jsp
@@ -238,9 +238,7 @@ renderResponse.setTitle(blogsEditEntryDisplayContext.getPageTitle(resourceBundle
 							</div>
 
 							<div class="entry-description form-group">
-								<aui:input disabled="<%= !blogsEditEntryDisplayContext.isCustomAbstract() %>" label="description" name="description" type="text" value="<%= blogsEditEntryDisplayContext.getDescription() %>">
-									<aui:validator name="required" />
-								</aui:input>
+								<aui:input disabled="<%= !blogsEditEntryDisplayContext.isCustomAbstract() %>" label="description" name="description" required="<%= true %>" type="text" value="<%= blogsEditEntryDisplayContext.getDescription() %>" />
 							</div>
 
 							<div class="clearfix">

--- a/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
+++ b/modules/apps/captcha/captcha-taglib/src/main/resources/META-INF/resources/captcha/simplecaptcha.jsp
@@ -35,9 +35,7 @@ String url = (String)request.getAttribute("liferay-captcha:captcha:url");
 			url="javascript:void(0);"
 		/>
 
-		<aui:input ignoreRequestValue="<%= true %>" label="text-verification" name="captchaText" size="10" type="text" value="">
-			<aui:validator name="required" />
-		</aui:input>
+		<aui:input ignoreRequestValue="<%= true %>" label="text-verification" name="captchaText" required="<%= true %>" size="10" type="text" value="" />
 	</div>
 
 	<aui:script>

--- a/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/checkout_step/address.jsp
+++ b/modules/apps/commerce/commerce-checkout-web/src/main/resources/META-INF/resources/checkout_step/address.jsp
@@ -151,9 +151,8 @@ boolean hasManageAddressesPermission = baseAddressCheckoutStepDisplayContext.has
 
 		<div class="form-group-autofit">
 			<c:if test="<%= commerceOrder.isGuestOrder() %>">
-				<aui:input name="email" type="text" wrapperCssClass="form-group-item">
+				<aui:input name="email" required="<%= true %>" type="text" wrapperCssClass="form-group-item">
 					<aui:validator name="email" />
-					<aui:validator name="required" />
 				</aui:input>
 			</c:if>
 		</div>

--- a/modules/apps/commerce/commerce-payment-web/src/main/resources/META-INF/resources/commerce_payment_method/details.jsp
+++ b/modules/apps/commerce/commerce-payment-web/src/main/resources/META-INF/resources/commerce_payment_method/details.jsp
@@ -34,9 +34,7 @@ CommercePaymentMethodGroupRel commercePaymentMethodGroupRel = commercePaymentMet
 	<liferay-ui:error exception="<%= CommercePaymentMethodGroupRelNameException.class %>" message="please-enter-a-valid-name" />
 
 	<commerce-ui:panel>
-		<aui:input label="name" localized="<%= true %>" name="nameMapAsXML" type="text" value='<%= BeanParamUtil.getString(commercePaymentMethodGroupRel, request, "name", commercePaymentMethodsDisplayContext.getCommercePaymentMethodEngineName(locale)) %>'>
-			<aui:validator name="required" />
-		</aui:input>
+		<aui:input label="name" localized="<%= true %>" name="nameMapAsXML" required="<%= true %>" type="text" value='<%= BeanParamUtil.getString(commercePaymentMethodGroupRel, request, "name", commercePaymentMethodsDisplayContext.getCommercePaymentMethodEngineName(locale)) %>' />
 
 		<aui:input label="description" localized="<%= true %>" name="descriptionMapAsXML" type="text" value='<%= BeanParamUtil.getString(commercePaymentMethodGroupRel, request, "description", commercePaymentMethodsDisplayContext.getCommercePaymentMethodEngineDescription(locale)) %>' />
 

--- a/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/details.jsp
+++ b/modules/apps/commerce/commerce-product-definitions-web/src/main/resources/META-INF/resources/definition/details.jsp
@@ -91,9 +91,7 @@ if ((cpDefinition != null) && (cpDefinition.getExpirationDate() != null)) {
 					</c:otherwise>
 				</c:choose>
 
-				<aui:input defaultLanguageId="<%= defaultLanguageId %>" label="name" localized="<%= true %>" name="nameMapAsXML" type="text">
-					<aui:validator name="required" />
-				</aui:input>
+				<aui:input defaultLanguageId="<%= defaultLanguageId %>" label="name" localized="<%= true %>" name="nameMapAsXML" required="<%= true %>" type="text" />
 
 				<aui:input defaultLanguageId="<%= defaultLanguageId %>" label="short-description" localized="<%= true %>" name="shortDescriptionMapAsXML" resizable="<%= true %>" type="textarea" />
 

--- a/modules/apps/commerce/commerce-shipping-web/src/main/resources/META-INF/resources/commerce_shipping_method/details.jsp
+++ b/modules/apps/commerce/commerce-shipping-web/src/main/resources/META-INF/resources/commerce_shipping_method/details.jsp
@@ -47,9 +47,7 @@ if (commerceShippingMethod != null) {
 	</c:if>
 
 	<commerce-ui:panel>
-		<aui:input label="name" localized="<%= true %>" name="nameMapAsXML" type="text" value='<%= BeanParamUtil.getString(commerceShippingMethod, request, "name", commerceShippingMethodsDisplayContext.getCommerceShippingMethodEngineName(locale)) %>'>
-			<aui:validator name="required" />
-		</aui:input>
+		<aui:input label="name" localized="<%= true %>" name="nameMapAsXML" required="<%= true %>" type="text" value='<%= BeanParamUtil.getString(commerceShippingMethod, request, "name", commerceShippingMethodsDisplayContext.getCommerceShippingMethodEngineName(locale)) %>' />
 
 		<aui:input label="description" localized="<%= true %>" name="descriptionMapAsXML" type="text" value='<%= BeanParamUtil.getString(commerceShippingMethod, request, "description", commerceShippingMethodsDisplayContext.getCommerceShippingMethodEngineDescription(locale)) %>' />
 

--- a/modules/apps/commerce/commerce-tax-engine-fixed-web/src/main/resources/META-INF/resources/edit_commerce_tax_fixed_rate.jspf
+++ b/modules/apps/commerce/commerce-tax-engine-fixed-web/src/main/resources/META-INF/resources/edit_commerce_tax_fixed_rate.jspf
@@ -50,10 +50,9 @@ if (commerceTaxFixedRate != null) {
 	</div>
 
 	<div class="col-md-6">
-		<aui:input label='<%= commerceTaxMethod.isPercentage() ? "rate" : "amount" %>' name="rate" suffix="<%= commerceTaxMethod.isPercentage() ? StringPool.PERCENT : HtmlUtil.escape(commerceTaxFixedRatesDisplayContext.getCommerceCurrencyCode()) %>" value="<%= commerceTaxFixedRatesDisplayContext.getLocalizedRate(commerceTaxMethod.isPercentage(), (commerceTaxFixedRate == null) ? 0 : commerceTaxFixedRate.getRate(), locale) %>">
+		<aui:input label='<%= commerceTaxMethod.isPercentage() ? "rate" : "amount" %>' name="rate" required="<%= true %>" suffix="<%= commerceTaxMethod.isPercentage() ? StringPool.PERCENT : HtmlUtil.escape(commerceTaxFixedRatesDisplayContext.getCommerceCurrencyCode()) %>" value="<%= commerceTaxFixedRatesDisplayContext.getLocalizedRate(commerceTaxMethod.isPercentage(), (commerceTaxFixedRate == null) ? 0 : commerceTaxFixedRate.getRate(), locale) %>">
 			<aui:validator name="min">0</aui:validator>
 			<aui:validator name="number" />
-			<aui:validator name="required" />
 		</aui:input>
 	</div>
 </div>

--- a/modules/apps/commerce/commerce-tax-engine-fixed-web/src/main/resources/META-INF/resources/edit_commerce_tax_fixed_rate_address_rel.jspf
+++ b/modules/apps/commerce/commerce-tax-engine-fixed-web/src/main/resources/META-INF/resources/edit_commerce_tax_fixed_rate_address_rel.jspf
@@ -51,10 +51,9 @@ if (commerceTaxFixedRateAddressRel != null) {
 	</div>
 
 	<div class="col-md-6">
-		<aui:input label='<%= commerceTaxMethod.isPercentage() ? "rate" : "amount" %>' name="rate" suffix="<%= commerceTaxMethod.isPercentage() ? StringPool.PERCENT : commerceTaxFixedRateAddressRelsDisplayContext.getCommerceCurrencyCode() %>" value="<%= commerceTaxFixedRateAddressRelsDisplayContext.getLocalizedRate(commerceTaxMethod.isPercentage(), (commerceTaxFixedRateAddressRel == null) ? 0 : commerceTaxFixedRateAddressRel.getRate(), locale) %>">
+		<aui:input label='<%= commerceTaxMethod.isPercentage() ? "rate" : "amount" %>' name="rate" required="<%= true %>" suffix="<%= commerceTaxMethod.isPercentage() ? StringPool.PERCENT : commerceTaxFixedRateAddressRelsDisplayContext.getCommerceCurrencyCode() %>" value="<%= commerceTaxFixedRateAddressRelsDisplayContext.getLocalizedRate(commerceTaxMethod.isPercentage(), (commerceTaxFixedRateAddressRel == null) ? 0 : commerceTaxFixedRateAddressRel.getRate(), locale) %>">
 			<aui:validator name="min">0</aui:validator>
 			<aui:validator name="number" />
-			<aui:validator name="required" />
 		</aui:input>
 	</div>
 </div>

--- a/modules/apps/commerce/commerce-tax-web/src/main/resources/META-INF/resources/commerce_tax_method/detail.jsp
+++ b/modules/apps/commerce/commerce-tax-web/src/main/resources/META-INF/resources/commerce_tax_method/detail.jsp
@@ -40,9 +40,7 @@ if (commerceTaxMethod != null) {
 	<liferay-ui:error exception="<%= CommerceTaxMethodNameException.class %>" message="please-enter-a-valid-name" />
 
 	<commerce-ui:panel>
-		<aui:input label="name" localized="<%= true %>" name="nameMapAsXML" type="text" value='<%= BeanParamUtil.getString(commerceTaxMethod, request, "name", commerceTaxMethodsDisplayContext.getCommerceTaxMethodEngineName(locale)) %>'>
-			<aui:validator name="required" />
-		</aui:input>
+		<aui:input label="name" localized="<%= true %>" name="nameMapAsXML" required="<%= true %>" type="text" value='<%= BeanParamUtil.getString(commerceTaxMethod, request, "name", commerceTaxMethodsDisplayContext.getCommerceTaxMethodEngineName(locale)) %>' />
 
 		<aui:input label="description" localized="<%= true %>" name="descriptionMapAsXML" type="text" value='<%= BeanParamUtil.getString(commerceTaxMethod, request, "description", commerceTaxMethodsDisplayContext.getCommerceTaxMethodEngineDescription(locale)) %>' />
 

--- a/modules/apps/commerce/commerce-term-web/src/main/resources/META-INF/resources/commerce_term_entry/details.jsp
+++ b/modules/apps/commerce/commerce-term-web/src/main/resources/META-INF/resources/commerce_term_entry/details.jsp
@@ -55,9 +55,7 @@ if ((commerceTermEntry != null) && (commerceTermEntry.getExpirationDate() != nul
 			>
 				<div class="row">
 					<div class="col">
-						<aui:input defaultLanguageId="<%= themeDisplay.getLanguageId() %>" label="title" localized="<%= true %>" name="labelMapAsXML" type="text">
-							<aui:validator name="required" />
-						</aui:input>
+						<aui:input defaultLanguageId="<%= themeDisplay.getLanguageId() %>" label="title" localized="<%= true %>" name="labelMapAsXML" required="<%= true %>" type="text" />
 
 						<aui:input name="priority" />
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_import.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_import.jsp
@@ -79,9 +79,7 @@ ImportDisplayContext importDisplayContext = new ImportDisplayContext(request, re
 		<liferay-ui:error exception="<%= InvalidFileException.class %>" message="the-selected-file-is-not-a-valid-zip-file" />
 
 		<liferay-frontend:fieldset>
-			<aui:input label="select-file" name="file" type="file">
-				<aui:validator name="required" />
-
+			<aui:input label="select-file" name="file" required="<%= true %>" type="file">
 				<aui:validator name="acceptFiles">
 					'zip'
 				</aui:validator>

--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -146,14 +146,12 @@ sb.append("\n");
 			<aui:input helpMessage="resize-automatically-help" inlineLabel="right" label="resize-automatically" labelCssClass="simple-toggle-switch" name="preferences--resizeAutomatically--" type="toggle-switch" value="<%= iFramePortletInstanceConfiguration.resizeAutomatically() %>" />
 
 			<div id="<portlet:namespace />displaySettings">
-				<aui:input name="preferences--heightMaximized--" type="text" value="<%= iFramePortletInstanceConfiguration.heightMaximized() %>">
+				<aui:input name="preferences--heightMaximized--" required="<%= true %>" type="text" value="<%= iFramePortletInstanceConfiguration.heightMaximized() %>">
 					<aui:validator name="digits" />
-					<aui:validator name="required" />
 				</aui:input>
 
-				<aui:input name="preferences--heightNormal--" type="text" value="<%= iFramePortletInstanceConfiguration.heightNormal() %>">
+				<aui:input name="preferences--heightNormal--" required="<%= true %>" type="text" value="<%= iFramePortletInstanceConfiguration.heightNormal() %>">
 					<aui:validator name="digits" />
-					<aui:validator name="required" />
 				</aui:input>
 
 				<aui:input name="preferences--width--" type="text" value="<%= iFramePortletInstanceConfiguration.width() %>" />

--- a/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/import.jsp
+++ b/modules/apps/knowledge-base/knowledge-base-web/src/main/resources/META-INF/resources/admin/import.jsp
@@ -62,9 +62,7 @@ renderResponse.setTitle(LanguageUtil.get(resourceBundle, "import"));
 						</div>
 					</aui:field-wrapper>
 
-					<aui:input id="file" label="upload-your-zip-file" name="file" type="file">
-						<aui:validator name="required" />
-
+					<aui:input id="file" label="upload-your-zip-file" name="file" required="<%= true %>" type="file">
 						<aui:validator name="acceptFiles">
 							'zip'
 						</aui:validator>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view_import.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view_import.jsp
@@ -40,9 +40,7 @@ LayoutUtilityPageEntryImportDisplayContext layoutUtilityPageEntryImportDisplayCo
 		<br /><br />
 
 		<liferay-frontend:fieldset>
-			<aui:input label="file" name="file" type="file">
-				<aui:validator name="required" />
-
+			<aui:input label="file" name="file" required="<%= true %>" type="file">
 				<aui:validator name="acceptFiles">
 					'zip'
 				</aui:validator>

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_import.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_import.jsp
@@ -40,9 +40,7 @@ ImportDisplayContext importDisplayContext = new ImportDisplayContext(request, re
 		<br /><br />
 
 		<liferay-frontend:fieldset>
-			<aui:input label="file" name="file" type="file">
-				<aui:validator name="required" />
-
+			<aui:input label="file" name="file" required="<%= true %>" type="file">
 				<aui:validator name="acceptFiles">
 					'zip'
 				</aui:validator>

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
@@ -231,16 +231,12 @@ renderResponse.setTitle(LanguageUtil.get(request, "create-account"));
 						<clay:col
 							md="6"
 						>
-							<aui:input label="password" name="password1" size="30" type="password" value="">
-								<aui:validator name="required" />
-							</aui:input>
+							<aui:input label="password" name="password1" required="<%= true %>" size="30" type="password" value="" />
 
-							<aui:input label="enter-again" name="password2" size="30" type="password" value="">
+							<aui:input label="enter-again" name="password2" required="<%= true %>" size="30" type="password" value="">
 								<aui:validator name="equalTo">
 									'#<portlet:namespace />password1'
 								</aui:validator>
-
-								<aui:validator name="required" />
 							</aui:input>
 						</clay:col>
 					</clay:row>

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_account.jsp
@@ -180,11 +180,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "create-account"));
 							</aui:input>
 						</c:if>
 
-						<aui:input model="<%= User.class %>" name="emailAddress">
-							<c:if test="<%= PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_EMAIL_ADDRESS_REQUIRED) %>">
-								<aui:validator name="required" />
-							</c:if>
-						</aui:input>
+						<aui:input model="<%= User.class %>" name="emailAddress" required="<%= PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_EMAIL_ADDRESS_REQUIRED) %>" />
 					</clay:col>
 				</clay:row>
 			</div>

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_anonymous_account.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/create_anonymous_account.jsp
@@ -68,16 +68,10 @@ renderResponse.setTitle(LanguageUtil.get(request, "anonymous-account"));
 				%>
 
 				<c:if test='<%= fullNameDefinition.isFieldRequired("last-name") %>'>
-					<aui:input model="<%= User.class %>" name="lastName">
-						<aui:validator name="required" />
-					</aui:input>
+					<aui:input model="<%= User.class %>" name="lastName" required="<%= true %>" />
 				</c:if>
 
-				<aui:input model="<%= User.class %>" name="emailAddress">
-					<c:if test="<%= PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_EMAIL_ADDRESS_REQUIRED, PropsValues.USERS_EMAIL_ADDRESS_REQUIRED) %>">
-						<aui:validator name="required" />
-					</c:if>
-				</aui:input>
+				<aui:input model="<%= User.class %>" name="emailAddress" required="<%= PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_EMAIL_ADDRESS_REQUIRED, PropsValues.USERS_EMAIL_ADDRESS_REQUIRED) %>" />
 			</clay:col>
 
 			<clay:col

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/forgot_password.jsp
@@ -104,9 +104,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "forgot-password"));
 						<aui:input name="redirect" type="hidden" value="<%= redirectURL %>" />
 					</c:if>
 
-					<aui:input label="<%= loginLabel %>" name="login" size="30" type="text" value="<%= login %>">
-						<aui:validator name="required" />
-					</aui:input>
+					<aui:input label="<%= loginLabel %>" name="login" required="<%= true %>" size="30" type="text" value="<%= login %>" />
 
 					<c:if test="<%= captchaConfiguration.sendPasswordCaptchaEnabled() %>">
 						<liferay-captcha:captcha />

--- a/modules/apps/login/login-web/src/main/resources/META-INF/resources/login.jsp
+++ b/modules/apps/login/login-web/src/main/resources/META-INF/resources/login.jsp
@@ -169,17 +169,13 @@
 					}
 					%>
 
-					<aui:input cssClass="clearable" label="<%= loginLabel %>" name="login" showRequiredLabel="<%= false %>" type="text" value="<%= login %>">
-						<aui:validator name="required" />
-
+					<aui:input cssClass="clearable" label="<%= loginLabel %>" name="login" required="<%= true %>" showRequiredLabel="<%= false %>" type="text" value="<%= login %>">
 						<c:if test="<%= authType.equals(CompanyConstants.AUTH_TYPE_EA) %>">
 							<aui:validator name="email" />
 						</c:if>
 					</aui:input>
 
-					<aui:input name="password" showRequiredLabel="<%= false %>" type="password" value="<%= password %>">
-						<aui:validator name="required" />
-					</aui:input>
+					<aui:input name="password" required="<%= true %>" showRequiredLabel="<%= false %>" type="password" value="<%= password %>" />
 
 					<span id="<portlet:namespace />passwordCapsLockSpan" style="display: none;"><liferay-ui:message key="caps-lock-is-on" /></span>
 

--- a/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/add_instance.jsp
+++ b/modules/apps/portal-instances/portal-instances-web/src/main/resources/META-INF/resources/add_instance.jsp
@@ -36,9 +36,7 @@
 
 				<aui:model-context model="<%= Company.class %>" />
 
-				<aui:input name="webId">
-					<aui:validator name="required" />
-				</aui:input>
+				<aui:input name="webId" required="<%= true %>" />
 
 				<aui:input fieldParam="virtualHostname" label="virtual-host" model="<%= VirtualHost.class %>" name="hostname" />
 

--- a/modules/apps/portal-language/portal-language-override-web/src/main/resources/META-INF/resources/configuration/icon/import_translations.jsp
+++ b/modules/apps/portal-language/portal-language-override-web/src/main/resources/META-INF/resources/configuration/icon/import_translations.jsp
@@ -74,9 +74,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "import-translations"));
 
 		</aui:select>
 
-		<aui:input id="file" label="file-upload" name="file" type="file">
-			<aui:validator name="required" />
-
+		<aui:input id="file" label="file-upload" name="file" required="<%= true %>" type="file">
 			<aui:validator name="acceptFiles">
 				'properties'
 			</aui:validator>

--- a/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/edit_ldap_server.jsp
+++ b/modules/apps/portal-settings/portal-settings-authentication-ldap-web/src/main/resources/META-INF/resources/com.liferay.portal.settings.web/edit_ldap_server.jsp
@@ -157,9 +157,7 @@ renderResponse.setTitle((ldapServerId == 0) ? LanguageUtil.get(resourceBundle, "
 	<div class="sheet">
 		<div class="panel-group panel-group-flush">
 			<aui:fieldset>
-				<aui:input cssClass="lfr-input-text-container" label="server-name" name='<%= "ldap--" + LDAPConstants.SERVER_NAME + "--" %>' type="text" value="<%= ldapServerName %>">
-					<aui:validator name="required" />
-				</aui:input>
+				<aui:input cssClass="lfr-input-text-container" label="server-name" name='<%= "ldap--" + LDAPConstants.SERVER_NAME + "--" %>' required="<%= true %>" type="text" value="<%= ldapServerName %>" />
 			</aui:fieldset>
 
 			<aui:fieldset>

--- a/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/shutdown.jsp
+++ b/modules/apps/server/server-admin-web/src/main/resources/META-INF/resources/shutdown.jsp
@@ -25,10 +25,9 @@
 	<c:otherwise>
 		<div class="sheet">
 			<div class="panel-group panel-group-flush">
-				<aui:input label="number-of-minutes" name="minutes" size="3" type="text">
+				<aui:input label="number-of-minutes" name="minutes" required="<%= true %>" size="3" type="text">
 					<aui:validator name="digits" />
 					<aui:validator name="min">1</aui:validator>
-					<aui:validator name="required" />
 				</aui:input>
 
 				<aui:input cssClass="lfr-textarea-container" label="custom-message" name="message" type="textarea" />

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
@@ -30,13 +30,9 @@ String taglibOnChange = "Liferay.Util.toggleDisabled('#" + liferayPortletRespons
 
 <aui:input disabled="<%= !useCustomName %>" label="name" localized="<%= true %>" maxlength='<%= ModelHintsUtil.getMaxLength(SiteNavigationMenuItem.class.getName(), "name") %>' name="name" placeholder="name" required="<%= true %>" type="text" value='<%= SiteNavigationMenuItemUtil.getSiteNavigationMenuItemXML(siteNavigationMenuItem, "name") %>' />
 
-<aui:input id="groupId" name="TypeSettingsProperties--groupId--" type="hidden" value="<%= (selLayout != null) ? selLayout.getGroupId() : StringPool.BLANK %>">
-	<aui:validator name="required" />
-</aui:input>
+<aui:input id="groupId" name="TypeSettingsProperties--groupId--" required="<%= true %>" type="hidden" value="<%= (selLayout != null) ? selLayout.getGroupId() : StringPool.BLANK %>" />
 
-<aui:input id="privateLayout" name="TypeSettingsProperties--privateLayout--" type="hidden" value="<%= (selLayout != null) ? selLayout.isPrivateLayout() : StringPool.BLANK %>">
-	<aui:validator name="required" />
-</aui:input>
+<aui:input id="privateLayout" name="TypeSettingsProperties--privateLayout--" required="<%= true %>" type="hidden" value="<%= (selLayout != null) ? selLayout.isPrivateLayout() : StringPool.BLANK %>" />
 
 <div class="form-group input-text-wrapper mb-2 text-default">
 	<div class="d-inline-block" id="<portlet:namespace />layoutItemRemove" role="button">
@@ -59,9 +55,7 @@ String taglibOnChange = "Liferay.Util.toggleDisabled('#" + liferayPortletRespons
 		</span>
 	</div>
 
-	<aui:input id="layoutUuid" name="TypeSettingsProperties--layoutUuid--" type="hidden" value="<%= (selLayout != null) ? selLayout.getUuid() : StringPool.BLANK %>">
-		<aui:validator name="required" />
-	</aui:input>
+	<aui:input id="layoutUuid" name="TypeSettingsProperties--layoutUuid--" required="<%= true %>" type="hidden" value="<%= (selLayout != null) ? selLayout.getUuid() : StringPool.BLANK %>" />
 </div>
 
 <%

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
@@ -28,9 +28,7 @@ String taglibOnChange = "Liferay.Util.toggleDisabled('#" + liferayPortletRespons
 	<aui:input checked="<%= useCustomName %>" helpMessage="use-custom-name-help" label="use-custom-name" labelCssClass="font-weight-normal" name="TypeSettingsProperties--useCustomName--" onChange="<%= taglibOnChange %>" type="checkbox" />
 </aui:fieldset>
 
-<aui:input disabled="<%= !useCustomName %>" label="name" localized="<%= true %>" maxlength='<%= ModelHintsUtil.getMaxLength(SiteNavigationMenuItem.class.getName(), "name") %>' name="name" placeholder="name" type="text" value='<%= SiteNavigationMenuItemUtil.getSiteNavigationMenuItemXML(siteNavigationMenuItem, "name") %>'>
-	<aui:validator name="required" />
-</aui:input>
+<aui:input disabled="<%= !useCustomName %>" label="name" localized="<%= true %>" maxlength='<%= ModelHintsUtil.getMaxLength(SiteNavigationMenuItem.class.getName(), "name") %>' name="name" placeholder="name" required="<%= true %>" type="text" value='<%= SiteNavigationMenuItemUtil.getSiteNavigationMenuItemXML(siteNavigationMenuItem, "name") %>' />
 
 <aui:input id="groupId" name="TypeSettingsProperties--groupId--" type="hidden" value="<%= (selLayout != null) ? selLayout.getGroupId() : StringPool.BLANK %>">
 	<aui:validator name="required" />

--- a/modules/apps/site-navigation/site-navigation-menu-item-node/src/main/resources/META-INF/resources/edit_node.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-node/src/main/resources/META-INF/resources/edit_node.jsp
@@ -20,6 +20,4 @@
 SiteNavigationMenuItem siteNavigationMenuItem = (SiteNavigationMenuItem)request.getAttribute(SiteNavigationWebKeys.SITE_NAVIGATION_MENU_ITEM);
 %>
 
-<aui:input defaultLanguageId="<%= LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()) %>" label="name" localized="<%= true %>" maxlength='<%= ModelHintsUtil.getMaxLength(SiteNavigationMenuItem.class.getName(), "name") %>' name="name" placeholder="name" type="text" value='<%= SiteNavigationMenuItemUtil.getSiteNavigationMenuItemXML(siteNavigationMenuItem, "name") %>'>
-	<aui:validator name="required" />
-</aui:input>
+<aui:input defaultLanguageId="<%= LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()) %>" label="name" localized="<%= true %>" maxlength='<%= ModelHintsUtil.getMaxLength(SiteNavigationMenuItem.class.getName(), "name") %>' name="name" placeholder="name" required="<%= true %>" type="text" value='<%= SiteNavigationMenuItemUtil.getSiteNavigationMenuItemXML(siteNavigationMenuItem, "name") %>' />

--- a/modules/apps/site-navigation/site-navigation-menu-item-url/src/main/resources/META-INF/resources/edit_url.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-url/src/main/resources/META-INF/resources/edit_url.jsp
@@ -32,9 +32,7 @@ if (siteNavigationMenuItem != null) {
 }
 %>
 
-<aui:input defaultLanguageId="<%= LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()) %>" label="name" localized="<%= true %>" maxlength='<%= ModelHintsUtil.getMaxLength(SiteNavigationMenuItem.class.getName(), "name") %>' name="name" placeholder="name" type="text" value='<%= SiteNavigationMenuItemUtil.getSiteNavigationMenuItemXML(siteNavigationMenuItem, "name") %>'>
-	<aui:validator name="required" />
-</aui:input>
+<aui:input defaultLanguageId="<%= LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()) %>" label="name" localized="<%= true %>" maxlength='<%= ModelHintsUtil.getMaxLength(SiteNavigationMenuItem.class.getName(), "name") %>' name="name" placeholder="name" required="<%= true %>" type="text" value='<%= SiteNavigationMenuItemUtil.getSiteNavigationMenuItemXML(siteNavigationMenuItem, "name") %>' />
 
 <aui:input label="url" name="TypeSettingsProperties--url--" placeholder="http://" required="<%= true %>" value="<%= url %>">
 	<aui:validator name="urlAllowRelative" />

--- a/modules/apps/site-navigation/site-navigation-menu-item-url/src/main/resources/META-INF/resources/edit_url.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-url/src/main/resources/META-INF/resources/edit_url.jsp
@@ -36,9 +36,7 @@ if (siteNavigationMenuItem != null) {
 	<aui:validator name="required" />
 </aui:input>
 
-<aui:input label="url" name="TypeSettingsProperties--url--" placeholder="http://" value="<%= url %>">
-	<aui:validator name="required" />
-
+<aui:input label="url" name="TypeSettingsProperties--url--" placeholder="http://" required="<%= true %>" value="<%= url %>">
 	<aui:validator name="urlAllowRelative" />
 </aui:input>
 

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/view_import.jsp
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/view_import.jsp
@@ -70,9 +70,7 @@ ImportStyleBookDisplayContext importStyleBookDisplayContext = new ImportStyleBoo
 		</c:if>
 
 		<liferay-frontend:fieldset>
-			<aui:input label="select-file" name="file" type="file">
-				<aui:validator name="required" />
-
+			<aui:input label="select-file" name="file" required="<%= true %>" type="file">
 				<aui:validator name="acceptFiles">
 					'zip'
 				</aui:validator>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/details.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/details.jsp
@@ -29,9 +29,7 @@ KaleoProcess kaleoProcess = (KaleoProcess)request.getAttribute(KaleoFormsWebKeys
 <div class="sheet">
 	<div class="panel-group panel-group-flush">
 		<aui:fieldset>
-			<aui:input cssClass="lfr-input-text" defaultLanguageId="<%= LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()) %>" localized="<%= true %>" name="name" type="text" value="<%= KaleoFormsUtil.getKaleoProcessName(kaleoProcess, portletSession) %>">
-				<aui:validator name="required" />
-			</aui:input>
+			<aui:input cssClass="lfr-input-text" defaultLanguageId="<%= LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()) %>" localized="<%= true %>" name="name" required="<%= true %>" type="text" value="<%= KaleoFormsUtil.getKaleoProcessName(kaleoProcess, portletSession) %>" />
 
 			<aui:input cssClass="lfr-editor-textarea" defaultLanguageId="<%= LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()) %>" localized="<%= true %>" name="description" type="textarea" value="<%= KaleoFormsUtil.getKaleoProcessDescription(kaleoProcess, portletSession) %>" wrapperCssClass="lfr-textarea-container" />
 		</aui:fieldset>

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/fields.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/fields.jsp
@@ -33,9 +33,7 @@ JSONArray availableDefinitionsJSONArray = JSONFactoryUtil.createJSONArray();
 
 	<aui:input name="ddmStructureId" type="hidden" value="<%= kaleoFormsAdminFieldsDisplayContext.getDDMStructureId() %>" />
 
-	<aui:input name="ddmStructureName" type="hidden" value="<%= kaleoFormsAdminFieldsDisplayContext.getDDMStructureName() %>">
-		<aui:validator name="required" />
-	</aui:input>
+	<aui:input name="ddmStructureName" required="<%= true %>" type="hidden" value="<%= kaleoFormsAdminFieldsDisplayContext.getDDMStructureName() %>" />
 </aui:field-wrapper>
 
 <liferay-ui:error exception="<%= RecordSetDDMStructureIdException.class %>" message="please-enter-a-valid-definition" />

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/task_template_search_container.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/task_template_search_container.jsp
@@ -58,9 +58,7 @@ KaleoFormsTaskTemplateSearchDisplayContext kaleoFormsTaskTemplateSearchDisplayCo
 				var="taskInputBuffer"
 			>
 				<c:if test="<%= taskFormsPair.equals(kaleoFormsTaskTemplateSearchDisplayContext.getInitialStateKaleoTaskFormPair()) %>">
-					<aui:input name="ddmTemplateId" type="hidden" value="<%= Validator.isNull(formName) ? StringPool.BLANK : String.valueOf(ddmTemplateId) %>">
-						<aui:validator name="required" />
-					</aui:input>
+					<aui:input name="ddmTemplateId" required="<%= true %>" type="hidden" value="<%= Validator.isNull(formName) ? StringPool.BLANK : String.valueOf(ddmTemplateId) %>" />
 				</c:if>
 			</liferay-util:buffer>
 

--- a/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-kaleo-forms-web/src/main/resources/META-INF/resources/admin/process/workflow.jsp
@@ -62,9 +62,7 @@ if (Validator.isNotNull(workflowDefinition)) {
 
 	<span class="badge badge-info" id="<portlet:namespace />workflowDefinitionDisplay"><%= HtmlUtil.escape(workflowDefinitionDisplay) %></span>
 
-	<aui:input name="workflowDefinition" type="hidden" value="<%= workflowDefinition %>">
-		<aui:validator name="required" />
-	</aui:input>
+	<aui:input name="workflowDefinition" required="<%= true %>" type="hidden" value="<%= workflowDefinition %>" />
 
 	<aui:input name="workflowDefinitionName" type="hidden" value="<%= workflowDefinitionName %>" />
 	<aui:input name="workflowDefinitionVersion" type="hidden" value="<%= workflowDefinitionVersion %>" />

--- a/portal-web/docroot/html/portal/setup_wizard.jsp
+++ b/portal-web/docroot/html/portal/setup_wizard.jsp
@@ -62,9 +62,7 @@
 									<liferay-ui:message key="portal" />
 								</h3>
 
-								<aui:input label="portal-name" name="companyName" value="<%= PropsValues.COMPANY_DEFAULT_NAME %>">
-									<aui:validator name="required" />
-								</aui:input>
+								<aui:input label="portal-name" name="companyName" required="<%= true %>" value="<%= PropsValues.COMPANY_DEFAULT_NAME %>" />
 
 								<aui:field-wrapper label="default-language" name="companyLocale">
 									<div class="form-group-autofit">
@@ -98,17 +96,12 @@
 									<liferay-ui:message key="administrator-user" />
 								</h3>
 
-								<aui:input label="first-name" name="adminFirstName" value="<%= PropsValues.DEFAULT_ADMIN_FIRST_NAME %>">
-									<aui:validator name="required" />
-								</aui:input>
+								<aui:input label="first-name" name="adminFirstName" required="<%= true %>" value="<%= PropsValues.DEFAULT_ADMIN_FIRST_NAME %>" />
 
-								<aui:input label="last-name" name="adminLastName" value="<%= PropsValues.DEFAULT_ADMIN_LAST_NAME %>">
-									<aui:validator name="required" />
-								</aui:input>
+								<aui:input label="last-name" name="adminLastName" required="<%= true %>" value="<%= PropsValues.DEFAULT_ADMIN_LAST_NAME %>" />
 
-								<aui:input label="email" name="adminEmailAddress">
+								<aui:input label="email" name="adminEmailAddress" required="<%= true %>">
 									<aui:validator name="email" />
-									<aui:validator name="required" />
 								</aui:input>
 							</aui:fieldset>
 						</div>
@@ -220,13 +213,9 @@
 
 									</aui:select>
 
-									<aui:input id="jdbcDefaultURL" label="jdbc-url" name='<%= "properties--" + PropsKeys.JDBC_DEFAULT_URL + "--" %>' value="<%= PropsValues.JDBC_DEFAULT_URL %>">
-										<aui:validator name="required" />
-									</aui:input>
+									<aui:input id="jdbcDefaultURL" label="jdbc-url" name='<%= "properties--" + PropsKeys.JDBC_DEFAULT_URL + "--" %>' required="<%= true %>" value="<%= PropsValues.JDBC_DEFAULT_URL %>" />
 
-									<aui:input id="jdbcDefaultDriverName" label="jdbc-driver-class-name" name='<%= "properties--" + PropsKeys.JDBC_DEFAULT_DRIVER_CLASS_NAME + "--" %>' value="<%= PropsValues.JDBC_DEFAULT_DRIVER_CLASS_NAME %>">
-										<aui:validator name="required" />
-									</aui:input>
+									<aui:input id="jdbcDefaultDriverName" label="jdbc-driver-class-name" name='<%= "properties--" + PropsKeys.JDBC_DEFAULT_DRIVER_CLASS_NAME + "--" %>' required="<%= true %>" value="<%= PropsValues.JDBC_DEFAULT_DRIVER_CLASS_NAME %>" />
 
 									<aui:input id="jdbcDefaultUserName" label="user-name" name='<%= "properties--" + PropsKeys.JDBC_DEFAULT_USERNAME + "--" %>' value="<%= PropsValues.JDBC_DEFAULT_USERNAME %>" />
 

--- a/portal-web/docroot/html/portal/update_password.jsp
+++ b/portal-web/docroot/html/portal/update_password.jsp
@@ -185,16 +185,12 @@ if (Validator.isNull(titlePage)) {
 					</c:if>
 
 					<aui:fieldset>
-						<aui:input class="lfr-input-text-container" label="password" name="password1" showRequiredLabel="<%= false %>" type="password">
-							<aui:validator name="required" />
-						</aui:input>
+						<aui:input class="lfr-input-text-container" label="password" name="password1" required="<%= true %>" showRequiredLabel="<%= false %>" type="password" />
 
-						<aui:input class="lfr-input-text-container" label="enter-again" name="password2" showRequiredLabel="<%= false %>" type="password">
+						<aui:input class="lfr-input-text-container" label="enter-again" name="password2" required="<%= true %>" showRequiredLabel="<%= false %>" type="password">
 							<aui:validator name="equalTo">
 								'#<portlet:namespace />password1'
 							</aui:validator>
-
-							<aui:validator name="required" />
 						</aui:input>
 					</aui:fieldset>
 

--- a/portal-web/docroot/html/portal/update_reminder_query.jsp
+++ b/portal-web/docroot/html/portal/update_reminder_query.jsp
@@ -86,9 +86,7 @@ if (referer.equals(themeDisplay.getPathMain() + "/portal/update_reminder_query")
 				}
 				%>
 
-				<aui:input autocomplete="off" cssClass="reminder-query-answer" label="answer" maxlength="<%= ModelHintsConstants.TEXT_MAX_LENGTH %>" name="reminderQueryAnswer" showRequiredLabel="<%= false %>" size="50" type='<%= PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_REMINDER_QUERIES_DISPLAY_IN_PLAIN_TEXT, PropsValues.USERS_REMINDER_QUERIES_DISPLAY_IN_PLAIN_TEXT) ? "text" : "password" %>' value="<%= answer %>">
-					<aui:validator name="required" />
-				</aui:input>
+				<aui:input autocomplete="off" cssClass="reminder-query-answer" label="answer" maxlength="<%= ModelHintsConstants.TEXT_MAX_LENGTH %>" name="reminderQueryAnswer" required="<%= true %>" showRequiredLabel="<%= false %>" size="50" type='<%= PrefsPropsUtil.getBoolean(company.getCompanyId(), PropsKeys.USERS_REMINDER_QUERIES_DISPLAY_IN_PLAIN_TEXT, PropsValues.USERS_REMINDER_QUERIES_DISPLAY_IN_PLAIN_TEXT) ? "text" : "password" %>' value="<%= answer %>" />
 			</aui:fieldset>
 
 			<aui:button-row>

--- a/portal-web/docroot/html/taglib/ui/user_name_fields/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/user_name_fields/page.jsp
@@ -61,11 +61,7 @@ FullNameDefinition fullNameDefinition = FullNameDefinitionFactory.getInstance(us
 
 		<c:choose>
 			<c:when test="<%= fullNameField.isFreeText() %>">
-				<aui:input bean="<%= bean %>" disabled="<%= !UsersAdminUtil.hasUpdateFieldPermission(permissionChecker, user, selUser, fieldName) %>" model="<%= User.class %>" name="<%= fieldName %>">
-					<c:if test="<%= fullNameField.isRequired() %>">
-						<aui:validator name="required" />
-					</c:if>
-				</aui:input>
+				<aui:input bean="<%= bean %>" disabled="<%= !UsersAdminUtil.hasUpdateFieldPermission(permissionChecker, user, selUser, fieldName) %>" model="<%= User.class %>" name="<%= fieldName %>" required="<%= fullNameField.isRequired() %>" />
 			</c:when>
 			<c:otherwise>
 				<aui:select disabled="<%= !UsersAdminUtil.hasUpdateFieldPermission(permissionChecker, user, selUser, fieldName) %>" label="<%= fieldName %>" name='<%= fieldName.concat("ListTypeValue") %>' showEmptyOption="<%= true %>">


### PR DESCRIPTION
Motivation
=======
This issue ([LPS-180284](https://issues.liferay.com/browse/LPS-180284)) was reported by a customer for a particular example but the issue can be reproduced in different places in the portal. In detail, the validation for a field shown with `<aui:input>` doesn't show the correct message: it mentions the `name` instead of the `label` field.

There are problematic uses of the tag in several modules:
- account
- blogs
- captcha
- commerce
- fragment
- iframe
- layout
- login
- portal-instances
- portal-language
- portal-settings
- portal-web
- portal-workflow
- server
- site-navigation
- sytle-book

I've sent this first to @liferay-echo because some of its modules are affected and the changes applied are in the style of [LPS-167115](https://issues.liferay.com/browse/LPS-167115). 

Please let me know if I should pass the PR around to the different teams or if a review by one team is enough since the changes are the same everywhere.

Proposed Solution
========

To use the `required` field directly in the taglib `<aui:input>` instead of an inner `validator` with the special name `required`. This way the message displayed when the field is not filled in uses the `label` instead of the `name`.

This is strictly necessary when the `name` and the `label` attributes in `<aui:input>` are different. (First commit c0ad1cbc511f0638c9bfe5a4233820550ffd4467.)

When `name` and `label` aren't the same there's no visual problem the second commit (87ee9919c11cbee6c8c1c9de63cd26a44e31dbf2) applies a similar change to avoid problems in the future when `name` and `label` might differ.

A similar case, that of `label` not being explicitly set, is addressed in the third commit (ff5b2653a428493fdf2273da46651ea6ae897747).


Steps to Verify
========
Those in [LPS-180284](https://issues.liferay.com/browse/LPS-180284) for the particular example of the Create Account form, but similar ones exist for all files address in the first commit (c0ad1cbc511f0638c9bfe5a4233820550ffd4467).

For example, one involving Echo would be:
1. Create a new Navigation Menu.
2. Add an URL item.
3. Without filling out any of the fields (Name and URL), click on the Add button.
Expected: The validation message for URL reads "The URL field is required.".
Observed: The validation message for URL reads "The type-settings-properties--url-- field is required.".


References to existing code
========

The same solution was applied for [LPS-167115](https://issues.liferay.com/browse/LPS-167115) [here](https://github.com/liferay-echo/liferay-portal/blob/master/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp#L72-L74).

Checklist (optional)
========

CODE:
- [x] I have considered breaking this PR into smaller PRs if the amount of changed code is too large (Although many files are changed, the changes are the same throughout so I decided to create just one PR.)
- [x] I have performed a self-review of my own code following Liferay's code conventions
- [x] I have checked other areas of the product for solutions to similar problems
- [ ] I have added tests that prove my fix is effective or that my feature works

COMMITS:
- [x] My commits organize changes in coherent units
- [x] There are no commits which should be combined into others (Maybe just one commit would have sufficed but this way might be cleaner.)
- [x] My commits are ordered in a way that ease understanding
- [x] My commit messages are well formatted and concisely describe what was changed and why it was changed

PR TITLE & DESCRIPTION:
- [x] My PR title includes an issue number and a descriptive title
- [x] My PR description explains the motivation for this change
- [x] My PR description explains the proposed solution
- [x] My PR description includes the steps to verify the change
- [ ] My PR description includes references to other places where this solution is used (if applies)
- [ ] My PR description includes visual aids to understand what has changed (if applies)
- [ ] My PR description explains alternative approaches considered and why they were discarded (if applies)