### PR TITLE
[TS] LPS-180849 Permission issue with shareable iframe fragments

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-content/src/main/java/com/liferay/layout/type/controller/content/internal/layout/type/controller/ContentLayoutTypeController.java
@@ -100,28 +100,29 @@ public class ContentLayoutTypeController extends BaseLayoutTypeControllerImpl {
 
 		Boolean hasUpdatePermissions = null;
 
-		if (layout.isDraftLayout()) {
-			Layout curLayout = _layoutLocalService.fetchLayout(
-				layout.getClassPK());
-
-			if (curLayout.isPending()) {
-				curLayout = layout;
-			}
-
-			hasUpdatePermissions = _hasUpdatePermissions(
-				themeDisplay.getPermissionChecker(), curLayout);
-
-			if (!hasUpdatePermissions) {
-				throw new PrincipalException.MustHavePermission(
-					themeDisplay.getPermissionChecker(), Layout.class.getName(),
-					layout.getLayoutId(), ActionKeys.UPDATE);
-			}
-		}
-
 		String layoutMode = ParamUtil.getString(
 			httpServletRequest, "p_l_mode", Constants.VIEW);
 
 		if (layoutMode.equals(Constants.EDIT)) {
+			if (layout.isDraftLayout()) {
+				Layout curLayout = _layoutLocalService.fetchLayout(
+					layout.getClassPK());
+
+				if (curLayout.isPending()) {
+					curLayout = layout;
+				}
+
+				hasUpdatePermissions = _hasUpdatePermissions(
+					themeDisplay.getPermissionChecker(), curLayout);
+
+				if (!hasUpdatePermissions) {
+					throw new PrincipalException.MustHavePermission(
+						themeDisplay.getPermissionChecker(),
+						Layout.class.getName(), layout.getLayoutId(),
+						ActionKeys.UPDATE);
+				}
+			}
+
 			if (hasUpdatePermissions == null) {
 				hasUpdatePermissions = _hasUpdatePermissions(
 					themeDisplay.getPermissionChecker(), layout);


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
The Guest user cannot see the contents of a shareable iframe if it is put in a fragment, because the user will be checked for UPDATE permission on the layout.

Proposed Solution
========
Only check the UPDATE permission if the layout is being edited.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://issues.liferay.com/browse/LPS-180849

Thank you and best regards,
István