### PR TITLE
LPS-187510 The icon of “mark as default” doesn't appear when creating utility pages if the user has a profile picture

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/clay/servlet/taglib/LayoutUtilityPageEntryVerticalCard.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/clay/servlet/taglib/LayoutUtilityPageEntryVerticalCard.java
@@ -146,6 +146,11 @@ public class LayoutUtilityPageEntryVerticalCard extends BaseVerticalCard {
 	}
 
 	@Override
+	public String getStickerImageSrc() {
+		return null;
+	}
+
+	@Override
 	public String getStickerShape() {
 		return null;
 	}


### PR DESCRIPTION
[Link to ticket](https://issues.liferay.com/browse/[LPS-187510](https://issues.liferay.com/browse/LPS-187510))