### PR TITLE
LPS-186288 Display draft configuration in Design section

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutLookAndFeelDisplayContext.java
@@ -151,14 +151,14 @@ public class LayoutLookAndFeelDisplayContext {
 					return StringPool.BLANK;
 				}
 
-				Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
+				Layout layout = _layoutsAdminDisplayContext.getLayout();
 
 				Layout masterLayout = LayoutLocalServiceUtil.getLayout(
-					selLayout.getMasterLayoutPlid());
+					layout.getMasterLayoutPlid());
 
 				String editLayoutURL = HttpComponentsUtil.addParameter(
 					HttpComponentsUtil.addParameter(
-						PortalUtil.getLayoutFullURL(selLayout, _themeDisplay),
+						PortalUtil.getLayoutFullURL(layout, _themeDisplay),
 						"p_l_mode", Constants.EDIT),
 					"p_l_back_url",
 					ParamUtil.getString(_httpServletRequest, "redirect"));
@@ -176,10 +176,9 @@ public class LayoutLookAndFeelDisplayContext {
 			"masterLayoutPlid",
 			() -> {
 				if (hasMasterLayout()) {
-					Layout selLayout =
-						_layoutsAdminDisplayContext.getSelLayout();
+					Layout layout = _layoutsAdminDisplayContext.getLayout();
 
-					return String.valueOf(selLayout.getMasterLayoutPlid());
+					return String.valueOf(layout.getMasterLayoutPlid());
 				}
 
 				return StringPool.BLANK;
@@ -195,13 +194,13 @@ public class LayoutLookAndFeelDisplayContext {
 		String masterLayoutName = LanguageUtil.get(
 			_httpServletRequest, "blank");
 
-		Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
+		Layout layout = _layoutsAdminDisplayContext.getLayout();
 
-		if (selLayout.getMasterLayoutPlid() > 0) {
+		if (layout.getMasterLayoutPlid() > 0) {
 			LayoutPageTemplateEntry layoutPageTemplateEntry =
 				LayoutPageTemplateEntryLocalServiceUtil.
 					fetchLayoutPageTemplateEntryByPlid(
-						selLayout.getMasterLayoutPlid());
+						layout.getMasterLayoutPlid());
 
 			if (layoutPageTemplateEntry != null) {
 				masterLayoutName = layoutPageTemplateEntry.getName();
@@ -241,9 +240,9 @@ public class LayoutLookAndFeelDisplayContext {
 		).put(
 			"styleBookEntryId",
 			() -> {
-				Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
+				Layout layout = _layoutsAdminDisplayContext.getLayout();
 
-				return String.valueOf(selLayout.getStyleBookEntryId());
+				return String.valueOf(layout.getStyleBookEntryId());
 			}
 		).put(
 			"styleBookEntryName", getStyleBookEntryName()
@@ -251,12 +250,12 @@ public class LayoutLookAndFeelDisplayContext {
 	}
 
 	public String getStyleBookEntryName() {
-		Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
+		Layout layout = _layoutsAdminDisplayContext.getLayout();
 
 		StyleBookEntry defaultStyleBookEntry =
-			DefaultStyleBookEntryUtil.getDefaultStyleBookEntry(selLayout);
+			DefaultStyleBookEntryUtil.getDefaultStyleBookEntry(layout);
 
-		if (selLayout.getStyleBookEntryId() > 0) {
+		if (layout.getStyleBookEntryId() > 0) {
 			return defaultStyleBookEntry.getName();
 		}
 
@@ -264,9 +263,7 @@ public class LayoutLookAndFeelDisplayContext {
 			return LanguageUtil.get(_httpServletRequest, "styles-from-theme");
 		}
 
-		if (hasEditableMasterLayout() &&
-			(selLayout.getMasterLayoutPlid() > 0)) {
-
+		if (hasEditableMasterLayout() && (layout.getMasterLayoutPlid() > 0)) {
 			return LanguageUtil.get(_httpServletRequest, "styles-from-master");
 		}
 
@@ -362,13 +359,13 @@ public class LayoutLookAndFeelDisplayContext {
 
 		boolean hasMasterLayout = false;
 
-		Layout selLayout = _layoutsAdminDisplayContext.getSelLayout();
+		Layout layout = _layoutsAdminDisplayContext.getLayout();
 
-		if (selLayout.getMasterLayoutPlid() > 0) {
+		if (layout.getMasterLayoutPlid() > 0) {
 			LayoutPageTemplateEntry layoutPageTemplateEntry =
 				LayoutPageTemplateEntryLocalServiceUtil.
 					fetchLayoutPageTemplateEntryByPlid(
-						selLayout.getMasterLayoutPlid());
+						layout.getMasterLayoutPlid());
 
 			if (layoutPageTemplateEntry != null) {
 				hasMasterLayout = true;
@@ -446,7 +443,7 @@ public class LayoutLookAndFeelDisplayContext {
 							_getLayoutRootNodeName(), false)));
 			}
 
-			Layout layout = _layoutsAdminDisplayContext.getSelLayout();
+			Layout layout = _layoutsAdminDisplayContext.getLayout();
 
 			if ((layout != null) && (layout.getMasterLayoutPlid() > 0)) {
 				clientExtensionEntryRels =

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -49,6 +49,7 @@ import com.liferay.petra.string.StringUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -899,6 +900,30 @@ public class LayoutsAdminDisplayContext {
 			String.valueOf(layout.getPlid()),
 			LiferayWindowState.POP_UP.toString(), null,
 			themeDisplay.getRequest());
+	}
+
+	public Long getPlid() {
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-153951")) {
+			return getSelPlid();
+		}
+
+		Layout selLayout = getSelLayout();
+
+		if (selLayout == null) {
+			return getSelPlid();
+		}
+
+		if (selLayout.isDraftLayout()) {
+			return selLayout.getPlid();
+		}
+
+		Layout draftLayout = selLayout.fetchDraftLayout();
+
+		if (draftLayout == null) {
+			return selLayout.getPlid();
+		}
+
+		return draftLayout.getPlid();
 	}
 
 	public List<BreadcrumbEntry> getPortletBreadcrumbEntries()

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -35,6 +35,7 @@ import com.liferay.item.selector.criteria.FileEntryItemSelectorReturnType;
 import com.liferay.item.selector.criteria.UUIDItemSelectorReturnType;
 import com.liferay.item.selector.criteria.file.criterion.FileItemSelectorCriterion;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.admin.constants.LayoutScreenNavigationEntryConstants;
 import com.liferay.layout.admin.web.internal.helper.LayoutActionsHelper;
 import com.liferay.layout.admin.web.internal.util.FaviconUtil;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
@@ -668,6 +669,28 @@ public class LayoutsAdminDisplayContext {
 		_keywords = ParamUtil.getString(httpServletRequest, "keywords");
 
 		return _keywords;
+	}
+
+	public Layout getLayout() {
+		Layout selLayout = getSelLayout();
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-153951")) {
+			return selLayout;
+		}
+
+		if (_isDraftLayoutConfiguration()) {
+			if (selLayout.isDraftLayout()) {
+				return getSelLayout();
+			}
+
+			Layout draftLayout = selLayout.fetchDraftLayout();
+
+			if (draftLayout != null) {
+				return draftLayout;
+			}
+		}
+
+		return selLayout;
 	}
 
 	public String getLayoutConversionPreviewURL(Layout layout) {
@@ -2249,6 +2272,13 @@ public class LayoutsAdminDisplayContext {
 		};
 
 		return _types;
+	}
+
+	private boolean _isDraftLayoutConfiguration() {
+		return StringUtil.equalsIgnoreCase(
+			ParamUtil.getString(
+				_liferayPortletRequest, "screenNavigationEntryKey"),
+			LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN);
 	}
 
 	private boolean _matchesHostname(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -527,10 +527,10 @@ public class LayoutsAdminDisplayContext {
 		).put(
 			"faviconFileEntryId",
 			() -> {
-				Layout selLayout = getSelLayout();
+				Layout layout = getLayout();
 
-				if (selLayout != null) {
-					return selLayout.getFaviconFileEntryId();
+				if (layout != null) {
+					return layout.getFaviconFileEntryId();
 				}
 
 				LayoutSet selLayoutSet = getSelLayoutSet();
@@ -550,9 +550,9 @@ public class LayoutsAdminDisplayContext {
 	}
 
 	public String getFaviconTitle() {
-		if (getSelLayout() != null) {
+		if (getLayout() != null) {
 			return FaviconUtil.getFaviconTitle(
-				_cetManager, getSelLayout(), themeDisplay.getLocale());
+				_cetManager, getLayout(), themeDisplay.getLocale());
 		}
 
 		return FaviconUtil.getFaviconTitle(
@@ -562,8 +562,8 @@ public class LayoutsAdminDisplayContext {
 	public String getFaviconURL() {
 		String faviconURL = StringPool.BLANK;
 
-		if (getSelLayout() != null) {
-			faviconURL = FaviconUtil.getFaviconURL(_cetManager, getSelLayout());
+		if (getLayout() != null) {
+			faviconURL = FaviconUtil.getFaviconURL(_cetManager, getLayout());
 		}
 
 		if (Validator.isNotNull(faviconURL)) {
@@ -1378,11 +1378,11 @@ public class LayoutsAdminDisplayContext {
 		String className = LayoutSet.class.getName();
 		long classPK = setLayoutSet.getLayoutSetId();
 
-		Layout selLayout = getSelLayout();
+		Layout layout = getLayout();
 
-		if (selLayout != null) {
+		if (layout != null) {
 			className = Layout.class.getName();
-			classPK = selLayout.getPlid();
+			classPK = layout.getPlid();
 		}
 
 		ClientExtensionEntryRel clientExtensionEntryRel =
@@ -1430,14 +1430,14 @@ public class LayoutsAdminDisplayContext {
 	}
 
 	public String getThemeFaviconCETExternalReferenceCode() {
-		Layout selLayout = getSelLayout();
+		Layout layout = getLayout();
 
-		if (selLayout != null) {
+		if (layout != null) {
 			ClientExtensionEntryRel clientExtensionEntryRel =
 				ClientExtensionEntryRelLocalServiceUtil.
 					fetchClientExtensionEntryRel(
 						PortalUtil.getClassNameId(Layout.class),
-						selLayout.getPlid(),
+						layout.getPlid(),
 						ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
 
 			if (clientExtensionEntryRel != null) {
@@ -1646,10 +1646,10 @@ public class LayoutsAdminDisplayContext {
 	}
 
 	public boolean isClearFaviconButtonEnabled() {
-		Layout selLayout = getSelLayout();
+		Layout layout = getLayout();
 
-		if (selLayout != null) {
-			if (selLayout.getFaviconFileEntryId() > 0) {
+		if (layout != null) {
+			if (layout.getFaviconFileEntryId() > 0) {
 				return true;
 			}
 
@@ -1657,7 +1657,7 @@ public class LayoutsAdminDisplayContext {
 				ClientExtensionEntryRelLocalServiceUtil.
 					fetchClientExtensionEntryRel(
 						PortalUtil.getClassNameId(Layout.class),
-						selLayout.getPlid(),
+						layout.getPlid(),
 						ClientExtensionEntryConstants.TYPE_THEME_FAVICON);
 
 			if (clientExtensionEntryRel != null) {
@@ -2014,21 +2014,21 @@ public class LayoutsAdminDisplayContext {
 	}
 
 	private String _getDefaultFaviconTitle() {
-		Layout selLayout = getSelLayout();
+		Layout layout = getLayout();
 
-		if (selLayout != null) {
+		if (layout != null) {
 			if (hasEditableMasterLayout() &&
-				(selLayout.getMasterLayoutPlid() > 0)) {
+				(layout.getMasterLayoutPlid() > 0)) {
 
 				Layout masterLayout = LayoutLocalServiceUtil.fetchLayout(
-					selLayout.getMasterLayoutPlid());
+					layout.getMasterLayoutPlid());
 
 				if (masterLayout != null) {
 					ClientExtensionEntryRel clientExtensionEntryRel =
 						ClientExtensionEntryRelLocalServiceUtil.
 							fetchClientExtensionEntryRel(
 								PortalUtil.getClassNameId(Layout.class),
-								selLayout.getPlid(),
+								layout.getPlid(),
 								ClientExtensionEntryConstants.
 									TYPE_THEME_FAVICON);
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutMVCActionCommand.java
@@ -247,10 +247,10 @@ public class EditLayoutMVCActionCommand extends BaseMVCActionCommand {
 			}
 			else {
 				layoutTypeSettingsUnicodeProperties.putAll(
-					formTypeSettingsUnicodeProperties);
+					layout.getTypeSettingsProperties());
 
 				layoutTypeSettingsUnicodeProperties.putAll(
-					layout.getTypeSettingsProperties());
+					formTypeSettingsUnicodeProperties);
 			}
 
 			layout = _layoutService.updateLayout(

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/advanced.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/advanced.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout selLayout = layoutsAdminDisplayContext.getLayout();
 
 UnicodeProperties layoutTypeSettingsUnicodeProperties = selLayout.getTypeSettingsProperties();
 %>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/basic_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/basic_settings.jsp
@@ -21,7 +21,7 @@
 	value="basic-settings"
 />
 
-<aui:model-context bean="<%= layoutsAdminDisplayContext.getSelLayout() %>" model="<%= Layout.class %>" />
+<aui:model-context bean="<%= layoutsAdminDisplayContext.getLayout() %>" model="<%= Layout.class %>" />
 
 <%
 LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLookAndFeelDisplayContext(request, layoutsAdminDisplayContext, liferayPortletResponse);

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/css.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/css.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout selLayout = layoutsAdminDisplayContext.getLayout();
 
 LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLookAndFeelDisplayContext(request, layoutsAdminDisplayContext, liferayPortletResponse);
 %>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/customization.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/customization.jsp
@@ -21,7 +21,7 @@
 	value="customization"
 />
 
-<aui:model-context bean="<%= layoutsAdminDisplayContext.getSelLayout() %>" model="<%= Layout.class %>" />
+<aui:model-context bean="<%= layoutsAdminDisplayContext.getLayout() %>" model="<%= Layout.class %>" />
 
 <%
 LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLookAndFeelDisplayContext(request, layoutsAdminDisplayContext, liferayPortletResponse);

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/customization_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/customization_settings.jsp
@@ -23,7 +23,7 @@ boolean prototypeGroup = false;
 String templateContent = null;
 String templateId = null;
 
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout selLayout = layoutsAdminDisplayContext.getLayout();
 
 if (selLayout != null) {
 	LayoutTypePortlet selLayoutTypePortlet = (LayoutTypePortlet)selLayout.getLayoutType();

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/javascript.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/javascript.jsp
@@ -17,7 +17,7 @@
 <%@ include file="/init.jsp" %>
 
 <%
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout selLayout = layoutsAdminDisplayContext.getLayout();
 
 UnicodeProperties layoutTypeSettingsUnicodeProperties = null;
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/design.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/design.jsp
@@ -54,7 +54,7 @@ LayoutRevision layoutRevision = LayoutStagingUtil.getLayoutRevision(selLayout);
 	<aui:input name="groupId" type="hidden" value="<%= layoutsAdminDisplayContext.getGroupId() %>" />
 	<aui:input name="liveGroupId" type="hidden" value="<%= layoutsAdminDisplayContext.getLiveGroupId() %>" />
 	<aui:input name="stagingGroupId" type="hidden" value="<%= layoutsAdminDisplayContext.getStagingGroupId() %>" />
-	<aui:input name="selPlid" type="hidden" value="<%= layoutsAdminDisplayContext.getSelPlid() %>" />
+	<aui:input name="selPlid" type="hidden" value="<%= layoutsAdminDisplayContext.getPlid() %>" />
 	<aui:input name="type" type="hidden" value="<%= selLayout.getType() %>" />
 	<aui:input name="<%= PortletDataHandlerKeys.SELECTED_LAYOUTS %>" type="hidden" />
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/theme.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/theme.jsp
@@ -23,7 +23,7 @@ LayoutSet layoutSet = layoutsAdminDisplayContext.getSelLayoutSet();
 
 Theme rootTheme = layoutSet.getTheme();
 
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout selLayout = layoutsAdminDisplayContext.getLayout();
 
 PortletURL redirectURL = layoutsAdminDisplayContext.getRedirectURL();
 %>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_theme_details.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_theme_details.jsp
@@ -19,7 +19,7 @@
 <%
 String themeId = ParamUtil.getString(request, "themeId");
 
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout setLayout = layoutsAdminDisplayContext.getLayout();
 LayoutSet selLayoutSet = layoutsAdminDisplayContext.getSelLayoutSet();
 
 Theme selTheme = null;
@@ -34,9 +34,9 @@ if (Validator.isNotNull(themeId)) {
 	useDefaultThemeSettings = true;
 }
 else {
-	if (selLayout != null) {
-		selTheme = selLayout.getTheme();
-		selColorScheme = selLayout.getColorScheme();
+	if (setLayout != null) {
+		selTheme = setLayout.getTheme();
+		selColorScheme = setLayout.getColorScheme();
 	}
 	else {
 		selTheme = selLayoutSet.getTheme();
@@ -105,8 +105,8 @@ String styleBookWarningMessage = layoutsAdminDisplayContext.getStyleBookWarningM
 					value = selTheme.getSetting(entry.getKey());
 				}
 				else {
-					if (selLayout != null) {
-						value = selLayout.getThemeSetting(entry.getKey(), "regular");
+					if (setLayout != null) {
+						value = setLayout.getThemeSetting(entry.getKey(), "regular");
 					}
 					else {
 						value = selLayoutSet.getThemeSetting(entry.getKey(), "regular");

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_info.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_info.jsp
@@ -22,7 +22,7 @@ String themeId = ParamUtil.getString(request, "themeId");
 
 Theme selTheme = null;
 
-Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
+Layout selLayout = layoutsAdminDisplayContext.getLayout();
 
 if (Validator.isNotNull(themeId) && Validator.isNotNull(companyId)) {
 	selTheme = ThemeLocalServiceUtil.getTheme(companyId, themeId);


### PR DESCRIPTION
Story: https://issues.liferay.com/browse/LPS-175136
Subtask: https://issues.liferay.com/browse/LPS-186288

Description
------
This changes are not at all related with the previous story, but the story related to this changes (https://issues.liferay.com/browse/LPS-175134) is in ready for release status, so, for that reason we are doing this changes here.  However, the two stories are part of the same epic and for that reason it is not a problem to add the changes here.

The explanation of these changes is that the design configurations have been moved from the draft page configurations to the public page configurations, but design configurations should continue apply to the draft page,so, **for that reason we have to show the draft configurations in the public page configurations**, and only to remember, the draft configurations will be copied to the public layout when the user click on the publish button. 
