### PR TITLE
LPS-178363 Cannot publish expired Web Content with Display Page whose latest version is in draft status

### DIFF
--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -979,6 +979,17 @@ public class JournalTestUtil {
 	}
 
 	public static JournalArticle updateArticle(
+			JournalArticle article, String title, String content,
+			boolean workflowEnabled, boolean approved,
+			ServiceContext serviceContext, Date expirationDate)
+		throws Exception {
+
+		return updateArticle(
+			article.getUserId(), article, _getLocalizedMap(title), content,
+			null, workflowEnabled, approved, serviceContext, expirationDate);
+	}
+
+	public static JournalArticle updateArticle(
 			long userId, JournalArticle article, Map<Locale, String> titleMap,
 			String content, boolean workflowEnabled, boolean approved,
 			ServiceContext serviceContext)

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -986,13 +986,14 @@ public class JournalTestUtil {
 
 		return updateArticle(
 			userId, article, titleMap, content, null, workflowEnabled, approved,
-			serviceContext);
+			serviceContext, null);
 	}
 
 	public static JournalArticle updateArticle(
 			long userId, JournalArticle article, Map<Locale, String> titleMap,
 			String content, Date displayDate, boolean workflowEnabled,
-			boolean approved, ServiceContext serviceContext)
+			boolean approved, ServiceContext serviceContext,
+			Date expirationDate)
 		throws Exception {
 
 		if (workflowEnabled) {
@@ -1033,6 +1034,30 @@ public class JournalTestUtil {
 			displayDateMinute = displayCal.get(Calendar.MINUTE);
 		}
 
+		int expirationDateMonth = 0;
+		int expirationDateDay = 0;
+		int expirationDateYear = 0;
+		int expirationDateHour = 0;
+		int expirationDateMinute = 0;
+		boolean neverExpire = true;
+
+		if (expirationDate != null) {
+			neverExpire = false;
+
+			User user = TestPropsValues.getUser();
+
+			Calendar displayCal = CalendarFactoryUtil.getCalendar(
+				user.getTimeZone());
+
+			displayCal.setTime(expirationDate);
+
+			expirationDateMonth = displayCal.get(Calendar.MONTH);
+			expirationDateDay = displayCal.get(Calendar.DATE);
+			expirationDateYear = displayCal.get(Calendar.YEAR);
+			expirationDateHour = displayCal.get(Calendar.HOUR_OF_DAY);
+			expirationDateMinute = displayCal.get(Calendar.MINUTE);
+		}
+
 		serviceContext.setCommand(Constants.UPDATE);
 		serviceContext.setLayoutFullURL("http://localhost");
 
@@ -1041,10 +1066,11 @@ public class JournalTestUtil {
 			article.getArticleId(), article.getVersion(), titleMap,
 			article.getDescriptionMap(), content, article.getDDMTemplateKey(),
 			article.getLayoutUuid(), displayDateMonth, displayDateDay,
-			displayDateYear, displayDateHour, displayDateMinute, 0, 0, 0, 0, 0,
-			true, 0, 0, 0, 0, 0, true, article.isIndexable(),
-			article.isSmallImage(), article.getSmallImageURL(), null, null,
-			null, serviceContext);
+			displayDateYear, displayDateHour, displayDateMinute,
+			expirationDateMonth, expirationDateDay, expirationDateYear,
+			expirationDateHour, expirationDateMinute, neverExpire, 0, 0, 0, 0,
+			0, true, article.isIndexable(), article.isSmallImage(),
+			article.getSmallImageURL(), null, null, null, serviceContext);
 	}
 
 	public static JournalArticle updateArticleWithWorkflow(

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/asset/model/test/JournalArticleAssetRendererTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/asset/model/test/JournalArticleAssetRendererTest.java
@@ -52,6 +52,8 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portletmvc4spring.test.mock.web.portlet.MockRenderRequest;
 
+import java.util.Date;
+
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -76,6 +78,36 @@ public class JournalArticleAssetRendererTest {
 
 		_serviceContext = ServiceContextTestUtil.getServiceContext(
 			_group.getGroupId());
+	}
+
+	@Test
+	public void testGetExportableArticleVersion() throws Exception {
+		JournalArticle article = JournalTestUtil.addArticleWithWorkflow(
+			_group.getGroupId(), true);
+
+		JournalTestUtil.updateArticle(
+			article, "title", article.getContent(), true, false,
+			_serviceContext, new Date(System.currentTimeMillis() + 600000));
+
+		JournalTestUtil.expireArticle(
+			article.getGroupId(), article, article.getVersion());
+
+		article.setVersion(1.1);
+
+		JournalTestUtil.updateArticle(
+			article, "title", article.getContent(), true, false,
+			_serviceContext, null);
+
+		AssetRendererFactory<JournalArticle> assetRendererFactory =
+			AssetRendererFactoryRegistryUtil.getAssetRendererFactoryByClass(
+				JournalArticle.class);
+
+		AssetRenderer<JournalArticle> assetRenderer =
+			assetRendererFactory.getAssetRenderer(
+				article.getResourcePrimKey(), 0);
+
+		Assert.assertEquals(
+			WorkflowConstants.STATUS_EXPIRED, assetRenderer.getStatus());
 	}
 
 	@Test

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRendererFactory.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRendererFactory.java
@@ -126,14 +126,14 @@ public class JournalArticleAssetRendererFactory
 				article = _journalArticleLocalService.fetchLatestArticle(
 					articleResource.getGroupId(),
 					articleResource.getArticleId(),
-					WorkflowConstants.STATUS_EXPIRED);
+					WorkflowConstants.STATUS_SCHEDULED);
 			}
 
 			if (article == null) {
 				article = _journalArticleLocalService.fetchLatestArticle(
 					articleResource.getGroupId(),
 					articleResource.getArticleId(),
-					WorkflowConstants.STATUS_SCHEDULED);
+					WorkflowConstants.STATUS_EXPIRED);
 			}
 
 			if (article == null) {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRendererFactory.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRendererFactory.java
@@ -126,6 +126,20 @@ public class JournalArticleAssetRendererFactory
 				article = _journalArticleLocalService.fetchLatestArticle(
 					articleResource.getGroupId(),
 					articleResource.getArticleId(),
+					WorkflowConstants.STATUS_EXPIRED);
+			}
+
+			if (article == null) {
+				article = _journalArticleLocalService.fetchLatestArticle(
+					articleResource.getGroupId(),
+					articleResource.getArticleId(),
+					WorkflowConstants.STATUS_SCHEDULED);
+			}
+
+			if (article == null) {
+				article = _journalArticleLocalService.fetchLatestArticle(
+					articleResource.getGroupId(),
+					articleResource.getArticleId(),
 					WorkflowConstants.STATUS_ANY);
 			}
 


### PR DESCRIPTION
LPS link: [LPS-178363](https://issues.liferay.com/browse/LPS-178363)

Motivation
=======
This PR contains the solution for [LPS-178363](https://issues.liferay.com/browse/LPS-178363) which fixes the [LPP-48264](https://issues.liferay.com/browse/LPP-48264). 
Issue: If we try to publish an expired Web Content with Display Page whose latest version is in draft status, an exception will be thrown on [this line](https://github.com/liferay/liferay-portal/blob/5329fcdb461f56b6921a56252983255a7ab0076c/portal-kernel/src/com/liferay/exportimport/kernel/lar/BaseStagedModelDataHandler.java#L924) because the Staging process is publishing the draft version of the Display Page and  the draft status is not an exportable status. We noticed that the [AssetRenderer](https://github.com/liferay/liferay-portal/blob/61dcdd0157a413052accb27608505f9079fe00b0/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRendererFactory.java#L108-L150) function tries to get an article with STATUS_ANY if there is no an approved version.

Proposed Solution
========
I added [two ways](https://github.com/liferay/liferay-portal/blob/51aef9a11b8a43d2fe2e4e63af9192a4ced9acde/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRendererFactory.java#L125-L137) to try to get an article version with an exportable status (STATUS_EXPIRED, STATUS_SCHEDULED) before trying to get it with STATUS_ANY. So if there is any web content with exportable status, it will be got first.

Steps to Verify
========
1.Enable Local Staging
2.Create a Display Page for Basic Web Content
3.Create a Basic Web Content with this Display Page
4.Expire the Web Content
5.Edit the Web Content and save it as draft marking it as "Never Expire"
6.Publish to Live

- Expected behavior:
The Web Content with its Display Page are published successfully.
