### PR TITLE
[TS] LPS-185456 Removal of getDDMStructureKey() from JournalArticle may break existing customizations

### DIFF
--- a/modules/apps/journal/journal-api/bnd.bnd
+++ b/modules/apps/journal/journal-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal API
 Bundle-SymbolicName: com.liferay.journal.api
-Bundle-Version: 31.2.1
+Bundle-Version: 31.3.0
 Export-Package:\
 	com.liferay.journal.configuration,\
 	com.liferay.journal.constants,\

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticle.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticle.java
@@ -108,6 +108,8 @@ public interface JournalArticle
 	public com.liferay.dynamic.data.mapping.model.DDMStructure
 		getDDMStructure();
 
+	public String getDDMStructureKey();
+
 	public com.liferay.dynamic.data.mapping.model.DDMTemplate getDDMTemplate();
 
 	@com.liferay.portal.kernel.json.JSON

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleWrapper.java
@@ -453,6 +453,11 @@ public class JournalArticleWrapper
 	}
 
 	@Override
+	public String getDDMStructureKey() {
+		return model.getDDMStructureKey();
+	}
+
+	@Override
 	public com.liferay.dynamic.data.mapping.model.DDMTemplate getDDMTemplate() {
 		return model.getDDMTemplate();
 	}

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/model/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/model/packageinfo
@@ -1,1 +1,1 @@
-version 14.1.0
+version 14.2.0

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -279,6 +279,16 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 		return DDMStructureLocalServiceUtil.fetchStructure(getDDMStructureId());
 	}
 
+	public String getDDMStructureKey() {
+		DDMStructure ddmStructure = getDDMStructure();
+
+		if (ddmStructure == null) {
+			return StringPool.BLANK;
+		}
+
+		return ddmStructure.getStructureKey();
+	}
+
 	@Override
 	public DDMTemplate getDDMTemplate() {
 		return DDMTemplateLocalServiceUtil.fetchTemplate(


### PR DESCRIPTION
Hi @liferay-echo 

We have a customer that has just upgraded to u72 and some of their templates are broken because of the removal of this method.

We are aware of this breaking change caused by [LPS-172989](https://issues.liferay.com/browse/LPS-172989) "Relate the JournalArticles to unique ids of structures". However, we would like to add a fallback so as not to break existing customer's customization that are already using that method.

What are your views on that?

Thanks

cc/ @jorgediaz-lr @dacousalr