### PR TITLE
LPS-185241 No experience selected in experience selector when the experience does not exist

### DIFF
--- a/modules/apps/segments/segments-test/build.gradle
+++ b/modules/apps/segments/segments-test/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	testIntegrationCompile project(":apps:layout:layout-test-util")
 	testIntegrationCompile project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationCompile project(":apps:portal-odata:portal-odata-api")
+	testIntegrationCompile project(":apps:portal-template:portal-template-react-renderer-api")
 	testIntegrationCompile project(":apps:product-navigation:product-navigation-control-menu-api")
 	testIntegrationCompile project(":apps:roles:roles-admin-api")
 	testIntegrationCompile project(":apps:segments:segments-api")

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/web/internal/display/context/test/SegmentsExperienceSelectorDisplayContextTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/web/internal/display/context/test/SegmentsExperienceSelectorDisplayContextTest.java
@@ -1,0 +1,372 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.segments.web.internal.display.context.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapDictionaryBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.template.react.renderer.ComponentDescriptor;
+import com.liferay.portal.template.react.renderer.ReactRenderer;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.product.navigation.control.menu.ProductNavigationControlMenuEntry;
+import com.liferay.segments.constants.SegmentsEntryConstants;
+import com.liferay.segments.model.SegmentsEntry;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.service.SegmentsEntryLocalService;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+import com.liferay.segments.test.util.SegmentsTestUtil;
+
+import java.io.IOException;
+import java.io.Writer;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.ServiceReference;
+import org.osgi.framework.ServiceRegistration;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Mikel Lorza
+ */
+@RunWith(Arquillian.class)
+public class SegmentsExperienceSelectorDisplayContextTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		Bundle bundle = FrameworkUtil.getBundle(
+			SegmentsExperienceSelectorDisplayContextTest.class);
+
+		BundleContext bundleContext = bundle.getBundleContext();
+
+		_mockReactRenderer = new MockReactRenderer();
+
+		_serviceRegistration = bundleContext.registerService(
+			ReactRenderer.class, _mockReactRenderer,
+			HashMapDictionaryBuilder.<String, Object>put(
+				"service.ranking", Integer.MAX_VALUE
+			).build());
+
+		Collection<ServiceReference<ProductNavigationControlMenuEntry>>
+			serviceReferences = bundleContext.getServiceReferences(
+				ProductNavigationControlMenuEntry.class,
+				"(product.navigation.control.menu.category.key=exp)");
+
+		Assert.assertEquals(
+			serviceReferences.toString(), 1, serviceReferences.size());
+
+		Iterator<ServiceReference<ProductNavigationControlMenuEntry>> iterator =
+			serviceReferences.iterator();
+
+		_productNavigationControlMenuEntry = bundleContext.getService(
+			iterator.next());
+	}
+
+	@After
+	public void tearDown() throws Exception {
+		_serviceRegistration.unregister();
+	}
+
+	@Test
+	public void testGetDataWithDefaultSegmentsExperience() throws Exception {
+		SegmentsExperience expectedDefaultSegmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(_layout.getPlid()));
+
+		Assert.assertNotNull(expectedDefaultSegmentsExperience);
+
+		Map<String, Object> actualData =
+			_getDataFromRenderingSegmentsExperienceSelector(
+				expectedDefaultSegmentsExperience.getSegmentsExperienceId());
+
+		Assert.assertNotNull(actualData);
+
+		JSONArray actualSegmentsExperiencesJSONArray =
+			(JSONArray)actualData.get("segmentsExperiences");
+
+		Assert.assertEquals(1, actualSegmentsExperiencesJSONArray.length());
+
+		JSONObject actualSegmentsExperienceJSONObject =
+			actualSegmentsExperiencesJSONArray.getJSONObject(0);
+
+		Assert.assertTrue(
+			actualSegmentsExperienceJSONObject.getBoolean("active"));
+		Assert.assertEquals(
+			expectedDefaultSegmentsExperience.getSegmentsEntryId(),
+			actualSegmentsExperienceJSONObject.getLong("segmentsEntryId"));
+		Assert.assertEquals(
+			SegmentsEntryConstants.getDefaultSegmentsEntryName(
+				LocaleUtil.ENGLISH),
+			actualSegmentsExperienceJSONObject.getString("segmentsEntryName"));
+		Assert.assertEquals(
+			expectedDefaultSegmentsExperience.getSegmentsExperienceId(),
+			actualSegmentsExperienceJSONObject.getLong("segmentsExperienceId"));
+		Assert.assertEquals(
+			expectedDefaultSegmentsExperience.getName(LocaleUtil.ENGLISH),
+			actualSegmentsExperienceJSONObject.getString(
+				"segmentsExperienceName"));
+		Assert.assertEquals(
+			"Active",
+			actualSegmentsExperienceJSONObject.getString("statusLabel"));
+		Assert.assertNotNull(
+			actualSegmentsExperienceJSONObject.getString("url"));
+
+		JSONObject actualSelectedSegmentsExperienceJSONObject =
+			(JSONObject)actualData.get("selectedSegmentsExperience");
+
+		Assert.assertEquals(
+			expectedDefaultSegmentsExperience.getSegmentsExperienceId(),
+			actualSelectedSegmentsExperienceJSONObject.getLong(
+				"segmentsExperienceId"));
+	}
+
+	@Test
+	public void testGetDataWithDefaultSegmentsExperienceAndSelectedAnonExistingSegmentsExperience()
+		throws Exception {
+
+		SegmentsExperience expectedDefaultSegmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(_layout.getPlid()));
+
+		Map<String, Object> actualData =
+			_getDataFromRenderingSegmentsExperienceSelector(123456);
+
+		Assert.assertNotNull(actualData);
+
+		JSONObject actualSelectedSegmentsExperienceJSONObject =
+			(JSONObject)actualData.get("selectedSegmentsExperience");
+
+		Assert.assertEquals(
+			expectedDefaultSegmentsExperience.getSegmentsExperienceId(),
+			actualSelectedSegmentsExperienceJSONObject.getLong(
+				"segmentsExperienceId"));
+	}
+
+	@Test
+	public void testGetDataWithDefaultSegmentsExperienceAndSelectedExperienceDoesNotBelongToLayout()
+		throws Exception {
+
+		SegmentsExperience expectedDefaultSegmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(_layout.getPlid()));
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		SegmentsExperience segmentsExperience =
+			SegmentsTestUtil.addSegmentsExperience(
+				_group.getGroupId(), layout.getPlid());
+
+		Map<String, Object> actualData =
+			_getDataFromRenderingSegmentsExperienceSelector(
+				segmentsExperience.getSegmentsExperienceId());
+
+		Assert.assertNotNull(actualData);
+
+		JSONObject actualSelectedSegmentsExperienceJSONObject =
+			(JSONObject)actualData.get("selectedSegmentsExperience");
+
+		Assert.assertEquals(
+			expectedDefaultSegmentsExperience.getSegmentsExperienceId(),
+			actualSelectedSegmentsExperienceJSONObject.getLong(
+				"segmentsExperienceId"));
+	}
+
+	@Test
+	public void testGetDataWithSegmentsExperience() throws Exception {
+		SegmentsExperience expectedSegmentsExperience =
+			SegmentsTestUtil.addSegmentsExperience(
+				_group.getGroupId(), _layout.getPlid());
+
+		SegmentsEntry expectedSegmentsEntry =
+			_segmentsEntryLocalService.fetchSegmentsEntry(
+				expectedSegmentsExperience.getSegmentsEntryId());
+
+		Assert.assertNotNull(expectedSegmentsEntry);
+
+		Map<String, Object> actualData =
+			_getDataFromRenderingSegmentsExperienceSelector(
+				expectedSegmentsExperience.getSegmentsExperienceId());
+
+		Assert.assertNotNull(actualData);
+
+		JSONArray actualSegmentsExperiencesJSONArray =
+			(JSONArray)actualData.get("segmentsExperiences");
+
+		Assert.assertEquals(2, actualSegmentsExperiencesJSONArray.length());
+
+		JSONObject actualSegmentsExperienceJSONObject =
+			actualSegmentsExperiencesJSONArray.getJSONObject(1);
+
+		Assert.assertFalse(
+			actualSegmentsExperienceJSONObject.getBoolean("active"));
+		Assert.assertEquals(
+			expectedSegmentsExperience.getSegmentsEntryId(),
+			actualSegmentsExperienceJSONObject.getLong("segmentsEntryId"));
+		Assert.assertEquals(
+			expectedSegmentsEntry.getName(LocaleUtil.ENGLISH),
+			actualSegmentsExperienceJSONObject.getString("segmentsEntryName"));
+		Assert.assertEquals(
+			expectedSegmentsExperience.getSegmentsExperienceId(),
+			actualSegmentsExperienceJSONObject.getLong("segmentsExperienceId"));
+		Assert.assertEquals(
+			expectedSegmentsExperience.getName(LocaleUtil.ENGLISH),
+			actualSegmentsExperienceJSONObject.getString(
+				"segmentsExperienceName"));
+		Assert.assertEquals(
+			"Inactive",
+			actualSegmentsExperienceJSONObject.getString("statusLabel"));
+		Assert.assertNotNull(
+			actualSegmentsExperienceJSONObject.getString("url"));
+
+		JSONObject actualSelectedSegmentsExperienceJSONObject =
+			(JSONObject)actualData.get("selectedSegmentsExperience");
+
+		Assert.assertEquals(
+			expectedSegmentsExperience.getSegmentsExperienceId(),
+			actualSelectedSegmentsExperienceJSONObject.getLong(
+				"segmentsExperienceId"));
+	}
+
+	private Map<String, Object> _getDataFromRenderingSegmentsExperienceSelector(
+			long selectedSegmentsExperienceId)
+		throws Exception {
+
+		_productNavigationControlMenuEntry.includeIcon(
+			_getMockHttpServletRequest(selectedSegmentsExperienceId),
+			new MockHttpServletResponse());
+
+		return _mockReactRenderer.getData();
+	}
+
+	private MockHttpServletRequest _getMockHttpServletRequest(
+			long segmentsExperienceId)
+		throws Exception {
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.CURRENT_URL, "http://localhost:8080/");
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+
+		mockHttpServletRequest.addParameter(
+			"segmentsExperienceId", String.valueOf(segmentsExperienceId));
+
+		return mockHttpServletRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(TestPropsValues.getCompanyId()));
+		themeDisplay.setLayout(_layout);
+		themeDisplay.setLayoutTypePortlet(
+			(LayoutTypePortlet)_layout.getLayoutType());
+		themeDisplay.setLocale(LocaleUtil.ENGLISH);
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+		themeDisplay.setPlid(_layout.getPlid());
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private Layout _layout;
+	private MockReactRenderer _mockReactRenderer;
+	private ProductNavigationControlMenuEntry
+		_productNavigationControlMenuEntry;
+
+	@Inject
+	private SegmentsEntryLocalService _segmentsEntryLocalService;
+
+	@Inject
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	private ServiceRegistration<?> _serviceRegistration;
+
+	private class MockReactRenderer implements ReactRenderer {
+
+		public Map<String, Object> getData() {
+			return _data;
+		}
+
+		@Override
+		public void renderReact(
+				ComponentDescriptor componentDescriptor,
+				Map<String, Object> data, HttpServletRequest httpServletRequest,
+				Writer writer)
+			throws IOException {
+
+			_data = data;
+		}
+
+		private Map<String, Object> _data;
+
+	}
+
+}

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/display/context/SegmentsExperienceSelectorDisplayContext.java
@@ -199,23 +199,36 @@ public class SegmentsExperienceSelectorDisplayContext {
 	private JSONObject _getSegmentsExperienceSelectedJSONObject()
 		throws PortalException {
 
-		JSONObject segmentsExperienceSelectedJSONObject =
-			_jsonFactory.createJSONObject();
-
 		SegmentsExperience segmentsExperience =
 			_fetchSegmentsExperienceFromRequest();
 
+		long plid = _themeDisplay.getPlid();
+
+		if ((segmentsExperience == null) ||
+			(segmentsExperience.getPlid() != plid)) {
+
+			long defaultSegmentsExperienceId =
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(plid);
+
+			segmentsExperience =
+				_segmentsExperienceLocalService.fetchSegmentsExperience(
+					defaultSegmentsExperienceId);
+		}
+
 		if (segmentsExperience != null) {
-			segmentsExperienceSelectedJSONObject =
+			JSONObject segmentsExperienceSelectedJSONObject =
 				_getSegmentsExperienceJSONObject(
 					segmentsExperience.getSegmentsExperienceId());
 
 			segmentsExperienceSelectedJSONObject.put(
 				"segmentsExperienceName",
 				_getSelectedSegmentsExperienceName(segmentsExperience));
+
+			return segmentsExperienceSelectedJSONObject;
 		}
 
-		return segmentsExperienceSelectedJSONObject;
+		return _jsonFactory.createJSONObject();
 	}
 
 	private JSONArray _getSegmentsExperiencesJSONArray()


### PR DESCRIPTION
Bug: https://issues.liferay.com/browse/LPS-185241

Description
----
Fix the bug showing as selected the default segments experience when the selected segments experience does not belong to the page or it does not exist