### PR TITLE
LPS-183305 Moves onClick for configure-chart to js

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletTest.java
+++ b/modules/apps/content-dashboard/content-dashboard-test/src/testIntegration/java/com/liferay/content/dashboard/web/internal/portlet/test/ContentDashboardAdminPortletTest.java
@@ -68,7 +68,6 @@ import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.DateUtil;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MimeTypesUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -259,30 +258,6 @@ public class ContentDashboardAdminPortletTest {
 		Assert.assertNotNull(context);
 		Assert.assertEquals(
 			LanguageConstants.VALUE_RTL, context.get("languageDirection"));
-	}
-
-	@Test
-	public void testGetOnClickConfiguration() throws Exception {
-		MVCPortlet mvcPortlet = (MVCPortlet)_portlet;
-
-		MockLiferayPortletRenderRequest mockLiferayPortletRenderRequest =
-			_getMockLiferayPortletRenderRequest();
-
-		mvcPortlet.render(
-			mockLiferayPortletRenderRequest,
-			new MockLiferayPortletRenderResponse());
-
-		String onClickConfiguration = ReflectionTestUtil.invoke(
-			mockLiferayPortletRenderRequest.getAttribute(
-				"com.liferay.content.dashboard.web.internal.display.context." +
-					"ContentDashboardAdminDisplayContext"),
-			"getOnClickConfiguration", new Class<?>[0]);
-
-		Assert.assertTrue(
-			onClickConfiguration.contains(
-				HtmlUtil.escapeJS(
-					"mvcRenderCommandName=/content_dashboard" +
-						"/edit_content_dashboard_configuration")));
 	}
 
 	@Test

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminDisplayContext.java
@@ -34,7 +34,6 @@ import com.liferay.learn.LearnMessage;
 import com.liferay.learn.LearnMessageUtil;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.GenericUtil;
-import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -51,7 +50,6 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -83,7 +81,6 @@ import java.util.Set;
 
 import javax.portlet.ActionURL;
 import javax.portlet.ResourceURL;
-import javax.portlet.WindowStateException;
 
 /**
  * @author Cristina González
@@ -318,49 +315,30 @@ public class ContentDashboardAdminDisplayContext {
 			contentDashboardItem);
 	}
 
-	public String getOnClickConfiguration() throws WindowStateException {
-		StringBundler sb = new StringBundler(13);
+	public String getPanelState() {
+		return SessionClicks.get(
+			_portal.getHttpServletRequest(_liferayPortletRequest),
+			"com.liferay.content.dashboard.web_panelState", "closed");
+	}
 
-		sb.append("Liferay.Portlet.openModal({namespace: '");
-
+	public String getPortletDisplayId() {
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)_liferayPortletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
 
 		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
 
-		sb.append(portletDisplay.getNamespace());
-
-		sb.append("', onClose: function() {Liferay.Portlet.refresh('#p_p_id_");
-		sb.append(portletDisplay.getId());
-		sb.append("_')}, portletSelector: '#p_p_id_");
-		sb.append(portletDisplay.getId());
-		sb.append("_', portletId: '");
-		sb.append(portletDisplay.getId());
-		sb.append("', title: '");
-		sb.append(
-			ResourceBundleUtil.getString(_resourceBundle, "configuration"));
-		sb.append("', url: '");
-
-		sb.append(
-			HtmlUtil.escapeJS(
-				PortletURLBuilder.createRenderURL(
-					_liferayPortletResponse
-				).setMVCRenderCommandName(
-					"/content_dashboard/edit_content_dashboard_configuration"
-				).setWindowState(
-					LiferayWindowState.POP_UP
-				).buildString()));
-
-		sb.append("'}); return false;");
-
-		return sb.toString();
+		return portletDisplay.getId();
 	}
 
-	public String getPanelState() {
-		return SessionClicks.get(
-			_portal.getHttpServletRequest(_liferayPortletRequest),
-			"com.liferay.content.dashboard.web_panelState", "closed");
+	public String getPortletURL() {
+		return PortletURLBuilder.createRenderURL(
+			_liferayPortletResponse
+		).setMVCRenderCommandName(
+			"/content_dashboard/edit_content_dashboard_configuration"
+		).setWindowState(
+			LiferayWindowState.POP_UP
+		).buildString();
 	}
 
 	public String getReviewDateString() {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ConfigurationButtonPropsTransformer.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/ConfigurationButtonPropsTransformer.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+import {openModal} from 'frontend-js-web';
+
+export default function ({additionalProps, ...props}) {
+	return {
+		...props,
+		onClick() {
+			const {chartConfigurationURL, portletSelector} = additionalProps;
+
+			openModal({
+				portletSelector,
+				title: Liferay.Language.get('configuration'),
+				url: chartConfigurationURL,
+			});
+		},
+	};
+}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/view.jsp
@@ -60,11 +60,18 @@ ContentDashboardAdminDisplayContext contentDashboardAdminDisplayContext = (Conte
 					<clay:content-col>
 						<span class="lfr-portal-tooltip" title="<%= LanguageUtil.get(request, "configure-chart") %>">
 							<clay:button
+								additionalProps='<%=
+									HashMapBuilder.<String, Object>put(
+										"chartConfigurationURL", contentDashboardAdminDisplayContext.getPortletURL()
+									).put(
+										"portletSelector", "#p_p_id_" + contentDashboardAdminDisplayContext.getPortletDisplayId()
+									).build()
+								%>'
 								borderless="<%= true %>"
 								cssClass="component-action"
 								displayType="secondary"
 								icon="cog"
-								onClick="<%= contentDashboardAdminDisplayContext.getOnClickConfiguration() %>"
+								propsTransformer="js/ConfigurationButtonPropsTransformer"
 								small="<%= true %>"
 							/>
 						</span>


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to remove the usage of a openModal component directly rendered from the backend and use a js component instead for the charts modal configuration in the Content Dashboard.

Proposed Solution
========
What I did to solve the problem is to create a js component that is called when the configure button is pressed and receives the necessary url and other props to render the modal.

Steps to Verify
========
1. Go to the Content Dashboard
2. Click on Configure Chart button
3. Check that the modal works correctly by interchanging audiences and saving them.