### PR TITLE
[TS] [Urgent] LPS-187703 Improve performance of SegmentsEntryRel reindexing process

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
@@ -149,10 +149,11 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 
 		Set<Long> oldClassPKs = _getOldDatabaseClassPKs(segmentsEntryId);
 
+		Set<Long> addClassPKs = new HashSet<>(newClassPKs);
 		Set<Long> deleteClassPKs = new HashSet<>();
 
 		for (Long oldClassPK : oldClassPKs) {
-			if (!newClassPKs.remove(oldClassPK)) {
+			if (!addClassPKs.remove(oldClassPK)) {
 				deleteClassPKs.add(oldClassPK);
 			}
 		}
@@ -169,7 +170,7 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 		serviceContext.setUserId(segmentsEntry.getUserId());
 
 		_segmentsEntryRelLocalService.addSegmentsEntryRels(
-			segmentsEntryId, classNameId, ArrayUtil.toLongArray(newClassPKs),
+			segmentsEntryId, classNameId, ArrayUtil.toLongArray(addClassPKs),
 			serviceContext);
 	}
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
@@ -147,7 +147,21 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 			return;
 		}
 
-		_segmentsEntryRelLocalService.deleteSegmentsEntryRels(segmentsEntryId);
+		Set<Long> oldClassPKs = _getOldDatabaseClassPKs(segmentsEntryId);
+
+		Set<Long> deleteClassPKs = new HashSet<>();
+
+		for (Long oldClassPK : oldClassPKs) {
+			if (!newClassPKs.remove(oldClassPK)) {
+				deleteClassPKs.add(oldClassPK);
+			}
+		}
+
+		long classNameId = _portal.getClassNameId(segmentsEntry.getType());
+
+		_segmentsEntryRelLocalService.deleteSegmentsEntryRels(
+			segmentsEntryId, classNameId,
+			ArrayUtil.toLongArray(deleteClassPKs));
 
 		ServiceContext serviceContext = new ServiceContext();
 
@@ -155,8 +169,8 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 		serviceContext.setUserId(segmentsEntry.getUserId());
 
 		_segmentsEntryRelLocalService.addSegmentsEntryRels(
-			segmentsEntryId, _portal.getClassNameId(segmentsEntry.getType()),
-			ArrayUtil.toLongArray(newClassPKs), serviceContext);
+			segmentsEntryId, classNameId, ArrayUtil.toLongArray(newClassPKs),
+			serviceContext);
 	}
 
 	private void _updateIndex(

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
@@ -131,22 +131,22 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 		SegmentsEntry segmentsEntry =
 			_segmentsEntryLocalService.fetchSegmentsEntry(segmentsEntryId);
 
-		if ((segmentsEntry != null) &&
-			(segmentsEntry.getCriteriaObj() != null)) {
+		if ((segmentsEntry == null) ||
+			(segmentsEntry.getCriteriaObj() == null)) {
 
-			_segmentsEntryRelLocalService.deleteSegmentsEntryRels(
-				segmentsEntryId);
-
-			ServiceContext serviceContext = new ServiceContext();
-
-			serviceContext.setScopeGroupId(segmentsEntry.getGroupId());
-			serviceContext.setUserId(segmentsEntry.getUserId());
-
-			_segmentsEntryRelLocalService.addSegmentsEntryRels(
-				segmentsEntryId,
-				_portal.getClassNameId(segmentsEntry.getType()),
-				ArrayUtil.toLongArray(newClassPKs), serviceContext);
+			return;
 		}
+
+		_segmentsEntryRelLocalService.deleteSegmentsEntryRels(segmentsEntryId);
+
+		ServiceContext serviceContext = new ServiceContext();
+
+		serviceContext.setScopeGroupId(segmentsEntry.getGroupId());
+		serviceContext.setUserId(segmentsEntry.getUserId());
+
+		_segmentsEntryRelLocalService.addSegmentsEntryRels(
+			segmentsEntryId, _portal.getClassNameId(segmentsEntry.getType()),
+			ArrayUtil.toLongArray(newClassPKs), serviceContext);
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
@@ -97,7 +97,7 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 		return SetUtil.fromArray(classPKs);
 	}
 
-	private Set<Long> _getOldClassPKs(
+	private Set<Long> _getOldIndexClassPKs(
 			long companyId, long segmentsEntryId, Indexer<Object> indexer)
 		throws SearchException {
 
@@ -149,7 +149,8 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 		throws PortalException {
 
 		Set<Long> classPKs = SetUtil.symmetricDifference(
-			_getOldClassPKs(companyId, segmentsEntryId, indexer), newClassPKs);
+			_getOldIndexClassPKs(companyId, segmentsEntryId, indexer),
+			newClassPKs);
 
 		for (long classPK : classPKs) {
 			indexer.reindex(type, classPK);

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
@@ -14,6 +14,7 @@
 
 package com.liferay.segments.internal.messaging;
 
+import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -35,6 +36,7 @@ import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.segments.internal.constants.SegmentsDestinationNames;
 import com.liferay.segments.model.SegmentsEntry;
+import com.liferay.segments.model.SegmentsEntryRelTable;
 import com.liferay.segments.provider.SegmentsEntryProviderRegistry;
 import com.liferay.segments.service.SegmentsEntryLocalService;
 import com.liferay.segments.service.SegmentsEntryRelLocalService;
@@ -95,6 +97,20 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 				segmentsEntryId, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		return SetUtil.fromArray(classPKs);
+	}
+
+	private Set<Long> _getOldDatabaseClassPKs(long segmentsEntryId) {
+		Iterable<Long> iterable = _segmentsEntryLocalService.dslQuery(
+			DSLQueryFactoryUtil.select(
+				SegmentsEntryRelTable.INSTANCE.classPK
+			).from(
+				SegmentsEntryRelTable.INSTANCE
+			).where(
+				SegmentsEntryRelTable.INSTANCE.segmentsEntryId.eq(
+					segmentsEntryId)
+			));
+
+		return SetUtil.fromIterator(iterable.iterator());
 	}
 
 	private Set<Long> _getOldIndexClassPKs(

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/messaging/test/SegmentsEntryReindexMessageListenerTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/internal/messaging/test/SegmentsEntryReindexMessageListenerTest.java
@@ -1,0 +1,194 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.segments.internal.messaging.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.messaging.Message;
+import com.liferay.portal.kernel.messaging.MessageListener;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.OrderByComparatorFactoryUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.segments.criteria.Criteria;
+import com.liferay.segments.criteria.CriteriaSerializer;
+import com.liferay.segments.criteria.contributor.SegmentsCriteriaContributor;
+import com.liferay.segments.internal.constants.SegmentsDestinationNames;
+import com.liferay.segments.model.SegmentsEntry;
+import com.liferay.segments.model.SegmentsEntryRel;
+import com.liferay.segments.service.SegmentsEntryRelLocalService;
+import com.liferay.segments.test.util.SegmentsTestUtil;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Michael Bowerman
+ */
+@RunWith(Arquillian.class)
+public class SegmentsEntryReindexMessageListenerTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_role = RoleTestUtil.addRole(RoleConstants.TYPE_REGULAR);
+
+		Criteria criteria = new Criteria();
+
+		_segmentsCriteriaContributor.contribute(
+			criteria, String.format("(roleIds eq '%s')", _role.getRoleId()),
+			Criteria.Conjunction.AND);
+
+		_segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			TestPropsValues.getGroupId(),
+			CriteriaSerializer.serialize(criteria), User.class.getName());
+
+		_user1 = UserTestUtil.addUser();
+		_user2 = UserTestUtil.addUser();
+	}
+
+	@Test
+	public void testSegmentsEntryRelAdded() throws Exception {
+		_roleLocalService.addUserRole(_user1.getUserId(), _role);
+
+		_invokeMessageListener();
+
+		List<SegmentsEntryRel> segmentsEntryRels =
+			_segmentsEntryRelLocalService.getSegmentsEntryRels(
+				_segmentsEntry.getSegmentsEntryId());
+
+		Assert.assertEquals(
+			segmentsEntryRels.toString(), 1, segmentsEntryRels.size());
+
+		SegmentsEntryRel segmentsEntryRel1 = segmentsEntryRels.get(0);
+
+		Assert.assertEquals(_user1.getUserId(), segmentsEntryRel1.getClassPK());
+
+		_roleLocalService.addUserRole(_user2.getUserId(), _role);
+
+		_invokeMessageListener();
+
+		segmentsEntryRels = _segmentsEntryRelLocalService.getSegmentsEntryRels(
+			_segmentsEntry.getSegmentsEntryId(), QueryUtil.ALL_POS,
+			QueryUtil.ALL_POS,
+			OrderByComparatorFactoryUtil.create(
+				"SegmentsEntryRel", "classPK", true));
+
+		Assert.assertEquals(
+			segmentsEntryRels.toString(), 2, segmentsEntryRels.size());
+
+		SegmentsEntryRel segmentsEntryRel2 = segmentsEntryRels.get(0);
+		SegmentsEntryRel segmentsEntryRel3 = segmentsEntryRels.get(1);
+
+		Assert.assertEquals(_user1.getUserId(), segmentsEntryRel2.getClassPK());
+		Assert.assertEquals(_user2.getUserId(), segmentsEntryRel3.getClassPK());
+	}
+
+	@Test
+	public void testSegmentsEntryRelRemoved() throws Exception {
+		_roleLocalService.addUserRole(_user1.getUserId(), _role);
+		_roleLocalService.addUserRole(_user2.getUserId(), _role);
+
+		_invokeMessageListener();
+
+		List<SegmentsEntryRel> segmentsEntryRels =
+			_segmentsEntryRelLocalService.getSegmentsEntryRels(
+				_segmentsEntry.getSegmentsEntryId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS,
+				OrderByComparatorFactoryUtil.create(
+					"SegmentsEntryRel", "classPK", true));
+
+		Assert.assertEquals(
+			segmentsEntryRels.toString(), 2, segmentsEntryRels.size());
+
+		SegmentsEntryRel segmentsEntryRel1 = segmentsEntryRels.get(0);
+		SegmentsEntryRel segmentsEntryRel2 = segmentsEntryRels.get(1);
+
+		Assert.assertEquals(_user1.getUserId(), segmentsEntryRel1.getClassPK());
+		Assert.assertEquals(_user2.getUserId(), segmentsEntryRel2.getClassPK());
+
+		_roleLocalService.deleteUserRole(_user2.getUserId(), _role);
+
+		_invokeMessageListener();
+
+		segmentsEntryRels = _segmentsEntryRelLocalService.getSegmentsEntryRels(
+			_segmentsEntry.getSegmentsEntryId());
+
+		Assert.assertEquals(
+			segmentsEntryRels.toString(), 1, segmentsEntryRels.size());
+
+		SegmentsEntryRel segmentsEntryRel3 = segmentsEntryRels.get(0);
+
+		Assert.assertEquals(_user1.getUserId(), segmentsEntryRel3.getClassPK());
+	}
+
+	private void _invokeMessageListener() throws Exception {
+		Message message = new Message();
+
+		message.put("companyId", _segmentsEntry.getCompanyId());
+		message.put("segmentsEntryId", _segmentsEntry.getSegmentsEntryId());
+		message.put("type", _segmentsEntry.getType());
+
+		_messageListener.receive(message);
+	}
+
+	@Inject(
+		filter = "destination.name=" + SegmentsDestinationNames.SEGMENTS_ENTRY_REINDEX
+	)
+	private MessageListener _messageListener;
+
+	@DeleteAfterTestRun
+	private Role _role;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@Inject(
+		filter = "segments.criteria.contributor.key=user",
+		type = SegmentsCriteriaContributor.class
+	)
+	private SegmentsCriteriaContributor _segmentsCriteriaContributor;
+
+	@DeleteAfterTestRun
+	private SegmentsEntry _segmentsEntry;
+
+	@Inject
+	private SegmentsEntryRelLocalService _segmentsEntryRelLocalService;
+
+	@DeleteAfterTestRun
+	private User _user1;
+
+	@DeleteAfterTestRun
+	private User _user2;
+
+}


### PR DESCRIPTION
Motivation
=======
Currently the SegmentsEntryRel reindexing process is extremely inefficient in regards to keeping the `SegmentsEntryRel` table in the database up to date. It removes every related entry to the segment, and then adds them back in. It would be much more efficient to only remove the entries that have actually been removed from the segment, and to only add the entries that have actually been added to the segment.

This inefficiency is causing a very large number of cache-clearing operations for the SegmentsEntryRel cache, proportional to the number of users in the segment. We have a customer who is also using clustering with cache replication, and their segments are big enough that so many cache-clearing messages are getting generated that it chokes up their entire cluster because of the excessive number of cache clearing messages that are being queued up to be sent to the other node. This is a blocker for them

Proposed Solution
========
To solve this issue, I implemented the proposed solution originally approved by the product team on [PTR-4003](https://issues.liferay.com/browse/PTR-4003). This solution is to only remove the entries from the SegmentsEntryRel table that have actually been removed from the segment, and to only add the entries that have actually been added to the segment (rather than remove and then re-add a bunch of entries redundantly).

Note that this implementation _assumes_ that all SegmentsEntryRel objects will have their classNameId set to the classNameId corresponding to the `type` of the SegmentsEntry. As far as I could tell, it did not seem to be possible (at least not without using the API) to change the `type` of a SegmentsEntry. Please let me know if this is not a valid assumption.

Steps to Verify
========
1. Start up Liferay and log in as the admin user.
2. Create two new users: "test1@liferay.com" and "test2@liferay.com".
3. From the Global Menu, navigate to Control Panel > Roles, and add a new Regular Role named "Test Role".
4. Assign the "Test Role" to "test1@liferay.com" and "test2@liferay.com".
5. From the Site Administration menu of the default Liferay DXP Site, navigate to People > Segments.
6. Create a new Segment named "Test Segment" with the following condition: Regular Role equals Test Role.
7. From the Global Menu, navigate to Control Panel > Server Administration > Script.
8. Execute the [CallSegmentsEntryRelReindex.groovy](https://issues.liferay.com/secure/attachment/504551/504551_CallSegmentsEntryRelReindex.groovy) script.

**Checkpoint:** Check the SegmentsEntryRel table in your database. You should see two rows, corresponding to the memberships of "test1@liferay.com" and "test2@liferay.com" in the "Test Segment".

9. Unassign the "Test Role" from the "test2@liferay.com" user.
10. Connect the debugger to Liferay and put breakpoints at the beginning of [SegmentsEntryRelPersistenceImpl.updateImpl](https://github.com/liferay/liferay-portal/blob/dcf1fd98e86a327e8bfc999363224e6d9ab03b60/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/persistence/impl/SegmentsEntryRelPersistenceImpl.java#L2271) and [SegmentsEntryRelPersistenceImpl.removeImpl](https://github.com/liferay/liferay-portal/blob/dcf1fd98e86a327e8bfc999363224e6d9ab03b60/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/persistence/impl/SegmentsEntryRelPersistenceImpl.java#L2238).
11. Navigate back to Control Panel > Server Administration > Script, and execute the [CallSegmentsEntryRelReindex.groovy](https://issues.liferay.com/secure/attachment/504551/CallSegmentsEntryRelReindex.groovy) script. Note whenever a breakpoint is reached and then resume the debugger.

**Expected Result:** The breakpoint for removeImpl would only be reached one time, to remove "test2@liferay.com" from the segment. The breakpoint for updateImpl would never be reached.
**Actual Result:** The breakpoint for removeImpl is reached twice, once to remove "test1@liferay.com" from the segment and a second time to remove "test2@liferay.com" from the segment. Then the breakpoint for updateImpl is reached to add "test1@liferay.com" back into the segment.

