### PR TITLE
LPS-188026 Move focus to the proper node when updating AI Creator modal

### DIFF
--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorModal.tsx
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/resources/META-INF/resources/ai_creator_modal/AICreatorModal.tsx
@@ -17,7 +17,7 @@ import {Container} from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import classNames from 'classnames';
 import {fetch} from 'frontend-js-web';
-import React, {FormEvent, useState} from 'react';
+import React, {FormEvent, useEffect, useRef, useState} from 'react';
 
 import {ErrorMessage} from './ErrorMessage';
 import {FormContent} from './FormContent';
@@ -45,6 +45,7 @@ export default function AICreatorModal({
 		opener.Liferay.fire('closeModal');
 	};
 
+	const modalContentRef = useRef<HTMLDivElement>(null);
 	const [status, setStatus] = useState<RequestStatus>({type: 'idle'});
 	const [text, setText] = useState<string | null>(null);
 
@@ -97,8 +98,12 @@ export default function AICreatorModal({
 			});
 	};
 
+	useEffect(() => {
+		modalContentRef.current?.focus();
+	});
+
 	return (
-		<>
+		<div className="h-100" ref={modalContentRef} tabIndex={-1}>
 			{status.type === 'loading' ? <LoadingMessage /> : null}
 
 			<ClayForm
@@ -151,6 +156,6 @@ export default function AICreatorModal({
 					</div>
 				</fieldset>
 			</ClayForm>
-		</>
+		</div>
 	);
 }


### PR DESCRIPTION
The idea of this PR is to properly move the browser focus when the AI Creator modal is updated. The order of precedence is:

1. If there is a loading alert, move the focus to it.
2. Otherwise, if there is an error alert, move the focus to it.
3. Otherwise, if there is some result message, move the focus to it.
4. Otherwise, do nothing.