### PR TITLE
LPS-176673 Replace alert divs with clay:alert taglib in site-admin-web module

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/add_group.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/add_group.jsp
@@ -56,9 +56,10 @@ AddGroupDisplayContext addGroupDisplayContext = (AddGroupDisplayContext)request.
 								/>
 							</c:when>
 							<c:otherwise>
-								<div class="alert alert-warning text-justify">
-									<liferay-ui:message key="sites-have-required-vocabularies.-you-need-to-create-at-least-one-category-in-all-required-vocabularies-in-order-to-create-a-site" />
-								</div>
+								<clay:alert
+									displayType="warning"
+									message='<%= LanguageUtil.get(request, "sites-have-required-vocabularies.-you-need-to-create-at-least-one-category-in-all-required-vocabularies-in-order-to-create-a-site") %>'
+								/>
 							</c:otherwise>
 						</c:choose>
 					</aui:fieldset>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/layout_set_merge_alert.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/layout_set_merge_alert.jsp
@@ -23,20 +23,23 @@ LayoutSetPrototype layoutSetPrototype = (LayoutSetPrototype)request.getAttribute
 String redirect = (String)request.getAttribute("edit_layout_set_prototype.jsp-redirect");
 
 int mergeFailCount = SitesUtil.getMergeFailCount(layoutSetPrototype);
+
+String randomNamespace = PortalUtil.generateRandomKey(request, "portlet_layout_set_prototypes_merge_alert") + StringPool.UNDERLINE;
 %>
 
 <c:if test="<%= mergeFailCount > PropsValues.LAYOUT_SET_PROTOTYPE_MERGE_FAIL_THRESHOLD %>">
-	<div class="alert alert-warning">
+	<clay:alert>
 		<liferay-ui:message arguments='<%= new Object[] {mergeFailCount, LanguageUtil.get(request, "site-template")} %>' key="the-propagation-of-changes-from-the-x-has-been-disabled-temporarily-after-x-errors" translateArguments="<%= false %>" />
 
 		<liferay-ui:message arguments="site-template" key="click-reset-and-propagate-to-reset-the-failure-count-and-propagate-changes-from-the-x" />
 
-		<%
-		String randomNamespace = PortalUtil.generateRandomKey(request, "portlet_layout_set_prototypes_merge_alert") + StringPool.UNDERLINE;
-		%>
-
-		<aui:button id='<%= randomNamespace + "resetButton" %>' useNamespace="<%= false %>" value="reset-and-propagate" />
-	</div>
+		<clay:button
+			cssClass="c-mt-2"
+			displayType="secondary"
+			id='<%= randomNamespace + "resetButton" %>'
+			label="reset-and-propagate"
+		/>
+	</clay:alert>
 
 	<script>
 		var resetButton = document.getElementById('<%= randomNamespace %>resetButton');
@@ -61,7 +64,9 @@ List<Layout> mergeFailFriendlyURLLayouts = SitesUtil.getMergeFailFriendlyURLLayo
 %>
 
 <c:if test="<%= !mergeFailFriendlyURLLayouts.isEmpty() %>">
-	<div class="alert alert-warning">
+	<clay:alert
+		displayType="warning"
+	>
 		<liferay-ui:message key="some-pages-from-the-site-template-cannot-be-propagated-because-their-friendly-urls-conflict-with-the-following-pages" />
 
 		<liferay-ui:message key="modify-the-friendly-url-of-the-pages-to-allow-their-propagation-from-the-site-template" />
@@ -94,5 +99,5 @@ List<Layout> mergeFailFriendlyURLLayouts = SitesUtil.getMergeFailFriendlyURLLayo
 			%>
 
 		</ul>
-	</div>
+	</clay:alert>
 </c:if>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/layout_set_merge_alert.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/layout_set_merge_alert.jsp
@@ -23,8 +23,6 @@ LayoutSetPrototype layoutSetPrototype = (LayoutSetPrototype)request.getAttribute
 String redirect = (String)request.getAttribute("edit_layout_set_prototype.jsp-redirect");
 
 int mergeFailCount = SitesUtil.getMergeFailCount(layoutSetPrototype);
-
-String randomNamespace = PortalUtil.generateRandomKey(request, "portlet_layout_set_prototypes_merge_alert") + StringPool.UNDERLINE;
 %>
 
 <c:if test="<%= mergeFailCount > PropsValues.LAYOUT_SET_PROTOTYPE_MERGE_FAIL_THRESHOLD %>">
@@ -33,30 +31,21 @@ String randomNamespace = PortalUtil.generateRandomKey(request, "portlet_layout_s
 
 		<liferay-ui:message arguments="site-template" key="click-reset-and-propagate-to-reset-the-failure-count-and-propagate-changes-from-the-x" />
 
-		<clay:button
+		<liferay-portlet:actionURL name="/site_admin/reset_merge_fail_count_and_merge" portletName="<%= SiteAdminPortletKeys.SITE_ADMIN %>" var="portletURL">
+			<portlet:param name="redirect" value="<%= redirect %>" />
+			<portlet:param name="layoutSetPrototypeId" value="<%= String.valueOf(layoutSetPrototype.getLayoutSetPrototypeId()) %>" />
+			<portlet:param name="groupId" value="<%= String.valueOf(groupId) %>" />
+			<portlet:param name="privateLayoutSet" value="<%= String.valueOf(layoutSet.isPrivateLayout()) %>" />
+		</liferay-portlet:actionURL>
+
+		<clay:link
 			cssClass="c-mt-2"
 			displayType="secondary"
-			id='<%= randomNamespace + "resetButton" %>'
+			href="<%= portletURL.toString() %>"
 			label="reset-and-propagate"
+			type="button"
 		/>
 	</clay:alert>
-
-	<script>
-		var resetButton = document.getElementById('<%= randomNamespace %>resetButton');
-
-		if (resetButton) {
-			resetButton.addEventListener('click', (event) => {
-				<liferay-portlet:actionURL name="/site_admin/reset_merge_fail_count_and_merge" portletName="<%= SiteAdminPortletKeys.SITE_ADMIN %>" var="portletURL">
-					<portlet:param name="redirect" value="<%= redirect %>" />
-					<portlet:param name="layoutSetPrototypeId" value="<%= String.valueOf(layoutSetPrototype.getLayoutSetPrototypeId()) %>" />
-					<portlet:param name="groupId" value="<%= String.valueOf(groupId) %>" />
-					<portlet:param name="privateLayoutSet" value="<%= String.valueOf(layoutSet.isPrivateLayout()) %>" />
-				</liferay-portlet:actionURL>
-
-				submitForm(document.hrefFm, '<%= portletURL.toString() %>');
-			});
-		}
-	</script>
 </c:if>
 
 <%

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/pages.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/pages.jsp
@@ -59,9 +59,10 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 	<c:choose>
 		<c:when test="<%= (publicLayoutSetPrototype == null) && (siteGroup.getPublicLayoutsPageCount() == 0) && !layoutSetPrototypes.isEmpty() %>">
 			<c:if test="<%= disableLayoutSetPrototypeInput %>">
-				<div class="alert alert-info">
-					<liferay-ui:message key="you-cannot-apply-a-site-template-because-you-modified-the-display-settings-of-this-site" />
-				</div>
+				<clay:alert
+					displayType="info"
+					message='<%= LanguageUtil.get(request, "you-cannot-apply-a-site-template-because-you-modified-the-display-settings-of-this-site") %>'
+				/>
 			</c:if>
 
 			<aui:select disabled="<%= disableLayoutSetPrototypeInput %>" helpMessage="site-templates-with-an-incompatible-application-adapter-are-disabled" label="site-template" name="publicLayoutSetPrototypeId">
@@ -85,9 +86,10 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 					<c:when test="<%= hasUnlinkLayoutSetPrototypePermission %>">
 						<div class="hide" id="<portlet:namespace />publicLayoutSetPrototypeIdOptions">
 							<c:if test="<%= disableLayoutSetPrototypeInput %>">
-								<div class="alert alert-info">
-									<liferay-ui:message key="you-cannot-enable-the-propagation-of-changes-because-you-modified-the-display-settings-of-this-site" />
-								</div>
+								<clay:alert
+									displayType="info"
+									message='<%= LanguageUtil.get(request, "you-cannot-enable-the-propagation-of-changes-because-you-modified-the-display-settings-of-this-site") %>'
+								/>
 							</c:if>
 
 							<aui:input disabled="<%= disableLayoutSetPrototypeInput %>" helpMessage="enable-propagation-of-changes-from-the-site-template-help" inlineLabel="right" label="enable-propagation-of-changes-from-the-site-template" labelCssClass="simple-toggle-switch" name="publicLayoutSetPrototypeLinkEnabled" type="toggle-switch" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
@@ -114,9 +116,10 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 			<c:choose>
 				<c:when test="<%= (publicLayoutSetPrototype != null) && !siteGroup.isStaged() && hasUnlinkLayoutSetPrototypePermission %>">
 					<c:if test="<%= disableLayoutSetPrototypeInput %>">
-						<div class="alert alert-info">
-							<liferay-ui:message key="you-cannot-enable-the-propagation-of-changes-because-you-modified-the-display-settings-of-this-site" />
-						</div>
+						<clay:alert
+							displayType="info"
+							message='<%= LanguageUtil.get(request, "you-cannot-enable-the-propagation-of-changes-because-you-modified-the-display-settings-of-this-site") %>'
+						/>
 					</c:if>
 
 					<aui:input disabled="<%= disableLayoutSetPrototypeInput %>" inlineLabel="right" label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(locale)), false) %>' labelCssClass="simple-toggle-switch" name="publicLayoutSetPrototypeLinkEnabled" type="toggle-switch" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/public_private_pages.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/public_private_pages.jsp
@@ -74,9 +74,10 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 	<c:choose>
 		<c:when test="<%= (publicLayoutSetPrototype == null) && (siteGroup.getPublicLayoutsPageCount() == 0) && !layoutSetPrototypes.isEmpty() %>">
 			<c:if test="<%= disableLayoutSetPrototypeInput %>">
-				<div class="alert alert-info">
-					<liferay-ui:message key="you-cannot-apply-a-site-template-because-you-modified-the-display-settings-of-this-site" />
-				</div>
+				<clay:alert
+					displayType="info"
+					message='<%= LanguageUtil.get(request, "you-cannot-apply-a-site-template-because-you-modified-the-display-settings-of-this-site") %>'
+				/>
 			</c:if>
 
 			<aui:select disabled="<%= disableLayoutSetPrototypeInput %>" helpMessage="site-templates-with-an-incompatible-application-adapter-are-disabled" label="site-template" name="publicLayoutSetPrototypeId">
@@ -100,9 +101,10 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 					<c:when test="<%= hasUnlinkLayoutSetPrototypePermission %>">
 						<div class="hide" id="<portlet:namespace />publicLayoutSetPrototypeIdOptions">
 							<c:if test="<%= disableLayoutSetPrototypeInput %>">
-								<div class="alert alert-info">
-									<liferay-ui:message key="you-cannot-enable-the-propagation-of-changes-because-you-modified-the-display-settings-of-this-site" />
-								</div>
+								<clay:alert
+									displayType="info"
+									message='<%= LanguageUtil.get(request, "you-cannot-enable-the-propagation-of-changes-because-you-modified-the-display-settings-of-this-site") %>'
+								/>
 							</c:if>
 
 							<aui:input disabled="<%= disableLayoutSetPrototypeInput %>" helpMessage="enable-propagation-of-changes-from-the-site-template-help" inlineLabel="right" label="enable-propagation-of-changes-from-the-site-template" labelCssClass="simple-toggle-switch" name="publicLayoutSetPrototypeLinkEnabled" type="toggle-switch" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
@@ -129,9 +131,10 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 			<c:choose>
 				<c:when test="<%= (publicLayoutSetPrototype != null) && !siteGroup.isStaged() && hasUnlinkLayoutSetPrototypePermission %>">
 					<c:if test="<%= disableLayoutSetPrototypeInput %>">
-						<div class="alert alert-info">
-							<liferay-ui:message key="you-cannot-enable-the-propagation-of-changes-because-you-modified-the-display-settings-of-this-site" />
-						</div>
+						<clay:alert
+							displayType="info"
+							message='<%= LanguageUtil.get(request, "you-cannot-enable-the-propagation-of-changes-because-you-modified-the-display-settings-of-this-site") %>'
+						/>
 					</c:if>
 
 					<aui:input disabled="<%= disableLayoutSetPrototypeInput %>" inlineLabel="right" label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(publicLayoutSetPrototype.getName(locale)), false) %>' labelCssClass="simple-toggle-switch" name="publicLayoutSetPrototypeLinkEnabled" type="toggle-switch" value="<%= publicLayoutSetPrototypeLinkEnabled %>" />
@@ -164,9 +167,10 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 	<c:choose>
 		<c:when test="<%= (privateLayoutSetPrototype == null) && (siteGroup.getPrivateLayoutsPageCount() == 0) && !layoutSetPrototypes.isEmpty() %>">
 			<c:if test="<%= disableLayoutSetPrototypeInput %>">
-				<div class="alert alert-info">
-					<liferay-ui:message key="you-cannot-apply-a-site-template-because-you-modified-the-display-settings-of-this-site" />
-				</div>
+				<clay:alert
+					displayType="info"
+					message='<%= LanguageUtil.get(request, "you-cannot-apply-a-site-template-because-you-modified-the-display-settings-of-this-site") %>'
+				/>
 			</c:if>
 
 			<aui:select disabled="<%= disableLayoutSetPrototypeInput %>" helpMessage="site-templates-with-an-incompatible-application-adapter-are-disabled" label="site-template" name="privateLayoutSetPrototypeId">
@@ -190,9 +194,10 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 					<c:when test="<%= hasUnlinkLayoutSetPrototypePermission %>">
 						<div class="hide" id="<portlet:namespace />privateLayoutSetPrototypeIdOptions">
 							<c:if test="<%= disableLayoutSetPrototypeInput %>">
-								<div class="alert alert-info">
-									<liferay-ui:message key="you-cannot-enable-the-propagation-of-changes-because-you-modified-the-display-settings-of-this-site" />
-								</div>
+								<clay:alert
+									displayType="info"
+									message='<%= LanguageUtil.get(request, "you-cannot-enable-the-propagation-of-changes-because-you-modified-the-display-settings-of-this-site") %>'
+								/>
 							</c:if>
 
 							<aui:input disabled="<%= disableLayoutSetPrototypeInput %>" helpMessage="enable-propagation-of-changes-from-the-site-template-help" inlineLabel="right" label="enable-propagation-of-changes-from-the-site-template" labelCssClass="simple-toggle-switch" name="privateLayoutSetPrototypeLinkEnabled" type="toggle-switch" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />
@@ -219,9 +224,10 @@ boolean hasUnlinkLayoutSetPrototypePermission = PortalPermissionUtil.contains(pe
 			<c:choose>
 				<c:when test="<%= (privateLayoutSetPrototype != null) && !siteGroup.isStaged() && hasUnlinkLayoutSetPrototypePermission %>">
 					<c:if test="<%= disableLayoutSetPrototypeInput %>">
-						<div class="alert alert-info">
-							<liferay-ui:message key="you-cannot-enable-the-propagation-of-changes-because-you-modified-the-display-settings-of-this-site" />
-						</div>
+						<clay:alert
+							displayType="info"
+							message='<%= LanguageUtil.get(request, "you-cannot-enable-the-propagation-of-changes-because-you-modified-the-display-settings-of-this-site") %>'
+						/>
 					</c:if>
 
 					<aui:input disabled="<%= disableLayoutSetPrototypeInput %>" inlineLabel="right" label='<%= LanguageUtil.format(request, "enable-propagation-of-changes-from-the-site-template-x", HtmlUtil.escape(privateLayoutSetPrototype.getName(locale)), false) %>' labelCssClass="simple-toggle-switch" name="privateLayoutSetPrototypeLinkEnabled" type="toggle-switch" value="<%= privateLayoutSetPrototypeLinkEnabled %>" />


### PR DESCRIPTION
Motivation
=======
The motivation behind this PR is to substitute the alerts created directly in html with clay:alerts taglib in the site-admin-web module.
https://issues.liferay.com/browse/LPS-176673
