### PR TITLE
LPS-188018 Create a Client Mock to be able to manually and POSHI testing simulating the real API interaction

### DIFF
--- a/modules/apps/ai-creator/ai-creator-openai-web/build.gradle
+++ b/modules/apps/ai-creator/ai-creator-openai-web/build.gradle
@@ -2,6 +2,7 @@ dependencies {
 	compileOnly group: "com.liferay", name: "biz.aQute.bnd.annotation", version: "4.2.0.LIFERAY-PATCHED-2"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.portal.kernel", version: "default"
 	compileOnly group: "com.liferay.portal", name: "com.liferay.util.taglib", version: "default"
+	compileOnly group: "commons-lang", name: "commons-lang", version: "2.6"
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "javax.servlet.jsp", name: "javax.servlet.jsp-api", version: "2.3.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/AICreatorOpenAIClient.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/AICreatorOpenAIClient.java
@@ -14,170 +14,18 @@
 
 package com.liferay.ai.creator.openai.web.internal.client;
 
-import com.liferay.ai.creator.openai.web.internal.exception.AICreatorOpenAIClientException;
-import com.liferay.petra.string.StringPool;
-import com.liferay.portal.kernel.json.JSONArray;
-import com.liferay.portal.kernel.json.JSONFactory;
-import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
-import com.liferay.portal.kernel.language.Language;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
-import com.liferay.portal.kernel.util.ContentTypes;
-import com.liferay.portal.kernel.util.Http;
-import com.liferay.portal.kernel.util.StringUtil;
-
-import java.io.InputStream;
-
-import java.net.HttpURLConnection;
-
 import java.util.Locale;
-
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Lourdes Fernández Besada
  */
-@Component(service = AICreatorOpenAIClient.class)
-public class AICreatorOpenAIClient {
+public interface AICreatorOpenAIClient {
 
 	public String getCompletion(
 			String apiKey, String content, Locale locale, String tone,
 			int words)
-		throws Exception {
+		throws Exception;
 
-		Http.Options options = new Http.Options();
-
-		options.addHeader("Authorization", "Bearer " + apiKey);
-		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
-		options.setLocation(ENDPOINT_COMPLETION);
-		options.setBody(
-			JSONUtil.put(
-				"messages",
-				JSONUtil.putAll(
-					JSONUtil.put(
-						"content",
-						_language.format(
-							locale,
-							"i-want-you-to-create-a-text-of-approximately-x-" +
-								"words,-and-using-a-x-tone",
-							new String[] {String.valueOf(words), tone})
-					).put(
-						"role", "system"
-					),
-					JSONUtil.put(
-						"content", content
-					).put(
-						"role", "user"
-					))
-			).put(
-				"model", "gpt-3.5-turbo"
-			).toString(),
-			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
-		options.setPost(true);
-
-		try (InputStream inputStream = _http.URLtoInputStream(options)) {
-			Http.Response response = options.getResponse();
-
-			JSONObject responseJSONObject = _jsonFactory.createJSONObject(
-				StringUtil.read(inputStream));
-
-			if (responseJSONObject.has("error")) {
-				JSONObject errorJSONObject = responseJSONObject.getJSONObject(
-					"error");
-
-				throw new AICreatorOpenAIClientException(
-					errorJSONObject.getString("code"),
-					errorJSONObject.getString("message"),
-					response.getResponseCode());
-			}
-			else if (response.getResponseCode() != HttpURLConnection.HTTP_OK) {
-				throw new AICreatorOpenAIClientException(
-					response.getResponseCode());
-			}
-
-			JSONArray jsonArray = responseJSONObject.getJSONArray("choices");
-
-			if (JSONUtil.isEmpty(jsonArray)) {
-				return StringPool.BLANK;
-			}
-
-			JSONObject choiceJSONObject = jsonArray.getJSONObject(0);
-
-			JSONObject messageJSONObject = choiceJSONObject.getJSONObject(
-				"message");
-
-			return messageJSONObject.getString("content");
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-
-			if (exception instanceof AICreatorOpenAIClientException) {
-				throw exception;
-			}
-
-			throw new AICreatorOpenAIClientException(exception);
-		}
-	}
-
-	public void validateAPIKey(String apiKey) throws Exception {
-		Http.Options options = new Http.Options();
-
-		options.addHeader("Authorization", "Bearer " + apiKey);
-		options.setLocation(ENDPOINT_VALIDATION);
-
-		try (InputStream inputStream = _http.URLtoInputStream(options)) {
-			Http.Response response = options.getResponse();
-
-			JSONObject responseJSONObject = _jsonFactory.createJSONObject(
-				StringUtil.read(inputStream));
-
-			if (responseJSONObject.has("error")) {
-				JSONObject errorJSONObject = responseJSONObject.getJSONObject(
-					"error");
-
-				throw new AICreatorOpenAIClientException(
-					errorJSONObject.getString("code"),
-					errorJSONObject.getString("message"),
-					response.getResponseCode());
-			}
-			else if (response.getResponseCode() != HttpURLConnection.HTTP_OK) {
-				throw new AICreatorOpenAIClientException(
-					response.getResponseCode());
-			}
-		}
-		catch (Exception exception) {
-			if (_log.isDebugEnabled()) {
-				_log.debug(exception);
-			}
-
-			if (exception instanceof AICreatorOpenAIClientException) {
-				throw exception;
-			}
-
-			throw new AICreatorOpenAIClientException(exception);
-		}
-	}
-
-	protected static final String ENDPOINT_COMPLETION =
-		"https://api.openai.com/v1/chat/completions";
-
-	protected static final String ENDPOINT_VALIDATION =
-		"https://api.openai.com/v1/models/text-davinci-003";
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		AICreatorOpenAIClient.class);
-
-	@Reference
-	private Http _http;
-
-	@Reference
-	private JSONFactory _jsonFactory;
-
-	@Reference
-	private Language _language;
+	public void validateAPIKey(String apiKey) throws Exception;
 
 }

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/AICreatorOpenAIClientImpl.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/AICreatorOpenAIClientImpl.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ai.creator.openai.web.internal.client;
+
+import com.liferay.ai.creator.openai.web.internal.exception.AICreatorOpenAIClientException;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.json.JSONArray;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.StringUtil;
+
+import java.io.InputStream;
+
+import java.net.HttpURLConnection;
+
+import java.util.Locale;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(service = AICreatorOpenAIClient.class)
+public class AICreatorOpenAIClientImpl implements AICreatorOpenAIClient {
+
+	@Override
+	public String getCompletion(
+			String apiKey, String content, Locale locale, String tone,
+			int words)
+		throws Exception {
+
+		Http.Options options = new Http.Options();
+
+		options.addHeader("Authorization", "Bearer " + apiKey);
+		options.addHeader("Content-Type", ContentTypes.APPLICATION_JSON);
+		options.setLocation(ENDPOINT_COMPLETION);
+		options.setBody(
+			JSONUtil.put(
+				"messages",
+				JSONUtil.putAll(
+					JSONUtil.put(
+						"content",
+						_language.format(
+							locale,
+							"i-want-you-to-create-a-text-of-approximately-x-" +
+								"words,-and-using-a-x-tone",
+							new String[] {String.valueOf(words), tone})
+					).put(
+						"role", "system"
+					),
+					JSONUtil.put(
+						"content", content
+					).put(
+						"role", "user"
+					))
+			).put(
+				"model", "gpt-3.5-turbo"
+			).toString(),
+			ContentTypes.APPLICATION_JSON, StringPool.UTF8);
+		options.setPost(true);
+
+		try (InputStream inputStream = _http.URLtoInputStream(options)) {
+			Http.Response response = options.getResponse();
+
+			JSONObject responseJSONObject = _jsonFactory.createJSONObject(
+				StringUtil.read(inputStream));
+
+			if (responseJSONObject.has("error")) {
+				JSONObject errorJSONObject = responseJSONObject.getJSONObject(
+					"error");
+
+				throw new AICreatorOpenAIClientException(
+					errorJSONObject.getString("code"),
+					errorJSONObject.getString("message"),
+					response.getResponseCode());
+			}
+			else if (response.getResponseCode() != HttpURLConnection.HTTP_OK) {
+				throw new AICreatorOpenAIClientException(
+					response.getResponseCode());
+			}
+
+			JSONArray jsonArray = responseJSONObject.getJSONArray("choices");
+
+			if (JSONUtil.isEmpty(jsonArray)) {
+				return StringPool.BLANK;
+			}
+
+			JSONObject choiceJSONObject = jsonArray.getJSONObject(0);
+
+			JSONObject messageJSONObject = choiceJSONObject.getJSONObject(
+				"message");
+
+			return messageJSONObject.getString("content");
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			if (exception instanceof AICreatorOpenAIClientException) {
+				throw exception;
+			}
+
+			throw new AICreatorOpenAIClientException(exception);
+		}
+	}
+
+	@Override
+	public void validateAPIKey(String apiKey) throws Exception {
+		Http.Options options = new Http.Options();
+
+		options.addHeader("Authorization", "Bearer " + apiKey);
+		options.setLocation(ENDPOINT_VALIDATION);
+
+		try (InputStream inputStream = _http.URLtoInputStream(options)) {
+			Http.Response response = options.getResponse();
+
+			JSONObject responseJSONObject = _jsonFactory.createJSONObject(
+				StringUtil.read(inputStream));
+
+			if (responseJSONObject.has("error")) {
+				JSONObject errorJSONObject = responseJSONObject.getJSONObject(
+					"error");
+
+				throw new AICreatorOpenAIClientException(
+					errorJSONObject.getString("code"),
+					errorJSONObject.getString("message"),
+					response.getResponseCode());
+			}
+			else if (response.getResponseCode() != HttpURLConnection.HTTP_OK) {
+				throw new AICreatorOpenAIClientException(
+					response.getResponseCode());
+			}
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			if (exception instanceof AICreatorOpenAIClientException) {
+				throw exception;
+			}
+
+			throw new AICreatorOpenAIClientException(exception);
+		}
+	}
+
+	protected static final String ENDPOINT_COMPLETION =
+		"https://api.openai.com/v1/chat/completions";
+
+	protected static final String ENDPOINT_VALIDATION =
+		"https://api.openai.com/v1/models/text-davinci-003";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		AICreatorOpenAIClientImpl.class);
+
+	@Reference
+	private Http _http;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Language _language;
+
+}

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/AICreatorOpenAIClientImpl.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/AICreatorOpenAIClientImpl.java
@@ -39,7 +39,10 @@ import org.osgi.service.component.annotations.Reference;
 /**
  * @author Lourdes Fernández Besada
  */
-@Component(service = AICreatorOpenAIClient.class)
+@Component(
+	property = "service.ranking:Integer=100",
+	service = AICreatorOpenAIClient.class
+)
 public class AICreatorOpenAIClientImpl implements AICreatorOpenAIClient {
 
 	@Override

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/MockAICreatorOpenAIClient.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/MockAICreatorOpenAIClient.java
@@ -15,7 +15,10 @@
 package com.liferay.ai.creator.openai.web.internal.client;
 
 import com.liferay.ai.creator.openai.web.internal.exception.AICreatorOpenAIClientException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.io.IOException;
 
@@ -41,7 +44,16 @@ public class MockAICreatorOpenAIClient implements AICreatorOpenAIClient {
 		if (Objects.equals(apiKey, "VALID_API_KEY") &&
 			Objects.equals(content, "USER_CONTENT")) {
 
-			return "OPENAI_API_COMPLETION_RESPONSE_CONTENT";
+			return _getSampleCompletion(0);
+		}
+
+		if (Validator.isNotNull(content) &&
+			content.startsWith(_USER_CONTENT_SLEEP_MILLIS_PREFIX)) {
+
+			return _getSampleCompletion(
+				GetterUtil.getLong(
+					content.substring(
+						_USER_CONTENT_SLEEP_MILLIS_PREFIX.length())));
 		}
 
 		throw _getAICreatorOpenAIClientException(content);
@@ -80,5 +92,28 @@ public class MockAICreatorOpenAIClient implements AICreatorOpenAIClient {
 			new UnsupportedOperationException(
 				"Invalid Key to use MockAICreatorOpenAIClient, Key: " + key));
 	}
+
+	private String _getSampleCompletion(long sleepMillis) {
+		if (sleepMillis <= 0) {
+			return "OPENAI_API_COMPLETION_RESPONSE_CONTENT";
+		}
+
+		try {
+			Thread.sleep(sleepMillis);
+		}
+		catch (InterruptedException interruptedException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(interruptedException);
+			}
+		}
+
+		return "OPENAI_API_COMPLETION_RESPONSE_CONTENT";
+	}
+
+	private static final String _USER_CONTENT_SLEEP_MILLIS_PREFIX =
+		"USER_CONTENT_SLEEP_MILLIS_";
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		MockAICreatorOpenAIClient.class);
 
 }

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/MockAICreatorOpenAIClient.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/MockAICreatorOpenAIClient.java
@@ -35,7 +35,7 @@ import org.osgi.service.component.annotations.Component;
  * @author Lourdes Fernández Besada
  */
 @Component(
-	property = "service.ranking:Integer=200",
+	enabled = false, property = "service.ranking:Integer=200",
 	service = AICreatorOpenAIClient.class
 )
 public class MockAICreatorOpenAIClient implements AICreatorOpenAIClient {

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/MockAICreatorOpenAIClient.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/MockAICreatorOpenAIClient.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.ai.creator.openai.web.internal.client;
+
+import com.liferay.ai.creator.openai.web.internal.exception.AICreatorOpenAIClientException;
+import com.liferay.portal.kernel.util.GetterUtil;
+
+import java.io.IOException;
+
+import java.net.HttpURLConnection;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import org.apache.commons.lang.StringUtils;
+
+import org.osgi.service.component.annotations.Component;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@Component(service = AICreatorOpenAIClient.class)
+public class MockAICreatorOpenAIClient implements AICreatorOpenAIClient {
+
+	@Override
+	public String getCompletion(
+		String apiKey, String content, Locale locale, String tone, int words) {
+
+		if (Objects.equals(apiKey, "VALID_API_KEY")) {
+			return "OPENAI_API_COMPLETION_RESPONSE_CONTENT";
+		}
+
+		throw _getAICreatorOpenAIClientException(apiKey);
+	}
+
+	@Override
+	public void validateAPIKey(String apiKey) {
+		if (Objects.equals(apiKey, "VALID_API_KEY")) {
+			return;
+		}
+
+		throw _getAICreatorOpenAIClientException(apiKey);
+	}
+
+	private AICreatorOpenAIClientException _getAICreatorOpenAIClientException(
+		String apiKey) {
+
+		if (Objects.equals(apiKey, "OPENAI_API_INVALID_API_KEY")) {
+			return new AICreatorOpenAIClientException(
+				"invalid_api_key", "invalid_api_key_message",
+				HttpURLConnection.HTTP_OK);
+		}
+
+		if (Objects.equals(apiKey, "OPENAI_API_IOEXCEPTION")) {
+			return new AICreatorOpenAIClientException(new IOException());
+		}
+
+		int responseCode = GetterUtil.getInteger(
+			StringUtils.substringBetween(
+				apiKey, "OPENAI_API_", "_RESPONSE_CODE"));
+
+		if (responseCode > 0) {
+			return new AICreatorOpenAIClientException(responseCode);
+		}
+
+		return new AICreatorOpenAIClientException(
+			new UnsupportedOperationException(
+				"Invalid API Key to use MockAICreatorOpenAIClient, API Key: " +
+					apiKey));
+	}
+
+}

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/MockAICreatorOpenAIClient.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/MockAICreatorOpenAIClient.java
@@ -38,11 +38,13 @@ public class MockAICreatorOpenAIClient implements AICreatorOpenAIClient {
 	public String getCompletion(
 		String apiKey, String content, Locale locale, String tone, int words) {
 
-		if (Objects.equals(apiKey, "VALID_API_KEY")) {
+		if (Objects.equals(apiKey, "VALID_API_KEY") &&
+			Objects.equals(content, "USER_CONTENT")) {
+
 			return "OPENAI_API_COMPLETION_RESPONSE_CONTENT";
 		}
 
-		throw _getAICreatorOpenAIClientException(apiKey);
+		throw _getAICreatorOpenAIClientException(content);
 	}
 
 	@Override
@@ -55,21 +57,20 @@ public class MockAICreatorOpenAIClient implements AICreatorOpenAIClient {
 	}
 
 	private AICreatorOpenAIClientException _getAICreatorOpenAIClientException(
-		String apiKey) {
+		String key) {
 
-		if (Objects.equals(apiKey, "OPENAI_API_INVALID_API_KEY")) {
+		if (Objects.equals(key, "OPENAI_API_INVALID_API_KEY")) {
 			return new AICreatorOpenAIClientException(
 				"invalid_api_key", "invalid_api_key_message",
 				HttpURLConnection.HTTP_OK);
 		}
 
-		if (Objects.equals(apiKey, "OPENAI_API_IOEXCEPTION")) {
+		if (Objects.equals(key, "OPENAI_API_IOEXCEPTION")) {
 			return new AICreatorOpenAIClientException(new IOException());
 		}
 
 		int responseCode = GetterUtil.getInteger(
-			StringUtils.substringBetween(
-				apiKey, "OPENAI_API_", "_RESPONSE_CODE"));
+			StringUtils.substringBetween(key, "OPENAI_API_", "_RESPONSE_CODE"));
 
 		if (responseCode > 0) {
 			return new AICreatorOpenAIClientException(responseCode);
@@ -77,8 +78,7 @@ public class MockAICreatorOpenAIClient implements AICreatorOpenAIClient {
 
 		return new AICreatorOpenAIClientException(
 			new UnsupportedOperationException(
-				"Invalid API Key to use MockAICreatorOpenAIClient, API Key: " +
-					apiKey));
+				"Invalid Key to use MockAICreatorOpenAIClient, Key: " + key));
 	}
 
 }

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/MockAICreatorOpenAIClient.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/MockAICreatorOpenAIClient.java
@@ -34,7 +34,10 @@ import org.osgi.service.component.annotations.Component;
 /**
  * @author Lourdes Fernández Besada
  */
-@Component(service = AICreatorOpenAIClient.class)
+@Component(
+	property = "service.ranking:Integer=200",
+	service = AICreatorOpenAIClient.class
+)
 public class MockAICreatorOpenAIClient implements AICreatorOpenAIClient {
 
 	@Override

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/MockAICreatorOpenAIClient.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/client/MockAICreatorOpenAIClient.java
@@ -94,7 +94,7 @@ public class MockAICreatorOpenAIClient implements AICreatorOpenAIClient {
 	}
 
 	private String _getSampleCompletion(long sleepMillis) {
-		if (sleepMillis <= 0) {
+		if ((sleepMillis <= 0) || (sleepMillis > 10000)) {
 			return "OPENAI_API_COMPLETION_RESPONSE_CONTENT";
 		}
 

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/portlet/action/BaseSaveConfigurationMVCActionCommand.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/portlet/action/BaseSaveConfigurationMVCActionCommand.java
@@ -32,6 +32,8 @@ import javax.portlet.ActionResponse;
 import javax.portlet.PortletException;
 
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Lourdes Fernández Besada
@@ -92,8 +94,11 @@ public abstract class BaseSaveConfigurationMVCActionCommand
 			String apiKey, boolean enableOpenAI, ThemeDisplay themeDisplay)
 		throws ConfigurationException;
 
-	@Reference
-	protected AICreatorOpenAIClient aiCreatorOpenAIClient;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	protected volatile AICreatorOpenAIClient aiCreatorOpenAIClient;
 
 	@Reference
 	protected Language language;

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/portlet/action/GetCompletionMVCResourceCommand.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/main/java/com/liferay/ai/creator/openai/web/internal/portlet/action/GetCompletionMVCResourceCommand.java
@@ -34,6 +34,8 @@ import javax.portlet.ResourceResponse;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 /**
  * @author Lourdes Fernández Besada
@@ -154,8 +156,11 @@ public class GetCompletionMVCResourceCommand extends BaseMVCResourceCommand {
 		}
 	}
 
-	@Reference
-	protected AICreatorOpenAIClient aiCreatorOpenAIClient;
+	@Reference(
+		policy = ReferencePolicy.DYNAMIC,
+		policyOption = ReferencePolicyOption.GREEDY
+	)
+	protected volatile AICreatorOpenAIClient aiCreatorOpenAIClient;
 
 	@Reference
 	private AICreatorOpenAIConfigurationManager

--- a/modules/apps/ai-creator/ai-creator-openai-web/src/test/java/com/liferay/ai/creator/openai/web/internal/client/AICreatorOpenAIClientTest.java
+++ b/modules/apps/ai-creator/ai-creator-openai-web/src/test/java/com/liferay/ai/creator/openai/web/internal/client/AICreatorOpenAIClientTest.java
@@ -62,7 +62,7 @@ public class AICreatorOpenAIClientTest {
 
 	@Before
 	public void setUp() throws IOException {
-		_aiCreatorOpenAIClient = new AICreatorOpenAIClient();
+		_aiCreatorOpenAIClient = new AICreatorOpenAIClientImpl();
 
 		_http = Mockito.mock(Http.class);
 
@@ -112,7 +112,7 @@ public class AICreatorOpenAIClientTest {
 
 		_assertOptions(
 			apiKey, content, ContentTypes.APPLICATION_JSON,
-			AICreatorOpenAIClient.ENDPOINT_COMPLETION);
+			AICreatorOpenAIClientImpl.ENDPOINT_COMPLETION);
 		_assertResponse(response);
 	}
 
@@ -124,7 +124,7 @@ public class AICreatorOpenAIClientTest {
 
 		_testIOException(
 			content, ContentTypes.APPLICATION_JSON,
-			AICreatorOpenAIClient.ENDPOINT_COMPLETION,
+			AICreatorOpenAIClientImpl.ENDPOINT_COMPLETION,
 			apiKey -> _aiCreatorOpenAIClient.getCompletion(
 				apiKey, content, LocaleUtil.getDefault(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomInt()));
@@ -138,7 +138,7 @@ public class AICreatorOpenAIClientTest {
 
 		_testResponseWithErrorKey(
 			content, ContentTypes.APPLICATION_JSON,
-			AICreatorOpenAIClient.ENDPOINT_COMPLETION,
+			AICreatorOpenAIClientImpl.ENDPOINT_COMPLETION,
 			apiKey -> _aiCreatorOpenAIClient.getCompletion(
 				apiKey, content, LocaleUtil.getDefault(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomInt()));
@@ -152,7 +152,7 @@ public class AICreatorOpenAIClientTest {
 
 		_testUnauthorizedResponseCode(
 			content, ContentTypes.APPLICATION_JSON,
-			AICreatorOpenAIClient.ENDPOINT_COMPLETION,
+			AICreatorOpenAIClientImpl.ENDPOINT_COMPLETION,
 			apiKey -> _aiCreatorOpenAIClient.getCompletion(
 				apiKey, content, LocaleUtil.getDefault(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomInt()));
@@ -169,7 +169,7 @@ public class AICreatorOpenAIClientTest {
 
 		_aiCreatorOpenAIClient.validateAPIKey(apiKey);
 
-		_assertOptions(apiKey, AICreatorOpenAIClient.ENDPOINT_VALIDATION);
+		_assertOptions(apiKey, AICreatorOpenAIClientImpl.ENDPOINT_VALIDATION);
 
 		_assertResponse(response);
 		_assertResponseJSONObject(responseJSONObject);
@@ -178,21 +178,21 @@ public class AICreatorOpenAIClientTest {
 	@Test
 	public void testValidateAPIKeyIOException() throws Exception {
 		_testIOException(
-			null, null, AICreatorOpenAIClient.ENDPOINT_VALIDATION,
+			null, null, AICreatorOpenAIClientImpl.ENDPOINT_VALIDATION,
 			apiKey -> _aiCreatorOpenAIClient.validateAPIKey(apiKey));
 	}
 
 	@Test
 	public void testValidateAPIKeyResponseWithErrorKey() throws Exception {
 		_testResponseWithErrorKey(
-			null, null, AICreatorOpenAIClient.ENDPOINT_VALIDATION,
+			null, null, AICreatorOpenAIClientImpl.ENDPOINT_VALIDATION,
 			apiKey -> _aiCreatorOpenAIClient.validateAPIKey(apiKey));
 	}
 
 	@Test
 	public void testValidateAPIKeyUnauthorizedResponseCode() throws Exception {
 		_testUnauthorizedResponseCode(
-			null, null, AICreatorOpenAIClient.ENDPOINT_VALIDATION,
+			null, null, AICreatorOpenAIClientImpl.ENDPOINT_VALIDATION,
 			apiKey -> _aiCreatorOpenAIClient.validateAPIKey(apiKey));
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-188018

In this PR we are adding a simulation of the OpenAI client so that it allows us to test the full functionality without interacting with the OpenAI API. This will allow us to do manual tests, POSHI tests, or even Integration tests that test all the functionality.

To enable the mock, go to the Gogo Shell and enable the mock component:

`scr:enable com.liferay.ai.creator.openai.web.internal.client.MockAICreatorOpenAIClient`

How the mock works when editing the configuration depends on the API Key that is entered. 

Using VALID_API_KEY will be considered as a valid API Key and will allow us to access the AI Creator button in the Web Content CKEditor when this functionality is enabled.

Using USER_CONTENT as the user prompt will produce an OK response simulation returning as completion the text "OPENAI_API_COMPLETION_RESPONSE_CONTENT"

To simulate a controlled error we have disposed of some keys that could be used as API Key and/or as the user prompt.

These are the Keys and their expected behavior:

OPENAI_API_INVALID_API_KEY --> The response will be the same as when the real API returns an invalid API key's response.
OPENAI_API_IOEXCEPTION --> The response will be the same as when the real API throws an exception.
OPENAI_API_{0}_RESPONSE_CODE --> The response will be the same as when the real API response code is {0}.

The mock has a text completion fast response, so the user can't see the loading view. In order to be able to see the loading view you can use the user prompt USER_CONTENT_SLEEP_MILLIS_XXX where XXX is the number of milliseconds of delay to apply and must be a number greater than 0 and lower than 10000.
