### PR TITLE
LPS 186577 Migrate SegmentsEditor collapses to ClayPanel

### DIFF
--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/_criteria_sidebar.scss
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/_criteria_sidebar.scss
@@ -8,14 +8,14 @@
 	width: $sidebarWidth;
 
 	.sidebar-header,
-	.sidebar-collapse-header,
+	.panel-header,
 	.empty-message {
 		font-weight: 600;
 	}
 
 	.sidebar-header,
 	.sidebar-search,
-	.sidebar-collapse-header,
+	.panel-header,
 	.empty-message {
 		padding: 1rem 1.5rem;
 	}
@@ -24,10 +24,7 @@
 		flex-basis: 0;
 		flex-grow: 1;
 		flex-shrink: 1;
-	}
-
-	.sidebar-collapse-groups {
-		flex-flow: column nowrap;
+		overflow-x: hidden;
 	}
 
 	.sidebar-collapse-item {
@@ -40,7 +37,7 @@
 		}
 	}
 
-	.sidebar-collapse-header {
+	.panel-header {
 		color: $dark;
 		font-size: 0.875rem;
 		word-wrap: break-word;
@@ -49,7 +46,7 @@
 			transition: transform $segmentsTransition;
 			will-change: transform;
 
-			&.active {
+			&.expanded {
 				transform: rotate(90deg);
 			}
 		}
@@ -60,7 +57,7 @@
 			content: '';
 			left: 1.5rem;
 			position: absolute;
-			right: 1.5rem;
+			right: 1.25rem;
 		}
 	}
 

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebar.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebar.js
@@ -44,7 +44,7 @@ export default function CriteriaSidebar({
 				/>
 			</div>
 
-			<div className="overflow-auto position-relative sidebar-collapse">
+			<div className="overflow-y-auto position-relative sidebar-collapse">
 				<CriteriaSidebarCollapse
 					onCollapseClick={onTitleClicked}
 					propertyGroups={propertyGroups}

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarCollapse.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarCollapse.js
@@ -87,7 +87,7 @@ const CriteriaSidebarCollapse = ({
 	const _handleClick = (key, editing) => () => onCollapseClick(key, editing);
 
 	return (
-		<ClayPanel.Group className="c-mt-1">
+		<ClayPanel.Group className="c-ml-1 c-mr-1 c-mt-1">
 			{propertyGroups.map((propertyGroup) => {
 				const key = propertyGroup.propertyKey;
 
@@ -101,88 +101,71 @@ const CriteriaSidebarCollapse = ({
 					: properties;
 
 				return (
-					<li
-						className={classNames(
-							`d-flex flex-column sidebar-collapse-item sidebar-collapse-${propertyGroup.propertyKey}`,
-							{
-								active,
-							}
-						)}
-						key={key}
-					>
-						<a
-							className="d-flex justify-content-between position-relative sidebar-collapse-header text-decoration-none text-uppercase"
-							onClick={_handleClick(key, active)}
-							tabIndex="0"
-						>
-							{propertyGroup.name}
+					<ClayPanel
+						collapsable={true}
+						displayTitle={
+							<div className="c-inner" tabIndex="-1">
+								<ClayPanel.Title className="d-flex justify-content-between text-uppercase">
+									{propertyGroup.name}
 
-							{searchValue && (
-								<ClayBadge
-									className="c-ml-auto c-mr-2"
-									displayType="secondary"
-									label={filteredProperties.length}
-								/>
-							)}
-
-							<span>
-								<ClayIcon
-									className={classNames({
-										active,
-									})}
-									symbol="angle-right"
-								/>
-							</span>
-						</a>
-
-						{active && (
-							<div className="flex-grow-1 overflow-y-auto sidebar-collapse-body">
-								<p className="c-pt-3 c-px-4 text-secondary">
-									{Liferay.Language.get(
-										'inherited-attributes-are-not-taken-into-account-to-include-members-in-segments'
+									{searchValue && (
+										<ClayBadge
+											className="mr-4 my-0"
+											displayType="secondary"
+											label={filteredProperties.length}
+										/>
 									)}
-								</p>
-
-								<ul className="c-pl-0">
-									{!filteredProperties.length && (
-										<li className="align-items-center d-flex empty-message h-100 justify-content-center position-relative">
-											{Liferay.Language.get(
-												'no-results-were-found'
-											)}
-										</li>
-									)}
-
-									{!!filteredProperties.length &&
-										filteredProperties.map(
-											({label, name, options, type}) => {
-												const defaultValue = getDefaultValue(
-													{
-														label,
-														name,
-														options,
-														type,
-													}
-												);
-
-												return (
-													<CriteriaSidebarItem
-														className={`color--${key}`}
-														defaultValue={
-															defaultValue
-														}
-														key={name}
-														label={label}
-														name={name}
-														propertyKey={key}
-														type={type}
-													/>
-												);
-											}
-										)}
-								</ul>
+								</ClayPanel.Title>
 							</div>
-						)}
-					</li>
+						}
+						expanded={active}
+						key={key}
+						onExpandedChange={_handleClick(key, active)}
+					>
+						<ClayPanel.Body className="c-px-0">
+							<p className="c-pt-1 c-px-4 text-secondary">
+								{Liferay.Language.get(
+									'inherited-attributes-are-not-taken-into-account-to-include-members-in-segments'
+								)}
+							</p>
+
+							<ul className="c-pl-0">
+								{!filteredProperties.length && (
+									<li className="align-items-center d-flex empty-message h-100 justify-content-center position-relative">
+										{Liferay.Language.get(
+											'no-results-were-found'
+										)}
+									</li>
+								)}
+
+								{!!filteredProperties.length &&
+									filteredProperties.map(
+										({label, name, options, type}) => {
+											const defaultValue = getDefaultValue(
+												{
+													label,
+													name,
+													options,
+													type,
+												}
+											);
+
+											return (
+												<CriteriaSidebarItem
+													className={`color--${key}`}
+													defaultValue={defaultValue}
+													key={name}
+													label={label}
+													name={name}
+													propertyKey={key}
+													type={type}
+												/>
+											);
+										}
+									)}
+							</ul>
+						</ClayPanel.Body>
+					</ClayPanel>
 				);
 			})}
 		</ClayPanel.Group>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarCollapse.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarCollapse.js
@@ -13,8 +13,7 @@
  */
 
 import ClayBadge from '@clayui/badge';
-import ClayIcon from '@clayui/icon';
-import classNames from 'classnames';
+import ClayPanel from '@clayui/panel';
 import {parse} from 'date-fns';
 import PropTypes from 'prop-types';
 import React from 'react';
@@ -88,7 +87,7 @@ const CriteriaSidebarCollapse = ({
 	const _handleClick = (key, editing) => () => onCollapseClick(key, editing);
 
 	return (
-		<ul className="c-mb-0 c-pl-0 d-flex sidebar-collapse-groups">
+		<ClayPanel.Group className="c-mt-1">
 			{propertyGroups.map((propertyGroup) => {
 				const key = propertyGroup.propertyKey;
 
@@ -186,7 +185,7 @@ const CriteriaSidebarCollapse = ({
 					</li>
 				);
 			})}
-		</ul>
+		</ClayPanel.Group>
 	);
 };
 

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/ContributorsBuilder.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/ContributorsBuilder.test.js.snap
@@ -64,11 +64,11 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
         >
           <div
             aria-orientation="vertical"
-            class="panel-group c-mt-1"
+            class="panel-group c-ml-1 c-mr-1 c-mt-1"
             role="tablist"
           >
             <div
-              class="panel c-mr-2"
+              class="panel"
               role="tablist"
             >
               <button
@@ -762,7 +762,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
               </div>
             </div>
             <div
-              class="panel c-mr-2"
+              class="panel"
               role="tablist"
             >
               <button
@@ -1234,11 +1234,11 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
         >
           <div
             aria-orientation="vertical"
-            class="panel-group c-mt-1"
+            class="panel-group c-ml-1 c-mr-1 c-mt-1"
             role="tablist"
           >
             <div
-              class="panel c-mr-2"
+              class="panel"
               role="tablist"
             >
               <button
@@ -1932,7 +1932,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
               </div>
             </div>
             <div
-              class="panel c-mr-2"
+              class="panel"
               role="tablist"
             >
               <button

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/ContributorsBuilder.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/ContributorsBuilder.test.js.snap
@@ -60,683 +60,36 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
           </div>
         </div>
         <div
-          class="overflow-auto position-relative sidebar-collapse"
+          class="overflow-y-auto position-relative sidebar-collapse"
         >
-          <ul
-            class="c-mb-0 c-pl-0 d-flex sidebar-collapse-groups"
+          <div
+            aria-orientation="vertical"
+            class="panel-group c-mt-1"
+            role="tablist"
           >
-            <li
-              class="d-flex flex-column sidebar-collapse-item sidebar-collapse-user active"
+            <div
+              class="panel c-mr-2"
+              role="tablist"
             >
-              <a
-                class="d-flex justify-content-between position-relative sidebar-collapse-header text-decoration-none text-uppercase"
-                tabindex="0"
+              <button
+                aria-expanded="true"
+                class="panel-header panel-header-link collapse-icon collapse-icon-middle show btn btn-unstyled"
+                role="tab"
+                type="button"
               >
-                User
-                <span>
-                  <svg
-                    class="lexicon-icon lexicon-icon-angle-right active"
-                    role="presentation"
-                  >
-                    <use
-                      xlink:href="#angle-right"
-                    />
-                  </svg>
-                </span>
-              </a>
-              <div
-                class="flex-grow-1 overflow-y-auto sidebar-collapse-body"
-              >
-                <p
-                  class="c-pt-3 c-px-4 text-secondary"
+                <div
+                  class="c-inner"
+                  tabindex="-1"
                 >
-                  inherited-attributes-are-not-taken-into-account-to-include-members-in-segments
-                </p>
-                <ul
-                  class="c-pl-0"
+                  <div
+                    class="d-flex justify-content-between text-uppercase"
+                  >
+                    User
+                  </div>
+                </div>
+                <span
+                  class="collapse-icon-closed"
                 >
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Ancestor Organization IDs
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Class PK
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Company ID
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-date"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#date"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Date Modified
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Email Address
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    First Name
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Group ID
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Group IDs
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Job Title
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Last Name
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Organization IDs
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Role IDs
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Scope Group ID
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Screen Name
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Team IDs
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    User Group IDs
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    User ID
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    User Name
-                  </li>
-                </ul>
-              </div>
-            </li>
-            <li
-              class="d-flex flex-column sidebar-collapse-item sidebar-collapse-user-organization"
-            >
-              <a
-                class="d-flex justify-content-between position-relative sidebar-collapse-header text-decoration-none text-uppercase"
-                tabindex="0"
-              >
-                User Organization
-                <span>
                   <svg
                     class="lexicon-icon lexicon-icon-angle-right"
                     role="presentation"
@@ -746,9 +99,1013 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     />
                   </svg>
                 </span>
-              </a>
-            </li>
-          </ul>
+                <span
+                  class="collapse-icon-open"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-down"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="#angle-down"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <div
+                class="panel-collapse"
+                role="tabpanel"
+              >
+                <div
+                  class="panel-body c-px-0"
+                >
+                  <p
+                    class="c-pt-1 c-px-4 text-secondary"
+                  >
+                    inherited-attributes-are-not-taken-into-account-to-include-members-in-segments
+                  </p>
+                  <ul
+                    class="c-pl-0"
+                  >
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Ancestor Organization IDs
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Class PK
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Company ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-date"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#date"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Date Modified
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Email Address
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      First Name
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Group ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Group IDs
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Job Title
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Last Name
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Organization IDs
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Role IDs
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Scope Group ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Screen Name
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Team IDs
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      User Group IDs
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      User ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      User Name
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+            <div
+              class="panel c-mr-2"
+              role="tablist"
+            >
+              <button
+                aria-expanded="false"
+                class="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
+                role="tab"
+                type="button"
+              >
+                <div
+                  class="c-inner"
+                  tabindex="-1"
+                >
+                  <div
+                    class="d-flex justify-content-between text-uppercase"
+                  >
+                    User Organization
+                  </div>
+                </div>
+                <span
+                  class="collapse-icon-closed"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="#angle-right"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="collapse-icon-open"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-down"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="#angle-down"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <div
+                class="panel-collapse collapse"
+                role="tabpanel"
+              >
+                <div
+                  class="panel-body c-px-0"
+                >
+                  <p
+                    class="c-pt-1 c-px-4 text-secondary"
+                  >
+                    inherited-attributes-are-not-taken-into-account-to-include-members-in-segments
+                  </p>
+                  <ul
+                    class="c-pl-0"
+                  >
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Class PK
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Company ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-date"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#date"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Date Modified
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Name
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Name Tree Path
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Organization ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Parent Organization ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Type
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>
@@ -873,683 +1230,36 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
           </div>
         </div>
         <div
-          class="overflow-auto position-relative sidebar-collapse"
+          class="overflow-y-auto position-relative sidebar-collapse"
         >
-          <ul
-            class="c-mb-0 c-pl-0 d-flex sidebar-collapse-groups"
+          <div
+            aria-orientation="vertical"
+            class="panel-group c-mt-1"
+            role="tablist"
           >
-            <li
-              class="d-flex flex-column sidebar-collapse-item sidebar-collapse-user active"
+            <div
+              class="panel c-mr-2"
+              role="tablist"
             >
-              <a
-                class="d-flex justify-content-between position-relative sidebar-collapse-header text-decoration-none text-uppercase"
-                tabindex="0"
+              <button
+                aria-expanded="true"
+                class="panel-header panel-header-link collapse-icon collapse-icon-middle show btn btn-unstyled"
+                role="tab"
+                type="button"
               >
-                User
-                <span>
-                  <svg
-                    class="lexicon-icon lexicon-icon-angle-right active"
-                    role="presentation"
-                  >
-                    <use
-                      xlink:href="#angle-right"
-                    />
-                  </svg>
-                </span>
-              </a>
-              <div
-                class="flex-grow-1 overflow-y-auto sidebar-collapse-body"
-              >
-                <p
-                  class="c-pt-3 c-px-4 text-secondary"
+                <div
+                  class="c-inner"
+                  tabindex="-1"
                 >
-                  inherited-attributes-are-not-taken-into-account-to-include-members-in-segments
-                </p>
-                <ul
-                  class="c-pl-0"
+                  <div
+                    class="d-flex justify-content-between text-uppercase"
+                  >
+                    User
+                  </div>
+                </div>
+                <span
+                  class="collapse-icon-closed"
                 >
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Ancestor Organization IDs
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Class PK
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Company ID
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-date"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#date"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Date Modified
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Email Address
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    First Name
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Group ID
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Group IDs
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Job Title
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Last Name
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Organization IDs
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Role IDs
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Scope Group ID
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Screen Name
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    Team IDs
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    User Group IDs
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    User ID
-                  </li>
-                  <li
-                    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
-                    draggable="true"
-                    tabindex="0"
-                  >
-                    <span
-                      class="inline-item"
-                    >
-                      <svg
-                        class="lexicon-icon lexicon-icon-drag"
-                        role="presentation"
-                      >
-                        <use
-                          xlink:href="#drag"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
-                    >
-                      <span
-                        class="inline-item"
-                      >
-                        <svg
-                          class="lexicon-icon lexicon-icon-text"
-                          role="presentation"
-                        >
-                          <use
-                            xlink:href="#text"
-                          />
-                        </svg>
-                      </span>
-                    </span>
-                    User Name
-                  </li>
-                </ul>
-              </div>
-            </li>
-            <li
-              class="d-flex flex-column sidebar-collapse-item sidebar-collapse-user-organization"
-            >
-              <a
-                class="d-flex justify-content-between position-relative sidebar-collapse-header text-decoration-none text-uppercase"
-                tabindex="0"
-              >
-                User Organization
-                <span>
                   <svg
                     class="lexicon-icon lexicon-icon-angle-right"
                     role="presentation"
@@ -1559,9 +1269,1013 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     />
                   </svg>
                 </span>
-              </a>
-            </li>
-          </ul>
+                <span
+                  class="collapse-icon-open"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-down"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="#angle-down"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <div
+                class="panel-collapse"
+                role="tabpanel"
+              >
+                <div
+                  class="panel-body c-px-0"
+                >
+                  <p
+                    class="c-pt-1 c-px-4 text-secondary"
+                  >
+                    inherited-attributes-are-not-taken-into-account-to-include-members-in-segments
+                  </p>
+                  <ul
+                    class="c-pl-0"
+                  >
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Ancestor Organization IDs
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Class PK
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Company ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-date"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#date"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Date Modified
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Email Address
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      First Name
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Group ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Group IDs
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Job Title
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Last Name
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Organization IDs
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Role IDs
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Scope Group ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Screen Name
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Team IDs
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      User Group IDs
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      User ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      User Name
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+            <div
+              class="panel c-mr-2"
+              role="tablist"
+            >
+              <button
+                aria-expanded="false"
+                class="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
+                role="tab"
+                type="button"
+              >
+                <div
+                  class="c-inner"
+                  tabindex="-1"
+                >
+                  <div
+                    class="d-flex justify-content-between text-uppercase"
+                  >
+                    User Organization
+                  </div>
+                </div>
+                <span
+                  class="collapse-icon-closed"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-right"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="#angle-right"
+                    />
+                  </svg>
+                </span>
+                <span
+                  class="collapse-icon-open"
+                >
+                  <svg
+                    class="lexicon-icon lexicon-icon-angle-down"
+                    role="presentation"
+                  >
+                    <use
+                      xlink:href="#angle-down"
+                    />
+                  </svg>
+                </span>
+              </button>
+              <div
+                class="panel-collapse collapse"
+                role="tabpanel"
+              >
+                <div
+                  class="panel-body c-px-0"
+                >
+                  <p
+                    class="c-pt-1 c-px-4 text-secondary"
+                  >
+                    inherited-attributes-are-not-taken-into-account-to-include-members-in-segments
+                  </p>
+                  <ul
+                    class="c-pl-0"
+                  >
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Class PK
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Company ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-date"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#date"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Date Modified
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Name
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Name Tree Path
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Organization ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Parent Organization ID
+                    </li>
+                    <li
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      draggable="true"
+                      tabindex="0"
+                    >
+                      <span
+                        class="inline-item"
+                      >
+                        <svg
+                          class="lexicon-icon lexicon-icon-drag"
+                          role="presentation"
+                        >
+                          <use
+                            xlink:href="#drag"
+                          />
+                        </svg>
+                      </span>
+                      <span
+                        class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                      >
+                        <span
+                          class="inline-item"
+                        >
+                          <svg
+                            class="lexicon-icon lexicon-icon-text"
+                            role="presentation"
+                          >
+                            <use
+                              xlink:href="#text"
+                            />
+                          </svg>
+                        </span>
+                      </span>
+                      Type
+                    </li>
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebar.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebar.test.js.snap
@@ -58,7 +58,7 @@ exports[`CriteriaSidebar renders 1`] = `
     >
       <div
         aria-orientation="vertical"
-        class="panel-group c-mt-1"
+        class="panel-group c-ml-1 c-mr-1 c-mt-1"
         role="tablist"
       />
     </div>

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebar.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebar.test.js.snap
@@ -54,10 +54,12 @@ exports[`CriteriaSidebar renders 1`] = `
       </div>
     </div>
     <div
-      class="overflow-auto position-relative sidebar-collapse"
+      class="overflow-y-auto position-relative sidebar-collapse"
     >
-      <ul
-        class="c-mb-0 c-pl-0 d-flex sidebar-collapse-groups"
+      <div
+        aria-orientation="vertical"
+        class="panel-group c-mt-1"
+        role="tablist"
       />
     </div>
   </div>

--- a/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/DateTimeInput.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/inputs/__snapshots__/DateTimeInput.test.js.snap
@@ -30,7 +30,7 @@ exports[`DateTimeInput renders date with no change in the input 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-6"
+              aria-controls="clay-id-16"
               aria-expanded="false"
               aria-haspopup="dialog"
               aria-label="Test label: select-date"
@@ -84,7 +84,7 @@ exports[`DateTimeInput renders date-time with no change in the input 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-5"
+              aria-controls="clay-id-13"
               aria-expanded="false"
               aria-haspopup="dialog"
               aria-label="Test label: select-date"
@@ -138,7 +138,7 @@ exports[`DateTimeInput renders previous date with wrong date 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-4"
+              aria-controls="clay-id-10"
               aria-expanded="false"
               aria-haspopup="dialog"
               aria-label="Test label: select-date"
@@ -192,7 +192,7 @@ exports[`DateTimeInput renders previous date with wrong date-time 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-2"
+              aria-controls="clay-id-4"
               aria-expanded="false"
               aria-haspopup="dialog"
               aria-label="Test label: select-date"
@@ -246,7 +246,7 @@ exports[`DateTimeInput renders type date 1`] = `
             class="input-group-inset-item input-group-inset-item-after"
           >
             <button
-              aria-controls="clay-id-3"
+              aria-controls="clay-id-7"
               aria-expanded="false"
               aria-haspopup="dialog"
               aria-label="Test label: select-date"

--- a/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.test.js.snap
@@ -481,22 +481,38 @@ exports[`SegmentEdit renders with given values 1`] = `
               </div>
             </div>
             <div
-              class="overflow-auto position-relative sidebar-collapse"
+              class="overflow-y-auto position-relative sidebar-collapse"
             >
-              <ul
-                class="c-mb-0 c-pl-0 d-flex sidebar-collapse-groups"
+              <div
+                aria-orientation="vertical"
+                class="panel-group c-mt-1"
+                role="tablist"
               >
-                <li
-                  class="d-flex flex-column sidebar-collapse-item sidebar-collapse-first-test-values-group active"
+                <div
+                  class="panel c-mr-2"
+                  role="tablist"
                 >
-                  <a
-                    class="d-flex justify-content-between position-relative sidebar-collapse-header text-decoration-none text-uppercase"
-                    tabindex="0"
+                  <button
+                    aria-expanded="true"
+                    class="panel-header panel-header-link collapse-icon collapse-icon-middle show btn btn-unstyled"
+                    role="tab"
+                    type="button"
                   >
-                    First Test Values Group
-                    <span>
+                    <div
+                      class="c-inner"
+                      tabindex="-1"
+                    >
+                      <div
+                        class="d-flex justify-content-between text-uppercase"
+                      >
+                        First Test Values Group
+                      </div>
+                    </div>
+                    <span
+                      class="collapse-icon-closed"
+                    >
                       <svg
-                        class="lexicon-icon lexicon-icon-angle-right active"
+                        class="lexicon-icon lexicon-icon-angle-right"
                         role="presentation"
                       >
                         <use
@@ -504,57 +520,74 @@ exports[`SegmentEdit renders with given values 1`] = `
                         />
                       </svg>
                     </span>
-                  </a>
-                  <div
-                    class="flex-grow-1 overflow-y-auto sidebar-collapse-body"
-                  >
-                    <p
-                      class="c-pt-3 c-px-4 text-secondary"
+                    <span
+                      class="collapse-icon-open"
                     >
-                      inherited-attributes-are-not-taken-into-account-to-include-members-in-segments
-                    </p>
-                    <ul
-                      class="c-pl-0"
-                    >
-                      <li
-                        class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--first-test-values-group"
-                        draggable="true"
-                        tabindex="0"
+                      <svg
+                        class="lexicon-icon lexicon-icon-angle-down"
+                        role="presentation"
                       >
-                        <span
-                          class="inline-item"
-                        >
-                          <svg
-                            class="lexicon-icon lexicon-icon-drag"
-                            role="presentation"
-                          >
-                            <use
-                              xlink:href="#drag"
-                            />
-                          </svg>
-                        </span>
-                        <span
-                          class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                        <use
+                          xlink:href="#angle-down"
+                        />
+                      </svg>
+                    </span>
+                  </button>
+                  <div
+                    class="panel-collapse"
+                    role="tabpanel"
+                  >
+                    <div
+                      class="panel-body c-px-0"
+                    >
+                      <p
+                        class="c-pt-1 c-px-4 text-secondary"
+                      >
+                        inherited-attributes-are-not-taken-into-account-to-include-members-in-segments
+                      </p>
+                      <ul
+                        class="c-pl-0"
+                      >
+                        <li
+                          class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--first-test-values-group"
+                          draggable="true"
+                          tabindex="0"
                         >
                           <span
                             class="inline-item"
                           >
                             <svg
-                              class="lexicon-icon lexicon-icon-text"
+                              class="lexicon-icon lexicon-icon-drag"
                               role="presentation"
                             >
                               <use
-                                xlink:href="#text"
+                                xlink:href="#drag"
                               />
                             </svg>
                           </span>
-                        </span>
-                        Value
-                      </li>
-                    </ul>
+                          <span
+                            class="c-mx-2 c-my-0 criteria-sidebar-item-type sticker sticker-dark"
+                          >
+                            <span
+                              class="inline-item"
+                            >
+                              <svg
+                                class="lexicon-icon lexicon-icon-text"
+                                role="presentation"
+                              >
+                                <use
+                                  xlink:href="#text"
+                                />
+                              </svg>
+                            </span>
+                          </span>
+                          Value
+                        </li>
+                      </ul>
+                    </div>
                   </div>
-                </li>
-              </ul>
+                </div>
+              </div>
             </div>
           </div>
         </div>

--- a/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.test.js.snap
@@ -485,11 +485,11 @@ exports[`SegmentEdit renders with given values 1`] = `
             >
               <div
                 aria-orientation="vertical"
-                class="panel-group c-mt-1"
+                class="panel-group c-ml-1 c-mr-1 c-mt-1"
                 role="tablist"
               >
                 <div
-                  class="panel c-mr-2"
+                  class="panel"
                   role="tablist"
                 >
                   <button


### PR DESCRIPTION
Motivation
=======
In order to generalize components we're trying to use as many Clay components in the portal as posible. This PR contains the code to replace the html displayed by the CriteriaSidebarCollapse.js with the ClayPanel component.
https://issues.liferay.com/browse/LPS-186577  
