### PR TITLE
LPS-187534 The "featured image" link of a web content is not validated when it points to a wrong image from document library

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -753,7 +753,8 @@ public class DLReferencesExportImportContentProcessor
 
 				boolean relativePortalURL = false;
 
-				if (content.regionMatches(
+				if (((beginPos == 0) && (endPos == content.length())) ||
+					content.regionMatches(
 						true, beginPos - _OFFSET_HREF_ATTRIBUTE, "href=", 0,
 						5) ||
 					content.regionMatches(
@@ -800,9 +801,11 @@ public class DLReferencesExportImportContentProcessor
 							curBeginPos, endPos);
 
 						if (substring.startsWith(hostName) &&
-							(content.regionMatches(
-								true, curBeginPos - _OFFSET_HREF_ATTRIBUTE,
-								"href=", 0, 5) ||
+							(((curBeginPos == 0) &&
+							  (endPos == content.length())) ||
+							 content.regionMatches(
+								 true, curBeginPos - _OFFSET_HREF_ATTRIBUTE,
+								 "href=", 0, 5) ||
 							 content.regionMatches(
 								 true, curBeginPos - _OFFSET_SRC_ATTRIBUTE,
 								 "src=", 0, 4))) {

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/exportimport/content/processor/DLReferencesExportImportContentProcessor.java
@@ -797,6 +797,10 @@ public class DLReferencesExportImportContentProcessor
 					for (String hostName : hostNames) {
 						int curBeginPos = beginPos - hostName.length();
 
+						if (curBeginPos < 0) {
+							continue;
+						}
+
 						String substring = content.substring(
 							curBeginPos, endPos);
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
@@ -485,6 +485,11 @@ public class JournalArticleModelValidator
 			ExportImportContentProcessorRegistryUtil.
 				getExportImportContentProcessor(JournalArticle.class.getName());
 
+		if (smallImage && Validator.isNotNull(smallImageURL)) {
+			exportImportContentProcessor.validateContentReferences(
+				groupId, smallImageURL);
+		}
+
 		exportImportContentProcessor.validateContentReferences(
 			groupId, content);
 	}


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-187534

The "featured image" link (aka smallImageURL) is not validated when it points to a wrong image URL from the document library.

These image URLs from the document library are validated when you include them on the "content" section, but they are not validated on the "featured image" link.
On the other hand, the Staging functionality is also handling the URLs in both places when you export a LAR.

So the validations are not consistent depending on where are executed

To solve it, I am:

1. **Commit 69251b02a23b6db488a0e4078340b189ad31d41f:** Add an additional call to the `exportImportContentProcessor.validateContentReferences` method in JournalArticleModelValidator
2. **Commit 6c2930ef24296de84fc60fe3f83e3ad24879b7c0:** If the content variable only contains the URL, `((beginPos == 0) && (endPos == content.length())` it is not necessary to do the content.regionMatches logic that checks where the URL starts

Let me know if you have any question