### PR TITLE
[TS] LPP-49065>LPS-185695 Display timing of duplicate message of friendly URL is strange when web content is added via widget

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/init.jsp
@@ -89,6 +89,7 @@ page import="com.liferay.portal.kernel.security.permission.ResourceActionsUtil" 
 page import="com.liferay.portal.kernel.service.ClassNameLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.GroupLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalServiceUtil" %><%@
+page import="com.liferay.portal.kernel.servlet.MultiSessionMessages" %><%@
 page import="com.liferay.portal.kernel.servlet.SessionMessages" %><%@
 page import="com.liferay.portal.kernel.trash.TrashHandler" %><%@
 page import="com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil" %><%@

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
@@ -22,6 +22,8 @@ assetPublisherDisplayContext.setPageKeywords();
 if (assetPublisherDisplayContext.isEnableTagBasedNavigation() && !assetPublisherDisplayContext.isSelectionStyleAssetList() && assetPublisherDisplayContext.isSelectionStyleManual() && (ArrayUtil.isNotEmpty(assetPublisherDisplayContext.getAllAssetCategoryIds()) || ArrayUtil.isNotEmpty(assetPublisherDisplayContext.getAllAssetTagNames()))) {
 	assetPublisherDisplayContext.setSelectionStyle(AssetPublisherSelectionStyleConstants.TYPE_DYNAMIC);
 }
+
+String friendlyURLChangedMessage = GetterUtil.getString(MultiSessionMessages.get(renderRequest, "friendlyURLChangedAssetPublisher"));
 %>
 
 <liferay-ui:success key='<%= AssetPublisherPortletKeys.ASSET_PUBLISHER + "requestProcessed" %>' message="your-request-completed-successfully" />
@@ -164,3 +166,15 @@ SearchContainer<AssetEntry> searchContainer = assetPublisherDisplayContext.getSe
 		window.location.hash = assetEntryId;
 	}
 </aui:script>
+
+<c:if test="<%= Validator.isNotNull(friendlyURLChangedMessage) %>">
+	<aui:script>
+		Liferay.Util.openToast({
+			message: '<%= friendlyURLChangedMessage %>',
+			toastProps: {
+				autoClose: 20000,
+			},
+			type: 'warning',
+		});
+	</aui:script>
+</c:if>

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/portlet/action/UpdateArticleMVCActionCommand.java
@@ -522,8 +522,11 @@ public class UpdateArticleMVCActionCommand extends BaseMVCActionCommand {
 			return Collections.emptyMap();
 		}
 
+		boolean portlet = !Validator.isBlank(
+			ParamUtil.getString(actionRequest, "portletResource"));
+
 		return HashMapBuilder.put(
-			"friendlyURLChanged",
+			portlet ? "friendlyURLChangedAssetPublisher" : "friendlyURLChanged",
 			() -> {
 				if (friendlyURLChangedMessages.isEmpty()) {
 					return null;


### PR DESCRIPTION
Hi Team
Please review this PR and leave your comment.
Thanks,
Loc
# Motivation
This PR is for fixing [LPS-185695](https://issues.liferay.com/browse/LPS-185695)
# Issue
The Asset Publisher widget does not have the Toast to display the warning from MultiSessionMessage. 
When sending the MultiSessionMessage, only the Web Content can receive it and display it. 
That is why when adding WC by Asset Publisher Widget, there is no warning until we access Web Content.
# Proposed Solution
Add the Toast to display a warning in the Asset Publisher which is similar to the Toast in Web Content. Then add the key to distinguish when the WC is created by Asset Publisher Widget or in the Web Content to display the warning in the correct time and place.
cc:@ces-quanhuynh
