### PR TITLE
[TS] LPS-185891 When moving a Web Content, users can view folders for which they don't have permissions

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1431,7 +1431,7 @@ public class JournalDisplayContext {
 	private JSONArray _getFoldersJSONArray(long groupId, long folderId) {
 		JSONArray jsonArray = JSONFactoryUtil.createJSONArray();
 
-		List<JournalFolder> folders = JournalFolderLocalServiceUtil.getFolders(
+		List<JournalFolder> folders = JournalFolderServiceUtil.getFolders(
 			groupId, folderId);
 
 		for (JournalFolder folder : folders) {


### PR DESCRIPTION
Hi @liferay-echo,

When moving a Web Content, users can view folders for which they don't have permissions. See [LPS-185891](https://issues.liferay.com/browse/LPS-185891) for details.

Instead of using the `JournalFolderLocalServiceUtil`, we can use `JournalFolderServiceUtil`. This way, user's permissions are checked when querying the database (if Inline Permission Check is enabled).

Could you review this change?

Thanks!