### PR TITLE
LPS-185051 Prefiltering collections with two collection displays in the same page applies the prefilter to the wrong collection

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/collection_general_panel/CollectionGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/collection_general_panel/CollectionGeneralPanel.js
@@ -111,7 +111,12 @@ export function CollectionGeneralPanel({item}) {
 				itemId: item.itemId,
 				segmentsExperienceId,
 			}).then(({url}) => url),
-		key: [CACHE_KEYS.collectionConfigurationUrl, collection?.key],
+		key: [
+			CACHE_KEYS.collectionConfigurationUrl,
+			collection?.key,
+			item.itemId,
+			segmentsExperienceId,
+		],
 	});
 
 	const previewItem = useDisplayPagePreviewItem();


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-185051