### PR TITLE
LPS-186991 Fix incorrect behaviors of Structures filter

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleService.java
@@ -726,9 +726,10 @@ public interface JournalArticleService extends BaseService {
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<JournalArticle> getArticlesByStructureId(
-		long groupId, long folderId, long classNameId, long ddmStructureId,
-		int status, int start, int end,
-		OrderByComparator<JournalArticle> orderByComparator);
+			long groupId, long folderId, long classNameId, long ddmStructureId,
+			int status, int start, int end,
+			OrderByComparator<JournalArticle> orderByComparator)
+		throws PortalException;
 
 	/**
 	 * Returns the number of web content articles matching the group and folder.

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceUtil.java
@@ -824,9 +824,10 @@ public class JournalArticleServiceUtil {
 	}
 
 	public static List<JournalArticle> getArticlesByStructureId(
-		long groupId, long folderId, long classNameId, long ddmStructureId,
-		int status, int start, int end,
-		OrderByComparator<JournalArticle> orderByComparator) {
+			long groupId, long folderId, long classNameId, long ddmStructureId,
+			int status, int start, int end,
+			OrderByComparator<JournalArticle> orderByComparator)
+		throws PortalException {
 
 		return getService().getArticlesByStructureId(
 			groupId, folderId, classNameId, ddmStructureId, status, start, end,

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceWrapper.java
@@ -863,10 +863,11 @@ public class JournalArticleServiceWrapper
 
 	@Override
 	public java.util.List<JournalArticle> getArticlesByStructureId(
-		long groupId, long folderId, long classNameId, long ddmStructureId,
-		int status, int start, int end,
-		com.liferay.portal.kernel.util.OrderByComparator<JournalArticle>
-			orderByComparator) {
+			long groupId, long folderId, long classNameId, long ddmStructureId,
+			int status, int start, int end,
+			com.liferay.portal.kernel.util.OrderByComparator<JournalArticle>
+				orderByComparator)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _journalArticleService.getArticlesByStructureId(
 			groupId, folderId, classNameId, ddmStructureId, status, start, end,

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceHttp.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceHttp.java
@@ -1276,12 +1276,14 @@ public class JournalArticleServiceHttp {
 	}
 
 	public static java.util.List<com.liferay.journal.model.JournalArticle>
-		getArticlesByStructureId(
-			HttpPrincipal httpPrincipal, long groupId, long folderId,
-			long classNameId, long ddmStructureId, int status, int start,
-			int end,
-			com.liferay.portal.kernel.util.OrderByComparator
-				<com.liferay.journal.model.JournalArticle> orderByComparator) {
+			getArticlesByStructureId(
+				HttpPrincipal httpPrincipal, long groupId, long folderId,
+				long classNameId, long ddmStructureId, int status, int start,
+				int end,
+				com.liferay.portal.kernel.util.OrderByComparator
+					<com.liferay.journal.model.JournalArticle>
+						orderByComparator)
+		throws com.liferay.portal.kernel.exception.PortalException {
 
 		try {
 			MethodKey methodKey = new MethodKey(
@@ -1298,6 +1300,13 @@ public class JournalArticleServiceHttp {
 				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
 			}
 			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
 				throw new com.liferay.portal.kernel.exception.SystemException(
 					exception);
 			}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
@@ -1022,17 +1022,24 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 
 	@Override
 	public List<JournalArticle> getArticlesByStructureId(
-		long groupId, long folderId, long classNameId, long ddmStructureId,
-		int status, int start, int end,
-		OrderByComparator<JournalArticle> orderByComparator) {
+			long groupId, long folderId, long classNameId, long ddmStructureId,
+			int status, int start, int end,
+			OrderByComparator<JournalArticle> orderByComparator)
+		throws PortalException {
+
+		List<Long> folderIds = new ArrayList<>();
+
+		if (folderId != JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
+			folderIds = _journalFolderService.getFolderIds(groupId, folderId);
+		}
 
 		QueryDefinition<JournalArticle> queryDefinition = new QueryDefinition<>(
 			status, start, end, orderByComparator);
 
 		return journalArticleFinder.filterFindByG_F_C_S_L(
-			groupId, ListUtil.fromArray(folderId),
-			JournalArticleConstants.CLASS_NAME_ID_DEFAULT, ddmStructureId,
-			LocaleUtil.getMostRelevantLocale(), queryDefinition);
+			groupId, folderIds, JournalArticleConstants.CLASS_NAME_ID_DEFAULT,
+			ddmStructureId, LocaleUtil.getMostRelevantLocale(),
+			queryDefinition);
 	}
 
 	/**

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
@@ -351,6 +351,8 @@ public class JournalManagementToolbarDisplayContext
 							currentURLObj, liferayPortletResponse)
 					).setNavigation(
 						(String)null
+					).setParameter(
+						"ddmStructureId", (String)null
 					).buildString());
 
 				labelItem.setCloseable(true);


### PR DESCRIPTION
Motivation
=======
The expected behavior of the Structures filter is that it would return all articles matching the structure in both the current folder _and all its descendants_. The reasoning behind this was to make it consistent with the other filters in the "FILTER BY NAVIGATION" menu, which function the same way (returning matching articles in both the current folder and its descendants). This behavior has been clearly defined on both [LPS-141474](https://issues.liferay.com/browse/LPS-141474) and [PTR-2706](https://issues.liferay.com/browse/PTR-2706).

However, currently, this expected behavior is not being met. Currently, only the articles within the current folder are being returned. Articles in the current folder's descendants are NOT being returned. This pull request aims to resolve that.

While I was testing this, I discovered a related bug, which is that when you click the "x" on the "Structures: [Structure Name]" level, the page does not change at all. The expected behavior is that it would restore the original folder view. This does not happen; nothing changes. So I fixed that as well (see ba92b6c5ecc65184a4943e65c7c0a349b86614e9)

See more details on [LPS-186991](https://issues.liferay.com/browse/LPS-186991)

Proposed Solution
========
To fix the first problem, I passed in the folderIds of both the current folder and all its descendants into the `filterFindByG_F_C_S_L` method, as opposed to only passing in the folderId of the current folder. Except in the case that the folder is the root folder, then I made us pass in an empty list, since that removes the folderId check entirely (since all folders are descendants of the root, so we want to return all matching web contents in the group regardless of folder).

To fix the second problem, I removed the "ddmStructureId" parameter of the "removeLabelURL", since its existence in the URL was causing the "Filter by Structures" screen to still be displayed.

Steps to Verify
========
1. Go to Content & Data -> Web Content -> Structure (tab).
2. Create a new structure "ST-Test" with any field.
3. Go to Content & Data -> Web Content -> Web Content (tab).
4. Create a new Web Content "ST-Parent" based on "ST-Test" .
5. Create a new folder "F-Child".
6. Inside "F-Child", new Web Content "ST-Child" based on "ST-Test" and create a new folder "F-GrandChild".
7. Inside "F-GrandChild", create a new Web Content "ST-GrandChild" based on "ST-Test".
8. Move to "F-Child", filter by structure and select "ST-Test".

 Expected Result: Works as the other filters by navigation, showing results in cascade (ST-Child, ST-GrandChild)
 Actual Result: Shows only ST-Child

