### PR TITLE
LPS-179425, LPS-179427, LPS-179428, LPS-179430, LPS-179431, LPS-179432, LPS-180033 Add test to assert error message when post asset library structured content folder with duplicated erc

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
@@ -21,6 +21,7 @@ import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.problem.Problem;
 import com.liferay.headless.delivery.client.resource.v1_0.StructuredContentFolderResource;
 import com.liferay.journal.model.JournalFolder;
+import com.liferay.journal.service.JournalFolderLocalServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
@@ -113,6 +114,38 @@ public class StructuredContentFolderResourceTest
 			).getProfileURL());
 
 		assertValid(page);
+	}
+
+	@Override
+	@Test
+	public void testPostStructuredContentFolderStructuredContentFolder()
+		throws Exception {
+
+		super.testPostStructuredContentFolderStructuredContentFolder();
+
+		StructuredContentFolder parentStructuredContentFolder =
+			testPostAssetLibraryStructuredContentFolder_addStructuredContentFolder(
+				_randomStructuredContentFolder());
+
+		StructuredContentFolder randomStructuredContentFolder =
+			_randomStructuredContentFolder();
+
+		randomStructuredContentFolder.setExternalReferenceCode("");
+
+		StructuredContentFolder postStructuredContentFolder =
+			structuredContentFolderResource.
+				postStructuredContentFolderStructuredContentFolder(
+					parentStructuredContentFolder.getId(),
+					randomStructuredContentFolder);
+
+		JournalFolder journalFolder = JournalFolderLocalServiceUtil.getFolder(
+			postStructuredContentFolder.getId());
+
+		Assert.assertEquals(
+			postStructuredContentFolder.getExternalReferenceCode(),
+			journalFolder.getUuid());
+
+		assertValid(postStructuredContentFolder);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
@@ -149,6 +149,48 @@ public class StructuredContentFolderResourceTest
 	}
 
 	@Override
+	@Test
+	public void testPutAssetLibraryStructuredContentFolderByExternalReferenceCode()
+		throws Exception {
+
+		super.
+			testPutAssetLibraryStructuredContentFolderByExternalReferenceCode();
+
+		StructuredContentFolder parentStructuredContentFolder =
+			testPostAssetLibraryStructuredContentFolder_addStructuredContentFolder(
+				_randomStructuredContentFolder());
+
+		StructuredContentFolder postStructuredContentFolder =
+			structuredContentFolderResource.
+				postStructuredContentFolderStructuredContentFolder(
+					parentStructuredContentFolder.getId(),
+					_randomStructuredContentFolder());
+
+		StructuredContentFolder randomStructuredContentFolder =
+			new StructuredContentFolder() {
+				{
+					name = postStructuredContentFolder.getName();
+				}
+			};
+
+		StructuredContentFolder putStructuredContentFolder =
+			structuredContentFolderResource.
+				putAssetLibraryStructuredContentFolderByExternalReferenceCode(
+					testDepotEntry.getDepotEntryId(),
+					StringUtil.toLowerCase(RandomTestUtil.randomString()),
+					randomStructuredContentFolder);
+
+		Assert.assertEquals(
+			postStructuredContentFolder.getName(),
+			putStructuredContentFolder.getName());
+		Assert.assertNotEquals(
+			postStructuredContentFolder.getExternalReferenceCode(),
+			putStructuredContentFolder.getExternalReferenceCode());
+
+		assertValid(putStructuredContentFolder);
+	}
+
+	@Override
 	protected String[] getAdditionalAssertFieldNames() {
 		return new String[] {"description", "name"};
 	}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
@@ -214,28 +214,48 @@ public class StructuredContentFolderResourceTest
 					parentStructuredContentFolder.getId(),
 					_randomStructuredContentFolder());
 
-		StructuredContentFolder randomStructuredContentFolder =
+		StructuredContentFolder randomStructuredContentFolder1 =
 			new StructuredContentFolder() {
 				{
 					name = postStructuredContentFolder.getName();
 				}
 			};
 
-		StructuredContentFolder putStructuredContentFolder =
+		StructuredContentFolder putStructuredContentFolder1 =
 			structuredContentFolderResource.
 				putAssetLibraryStructuredContentFolderByExternalReferenceCode(
 					testDepotEntry.getDepotEntryId(),
 					StringUtil.toLowerCase(RandomTestUtil.randomString()),
-					randomStructuredContentFolder);
+					randomStructuredContentFolder1);
 
 		Assert.assertEquals(
 			postStructuredContentFolder.getName(),
-			putStructuredContentFolder.getName());
+			putStructuredContentFolder1.getName());
 		Assert.assertNotEquals(
 			postStructuredContentFolder.getExternalReferenceCode(),
-			putStructuredContentFolder.getExternalReferenceCode());
+			putStructuredContentFolder1.getExternalReferenceCode());
 
-		assertValid(putStructuredContentFolder);
+		assertValid(putStructuredContentFolder1);
+
+		StructuredContentFolder randomStructuredContentFolder2 =
+			_randomStructuredContentFolder();
+
+		StructuredContentFolder structuredContentFolder =
+			testPostAssetLibraryStructuredContentFolder_addStructuredContentFolder(
+				randomStructuredContentFolder2);
+
+		randomStructuredContentFolder2.setExternalReferenceCode(
+			StringUtil.toLowerCase(RandomTestUtil.randomString()));
+
+		StructuredContentFolder putStructuredContentFolder2 =
+			structuredContentFolderResource.
+				putAssetLibraryStructuredContentFolderByExternalReferenceCode(
+					testDepotEntry.getDepotEntryId(),
+					structuredContentFolder.getExternalReferenceCode(),
+					randomStructuredContentFolder2);
+
+		assertEquals(putStructuredContentFolder2, structuredContentFolder);
+		assertValid(putStructuredContentFolder2);
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
@@ -69,6 +69,30 @@ public class StructuredContentFolderResourceTest
 					", groupId=", testDepotEntry.getGroupId(), "}"),
 				problem.getTitle());
 		}
+
+		StructuredContentFolder parentStructuredContentFolder =
+			testPostAssetLibraryStructuredContentFolder_addStructuredContentFolder(
+				_randomStructuredContentFolder());
+
+		StructuredContentFolder postStructuredContentFolder =
+			structuredContentFolderResource.
+				postStructuredContentFolderStructuredContentFolder(
+					parentStructuredContentFolder.getId(),
+					_randomStructuredContentFolder());
+
+		assertHttpResponseStatusCode(
+			204,
+			structuredContentFolderResource.
+				deleteAssetLibraryStructuredContentFolderByExternalReferenceCodeHttpResponse(
+					testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode_getAssetLibraryId(),
+					postStructuredContentFolder.getExternalReferenceCode()));
+
+		assertHttpResponseStatusCode(
+			404,
+			structuredContentFolderResource.
+				getAssetLibraryStructuredContentFolderByExternalReferenceCodeHttpResponse(
+					testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode_getAssetLibraryId(),
+					postStructuredContentFolder.getExternalReferenceCode()));
 	}
 
 	@Override

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
@@ -18,9 +18,11 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.delivery.client.dto.v1_0.StructuredContentFolder;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.pagination.Pagination;
+import com.liferay.headless.delivery.client.problem.Problem;
 import com.liferay.headless.delivery.client.resource.v1_0.StructuredContentFolderResource;
 import com.liferay.journal.model.JournalFolder;
 import com.liferay.journal.test.util.JournalTestUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -35,6 +37,38 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class StructuredContentFolderResourceTest
 	extends BaseStructuredContentFolderResourceTestCase {
+
+	@Override
+	@Test
+	public void testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode()
+		throws Exception {
+
+		super.
+			testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode();
+
+		String externalReferenceCode = StringUtil.toLowerCase(
+			RandomTestUtil.randomString());
+
+		try {
+			structuredContentFolderResource.
+				deleteAssetLibraryStructuredContentFolderByExternalReferenceCode(
+					testDeleteAssetLibraryStructuredContentFolderByExternalReferenceCode_getAssetLibraryId(),
+					externalReferenceCode);
+
+			Assert.fail();
+		}
+		catch (Problem.ProblemException problemException) {
+			Problem problem = problemException.getProblem();
+
+			Assert.assertEquals("NOT_FOUND", problem.getStatus());
+			Assert.assertEquals(
+				StringBundler.concat(
+					"No JournalFolder exists with the key {",
+					"externalReferenceCode=", externalReferenceCode,
+					", groupId=", testDepotEntry.getGroupId(), "}"),
+				problem.getTitle());
+		}
+	}
 
 	@Override
 	@Test

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
@@ -118,6 +118,30 @@ public class StructuredContentFolderResourceTest
 
 	@Override
 	@Test
+	public void testPostAssetLibraryStructuredContentFolder() throws Exception {
+		super.testPostAssetLibraryStructuredContentFolder();
+
+		StructuredContentFolder randomStructuredContentFolder =
+			_randomStructuredContentFolder();
+
+		randomStructuredContentFolder.setExternalReferenceCode("");
+
+		StructuredContentFolder postStructuredContentFolder =
+			testPostAssetLibraryStructuredContentFolder_addStructuredContentFolder(
+				randomStructuredContentFolder);
+
+		JournalFolder journalFolder = JournalFolderLocalServiceUtil.getFolder(
+			postStructuredContentFolder.getId());
+
+		Assert.assertEquals(
+			postStructuredContentFolder.getExternalReferenceCode(),
+			journalFolder.getUuid());
+
+		assertValid(postStructuredContentFolder);
+	}
+
+	@Override
+	@Test
 	public void testPostStructuredContentFolderStructuredContentFolder()
 		throws Exception {
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/StructuredContentFolderResourceTest.java
@@ -16,6 +16,7 @@ package com.liferay.headless.delivery.resource.v1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.headless.delivery.client.dto.v1_0.StructuredContentFolder;
+import com.liferay.headless.delivery.client.http.HttpInvoker;
 import com.liferay.headless.delivery.client.pagination.Page;
 import com.liferay.headless.delivery.client.pagination.Pagination;
 import com.liferay.headless.delivery.client.problem.Problem;
@@ -145,23 +146,46 @@ public class StructuredContentFolderResourceTest
 	public void testPostAssetLibraryStructuredContentFolder() throws Exception {
 		super.testPostAssetLibraryStructuredContentFolder();
 
-		StructuredContentFolder randomStructuredContentFolder =
+		StructuredContentFolder randomStructuredContentFolder1 =
 			_randomStructuredContentFolder();
 
-		randomStructuredContentFolder.setExternalReferenceCode("");
+		randomStructuredContentFolder1.setExternalReferenceCode("");
 
-		StructuredContentFolder postStructuredContentFolder =
+		StructuredContentFolder postStructuredContentFolder1 =
 			testPostAssetLibraryStructuredContentFolder_addStructuredContentFolder(
-				randomStructuredContentFolder);
+				randomStructuredContentFolder1);
 
 		JournalFolder journalFolder = JournalFolderLocalServiceUtil.getFolder(
-			postStructuredContentFolder.getId());
+			postStructuredContentFolder1.getId());
 
 		Assert.assertEquals(
-			postStructuredContentFolder.getExternalReferenceCode(),
+			postStructuredContentFolder1.getExternalReferenceCode(),
 			journalFolder.getUuid());
 
-		assertValid(postStructuredContentFolder);
+		assertValid(postStructuredContentFolder1);
+
+		StructuredContentFolder postStructuredContentFolder2 =
+			testPostAssetLibraryStructuredContentFolder_addStructuredContentFolder(
+				_randomStructuredContentFolder());
+
+		StructuredContentFolder randomStructuredContentFolder2 =
+			_randomStructuredContentFolder();
+
+		randomStructuredContentFolder2.setExternalReferenceCode(
+			postStructuredContentFolder2.getExternalReferenceCode());
+
+		HttpInvoker.HttpResponse httpResponse =
+			structuredContentFolderResource.
+				postAssetLibraryStructuredContentFolderHttpResponse(
+					testDepotEntry.getDepotEntryId(),
+					randomStructuredContentFolder2);
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				"Duplicate journal folder external reference code ",
+				postStructuredContentFolder2.getExternalReferenceCode(),
+				" in group ", testDepotEntry.getGroupId()),
+			httpResponse.getContent());
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-179425
https://liferay.atlassian.net/browse/LPS-179427
https://liferay.atlassian.net/browse/LPS-179428
https://liferay.atlassian.net/browse/LPS-179430
https://liferay.atlassian.net/browse/LPS-179431
https://liferay.atlassian.net/browse/LPS-179432
https://liferay.atlassian.net/browse/LPS-180033