### PR TITLE
LPS-186546 - Support executing object standalone actions through Info Framework

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -138,8 +138,9 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 		InfoItemFormProvider<ObjectEntry> infoItemFormProvider =
 			new ObjectEntryInfoItemFormProvider(
 				objectDefinition, _infoItemFieldReaderFieldSetProvider,
-				_listTypeEntryLocalService, _objectDefinitionLocalService,
-				_objectFieldLocalService, _objectFieldSettingLocalService,
+				_listTypeEntryLocalService, _objectActionLocalService,
+				_objectDefinitionLocalService, _objectFieldLocalService,
+				_objectFieldSettingLocalService,
 				_objectRelationshipLocalService, _objectScopeProviderRegistry,
 				_restContextPathResolverRegistry,
 				_templateInfoItemFieldSetProvider, _userLocalService);
@@ -219,10 +220,10 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 					_assetDisplayPageFriendlyURLProvider, _dlAppLocalService,
 					_dlFileEntryLocalService, _dlURLHelper,
 					_infoItemFieldReaderFieldSetProvider, _jsonFactory,
-					_listTypeEntryLocalService, objectDefinition,
-					_objectDefinitionLocalService, _objectEntryLocalService,
-					_objectEntryManagerRegistry, _objectFieldLocalService,
-					_objectRelationshipLocalService,
+					_listTypeEntryLocalService, _objectActionLocalService,
+					objectDefinition, _objectDefinitionLocalService,
+					_objectEntryLocalService, _objectEntryManagerRegistry,
+					_objectFieldLocalService, _objectRelationshipLocalService,
 					_templateInfoItemFieldSetProvider, _userLocalService),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"company.id", objectDefinition.getCompanyId()

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -23,6 +23,7 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.frontend.data.set.view.FDSView;
 import com.liferay.frontend.data.set.view.table.FDSTableSchemaBuilderFactory;
+import com.liferay.info.item.action.executor.InfoItemActionExecutor;
 import com.liferay.info.item.capability.InfoItemCapability;
 import com.liferay.info.item.creator.InfoItemCreator;
 import com.liferay.info.item.field.reader.InfoItemFieldReaderFieldSetProvider;
@@ -59,6 +60,7 @@ import com.liferay.object.service.ObjectFieldSettingLocalService;
 import com.liferay.object.service.ObjectRelationshipLocalService;
 import com.liferay.object.service.ObjectViewLocalService;
 import com.liferay.object.web.internal.asset.model.ObjectEntryAssetRendererFactory;
+import com.liferay.object.web.internal.info.item.action.ObjectEntryInfoItemActionExecutor;
 import com.liferay.object.web.internal.info.item.creator.ObjectEntryInfoItemCreator;
 import com.liferay.object.web.internal.info.item.provider.ObjectEntryInfoItemCapabilitiesProvider;
 import com.liferay.object.web.internal.info.item.provider.ObjectEntryInfoItemDetailsProvider;
@@ -177,6 +179,15 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 				new ObjectEntryInfoItemCapabilitiesProvider(
 					_displayPageInfoItemCapability, _editPageInfoItemCapability,
 					_templateInfoItemCapability),
+				HashMapDictionaryBuilder.<String, Object>put(
+					"company.id", objectDefinition.getCompanyId()
+				).put(
+					"item.class.name", objectDefinition.getClassName()
+				).build()),
+			_bundleContext.registerService(
+				InfoItemActionExecutor.class,
+				new ObjectEntryInfoItemActionExecutor(
+					objectDefinition, _objectEntryManagerRegistry),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"company.id", objectDefinition.getCompanyId()
 				).put(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/action/ObjectEntryInfoItemActionExecutor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/action/ObjectEntryInfoItemActionExecutor.java
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.object.web.internal.info.item.action;
+
+import com.liferay.info.exception.InfoItemActionExecutionException;
+import com.liferay.info.item.ClassPKInfoItemIdentifier;
+import com.liferay.info.item.InfoItemIdentifier;
+import com.liferay.info.item.action.executor.InfoItemActionExecutor;
+import com.liferay.object.model.ObjectAction;
+import com.liferay.object.model.ObjectDefinition;
+import com.liferay.object.model.ObjectEntry;
+import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
+import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManagerProvider;
+import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.vulcan.dto.converter.DTOConverterContext;
+import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
+
+/**
+ * @author Rubén Pulido
+ */
+public class ObjectEntryInfoItemActionExecutor
+	implements InfoItemActionExecutor<ObjectEntry> {
+
+	public ObjectEntryInfoItemActionExecutor(
+		ObjectDefinition objectDefinition,
+		ObjectEntryManagerRegistry objectEntryManagerRegistry) {
+
+		_objectDefinition = objectDefinition;
+		_objectEntryManagerRegistry = objectEntryManagerRegistry;
+	}
+
+	@Override
+	public void executeInfoItemAction(
+			InfoItemIdentifier infoItemIdentifier, String fieldId)
+		throws InfoItemActionExecutionException {
+
+		try {
+			if (!(infoItemIdentifier instanceof ClassPKInfoItemIdentifier)) {
+				throw new InfoItemActionExecutionException();
+			}
+
+			ServiceContext serviceContext =
+				ServiceContextThreadLocal.getServiceContext();
+
+			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+			DefaultObjectEntryManager defaultObjectEntryManager =
+				DefaultObjectEntryManagerProvider.provide(
+					_objectEntryManagerRegistry.getObjectEntryManager(
+						_objectDefinition.getStorageType()));
+
+			DTOConverterContext dtoConverterContext =
+				new DefaultDTOConverterContext(
+					null, _objectDefinition.getObjectDefinitionId(),
+					themeDisplay.getLocale(), null, themeDisplay.getUser());
+
+			String objectActionName = fieldId;
+
+			String objectActionPrefix =
+				ObjectAction.class.getSimpleName() + StringPool.UNDERLINE;
+
+			if (objectActionName.startsWith(objectActionPrefix)) {
+				objectActionName = objectActionName.substring(
+					objectActionPrefix.length());
+			}
+
+			ClassPKInfoItemIdentifier classPKInfoItemIdentifier =
+				(ClassPKInfoItemIdentifier)infoItemIdentifier;
+
+			defaultObjectEntryManager.executeObjectAction(
+				dtoConverterContext, objectActionName, _objectDefinition,
+				classPKInfoItemIdentifier.getClassPK());
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			throw new InfoItemActionExecutionException();
+		}
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		ObjectEntryInfoItemActionExecutor.class);
+
+	private final ObjectDefinition _objectDefinition;
+	private final ObjectEntryManagerRegistry _objectEntryManagerRegistry;
+
+}

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFieldValuesProvider.java
@@ -21,6 +21,7 @@ import com.liferay.document.library.kernel.service.DLFileEntryLocalService;
 import com.liferay.document.library.util.DLURLHelper;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldValue;
+import com.liferay.info.field.type.ActionInfoFieldType;
 import com.liferay.info.field.type.ImageInfoFieldType;
 import com.liferay.info.field.type.TextInfoFieldType;
 import com.liferay.info.field.type.URLInfoFieldType;
@@ -33,13 +34,16 @@ import com.liferay.info.type.KeyLocalizedLabelPair;
 import com.liferay.info.type.WebImage;
 import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
+import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
+import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
 import com.liferay.object.model.ObjectRelationship;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
+import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectEntryLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
@@ -95,6 +99,7 @@ public class ObjectEntryInfoItemFieldValuesProvider
 		InfoItemFieldReaderFieldSetProvider infoItemFieldReaderFieldSetProvider,
 		JSONFactory jsonFactory,
 		ListTypeEntryLocalService listTypeEntryLocalService,
+		ObjectActionLocalService objectActionLocalService,
 		ObjectDefinition objectDefinition,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectEntryLocalService objectEntryLocalService,
@@ -113,6 +118,7 @@ public class ObjectEntryInfoItemFieldValuesProvider
 			infoItemFieldReaderFieldSetProvider;
 		_jsonFactory = jsonFactory;
 		_listTypeEntryLocalService = listTypeEntryLocalService;
+		_objectActionLocalService = objectActionLocalService;
 		_objectDefinition = objectDefinition;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectEntryLocalService = objectEntryLocalService;
@@ -329,6 +335,14 @@ public class ObjectEntryInfoItemFieldValuesProvider
 					objectEntry.getObjectDefinitionId(), false),
 				objectEntry.getValues()));
 
+		if (FeatureFlagManagerUtil.isEnabled("LPS-169992")) {
+			objectEntryFieldValues.addAll(
+				_getObjectActionsInfoFieldValues(
+					_objectActionLocalService.getObjectActions(
+						_objectDefinition.getObjectDefinitionId(),
+						ObjectActionTriggerConstants.KEY_STANDALONE)));
+		}
+
 		return objectEntryFieldValues;
 	}
 
@@ -382,6 +396,40 @@ public class ObjectEntryInfoItemFieldValuesProvider
 				objectEntry.getProperties()));
 
 		return objectEntryFieldValues;
+	}
+
+	private List<InfoFieldValue<Object>> _getObjectActionsInfoFieldValues(
+		List<ObjectAction> objectActions) {
+
+		List<InfoFieldValue<Object>> objectFieldsInfoFieldValues =
+			new ArrayList<>();
+
+		for (ObjectAction objectAction : objectActions) {
+			InfoLocalizedValue<String> actionLabelLocalizedValue =
+				InfoLocalizedValue.<String>builder(
+				).defaultLocale(
+					LocaleUtil.fromLanguageId(
+						objectAction.getDefaultLanguageId())
+				).values(
+					objectAction.getLabelMap()
+				).build();
+
+			objectFieldsInfoFieldValues.add(
+				new InfoFieldValue<>(
+					InfoField.builder(
+					).infoFieldType(
+						ActionInfoFieldType.INSTANCE
+					).namespace(
+						ObjectAction.class.getSimpleName()
+					).name(
+						objectAction.getName()
+					).labelInfoLocalizedValue(
+						actionLabelLocalizedValue
+					).build(),
+					actionLabelLocalizedValue));
+		}
+
+		return objectFieldsInfoFieldValues;
 	}
 
 	private List<InfoFieldValue<Object>> _getObjectFieldsInfoFieldValues(
@@ -665,6 +713,7 @@ public class ObjectEntryInfoItemFieldValuesProvider
 		_infoItemFieldReaderFieldSetProvider;
 	private final JSONFactory _jsonFactory;
 	private final ListTypeEntryLocalService _listTypeEntryLocalService;
+	private final ObjectActionLocalService _objectActionLocalService;
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
 	private final ObjectEntryLocalService _objectEntryLocalService;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -18,6 +18,7 @@ import com.liferay.info.exception.NoSuchFormVariationException;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
 import com.liferay.info.field.InfoFieldSetEntry;
+import com.liferay.info.field.type.ActionInfoFieldType;
 import com.liferay.info.field.type.FileInfoFieldType;
 import com.liferay.info.field.type.MultiselectInfoFieldType;
 import com.liferay.info.field.type.NumberInfoFieldType;
@@ -32,11 +33,13 @@ import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.info.localized.bundle.FunctionInfoLocalizedValue;
 import com.liferay.list.type.model.ListTypeEntry;
 import com.liferay.list.type.service.ListTypeEntryLocalService;
+import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.constants.ObjectFieldConstants;
 import com.liferay.object.constants.ObjectFieldValidationConstants;
 import com.liferay.object.constants.ObjectRelationshipConstants;
 import com.liferay.object.exception.NoSuchObjectDefinitionException;
 import com.liferay.object.field.setting.util.ObjectFieldSettingUtil;
+import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
 import com.liferay.object.model.ObjectEntry;
 import com.liferay.object.model.ObjectField;
@@ -46,6 +49,7 @@ import com.liferay.object.rest.context.path.RESTContextPathResolver;
 import com.liferay.object.rest.context.path.RESTContextPathResolverRegistry;
 import com.liferay.object.scope.ObjectScopeProvider;
 import com.liferay.object.scope.ObjectScopeProviderRegistry;
+import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.object.service.ObjectDefinitionLocalService;
 import com.liferay.object.service.ObjectFieldLocalService;
 import com.liferay.object.service.ObjectFieldSettingLocalService;
@@ -93,6 +97,7 @@ public class ObjectEntryInfoItemFormProvider
 		ObjectDefinition objectDefinition,
 		InfoItemFieldReaderFieldSetProvider infoItemFieldReaderFieldSetProvider,
 		ListTypeEntryLocalService listTypeEntryLocalService,
+		ObjectActionLocalService objectActionLocalService,
 		ObjectDefinitionLocalService objectDefinitionLocalService,
 		ObjectFieldLocalService objectFieldLocalService,
 		ObjectFieldSettingLocalService objectFieldSettingLocalService,
@@ -106,6 +111,7 @@ public class ObjectEntryInfoItemFormProvider
 		_infoItemFieldReaderFieldSetProvider =
 			infoItemFieldReaderFieldSetProvider;
 		_listTypeEntryLocalService = listTypeEntryLocalService;
+		_objectActionLocalService = objectActionLocalService;
 		_objectDefinitionLocalService = objectDefinitionLocalService;
 		_objectFieldLocalService = objectFieldLocalService;
 		_objectFieldSettingLocalService = objectFieldSettingLocalService;
@@ -310,6 +316,53 @@ public class ObjectEntryInfoItemFormProvider
 		}
 
 		return acceptedFileExtensionsObjectFieldSetting.getValue();
+	}
+
+	private List<InfoFieldSetEntry>
+		_getActionObjectDefinitionInfoFieldSetEntries() {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-169992")) {
+			return Collections.emptyList();
+		}
+
+		List<InfoFieldSetEntry> infoFieldSetEntries = new ArrayList<>();
+
+		InfoFieldSet.Builder infoFieldSetBuilder = InfoFieldSet.builder(
+		).labelInfoLocalizedValue(
+			InfoLocalizedValue.localize(
+				ObjectEntryInfoItemFields.class, "actions")
+		).name(
+			_objectDefinition.getName()
+		);
+
+		List<ObjectAction> objectActions =
+			_objectActionLocalService.getObjectActions(
+				_objectDefinition.getObjectDefinitionId(),
+				ObjectActionTriggerConstants.KEY_STANDALONE);
+
+		for (ObjectAction objectAction : objectActions) {
+			infoFieldSetEntries.add(
+				infoFieldSetBuilder.infoFieldSetEntry(
+					InfoField.builder(
+					).infoFieldType(
+						ActionInfoFieldType.INSTANCE
+					).namespace(
+						ObjectAction.class.getSimpleName()
+					).name(
+						objectAction.getName()
+					).labelInfoLocalizedValue(
+						InfoLocalizedValue.<String>builder(
+						).defaultLocale(
+							LocaleUtil.fromLanguageId(
+								objectAction.getDefaultLanguageId())
+						).values(
+							objectAction.getLabelMap()
+						).build()
+					).build()
+				).build());
+		}
+
+		return infoFieldSetEntries;
 	}
 
 	private List<InfoFieldSetEntry>
@@ -533,6 +586,8 @@ public class ObjectEntryInfoItemFormProvider
 			_getDisplayPageInfoFieldSet()
 		).infoFieldSetEntry(
 			_infoItemFieldReaderFieldSetProvider.getInfoFieldSet(modelClassName)
+		).infoFieldSetEntries(
+			_getActionObjectDefinitionInfoFieldSetEntries()
 		).labelInfoLocalizedValue(
 			InfoLocalizedValue.<String>builder(
 			).defaultLocale(
@@ -824,6 +879,7 @@ public class ObjectEntryInfoItemFormProvider
 	private final InfoItemFieldReaderFieldSetProvider
 		_infoItemFieldReaderFieldSetProvider;
 	private final ListTypeEntryLocalService _listTypeEntryLocalService;
+	private final ObjectActionLocalService _objectActionLocalService;
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectDefinitionLocalService _objectDefinitionLocalService;
 	private final ObjectFieldLocalService _objectFieldLocalService;


### PR DESCRIPTION
Motivation
=======
This PR adds support for executing standalone object actions through Info Framework.

Proposed Solution
========
- Add an implementation of InfoItemActionExecutor for ObjectEntries
- Include object standalone actions as additional fields in ObjectEntry implementation of InfoItemFormProvider
- Include object standalone actions as additional fields in ObjectEntry implementation of InfoItemFieldValuesProvider

References to existing code
========
For executing the action, similar code as the one used in [ObjectEntryResourceImpl](https://github.com/liferay/liferay-portal/blob/a3a98ccd3270bc583225169cfcc6b2981a9b8456/modules/apps/object/object-rest-impl/src/main/java/com/liferay/object/rest/internal/resource/v1_0/ObjectEntryResourceImpl.java#L384-L386) is used.

//cc @jkappler @ealonso @sandrodw3