### PR TITLE
[TS] LPS-187161

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -4725,7 +4725,11 @@ public class JournalArticleLocalServiceImpl
 				LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()));
 
 			if (Validator.isNull(urlTitle)) {
-				throw new ArticleFriendlyURLException();
+				urlTitle = ParamUtil.getString(serviceContext, "urlTitle");
+
+				if (!imported || Validator.isNull(urlTitle)) {
+					throw new ArticleFriendlyURLException();
+				}
 			}
 		}
 


### PR DESCRIPTION
Motivation
=======
This is a PR that aims to fix the FriendlyURLException that is thrown when publishing to Live after locales having been changed in the following way:
- The original default locale is no longer available.
- The new default locale was not one of the original available locales.

Proposed Solution
========
The approach taken is to pick the original urlTitle if we are in the middle of publishing to Live.

Steps to Verify
========

1. Create a new site
2. Establish Catalan and Spanish as site languages making Catalan as the default Language
3. Enable local Staging
4. Create a new Web Content filling only the Catalan fields
5. Publish to Live
6. Change the locales to Spanish, French making French as the default language
7. Publish to Live selecting all the contents to publish

Expected behavior: The publishing result is successful.