### PR TITLE
[TECHNICAL SUPPORT] LPS-185801 Losing control of JournalArticles batch sizes while "Index All Article Versions Enabled" option is disabled

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributor.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/search/spi/model/index/contributor/JournalArticleModelIndexerWriterContributor.java
@@ -85,7 +85,7 @@ public class JournalArticleModelIndexerWriterContributor
 		else {
 			batchIndexingActionable.setInterval(
 				_batchIndexingHelper.getBulkSize(
-					JournalArticleResource.class.getName()));
+					JournalArticle.class.getName()));
 			batchIndexingActionable.setPerformActionMethod(
 				(JournalArticleResource articleResource) -> {
 					JournalArticle latestIndexableArticle =


### PR DESCRIPTION
Hey,
[LPS-185801](https://issues.liferay.com/browse/LPS-185801),

We lost control over the batch size when Index All Article Versions were disabled. Based on the answer from [PTR-3958](https://issues.liferay.com/browse/PTR-3958), I created this solution.
Please review it.

Thanks,