### PR TITLE
LPS-185583 Custom values are lost in display page templates configuration when editing it

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutActionsDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutActionsDisplayContext.java
@@ -215,7 +215,18 @@ public class LayoutActionsDisplayContext {
 		).setParameter(
 			"privateLayout", layout.isPrivateLayout()
 		).setParameter(
-			"selPlid", layout.getPlid()
+			"selPlid",
+			() -> {
+				if (layout.isTypeAssetDisplay() && !layout.isDraftLayout()) {
+					Layout draftLayout = layout.fetchDraftLayout();
+
+					if (draftLayout != null) {
+						return draftLayout.getPlid();
+					}
+				}
+
+				return layout.getPlid();
+			}
 		).buildPortletURL(
 		).toString();
 	}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/DisplayPageActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/DisplayPageActionDropdownItemsProvider.java
@@ -52,7 +52,6 @@ import java.util.List;
 import java.util.Objects;
 
 import javax.portlet.PortletRequest;
-import javax.portlet.PortletURL;
 import javax.portlet.RenderRequest;
 import javax.portlet.RenderResponse;
 import javax.portlet.ResourceURL;
@@ -150,9 +149,6 @@ public class DisplayPageActionDropdownItemsProvider {
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
 					DropdownItemListBuilder.add(
-						() -> hasUpdatePermission,
-						_getConfigureDisplayPageActionUnsafeConsumer()
-					).add(
 						() -> LayoutPageTemplateEntryPermission.contains(
 							_themeDisplay.getPermissionChecker(),
 							_layoutPageTemplateEntry, ActionKeys.PERMISSIONS),
@@ -173,27 +169,6 @@ public class DisplayPageActionDropdownItemsProvider {
 				dropdownGroupItem.setSeparator(true);
 			}
 		).build();
-	}
-
-	private UnsafeConsumer<DropdownItem, Exception>
-		_getConfigureDisplayPageActionUnsafeConsumer() {
-
-		PortletURL editPageURL = PortalUtil.getControlPanelPortletURL(
-			_httpServletRequest, LayoutAdminPortletKeys.GROUP_PAGES,
-			PortletRequest.RENDER_PHASE);
-
-		return dropdownItem -> {
-			dropdownItem.setHref(
-				editPageURL, "mvcRenderCommandName",
-				"/layout_admin/edit_layout", "redirect",
-				_themeDisplay.getURLCurrent(), "backURL",
-				_themeDisplay.getURLCurrent(), "portletResource",
-				LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES,
-				"selPlid", _layoutPageTemplateEntry.getPlid());
-			dropdownItem.setIcon("cog");
-			dropdownItem.setLabel(
-				LanguageUtil.get(_httpServletRequest, "configure"));
-		};
 	}
 
 	private UnsafeConsumer<DropdownItem, Exception>

--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/frontend/taglib/servlet/taglib/LayoutOpenGraphScreenNavigationEntry.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/frontend/taglib/servlet/taglib/LayoutOpenGraphScreenNavigationEntry.java
@@ -50,7 +50,7 @@ public class LayoutOpenGraphScreenNavigationEntry
 				return false;
 			}
 
-			if (layout.isTypeAssetDisplay()) {
+			if (layout.isTypeAssetDisplay() && layout.isDraftLayout()) {
 				return true;
 			}
 

--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/frontend/taglib/servlet/taglib/LayoutSEOScreenNavigationEntry.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/frontend/taglib/servlet/taglib/LayoutSEOScreenNavigationEntry.java
@@ -38,7 +38,7 @@ public class LayoutSEOScreenNavigationEntry
 
 	@Override
 	public boolean isVisible(User user, Layout layout) {
-		if (layout.isTypeAssetDisplay()) {
+		if (layout.isTypeAssetDisplay() && layout.isDraftLayout()) {
 			return true;
 		}
 

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/open_graph.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/open_graph.jsp
@@ -46,6 +46,7 @@ Layout selLayout = layoutsSEODisplayContext.getSelLayout();
 	wrappedFormContent="<%= false %>"
 >
 	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+	<aui:input name="backURL" type="hidden" value="<%= backURL %>" />
 	<aui:input name="portletResource" type="hidden" value='<%= ParamUtil.getString(request, "portletResource") %>' />
 	<aui:input name="groupId" type="hidden" value="<%= layoutsSEODisplayContext.getGroupId() %>" />
 	<aui:input name="privateLayout" type="hidden" value="<%= layoutsSEODisplayContext.isPrivateLayout() %>" />

--- a/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
+++ b/modules/apps/layout/layout-seo-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/seo.jsp
@@ -36,13 +36,8 @@ UnicodeProperties layoutTypeSettingsUnicodeProperties = selLayout.getTypeSetting
 	<link href="<%= PortalUtil.getStaticResourceURL(request, PortalUtil.getPathProxy() + application.getContextPath() + "/css/main.css") %>" rel="stylesheet" type="text/css" />
 </liferay-util:html-top>
 
-<portlet:actionURL name="/layout/edit_seo" var="editSEOURL">
+<portlet:actionURL copyCurrentRenderParameters="<%= true %>" name="/layout/edit_seo" var="editSEOURL">
 	<portlet:param name="mvcRenderCommandName" value="/layout/edit_seo" />
-	<portlet:param name="redirect" value="<%= currentURL %>" />
-	<portlet:param name="portletResource" value='<%= ParamUtil.getString(request, "portletResource") %>' />
-	<portlet:param name="groupId" value="<%= String.valueOf(layoutsSEODisplayContext.getGroupId()) %>" />
-	<portlet:param name="privateLayout" value="<%= String.valueOf(layoutsSEODisplayContext.isPrivateLayout()) %>" />
-	<portlet:param name="layoutId" value="<%= String.valueOf(layoutsSEODisplayContext.getLayoutId()) %>" />
 </portlet:actionURL>
 
 <h2 class="mb-4 text-7"><liferay-ui:message key="seo" /></h2>
@@ -54,6 +49,13 @@ UnicodeProperties layoutTypeSettingsUnicodeProperties = selLayout.getTypeSetting
 	name="fm"
 	wrappedFormContent="<%= false %>"
 >
+	<aui:input name="redirect" type="hidden" value="<%= currentURL %>" />
+	<aui:input name="backURL" type="hidden" value="<%= backURL %>" />
+	<aui:input name="portletResource" type="hidden" value='<%= ParamUtil.getString(request, "portletResource") %>' />
+	<aui:input name="groupId" type="hidden" value="<%= layoutsSEODisplayContext.getGroupId() %>" />
+	<aui:input name="privateLayout" type="hidden" value="<%= layoutsSEODisplayContext.isPrivateLayout() %>" />
+	<aui:input name="layoutId" type="hidden" value="<%= layoutsSEODisplayContext.getLayoutId() %>" />
+
 	<liferay-frontend:edit-form-body>
 		<clay:sheet
 			cssClass="ml-0"


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-185583)

Some configuration that should only be available for draft display pages is exposed for the published layout (SEO and OpenGraph). This PR deals with this situation

## Change summary:

* Remove configuration in display page card that was leading to the published display page
* Changed so that clicking on configuration when editing a display page will lead to the draft configuration and not published configuration
* Some changes in the JSPs of SEO and OpenGraph since there was a backURL issue
* Don't show screen navigation entries for SEO and OpenGraph for published display page templates to avoid future issues


## Test Scenario No. 1

* Start the portal
* Go to Design -> Page Templates -> Display Page Templates
* Create a new Display Page Template (for simplicity, we will create one for categories)
* Publish the empty display page
* Check the kebab actions of the cards, "Configure is not shown"

## Test Scenario No. 2

* Start the portal
* Go to Design -> Page Templates -> Display Page Templates
* Create a new Display Page Template (for simplicity, we will create one for categories)
* Click on the kebab on the top right of the page, and click "Configure"
* Click on SEO Settings and fill in the fields for title and description
* Save, press back and publish the display page template
* Click on the kebab and select "Mark as default"
* Go to Categorization -> Categories
* Create a new vocabulary
* Create a new category
* In the kebab for category, click on View Display Page
* Inspect the page and search for the values specified in the title and description, they should be present  

![config](https://github.com/liferay-echo/liferay-portal/assets/4267448/faaa6e07-41ed-42af-9a1d-fe9de75791c2)

