### PR TITLE
LPS-187268 Avoid NullPointerException after using getParameters from httpsServletRequest

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/LayoutStructureCommonStylesCSSServlet.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/LayoutStructureCommonStylesCSSServlet.java
@@ -50,7 +50,6 @@ import com.liferay.portal.kernel.servlet.PortalSessionThreadLocal;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -140,13 +139,12 @@ public class LayoutStructureCommonStylesCSSServlet extends HttpServlet {
 		httpServletResponse.setContentType(ContentTypes.TEXT_CSS_UTF8);
 		httpServletResponse.setStatus(HttpServletResponse.SC_OK);
 
-		Map<String, String[]> parameterMap = HttpComponentsUtil.getParameterMap(
-			httpServletRequest.getQueryString());
+		long plid = ParamUtil.getLong(httpServletRequest, "plid");
+		Layout layout = null;
 
-		String[] plids = parameterMap.get("plid");
-
-		Layout layout = _layoutLocalService.fetchLayout(
-			GetterUtil.getLong(plids[0]));
+		if (plid > 0) {
+			layout = _layoutLocalService.fetchLayout(plid);
+		}
 
 		if ((layout == null) ||
 			(!layout.isTypeAssetDisplay() && !layout.isTypeContent())) {

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/LayoutStructureCommonStylesCSSServlet.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/LayoutStructureCommonStylesCSSServlet.java
@@ -139,8 +139,9 @@ public class LayoutStructureCommonStylesCSSServlet extends HttpServlet {
 		httpServletResponse.setContentType(ContentTypes.TEXT_CSS_UTF8);
 		httpServletResponse.setStatus(HttpServletResponse.SC_OK);
 
-		long plid = ParamUtil.getLong(httpServletRequest, "plid");
 		Layout layout = null;
+
+		long plid = ParamUtil.getLong(httpServletRequest, "plid");
 
 		if (plid > 0) {
 			layout = _layoutLocalService.fetchLayout(plid);

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/SegmentsExperienceUtil.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/SegmentsExperienceUtil.java
@@ -18,15 +18,11 @@ import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.GetterUtil;
-import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.segments.manager.SegmentsExperienceManager;
 import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.service.SegmentsExperienceLocalServiceUtil;
-
-import java.util.Map;
 
 import javax.servlet.http.HttpServletRequest;
 
@@ -64,12 +60,13 @@ public class SegmentsExperienceUtil {
 			return themeDisplay.getLayout();
 		}
 
-		Map<String, String[]> parameterMap = HttpComponentsUtil.getParameterMap(
-			httpServletRequest.getQueryString());
+		long plid = ParamUtil.getLong(httpServletRequest, "plid");
 
-		String[] plids = parameterMap.get("plid");
+		if (plid > 0) {
+			return LayoutLocalServiceUtil.fetchLayout(plid);
+		}
 
-		return LayoutLocalServiceUtil.fetchLayout(GetterUtil.getLong(plids[0]));
+		return null;
 	}
 
 	private static boolean _isValidSegmentsExperienceId(

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/servlet/test/LayoutStructureCommonStylesCSSServletTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/servlet/test/LayoutStructureCommonStylesCSSServletTest.java
@@ -22,15 +22,14 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.servlet.HttpMethods;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.Http;
 import com.liferay.portal.kernel.util.LocaleUtil;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
@@ -49,6 +48,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 /**
@@ -171,11 +171,15 @@ public class LayoutStructureCommonStylesCSSServletTest {
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
 
-		mockHttpServletRequest.setAttribute("plid", _layout.getPlid());
-		mockHttpServletRequest.setAttribute(
+		mockHttpServletRequest.setMethod(HttpMethods.GET);
+
+		mockHttpServletRequest.setParameter(
+			"plid", String.valueOf(_layout.getPlid()));
+		mockHttpServletRequest.setParameter(
 			"segmentsExperienceId",
-			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
-				_layout.getPlid()));
+			String.valueOf(
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(_layout.getPlid())));
 
 		ThemeDisplay themeDisplay = _getThemeDisplay();
 
@@ -229,28 +233,11 @@ public class LayoutStructureCommonStylesCSSServletTest {
 		_layoutPageTemplateStructureLocalService;
 
 	@Inject
-	private Portal _portal;
-
-	@Inject
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 	@Inject(
 		filter = "osgi.http.whiteboard.servlet.name=com.liferay.layout.taglib.internal.servlet.LayoutStructureCommonStylesCSSServlet"
 	)
 	private Servlet _servlet;
-
-	private class MockHttpServletRequest
-		extends org.springframework.mock.web.MockHttpServletRequest {
-
-		public MockHttpServletRequest() {
-			super(Http.Method.GET.toString(), null);
-		}
-
-		@Override
-		public String getQueryString() {
-			return "plid=" + _layout.getPlid();
-		}
-
-	}
 
 }


### PR DESCRIPTION
Task: https://issues.liferay.com/browse/LPS-187157
Subtask: https://issues.liferay.com/browse/LPS-187268

Description
------
Change code to avoid null pointer exception when accessing to plids[0] because it could be null.