### PR TITLE
LPS-188078 Handle the possibility of the comment user being null (i.e. they were deleted at some point after they made the comment)

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/comment/CommentUtil.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/comment/CommentUtil.java
@@ -48,18 +48,6 @@ public class CommentUtil {
 			Comment comment, HttpServletRequest httpServletRequest)
 		throws PortalException {
 
-		User commentUser = comment.getUser();
-
-		String portraitURL = StringPool.BLANK;
-
-		if (commentUser.getPortraitId() > 0) {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)httpServletRequest.getAttribute(
-					WebKeys.THEME_DISPLAY);
-
-			portraitURL = commentUser.getPortraitURL(themeDisplay);
-		}
-
 		Date createDate = comment.getCreateDate();
 
 		String dateDescription = LanguageUtil.format(
@@ -77,14 +65,7 @@ public class CommentUtil {
 				System.currentTimeMillis() - modifiedDate.getTime(), true));
 
 		return JSONUtil.put(
-			"author",
-			JSONUtil.put(
-				"fullName", commentUser.getFullName()
-			).put(
-				"portraitURL", portraitURL
-			).put(
-				"userId", commentUser.getUserId()
-			)
+			"author", _getAuthorJSONObject(comment, httpServletRequest)
 		).put(
 			"body", comment.getBody()
 		).put(
@@ -119,6 +100,41 @@ public class CommentUtil {
 
 				return serviceContext;
 			});
+	}
+
+	private static JSONObject _getAuthorJSONObject(
+			Comment comment, HttpServletRequest httpServletRequest)
+		throws PortalException {
+
+		User commentUser = comment.getUser();
+
+		if (commentUser == null) {
+			return JSONUtil.put(
+				"fullName", LanguageUtil.get(httpServletRequest, "deleted-user")
+			).put(
+				"portraitURL", StringPool.BLANK
+			).put(
+				"userId", 0L
+			);
+		}
+
+		String portraitURL = StringPool.BLANK;
+
+		if (commentUser.getPortraitId() > 0) {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			portraitURL = commentUser.getPortraitURL(themeDisplay);
+		}
+
+		return JSONUtil.put(
+			"fullName", commentUser.getFullName()
+		).put(
+			"portraitURL", portraitURL
+		).put(
+			"userId", commentUser.getUserId()
+		);
 	}
 
 	private static int _getWorkflowAction(ActionRequest actionRequest) {


### PR DESCRIPTION
Motivation
=======
If a comment was made on a fragment by a user who has since been deleted, then the entire page editor fails to load. This is a very poor user experience, as it is a scenario that is fairly likely to occur and it prevents the user from being able to edit the page at all if it happens.

Proposed Solution
========
Handle the possibility of the comment user being null in the CommentUtil#getCommentJSONObject class.

Steps to Verify
========
1. Start up Liferay and log in as the admin user.
2. Create a user and assign it the Site Administrator role for the default Liferay DXP Site.
3. Log in with the new user and edit the Home Page.
4. Add an HTML fragment onto the Home Page.
5. Leave a comment on the HTML fragment.
6. Log out and then log back in with the Admin user.
7. Deactivate and then delete the new user.
8. Go back to the Home page as the Admin user and edit it.

References to existing code (if applies)
========
Here is a place where a similar solution is applied: https://github.com/liferay/liferay-portal/blob/f6d10ea9c662b8d5408636c2805681d249dd0a1a/modules/apps/sharing/sharing-taglib/src/main/java/com/liferay/sharing/taglib/internal/util/CollaboratorsUtil.java#L127-L134

cc:// @mbowerman