### PR TITLE
LPS-188388 Avoid accessing editable values on Fragments if empty

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_content/FragmentContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_content/FragmentContent.js
@@ -165,40 +165,44 @@ const FragmentContent = ({
 
 			Promise.all(
 				getAllEditables(fragmentElement).map((editable) => {
-					const editableValue =
-						editableValues[editable.editableValueNamespace][
-							editable.editableId
-						];
+					if (Object.keys(editableValues).length) {
+						const editableValue =
+							editableValues[editable.editableValueNamespace][
+								editable.editableId
+							];
 
-					return Promise.all([
-						resolveEditableValue(
-							editableValue,
-							languageId,
-							getFieldValue
-						),
-						resolveEditableConfig(
-							editableValue?.config || {},
-							languageId,
-							getFieldValue
-						),
-					]).then(([value, editableConfig]) => {
-						editable.processor.render(
-							editable.element,
-							value,
-							editableConfig,
-							languageId,
-							withinCollection
-						);
-
-						editable.element.classList.add('page-editor__editable');
-
-						if (TEXT_EDITABLE_TYPES.has(editable.type)) {
-							editable.element.setAttribute(
-								'data-tooltip-floating',
-								true
+						return Promise.all([
+							resolveEditableValue(
+								editableValue,
+								languageId,
+								getFieldValue
+							),
+							resolveEditableConfig(
+								editableValue?.config || {},
+								languageId,
+								getFieldValue
+							),
+						]).then(([value, editableConfig]) => {
+							editable.processor.render(
+								editable.element,
+								value,
+								editableConfig,
+								languageId,
+								withinCollection
 							);
-						}
-					});
+
+							editable.element.classList.add(
+								'page-editor__editable'
+							);
+
+							if (TEXT_EDITABLE_TYPES.has(editable.type)) {
+								editable.element.setAttribute(
+									'data-tooltip-floating',
+									true
+								);
+							}
+						});
+					}
 				})
 			).then(() => {
 				if (isMounted() && fragmentElement) {


### PR DESCRIPTION
**Motivation**
The customer opened a ticker reporting an issue related to editing an existing fragment, after setting the environment and testing different scenarios, I managed to identify that a specific value in the Fragment Content file related to the title of a editable field thad contained a unexpected value when the existing fragment was updated with a lfr-editable  property.

**Proposed Solution**
After debugging I could notice that the object editableValues had no value, so I introduced a condition to avoid checking an empty object and, consequently, stop generating an error.

**Steps to Verify**

Described also on [LPS-188388](https://liferay.atlassian.net/browse/LPS-188388)

Start your liferay-portal 

Access Control Panel > System Settings > Page Fragments > Enable Propagate Fragment Changes Automatically.

Navigate to the Global site and export the [collections-20230615170457241.zip](https://github.com/liferay-echo/liferay-portal/files/11827352/collections-20230615170457241.zip) fragment collection. (Also tested after creating manually with different contents)

Go to the Home page and add the fragments "Accordion" and "Item de Accordion" to the page > Publish the page.

Return to the Global site and modify the fragment "Accordion" with the following change:
`<h2 class="neo-accordion-title" data-lfr-editable-id="title" data-lfr-editable-type="text">Título do accordion</h2>
`

Open the Home Page and try to edit it.


Expected Behaviour:
The fragment changes propagate successfully, with no error on the page. Including when editing the Page Content.

Actual Behaviour:
An error message appears: "Error An unexpected error occured while rendering this item" is showed when editing the page. (Screenshot attached)

What to do next

**Suggestions for testing**
Please feel free to test without downloading the attached document.

**Screenshots** 
![Screenshot from 2023-06-21 19-25-25](https://github.com/liferay-echo/liferay-portal/assets/41641596/b6ba998d-bb1a-4e1e-9e6f-4049f1aad960)
Current result
