### PR TITLE
LPS-186873 Empty state title is not translated 

### DIFF
--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/js/SelectAssetCategoryInfoItem.es.js
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/js/SelectAssetCategoryInfoItem.es.js
@@ -151,7 +151,7 @@ function SelectAssetCategory({
 									'no-categories-were-found'
 								)}
 								imgSrc={`${themeDisplay.getPathThemeImages()}/states/empty_state.gif`}
-								title={null}
+								title={Liferay.Language.get('no-results-found')}
 							/>
 						)}
 					</div>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingComments.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingComments.js
@@ -291,7 +291,7 @@ export default function ChangeTrackingComments({
 					description={Liferay.Language.get('no-comments-yet')}
 					imgSrc={`${themeDisplay.getPathThemeImages()}/states/empty_state.gif`}
 					small
-					title={null}
+					title={Liferay.Language.get('no-results-found')}
 				/>
 			);
 		}

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingIndicator.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingIndicator.js
@@ -615,7 +615,7 @@ const PublicationsSearchContainer = ({
 										? `${themeDisplay.getPathThemeImages()}/states/search_state.gif`
 										: `${themeDisplay.getPathThemeImages()}/states/empty_state.gif`
 								}
-								title={null}
+								title={Liferay.Language.get('no-results-found')}
 							/>
 						</div>
 					</div>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingChangesView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingChangesView.js
@@ -2560,7 +2560,7 @@ export default function ChangeTrackingChangesView({
 									'there-are-no-changes-to-display-in-this-view'
 								)}
 								imgSrc={`${themeDisplay.getPathThemeImages()}/states/search_state.gif`}
-								title={null}
+								title={Liferay.Language.get('no-results-found')}
 							/>
 						</ClayTable.Cell>
 					</ClayTable.Row>
@@ -2666,7 +2666,7 @@ export default function ChangeTrackingChangesView({
 								'no-changes-were-found'
 							)}
 							imgSrc={`${themeDisplay.getPathThemeImages()}/states/empty_state.gif`}
-							title={null}
+							title={Liferay.Language.get('no-results-found')}
 						/>
 					</ClayLayout.Sheet>
 				</div>

--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRenderView.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/views/ChangeTrackingRenderView.js
@@ -1103,7 +1103,7 @@ export default function ChangeTrackingRenderView({
 						'there-are-no-changes-to-display-in-this-view'
 					)}
 					imgSrc={`${themeDisplay.getPathThemeImages()}/states/search_state.gif`}
-					title={null}
+					title={Liferay.Language.get('no-results-found')}
 				/>
 			);
 		}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/TreeFilter/TreeFilter.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/TreeFilter/TreeFilter.js
@@ -315,7 +315,7 @@ const TreeFilter = ({
 									'no-results-were-found'
 								)}
 								imgSrc={`${themeDisplay.getPathThemeImages()}/states/empty_state.gif`}
-								title={null}
+								title={Liferay.Language.get('no-results-found')}
 							/>
 						)}
 					</div>

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/pages/RuleList.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-web/src/main/resources/META-INF/resources/admin/js/pages/RuleList.es.js
@@ -59,7 +59,7 @@ const EmptyState = () => (
 				'there-are-no-rules-yet-click-on-plus-icon-below-to-add-the-first'
 			)}
 			imgSrc={`${themeDisplay.getPathThemeImages()}/states/empty_state.gif`}
-			title={null}
+			title={Liferay.Language.get('no-results-found')}
 		/>
 	</ClayLayout.Sheet>
 );

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/select_layout/js/SelectLayout.es.js
@@ -111,7 +111,7 @@ const EmptyState = () => {
 				className="mt-0"
 				description={Liferay.Language.get('there-are-no-pages')}
 				imgSrc={`${themeDisplay.getPathThemeImages()}/states/empty_state.gif`}
-				title={null}
+				title={Liferay.Language.get('no-results-found')}
 			/>
 		</ClayLayout.Sheet>
 	);

--- a/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/select_sxp_blueprint_modal/SelectSXPBlueprintModal.js
+++ b/modules/apps/portal-search/portal-search-web/src/main/resources/META-INF/resources/js/components/select_sxp_blueprint_modal/SelectSXPBlueprintModal.js
@@ -242,6 +242,9 @@ const SelectSXPBlueprintModal = ({observer, onClose, onSubmit, selectedId}) => {
 
 		return (
 			<ClayEmptyState
+				description={Liferay.Language.get(
+					'sorry,-no-results-were-found'
+				)}
 				imgProps={{
 					alt: Liferay.Language.get('no-results-found'),
 					title: Liferay.Language.get('no-results-found'),

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserSubscriptions.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/home/UserSubscriptions.es.js
@@ -191,6 +191,9 @@ export default withRouter(
 								emptyState={
 									<ClayEmptyState
 										className="empty-state-icon"
+										description={Liferay.Language.get(
+											'sorry,-no-results-were-found'
+										)}
 										title={Liferay.Language.get(
 											'there-are-no-results'
 										)}
@@ -224,6 +227,9 @@ export default withRouter(
 							topics.myUserAccountSubscriptions.items &&
 							!topics.myUserAccountSubscriptions.items.length && (
 								<ClayEmptyState
+									description={Liferay.Language.get(
+										'sorry,-no-results-were-found'
+									)}
 									title={Liferay.Language.get(
 										'there-are-no-results'
 									)}
@@ -305,6 +311,9 @@ export default withRouter(
 								!threads.myUserAccountSubscriptions.items
 									.length && (
 									<ClayEmptyState
+										description={Liferay.Language.get(
+											'sorry,-no-results-were-found'
+										)}
 										title={Liferay.Language.get(
 											'there-are-no-results'
 										)}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/components/QuestionList.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/questions/components/QuestionList.es.js
@@ -77,6 +77,9 @@ const QuestionList = ({
 							</ClayEmptyState>
 						) : (
 							<ClayEmptyState
+								description={Liferay.Language.get(
+									'sorry,-no-results-were-found'
+								)}
 								title={Liferay.Language.get(
 									'there-are-no-results'
 								)}

--- a/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
+++ b/modules/apps/questions/questions-web/src/main/resources/META-INF/resources/js/pages/tags/Tags.es.js
@@ -156,6 +156,9 @@ export default withRouter(({history, location}) => {
 									'there-are-no-results'
 								)}
 								className="empty-state-icon"
+								description={Liferay.Language.get(
+									'sorry,-no-results-were-found'
+								)}
 								title={Liferay.Language.get(
 									'there-are-no-results'
 								)}

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/LayoutPreview.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/LayoutPreview.js
@@ -102,6 +102,7 @@ export default React.memo(function LayoutPreview() {
 							'you-cannot-preview-the-style-book-because-your-site-is-empty'
 						)}
 						imgSrc={`${themeDisplay.getPathThemeImages()}/states/empty_state.gif`}
+						title={Liferay.Language.get('no-results-found')}
 					/>
 				)}
 			</div>

--- a/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/DiagramTable/DiagramTable.js
+++ b/modules/dxp/apps/commerce/commerce-shop-by-diagram-web/src/main/resources/META-INF/resources/js/DiagramTable/DiagramTable.js
@@ -252,6 +252,9 @@ function DiagramTable({
 			{mappedProducts && !mappedProducts.length && !loaderActive && (
 				<ClayEmptyState
 					className="full-height-content"
+					description={Liferay.Language.get(
+						'sorry,-no-results-were-found'
+					)}
 					title={Liferay.Language.get('there-are-no-results')}
 				/>
 			)}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/List.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/List.es.js
@@ -271,6 +271,9 @@ class List extends PureComponent {
 							<>
 								{!displayError && !resultIds.length && (
 									<ClayEmptyState
+										description={Liferay.Language.get(
+											'sorry,-no-results-were-found'
+										)}
 										title={Liferay.Language.get(
 											'no-results-found'
 										)}

--- a/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/List.es.js
+++ b/modules/dxp/apps/portal-search-tuning/portal-search-tuning-rankings-web/src/main/resources/META-INF/resources/js/components/list/List.es.js
@@ -270,7 +270,11 @@ class List extends PureComponent {
 						{!dataLoading && (
 							<>
 								{!displayError && !resultIds.length && (
-									<ClayEmptyState />
+									<ClayEmptyState
+										title={Liferay.Language.get(
+											'no-results-found'
+										)}
+									/>
 								)}
 
 								{displayError && (

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/index.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/preview_sidebar/index.js
@@ -293,7 +293,10 @@ function PreviewSidebar({
 						_renderHits()
 					) : totalHits === 0 ? (
 						<div className="empty-list-message">
-							<ClayEmptyState description="" />
+							<ClayEmptyState
+								description=""
+								title={Liferay.Language.get('no-results-found')}
+							/>
 						</div>
 					) : (
 						!errors.length && (

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_options/js/configuration/SelectSXPBlueprintModal.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_options/js/configuration/SelectSXPBlueprintModal.js
@@ -239,6 +239,9 @@ const SelectSXPBlueprintModal = ({observer, onClose, onSubmit, selectedId}) => {
 
 		return (
 			<ClayEmptyState
+				description={Liferay.Language.get(
+					'sorry,-no-results-were-found'
+				)}
 				imgProps={{
 					alt: Liferay.Language.get('no-results-found'),
 					title: Liferay.Language.get('no-results-found'),

--- a/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/Blueprints.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/portlet/search/Blueprints.path
@@ -327,7 +327,7 @@
 </tr>
 <tr>
 	<td>BLUEPRINTS_PREVIEW_SEARCH_RESULT_EMPTY</td>
-	<td>//div[contains(@class,'preview-sidebar')]//span[contains(.,'No results found')]</td>
+	<td>//div[contains(@class,'preview-sidebar')]//span[contains(.,'No Results Found')]</td>
 	<td></td>
 </tr>
 <tr>


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-186873

Currently if an ClayEmptyState has no title, by default a title is added which is always in English. To avoid this, we need to add a translated title. The same goes for the description.

cc @veroglez 