### PR TITLE
[TS] LPS-187648 | Unmapped fragment value not showing after publishing

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/MappingPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/MappingPanel.js
@@ -71,6 +71,10 @@ export function MappingPanel({item}) {
 			};
 		}
 
+		if (!isMapped(nextEditableValue)) {
+			delete nextEditableValue.collectionFieldId;
+		}
+
 		const nextEditableValues = {
 			...fragmentEntryLink.editableValues,
 			[processoryKey]: {


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://issues.liferay.com/browse/LPS-187648
Thank you!


--------------

The root cause of the issue was that an empty "collectionFieldId":"" was left in the editableValues field after unmapping the previous mapping. As a result, the fragments showed the default value instead the edited value. I fixed the issue by removing the collectionFieldId from the JSON when the mapped option is unmapped.

**Reproduction Steps:**

1. Go to Content & Data --> Web Content and create basic web content.
2. Go to Site Builder --> Pages and add a content (blank) page, add to it a Collection Display fragment, and select the recent content collection provider.
3. Add a paragraph fragment to the collection display, click twice on the Paragraph fragment, switch the Mapping tab in the right-hand-site panel, and set the mapping to "Author", then publish the page.
Checkpoint: The modified paragraph appears on the page.
4. Click twice on the Paragraph fragment, switch the Mapping tab in the right hand-site-panel, and set the mapping to "Unmapped"
5. Double-click on the Paragraph fragment and set a random text, and publish the page.
6. Observe the paragraph fragment on page view.

**Expected Result:**  The edited paragraph should be displayed after publishing the page.
**Actual Result:** The edited paragraph is not viewed on the published page. instead, the default value is returned. The edited paragraph appears only when editing the page.