### PR TITLE
[TS] LPS-186036

### DIFF
--- a/learn-resources/portlet-configuration-web.json
+++ b/learn-resources/portlet-configuration-web.json
@@ -1,15 +1,15 @@
 {
 	"general": {
 		"ar_SA": {
-			"message": "اقرأ المزيد.",
+			"message": "لمعرفة المزيد.",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"ca_ES": {
-			"message": "Llegir més.",
+			"message": "Aprèn més.",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"de_DE": {
-			"message": "Mehr dazu hier.",
+			"message": "Mehr erfahren.",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"en_US": {
@@ -17,23 +17,23 @@
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"es_ES": {
-			"message": "Leer más.",
+			"message": "Aprender más.",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"eu": {
-			"message": "Irakurri gehiago.",
+			"message": "Irasi gehiago.",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"fi_FI": {
-			"message": "Lue lisää.",
+			"message": "Lisää.",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"fr_CA": {
-			"message": "Lire plus.",
+			"message": "Pour en savoir plus.",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"fr_FR": {
-			"message": "Lire plus.",
+			"message": "Pour en savoir plus.",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"gl_ES": {
@@ -41,19 +41,19 @@
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"hu_HU": {
-			"message": "Bővebben.",
+			"message": "További információk.",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"ja_JP": {
-			"message": "詳しい内容はこちらをご覧ください。",
+			"message": "詳細ヘルプ。",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"nl_NL": {
-			"message": "Meer hierover.",
+			"message": "Meer weten.",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"pt_BR": {
-			"message": "Leia mais.",
+			"message": "Aprender mais.",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"sv_SE": {
@@ -65,7 +65,7 @@
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		},
 		"zh_TW": {
-			"message": "閱讀更多。",
+			"message": "學習更多。",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		}
 	}

--- a/learn-resources/portlet-configuration-web.json
+++ b/learn-resources/portlet-configuration-web.json
@@ -1,7 +1,71 @@
 {
 	"general": {
+		"ar_SA": {
+			"message": "اقرأ المزيد.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"ca_ES": {
+			"message": "Llegir més.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"de_DE": {
+			"message": "Mehr dazu hier.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
 		"en_US": {
 			"message": "Learn more.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"es_ES": {
+			"message": "Leer más.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"eu": {
+			"message": "Irakurri gehiago.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"fi_FI": {
+			"message": "Lue lisää.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"fr_CA": {
+			"message": "Lire plus.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"fr_FR": {
+			"message": "Lire plus.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"gl_ES": {
+			"message": "Ler máis.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"hu_HU": {
+			"message": "Bővebben.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"ja_JP": {
+			"message": "詳しい内容はこちらをご覧ください。",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"nl_NL": {
+			"message": "Meer hierover.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"pt_BR": {
+			"message": "Leia mais.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"sv_SE": {
+			"message": "Läs mer.",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"zh_CN": {
+			"message": "了解更多。",
+			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
+		},
+		"zh_TW": {
+			"message": "閱讀更多。",
 			"url": "https://learn.liferay.com/dxp/latest/en/site-building/creating-pages/using-widget-pages/configuring-widgets/communication-between-widgets.html"
 		}
 	}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -15177,7 +15177,7 @@ set-the-sender-address-on-the-one-time-password-email=تعيين عنوان ال
 set-to-x=تعيين إلى {0}
 set-up-its-destination-to-make-it-visible=قم بإعداد وجهتها لجعلها مرئية.
 set-up-slas=إعداد اتفاقيات SLA
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=قم بإعداد الاتصال بين المداخل التي تستخدم خواص العرض العام. لكل من الخواص العامة لهذا المدخل، يمكن إهمال القيم التي تأتي من مداخل أخرى أو قراءة القيم من خواص أخرى. <a href="{0}" target="_blank">اقرأ المزيد.</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=قم بإعداد الاتصال بين المداخل التي تستخدم خواص العرض العام. لكل من الخواص العامة لهذا المدخل، يمكن إهمال القيم التي تأتي من مداخل أخرى أو قراءة القيم من خواص أخرى.
 set-user=تعيين المستخدم الافتراضي
 set-x-as-your-preferred-language=عيِّن {0} بوصفه لغتك المفضلة.
 set-x-to-x=تعيين {0} إلى {1}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -15179,7 +15179,7 @@ set-the-sender-address-on-the-one-time-password-email=Estableix l'adreça del re
 set-to-x=Estableix en {0}
 set-up-its-destination-to-make-it-visible=Configura la destinació per fer-la visible.
 set-up-slas=Establiu els SLS
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Determineu la comunicació entre els mòduls de portal que utilitzen paràmetres públics compartits. Per a cadascun dels paràmetres públics d'aquest mòdul de portal, es pot ignorar els valors procedents d'altres mòduls o llegir el valor d'altres paràmetres. <a href="{0}" target="_blank">Llegir més.</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Determineu la comunicació entre els mòduls de portal que utilitzen paràmetres públics compartits. Per a cadascun dels paràmetres públics d'aquest mòdul de portal, es pot ignorar els valors procedents d'altres mòduls o llegir el valor d'altres paràmetres.
 set-user=Estableix l'usuari per defecte
 set-x-as-your-preferred-language=Estableix {0} com al teu idioma preferit.
 set-x-to-x=Establiu {0} a {1}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -15179,7 +15179,7 @@ set-the-sender-address-on-the-one-time-password-email=Legen Sie die Absender-E-M
 set-to-x=Festgelegt auf {0}
 set-up-its-destination-to-make-it-visible=Legen Sie das Ziel fest, um es sichtbar zu machen.
 set-up-slas=SLAs einrichten
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Einstellungen um die Kommunikation zwischen Portlets zu erlauben, die gleiche Render-Parameter teilen. Für jeden der öffentlichen Parameter in diesem Portlet ist es möglich, die Werte, die von anderen Portlets kommen, zu ignorieren oder den Wert von einem anderen Parameter zu lesen. <a href="{0}" target="_blank">Mehr dazu hier.</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Einstellungen um die Kommunikation zwischen Portlets zu erlauben, die gleiche Render-Parameter teilen. Für jeden der öffentlichen Parameter in diesem Portlet ist es möglich, die Werte, die von anderen Portlets kommen, zu ignorieren oder den Wert von einem anderen Parameter zu lesen.
 set-user=Standardbenutzer festlegen
 set-x-as-your-preferred-language={0} als bevorzugte Sprache festlegen.
 set-x-to-x=Legen Sie {0} auf {1} fest

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -15179,7 +15179,7 @@ set-the-sender-address-on-the-one-time-password-email=Establece la dirección de
 set-to-x=Establecer en {0}
 set-up-its-destination-to-make-it-visible=Configure el destino para que sea visible.
 set-up-slas=Configurar SLA
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Determine la comunicación entre portlets que utilizan parámetros públicos compartidos. Para cada uno de los parámetros públicos en este portlet, es posible ignorar los valores provenientes de otros portlets o leerlo de otros parámetros. <a href="{0}" target="_blank">Leer más.</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Determine la comunicación entre portlets que utilizan parámetros públicos compartidos. Para cada uno de los parámetros públicos en este portlet, es posible ignorar los valores provenientes de otros portlets o leerlo de otros parámetros.
 set-user=Establecer usuario por defecto
 set-x-as-your-preferred-language=Establecer {0} como su idioma preferido.
 set-x-to-x=Establecer {0} en {1}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -15179,7 +15179,7 @@ set-the-sender-address-on-the-one-time-password-email=Establece la dirección de
 set-to-x=Establecer en {0}
 set-up-its-destination-to-make-it-visible=Configure el destino para que sea visible.
 set-up-slas=Configurar SLA
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Determine la comunicación entre portlets que utilizan parámetros públicos compartidos. Para cada uno de los parámetros públicos en este portlet, es posible ignorar los valores provenientes de otros portlets o leerlo de otros parámetros.
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Determine la comunicación entre portlets que utilizan parámetros públicos compartidos. Para cada uno de los parámetros públicos en este portlet, es posible ignorar los valores provenientes de otros portlets o leerlo de otros parámetros. <a href="{0}" target="_blank">Leer más.</a>
 set-user=Set Default User (Automatic Copy)
 set-x-as-your-preferred-language=Establecer {0} como su idioma preferido.
 set-x-to-x=Establecer {0} en {1}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -15179,7 +15179,7 @@ set-the-sender-address-on-the-one-time-password-email=Establece la dirección de
 set-to-x=Establecer en {0}
 set-up-its-destination-to-make-it-visible=Configure el destino para que sea visible.
 set-up-slas=Configurar SLA
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Determine la comunicación entre portlets que utilizan parámetros públicos compartidos. Para cada uno de los parámetros públicos en este portlet, es posible ignorar los valores provenientes de otros portlets o leerlo de otros parámetros. <a href="{0}" target="_blank">Leer más.</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Determine la comunicación entre portlets que utilizan parámetros públicos compartidos. Para cada uno de los parámetros públicos en este portlet, es posible ignorar los valores provenientes de otros portlets o leerlo de otros parámetros.
 set-user=Set Default User (Automatic Copy)
 set-x-as-your-preferred-language=Establecer {0} como su idioma preferido.
 set-x-to-x=Establecer {0} en {1}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -15176,7 +15176,7 @@ set-the-sender-address-on-the-one-time-password-email=Aseta se lähettäjän sä
 set-to-x=Aseta {0}
 set-up-its-destination-to-make-it-visible=Määritä sen kohde tehdäksesi se näkyväksi.
 set-up-slas=Määrittele SLA:t
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Määrittele julkisia "render" parameterja käyttävien portlettien välinen yhteydenpito. Jokaiselle tämän portletin julkiselle parametrille on mahdollistaa estää muilta portleteilta tulevat parametrien arvot tai lukea arvo toisesta parametrista. <a href="{0}" target="_blank">Lue lisää.</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Määrittele julkisia "render" parameterja käyttävien portlettien välinen yhteydenpito. Jokaiselle tämän portletin julkiselle parametrille on mahdollistaa estää muilta portleteilta tulevat parametrien arvot tai lukea arvo toisesta parametrista.
 set-user=Aseta oletuskäyttäjä
 set-x-as-your-preferred-language=Aseta {0} ensisijaiseksi kieleksesi.
 set-x-to-x=Aseta {0} > {1}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -15177,7 +15177,7 @@ set-the-sender-address-on-the-one-time-password-email=Indiquez l'adresse e-mail 
 set-to-x=Régler sur {0}
 set-up-its-destination-to-make-it-visible=Configurez la destination pour la rendre visible.
 set-up-slas=Configurer des SLA
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Définit les communications parmi les portlets qui utilisent des paramètres publics. Pour chaque paramètre public de ce portlet, il est possible d'ignorer les valeurs provenant des autres portlets ou de lire la valeur d'un autre paramètre. <a href="{0}" target="_blank">Lire plus.</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Définit les communications parmi les portlets qui utilisent des paramètres publics. Pour chaque paramètre public de ce portlet, il est possible d'ignorer les valeurs provenant des autres portlets ou de lire la valeur d'un autre paramètre.
 set-user=Set Default User (Automatic Copy)
 set-x-as-your-preferred-language=Sélectionnez {0} comme votre langue favorite.
 set-x-to-x=Set {0} to {1} (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -15177,7 +15177,7 @@ set-the-sender-address-on-the-one-time-password-email=Set the sender address on 
 set-to-x=Estabelecer en {0}
 set-up-its-destination-to-make-it-visible=Set up its destination to make it visible. (Automatic Copy)
 set-up-slas=Configurar SLA
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Establecer a comunicación a través portlets que usan parámetros de renderizado públicos. Para cada un dos parámetros públicos do portlet, é posible ignorar os valores chegados de outros portlets ou ler o valor desde outro parámetro. <a href="{0}" target="_blank">Ler máis.</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Establecer a comunicación a través portlets que usan parámetros de renderizado públicos. Para cada un dos parámetros públicos do portlet, é posible ignorar os valores chegados de outros portlets ou ler o valor desde outro parámetro.
 set-user=Set Default User (Automatic Copy)
 set-x-as-your-preferred-language=Set {0} as your preferred language. (Automatic Copy)
 set-x-to-x=Set {0} to {1} (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -15180,7 +15180,7 @@ set-the-sender-address-on-the-one-time-password-email=Állítsa be a küldő e-m
 set-to-x=Beállítás: {0}
 set-up-its-destination-to-make-it-visible=A láthatóvá tételéhez állítsa be a célját.
 set-up-slas=SLA-k beállítása
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=A nyilvános megjelenítési paraméterekkel rendelkező portletek közötti kommunikáció beállítása. Ebben a portletben mindegyik nyilvános paraméternél lehetséges a más portletekből érkező értékek figyelmen kívül hagyása vagy más paraméterből való beolvasása. <a href="{0}" target="_blank">Bővebben</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=A nyilvános megjelenítési paraméterekkel rendelkező portletek közötti kommunikáció beállítása. Ebben a portletben mindegyik nyilvános paraméternél lehetséges a más portletekből érkező értékek figyelmen kívül hagyása vagy más paraméterből való beolvasása.
 set-user=Alapértelmezett felhasználó beállítása
 set-x-as-your-preferred-language=Preferált nyelvnek állítsd be ezt: {0}.
 set-x-to-x={0} beállítása {1} értékre

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -15179,7 +15179,7 @@ set-the-sender-address-on-the-one-time-password-email=ユーザーに届くワ�
 set-to-x={0}に設定
 set-up-its-destination-to-make-it-visible=宛先が見えるように設定してください。
 set-up-slas=SLAのセットアップ
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=このメニューではパブリックレンダーパラメータを利用するポートレットとの通信パラメータを設定できます。ポートレットの各パラメータに対し、他のポートレットから送られる値を無視、または受け取るといった設定が可能です。<a href="{0}" target="_blank">詳しい内容はこちらをご覧ください</a>。
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=このメニューではパブリックレンダーパラメータを利用するポートレットとの通信パラメータを設定できます。ポートレットの各パラメータに対し、他のポートレットから送られる値を無視、または受け取るといった設定が可能です。
 set-user=デフォルトユーザーを設定
 set-x-as-your-preferred-language={0}を言語として指定します
 set-x-to-x={0} を {1} に設定

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -15180,7 +15180,7 @@ set-the-sender-address-on-the-one-time-password-email=Stel het e-mailadres in va
 set-to-x=Instellen op {0}
 set-up-its-destination-to-make-it-visible=Stel de bestemming in om ze zichtbaar te maken.
 set-up-slas=SLA's instellen
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=De communicatie instellen tussen portlets die gebruikmaken van openbare weergaveparameters. Voor elke openbare parameter in de portlet is het mogelijk om waarden die van andere portlets komen te negeren, of de waarde van een andere parameter te gebruiken. <a href="{0}" target="_blank">Meer hierover.</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=De communicatie instellen tussen portlets die gebruikmaken van openbare weergaveparameters. Voor elke openbare parameter in de portlet is het mogelijk om waarden die van andere portlets komen te negeren, of de waarde van een andere parameter te gebruiken.
 set-user=Standaardgebruiker instellen
 set-x-as-your-preferred-language={0} als voorkeurstaal instellen.
 set-x-to-x={0} instellen als {1}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -15177,7 +15177,7 @@ set-the-sender-address-on-the-one-time-password-email=Definir o endereço de e-m
 set-to-x=Definir para {0}
 set-up-its-destination-to-make-it-visible=Definir seu destino para torná-lo visível.
 set-up-slas=Definir SLAs
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Configurar a comunicação entre portlets que usam parâmetros públicos. Para cada parâmetro público neste portlet, é possível ignorar valores vindos de outros portlets ou ler valores de outro parâmetro. <a href="{0}" target="_blank">Leia mais.</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Configurar a comunicação entre portlets que usam parâmetros públicos. Para cada parâmetro público neste portlet, é possível ignorar valores vindos de outros portlets ou ler valores de outro parâmetro.
 set-user=Definir usuário padrão
 set-x-as-your-preferred-language=Define {0} como seu idioma preferido.
 set-x-to-x=Definir {0} para {1}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -15179,7 +15179,7 @@ set-the-sender-address-on-the-one-time-password-email=Defina o endereço do reme
 set-to-x=Set to {0} (Automatic Copy)
 set-up-its-destination-to-make-it-visible=Configure seu destino para torná-lo visível. (Automatic Translation)
 set-up-slas=Configurar SLAs (Automatic Translation)
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Configurar a comunicação entre portlets que utilizam parâmetros de renderização públicos. Para cada parâmetro público nesta portlet, é possível ignorar valores vindos de outras portlets ou ler valores de outro parâmetro. <a href="{0}" target="_blank">Leia mais.</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Configurar a comunicação entre portlets que utilizam parâmetros de renderização públicos. Para cada parâmetro público nesta portlet, é possível ignorar valores vindos de outras portlets ou ler valores de outro parâmetro.
 set-user=Set Default User (Automatic Copy)
 set-x-as-your-preferred-language=Definir {0} como seu idioma preferido.
 set-x-to-x=Set {0} to {1} (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -15177,7 +15177,7 @@ set-the-sender-address-on-the-one-time-password-email=Ange avsändarens e-postad
 set-to-x=Ange till {0}
 set-up-its-destination-to-make-it-visible=Konfigurera dess destination för att göra den synlig.
 set-up-slas=Konfigurera SLA:er
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Konfigurera kommunikation bland portlets som använder offentliga parametrar för återgivning. För varje offentlig parameter i denna portlet är det möjligt att ignorera värden som kommer från andra portlets eller att läsa värdet från en annan parameter. <a href="{0}" target="_blank">Läs mer.</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=Konfigurera kommunikation bland portlets som använder offentliga parametrar för återgivning. För varje offentlig parameter i denna portlet är det möjligt att ignorera värden som kommer från andra portlets eller att läsa värdet från en annan parameter.
 set-user=Ange standardanvändare
 set-x-as-your-preferred-language=Välj {0} som ditt önskade språk.
 set-x-to-x=Ställ in {0} till {1}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -15179,7 +15179,7 @@ set-the-sender-address-on-the-one-time-password-email=设置发件人电子邮�
 set-to-x=设为 {0}
 set-up-its-destination-to-make-it-visible=设置其目标，将它设为可见。
 set-up-slas=设置服务水平协议
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=设置使用公共渲染参数的portlet之间的通讯机制。这一portlet中的每一个公共参数都能忽略来自其他portlet的值，也能读取另外一个参数值。<a href="{0}" target="_blank">了解更多。</a>
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=设置使用公共渲染参数的portlet之间的通讯机制。这一portlet中的每一个公共参数都能忽略来自其他portlet的值，也能读取另外一个参数值。
 set-user=设置默认用户
 set-x-as-your-preferred-language=设置{0}作为您的首选语言。
 set-x-to-x=将{0}设置为{1}

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -15178,7 +15178,7 @@ set-the-sender-address-on-the-one-time-password-email=設置寄件者的電子�
 set-to-x=設為 {0}
 set-up-its-destination-to-make-it-visible=設置其目標，將它設為可見。
 set-up-slas=設定 SLAs
-set-up-the-communication-among-the-portlets-that-use-public-render-parameters=在使用公開顯示參數的Portlet間設定通訊。在這Portlet對每個公開參數是可能的忽略來自其他Portlet的值或讀取來自其他參數的值。<a href="{0}" target="_blank">閱讀更多</a>。
+set-up-the-communication-among-the-portlets-that-use-public-render-parameters=在使用公開顯示參數的Portlet間設定通訊。在這Portlet對每個公開參數是可能的忽略來自其他Portlet的值或讀取來自其他參數的值。
 set-user=Set Default User (Automatic Copy)
 set-x-as-your-preferred-language=設定 {0} 作為您偏好語系。
 set-x-to-x=Set {0} to {1} (Automatic Copy)


### PR DESCRIPTION
Hi team,

This is a PR that aims to fix the duplication of links in the portlet configuration tab Communication in other supported languages than English.

Could you please review it? Please, let me know if further clarifications are needed for this review.

Thanks!

Motivation
=======
Fix the duplication of links in the portlet configuration tab Communication in other supported languages than English.

Proposed Solution
========
Remove the links from the translations to add them in the JSON file used by Liferay Learn Taglib.

Steps to Verify
========

1. Add an Asset Publisher widget to Home page
2. Navigate in the page with different language (in my case localhost:8080/es)
3. Go to Asset Publisher > Configuration > Communication