### PR TITLE
[TS] LPS-186411 Cookies set by SegmentsExperimentSegmentsExperienceRequestProcessor can't be bulk removed

### DIFF
--- a/modules/dxp/apps/segments/segments-experiment-test/src/testIntegration/java/com/liferay/segments/experiment/web/internal/processor/test/SegmentsExperimentSegmentsExperienceRequestProcessorTest.java
+++ b/modules/dxp/apps/segments/segments-experiment-test/src/testIntegration/java/com/liferay/segments/experiment/web/internal/processor/test/SegmentsExperimentSegmentsExperienceRequestProcessorTest.java
@@ -192,7 +192,7 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessorTest {
 
 			mockHttpServletRequest.setCookies(
 				new Cookie(
-					"ab_test_variant_id",
+					"ab_test_variant_id_" + _layout.getPlid(),
 					segmentsExperiment.getSegmentsExperienceKey()));
 
 			long[] segmentsExperienceIds =

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/processor/SegmentsExperimentSegmentsExperienceRequestProcessor.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/processor/SegmentsExperimentSegmentsExperienceRequestProcessor.java
@@ -227,7 +227,7 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 
 		for (Cookie cookie : cookies) {
 			if (Objects.equals(
-					cookie.getName(), _AB_TEST_VARIANT_ID_COOKIE_NAME)) {
+					cookie.getName(), _AB_TEST_VARIANT_ID_COOKIE_PREFIX)) {
 
 				return cookie;
 			}
@@ -335,7 +335,7 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 		long segmentsExperienceId) {
 
 		Cookie abTestVariantIdCookie = new Cookie(
-			_AB_TEST_VARIANT_ID_COOKIE_NAME,
+			_AB_TEST_VARIANT_ID_COOKIE_PREFIX,
 			_getSegmentsExperienceKey(segmentsExperienceId));
 
 		String domain = CookiesManagerUtil.getDomain(httpServletRequest);
@@ -367,8 +367,8 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 			httpServletRequest, httpServletResponse, cookie.getName());
 	}
 
-	private static final String _AB_TEST_VARIANT_ID_COOKIE_NAME =
-		"ab_test_variant_id";
+	private static final String _AB_TEST_VARIANT_ID_COOKIE_PREFIX =
+		"ab_test_variant_id_";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SegmentsExperimentSegmentsExperienceRequestProcessor.class);

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/processor/SegmentsExperimentSegmentsExperienceRequestProcessor.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/processor/SegmentsExperimentSegmentsExperienceRequestProcessor.java
@@ -374,6 +374,22 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 	private void _unsetCookies(
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
+
+		Cookie[] cookies = httpServletRequest.getCookies();
+
+		if (ArrayUtil.isEmpty(cookies)) {
+			return;
+		}
+
+		for (Cookie cookie : cookies) {
+			if (StringUtil.startsWith(
+					cookie.getName(), _AB_TEST_VARIANT_ID_COOKIE_PREFIX)) {
+
+				CookiesManagerUtil.deleteCookies(
+					CookiesManagerUtil.getDomain(httpServletRequest),
+					httpServletRequest, httpServletResponse, cookie.getName());
+			}
+		}
 	}
 
 	private static final String _AB_TEST_VARIANT_ID_COOKIE_PREFIX =

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/processor/SegmentsExperimentSegmentsExperienceRequestProcessor.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/processor/SegmentsExperimentSegmentsExperienceRequestProcessor.java
@@ -16,6 +16,7 @@ package com.liferay.segments.experiment.web.internal.processor;
 
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.cookies.CookiesManagerUtil;
 import com.liferay.portal.kernel.cookies.constants.CookiesConstants;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -66,7 +67,7 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 		HttpServletRequest httpServletRequest,
 		HttpServletResponse httpServletResponse) {
 
-		_unsetCookie(httpServletRequest, httpServletResponse);
+		_unsetCookies(httpServletRequest, httpServletResponse);
 	}
 
 	@Override
@@ -145,7 +146,7 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 			}
 		}
 
-		_unsetCookie(httpServletRequest, httpServletResponse);
+		_unsetCookie(httpServletRequest, httpServletResponse, plid);
 
 		if (ArrayUtil.isEmpty(segmentsExperienceIds)) {
 			segmentsExperienceId =
@@ -189,8 +190,8 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 			segmentsExperimentRels);
 
 		_setCookie(
-			httpServletRequest, httpServletResponse,
-			themeDisplay.getURLCurrent(), segmentsExperienceId);
+			httpServletRequest, httpServletResponse, plid,
+			segmentsExperienceId);
 
 		httpServletRequest.setAttribute(
 			SegmentsExperimentWebKeys.SEGMENTS_EXPERIMENT, segmentsExperiment);
@@ -218,7 +219,9 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 			segmentsExperienceIds);
 	}
 
-	private Cookie _getCookie(HttpServletRequest httpServletRequest) {
+	private Cookie _getCookie(
+		HttpServletRequest httpServletRequest, long plid) {
+
 		Cookie[] cookies = httpServletRequest.getCookies();
 
 		if (ArrayUtil.isEmpty(cookies)) {
@@ -227,7 +230,8 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 
 		for (Cookie cookie : cookies) {
 			if (Objects.equals(
-					cookie.getName(), _AB_TEST_VARIANT_ID_COOKIE_PREFIX)) {
+					cookie.getName(),
+					_AB_TEST_VARIANT_ID_COOKIE_PREFIX + plid)) {
 
 				return cookie;
 			}
@@ -239,7 +243,7 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 	private long _getCurrentSegmentsExperienceId(
 		long groupId, long plid, HttpServletRequest httpServletRequest) {
 
-		Cookie cookie = _getCookie(httpServletRequest);
+		Cookie cookie = _getCookie(httpServletRequest, plid);
 
 		if (cookie == null) {
 			return -1;
@@ -331,11 +335,11 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 
 	private void _setCookie(
 		HttpServletRequest httpServletRequest,
-		HttpServletResponse httpServletResponse, String path,
+		HttpServletResponse httpServletResponse, long plid,
 		long segmentsExperienceId) {
 
 		Cookie abTestVariantIdCookie = new Cookie(
-			_AB_TEST_VARIANT_ID_COOKIE_PREFIX,
+			_AB_TEST_VARIANT_ID_COOKIE_PREFIX + plid,
 			_getSegmentsExperienceKey(segmentsExperienceId));
 
 		String domain = CookiesManagerUtil.getDomain(httpServletRequest);
@@ -345,7 +349,7 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 		}
 
 		abTestVariantIdCookie.setMaxAge(CookiesConstants.MAX_AGE);
-		abTestVariantIdCookie.setPath(path);
+		abTestVariantIdCookie.setPath(StringPool.SLASH);
 
 		CookiesManagerUtil.addCookie(
 			CookiesConstants.CONSENT_TYPE_PERSONALIZATION,
@@ -354,9 +358,9 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 
 	private void _unsetCookie(
 		HttpServletRequest httpServletRequest,
-		HttpServletResponse httpServletResponse) {
+		HttpServletResponse httpServletResponse, long plid) {
 
-		Cookie cookie = _getCookie(httpServletRequest);
+		Cookie cookie = _getCookie(httpServletRequest, plid);
 
 		if (cookie == null) {
 			return;
@@ -365,6 +369,11 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 		CookiesManagerUtil.deleteCookies(
 			CookiesManagerUtil.getDomain(httpServletRequest),
 			httpServletRequest, httpServletResponse, cookie.getName());
+	}
+
+	private void _unsetCookies(
+		HttpServletRequest httpServletRequest,
+		HttpServletResponse httpServletResponse) {
 	}
 
 	private static final String _AB_TEST_VARIANT_ID_COOKIE_PREFIX =


### PR DESCRIPTION
Motivation
=======
SegmentsExperimentSegmentsExperienceRequestProcessor can set multiple cookies with different paths. During logout, at best 1 URLCurrent can be identified from themeDisplay. (During a forced logout after a password change, themeDisplay is null, hence the "at best"). If there are cookies that do not match this path, they will not be present in the request, so those cookies will not be removeable.

Proposed Solution
========
By setting the Path of all cookies set by this class to the root, we will always have browsers send them in the request and we can remove them in the response. In order to do this, I suggest we create the cookies with the original name+plid names as unique names.

Steps to Verify
========
Sadly I don't have clear reproduction steps for this, but if one can store a cookie while a user is logged in with the name= "ab_test_variant_id", value="123" and path="/home" and log out you will see that the cookie remained.
