### PR TITLE
LPS-186419 Add button classes and clean CSS in control menu

### DIFF
--- a/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/control-menu/ControlMenu.js
+++ b/modules/apps/digital-signature/digital-signature-web/src/main/resources/META-INF/resources/js/components/control-menu/ControlMenu.js
@@ -46,7 +46,7 @@ export function BackButtonPortal({backURL = '/'}) {
 		<ReactPortal container={container}>
 			<li className="control-menu-nav-item">
 				<Link
-					className="control-menu-icon lfr-icon-item"
+					className="btn-monospaced btn-sm lfr-icon-item"
 					tabIndex={1}
 					to={backURL}
 				>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/hooks/useBack.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/hooks/useBack.es.js
@@ -78,7 +78,7 @@ export function useBack() {
 		onBack,
 		true,
 		document.querySelector(
-			`#${portletNamespace}controlMenu .sites-control-group span .control-menu-icon`
+			`#${portletNamespace}controlMenu .sites-control-group span .lfr-icon-item`
 		)
 	);
 }

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/edit_layout_control_menu_entry_icon.tmpl
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/control/menu/edit_layout_control_menu_entry_icon.tmpl
@@ -1,5 +1,5 @@
 <li class="control-menu-nav-item">
-	<a aria-label="${configurePage}" class="control-menu-icon lfr-portal-tooltip" data-qa-id="editLayout" data-title="${configurePage}" href="${editPageURL}">
+	<a aria-label="${configurePage}" class="btn-monospaced btn-sm lfr-portal-tooltip" data-qa-id="editLayout" data-title="${configurePage}" href="${editPageURL}">
 		${iconCog}
 	</a>
 </li>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/information_messages.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/information_messages.jsp
@@ -23,9 +23,10 @@ LayoutInformationMessagesDisplayContext layoutInformationMessagesDisplayContext 
 <li class="control-menu-nav-item lfr-portal-tooltip">
 	<clay:button
 		aria-label='<%= LanguageUtil.get(request, "additional-information") %>'
-		cssClass="control-menu-icon icon-monospaced"
 		data-qa-id="info"
 		displayType="unstyled"
+		monospaced="<%= true %>"
+		small="<%= true %>"
 		symbol="information-live"
 		title='<%= LanguageUtil.get(request, "additional-information") %>'
 	/>

--- a/modules/apps/layout/layout-reports-web/src/main/resources/com/liferay/layout/reports/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/com/liferay/layout/reports/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,5 +1,5 @@
 <li class="control-menu-nav-item layout-reports-icon ${cssClass}">
-	<button aria-label="${title}" aria-pressed="false" class="control-menu-icon lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-layout-reports-panel open-admin-panel" data-target="#layoutReportsPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" id="layoutReportsPanelToggleId">
+	<button aria-label="${title}" aria-pressed="false" class="btn-monospaced btn-sm lfr-portal-tooltip product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-layout-reports-panel open-admin-panel" data-target="#layoutReportsPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" id="layoutReportsPanelToggleId">
 		${iconTag}
 	</button>
 </li>

--- a/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/dynamic_include/init.jsp
@@ -30,7 +30,7 @@
  */
 --%>
 
-<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/react" prefix="react" %>
 
 <%@ page import="com.liferay.layout.set.prototype.web.internal.display.context.PropagationMessageDisplayContext" %>

--- a/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/dynamic_include/propagation_message.jsp
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/dynamic_include/propagation_message.jsp
@@ -21,11 +21,11 @@ PropagationMessageDisplayContext propagationMessageDisplayContext = new Propagat
 %>
 
 <li class="control-menu-nav-item">
-	<liferay-ui:icon
-		cssClass="control-menu-icon icon-monospaced"
+	<clay:button
+		displayType="unstyled"
 		icon="merge"
-		label="<%= false %>"
-		markupView="lexicon"
+		monospaced="<%= true %>"
+		small="<%= true %>"
 	/>
 
 	<react:component

--- a/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
+++ b/modules/apps/product-navigation/product-navigation-control-menu-theme-contributor/src/main/resources/META-INF/resources/control_menu/_control_menu.scss
@@ -18,27 +18,6 @@ html#{$cadmin-selector} {
 			z-index: $control-menu-zindex;
 		}
 
-		.control-menu-icon,
-		.control-menu-icon .dropdown-toggle {
-			border-radius: 4px;
-			display: inline-block;
-			height: 32px;
-			line-height: 32px;
-			text-align: center;
-			transition: box-shadow 0.15s ease-in-out;
-			width: 32px;
-
-			&:focus {
-				box-shadow: $control-menu-focus-box-shadow;
-				outline: 0;
-			}
-
-			.portlet-options {
-				display: flex;
-				height: 32px;
-			}
-		}
-
 		.control-menu-level-1 {
 			> .container-fluid {
 				padding: 8px;

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/portlet_options.jsp
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/resources/META-INF/resources/entries/portlet_options.jsp
@@ -17,9 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <li class="control-menu-nav-item" data-qa-id="headerOptions">
-	<div class="control-menu-icon">
-		<liferay-frontend:icon-options
-			monospaced="<%= true %>"
-		/>
-	</div>
+	<liferay-frontend:icon-options
+		monospaced="<%= true %>"
+	/>
 </li>

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/com/liferay/product/navigation/product/menu/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/com/liferay/product/navigation/product/menu/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,6 +1,6 @@
 <li class="control-menu-nav-item ${cssClass}">
 	<div role="tablist">
-		<button aria-controls="${portletNamespace}sidenavSliderId" aria-label="${title}" aria-selected="${isOpen}" class="control-menu-icon lfr-portal-tooltip product-menu-toast-toggle product-menu-toggle sidenav-toggler" data-content="body" data-open-class="open product-menu-open" data-qa-id="productMenu" data-target="#${portletNamespace}sidenavSliderId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" ${dataURL} id="${portletNamespace}sidenavToggleId" role="tab">
+		<button aria-controls="${portletNamespace}sidenavSliderId" aria-label="${title}" aria-selected="${isOpen}" class="btn-monospaced btn-sm lfr-portal-tooltip product-menu-toast-toggle product-menu-toggle sidenav-toggler" data-content="body" data-open-class="open product-menu-open" data-qa-id="productMenu" data-target="#${portletNamespace}sidenavSliderId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" ${dataURL} id="${portletNamespace}sidenavToggleId" role="tab">
 			${closedIcon}
 
 			${openIcon}

--- a/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/apps/product-navigation/product-navigation-simulation-web/src/main/resources/com/liferay/product/navigation/simulation/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,5 +1,5 @@
 <li class="control-menu-nav-item d-none d-sm-inline-flex simulation-icon">
-	<button aria-label="${title}" class="control-menu-icon lfr-portal-tooltip overflow-hidden product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-simulation-panel open-admin-panel" data-qa-id="simulation"  data-target="#${portletNamespace}simulationPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" data-url="${simulationPanelURL}" id="${portletNamespace}simulationToggleId">
+	<button aria-label="${title}" class="btn-monospaced btn-sm lfr-portal-tooltip overflow-hidden product-menu-toggle sidenav-toggler" data-content="body" data-open-class="lfr-has-simulation-panel open-admin-panel" data-qa-id="simulation"  data-target="#${portletNamespace}simulationPanelId" data-title="${title}" data-toggle="liferay-sidenav" data-type="fixed-push" data-type-mobile="fixed" data-url="${simulationPanelURL}" id="${portletNamespace}simulationToggleId">
 		${iconTag}
 	</button>
 </li>

--- a/modules/apps/product-navigation/product-navigation-taglib/src/main/java/com/liferay/product/navigation/taglib/display/context/ProductNavigationControlMenuTagDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-taglib/src/main/java/com/liferay/product/navigation/taglib/display/context/ProductNavigationControlMenuTagDisplayContext.java
@@ -242,7 +242,7 @@ public class ProductNavigationControlMenuTagDisplayContext {
 		String linkCssClass = productNavigationControlMenuEntry.getLinkCssClass(
 			_httpServletRequest);
 
-		iconTag.setLinkCssClass("control-menu-icon " + linkCssClass);
+		iconTag.setLinkCssClass("btn-monospaced btn-sm " + linkCssClass);
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)_httpServletRequest.getAttribute(

--- a/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/com/liferay/analytics/reports/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/dxp/apps/analytics/analytics-reports-web/src/main/resources/com/liferay/analytics/reports/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,7 +1,7 @@
 <li class="control-menu-nav-item hidden-xs analytics-reports-icon ${cssClass}">
 	<button
 		aria-label="${title}"
-		class="control-menu-icon lfr-portal-tooltip product-menu-toggle sidenav-toggler"
+		class="btn-monospaced btn-sm lfr-portal-tooltip product-menu-toggle sidenav-toggler"
 		data-content="body"
 		data-open-class="lfr-has-analytics-reports-panel open-admin-panel"
 		data-target="#${portletNamespace}analyticsReportsPanelId"

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderBackButton.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderBackButton.es.js
@@ -36,10 +36,8 @@ const HeaderBackButton = ({basePath, container}) => {
 			container={container}
 			elementId="backButton"
 		>
-			<Link className="control-menu-icon" to={backPath}>
-				<span className="icon-monospaced">
-					<ClayIcon symbol="angle-left" />
-				</span>
+			<Link className="btn-monospaced btn-sm" to={backPath}>
+				<ClayIcon symbol="angle-left" />
 			</Link>
 		</Portal>
 	);

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderKebab.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderKebab.es.js
@@ -36,25 +36,24 @@ const HeaderKebab = ({kebabItems = []}) => {
 			elementId="headerKebab"
 			position="before"
 		>
-			<div className="control-menu-icon">
-				<ClayDropDown
-					active={active}
-					onActiveChange={setActive}
-					trigger={
-						<ClayButton
-							className="component-action"
-							displayType="unstyled"
-							monospaced
-						>
-							<ClayIcon symbol="ellipsis-v" />
-						</ClayButton>
-					}
-				>
-					{kebabItems.map((kebabItem, index) => (
-						<HeaderKebab.Item {...kebabItem} key={index} />
-					))}
-				</ClayDropDown>
-			</div>
+			<ClayDropDown
+				active={active}
+				onActiveChange={setActive}
+				trigger={
+					<ClayButton
+						className="component-action"
+						displayType="unstyled"
+						monospaced
+						size="sm"
+					>
+						<ClayIcon symbol="ellipsis-v" />
+					</ClayButton>
+				}
+			>
+				{kebabItems.map((kebabItem, index) => (
+					<HeaderKebab.Item {...kebabItem} key={index} />
+				))}
+			</ClayDropDown>
 		</Portal>
 	);
 };

--- a/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderReindexStatus.es.js
+++ b/modules/dxp/apps/portal-workflow/portal-workflow-metrics-web/src/main/resources/META-INF/resources/js/shared/components/header/HeaderReindexStatus.es.js
@@ -26,16 +26,14 @@ const HeaderReindexStatus = ({container}) => {
 					elementId="headerReindexStatus"
 					position="after"
 				>
-					<div className="control-menu-icon px-2">
-						<span
-							aria-hidden="true"
-							className="loading-animation loading-animation-sm m-0"
-							data-tooltip-align="bottom"
-							title={Liferay.Language.get(
-								'the-workflow-metrics-data-is-currently-reindexing'
-							)}
-						></span>
-					</div>
+					<span
+						aria-hidden="true"
+						className="c-m-0 c-pr-2 loading-animation loading-animation-sm"
+						data-tooltip-align="bottom"
+						title={Liferay.Language.get(
+							'the-workflow-metrics-data-is-currently-reindexing'
+						)}
+					></span>
 				</Portal>
 			)}
 		</>

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/icon.tmpl
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/com/liferay/segments/experiment/web/internal/product/navigation/control/menu/icon.tmpl
@@ -1,7 +1,7 @@
 <li class="control-menu-nav-item segments-experiment-icon ${cssClass}">
 	<button
 		aria-label="${title}"
-		class="control-menu-icon lfr-portal-tooltip product-menu-toggle sidenav-toggler"
+		class="btn-monospaced btn-sm lfr-portal-tooltip product-menu-toggle sidenav-toggler"
 		data-content="body"
 		data-open-class="open-admin-panel"
 		data-qa-id="segmentsExperimentPanel"


### PR DESCRIPTION
## Motivation

[Link to ticket](https://issues.liferay.com/browse/LPS-186419)

Due to a previous task ([LPS-176251](https://issues.liferay.com/browse/LPS-176251)), we observed that the use of the css class control-menu-icon was not necessary since the same result could be obtained using the existing monoespaced and small classes for the buttons. 
## Proposed solution

Instead of using control-menu-icon, use monoespaced and small button classes.

## Test Scenarios

### Test Scenario 1

* Navigate to Applications menu > Applications > Workflow > Metrics. * Check the focus visible state for the kebab menu.

<img width="1222" alt="Pasted Graphic 2" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/9a792f94-6dab-4657-bdc3-3687323e20f7">

### Test Scenario 2

* Navigate to Applications menu > Applications > Workflow > Metrics. * Click on one process and check the focus visible state for the back button.

<img width="1223" alt="Pasted Graphic 3" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/1fbe6e16-30b8-4626-a849-b72d7c8aae54">

### Test Scenario 3

* Navigate to product menu.
* Check all the icons in control menu: 

<img width="1222" alt="Liferay DXP" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/d09c8dc2-98cf-42f7-b19f-6a7eb3eb4b2c">

### Test Scenario 4

* Navigate to Applications menu > Control Panel > Configuration > Instance Settings.
* Go to Digital Signature.
* Check the back button.

<img width="1326" alt="Digital Signature Configuration" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/4b6a7d13-2a09-4804-9a4a-71cf11aa5c71">

### Test Scenario 5

* Navigate to Applications menu > Applications > Workflow > Metrics.
* Go to Settings (click on the kebab menu in the control-menu bar).
* Reindex All for Workflow Metrics Indexes and check the loading icon next to the user.

<img width="1226" alt="Pasted Graphic 7" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/df0d4ef0-53d5-483a-aeca-9eb8dc244947">

### Test Scenario 6

* Navigate to Applications menu > Control Panel > Sites > Site Template.
* Create a new site template and click on it once created.
* Check the propagation button.

<img width="442" alt="site template" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/f058b990-f763-4f82-aaca-5928fb005611">

### Test Scenario 7

* Navigate to Content & Data > Forms.
* Create a new form.
* In that view, check the back button.
