### PR TITLE
LPS-185466 Failure in bulk execution when creating a webcontent with a display or expiration date of year 10000 or later

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
@@ -31,6 +31,7 @@ import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.journal.configuration.JournalFileUploadsConfiguration;
 import com.liferay.journal.constants.JournalArticleConstants;
 import com.liferay.journal.exception.ArticleContentException;
+import com.liferay.journal.exception.ArticleDisplayDateException;
 import com.liferay.journal.exception.ArticleExpirationDateException;
 import com.liferay.journal.exception.ArticleIdException;
 import com.liferay.journal.exception.ArticleSmallImageNameException;
@@ -124,13 +125,26 @@ public class JournalArticleModelValidator
 				throw localeException;
 			}
 
-			if ((expirationDate != null) &&
-				(expirationDate.before(new Date()) ||
-				 ((displayDate != null) &&
-				  expirationDate.before(displayDate)))) {
+			if (displayDate.getYear() > 9999L) {
+				throw new ArticleDisplayDateException(
+					"Display date " + displayDate + " is after year 9999");
+			}
 
-				throw new ArticleExpirationDateException(
-					"Expiration date " + expirationDate + " is in the past");
+			if (expirationDate != null) {
+				if (expirationDate.before(new Date()) ||
+					((displayDate != null) &&
+					 expirationDate.before(displayDate))) {
+
+					throw new ArticleExpirationDateException(
+						"Expiration date " + expirationDate +
+							" is in the past");
+				}
+
+				if (expirationDate.getYear() > 9999L) {
+					throw new ArticleExpirationDateException(
+						"Expiration date " + displayDate +
+							" is after year 9999");
+				}
 			}
 		}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-185466

When an user adds a 0 to the display date or expiration date by mistake:

- 05/23/2023 => 05/23/20230

The webcontent is no correctly indexed, so the final user is not able to find it.
This error is only written to the log files, so it is difficult to detect it.

To avoid this error, I have added an additional validation on JournalArticleModelValidator where we are already validating the expirationDate values.

Let me know if you have any question.