### PR TITLE
LPS-188391 - Discard changes to a content does not revert all changes properly if there is a failure during the discard

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DiscardDraftLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/DiscardDraftLayoutMVCActionCommand.java
@@ -20,7 +20,7 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.util.LayoutCopyHelper;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseTransactionalMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalService;
@@ -49,10 +49,11 @@ import org.osgi.service.component.annotations.Reference;
 	},
 	service = MVCActionCommand.class
 )
-public class DiscardDraftLayoutMVCActionCommand extends BaseMVCActionCommand {
+public class DiscardDraftLayoutMVCActionCommand
+	extends BaseTransactionalMVCActionCommand {
 
 	@Override
-	protected void doProcessAction(
+	protected void doTransactionalCommand(
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java
@@ -171,6 +171,8 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 				if (_log.isWarnEnabled()) {
 					_log.warn(exception);
 				}
+
+				throw new RuntimeException(exception);
 			}
 		};
 


### PR DESCRIPTION
**Motivation**
Trying to solve an issue with a customer.  The customer is having an issue where they make a change to a page, discard the change and the changes are not discarded.

**Proposed Solution**
Attempting to modify the methods to become transactional.

**Steps to Verify**
Unfortunately we have not been able to replicate the issue except on the customer environment.  But these are the steps

- Add 2 web content articles (WC1, WC2)
- Add Web Content Display to Homepage to and configure to WC1
- Publish page
- Edit Home Page again and change to WC2.  
- Add Breakpoint to LayoutCopyHelperImpl
-  Discard the change
- At the breakpoint change the value to cause a failure.
