### PR TITLE
[TS] LPS-184602 | Site Navigation Menu in theme resets after Site Template propagation

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/PortletImportControllerImpl.java
@@ -526,6 +526,14 @@ public class PortletImportControllerImpl implements PortletImportController {
 			long elementPlid = GetterUtil.getLong(
 				element.attributeValue("plid"));
 
+			Map<String, String[]> parameterMap =
+				portletDataContext.getParameterMap();
+
+			parameterMap.put(
+				"preferencePlid", new String[] {String.valueOf(elementPlid)});
+
+			portletDataContext.setParameterMap(parameterMap);
+
 			if ((ownerType == PortletKeys.PREFS_OWNER_TYPE_LAYOUT) &&
 				(ownerId != PortletKeys.PREFS_OWNER_ID_DEFAULT) &&
 				(elementPlid == PortletKeys.PREFS_PLID_SHARED)) {

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/SiteNavigationMenuExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/SiteNavigationMenuExportImportPortletPreferencesProcessor.java
@@ -27,6 +27,7 @@ import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.site.navigation.constants.SiteNavigationConstants;
 import com.liferay.site.navigation.constants.SiteNavigationMenuPortletKeys;
 import com.liferay.site.navigation.model.SiteNavigationMenu;
@@ -134,11 +135,24 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 
 			long siteNavigationMenuId = 0;
 
+			long originalPlid = MapUtil.getLong(
+				portletDataContext.getParameterMap(), "preferencePlid");
+
 			List<com.liferay.portal.kernel.model.PortletPreferences>
+				serviceBuilderPortletPreferencesList;
+
+			if (originalPlid == PortletKeys.PREFS_PLID_SHARED) {
+				serviceBuilderPortletPreferencesList =
+					_portletPreferencesLocalService.getPortletPreferences(
+						PortletKeys.PREFS_PLID_SHARED,
+						portletDataContext.getPortletId());
+			}
+			else {
 				serviceBuilderPortletPreferencesList =
 					_portletPreferencesLocalService.getPortletPreferences(
 						portletDataContext.getPlid(),
 						portletDataContext.getPortletId());
+			}
 
 			if (!serviceBuilderPortletPreferencesList.isEmpty()) {
 				com.liferay.portal.kernel.model.PortletPreferences


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-184602
Thank you!

-------

The root cause of the issue is that when the propagation exports a page all the preferences get exported, the shared ones and the ones belonging to the layout. On the import side of the process, we had no way to differentiate between these preferences as the dataContext only know the plid of the current layout and I did not manage to retrieve the plid directly from the preferences. In the case of content pages, there was a use case where the shared preference would be overwritten by the default one of the layout. My solution avoids these cases by differentiating between shared preferences and layout-specific preferences.

for more information: https://issues.liferay.com/browse/PTR-3920