### PR TITLE
[TS] LPS-188772 check value of max in case is less than 0 is not filtering the sites

### DIFF
--- a/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/portlet/action/ApplicationsMenuPanelAppsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-applications-menu-web/src/main/java/com/liferay/product/navigation/applications/menu/web/internal/portlet/action/ApplicationsMenuPanelAppsMVCResourceCommand.java
@@ -309,7 +309,7 @@ public class ApplicationsMenuPanelAppsMVCResourceCommand
 				sitesJSONObject.put(
 					"mySites",
 					_getSitesJSONArray(
-						ListUtil.subList(filteredGroups, 0, max),
+						ListUtil.subList(filteredGroups, 0, Math.max(0, max)),
 						resourceRequest, themeDisplay));
 
 				max -= filteredGroups.size();


### PR DESCRIPTION
Motivation
=======
When having more than 10 sites and navigating through them, all sites are listed in the application menu

Proposed Solution
========
Checking the value of max variable, that's used to filter the "my sites" section and avoid it to being less than zero.

Steps to Verify
========

1. Create 11 sites with a page
2. Navigate through them (most than 8)
3. Open the dockbar to list the sites

Expected result:
8 sites are listed + view all link.

Current result:
All sites are listed

Checklist (optional)
========

CODE:
- [X] I have considered breaking this PR into smaller PRs if the amount of changed code is too large
- [X] I have performed a self-review of my own code following Liferay's code conventions
- [X] I have checked other areas of the product for solutions to similar problems
- [ ] I have added tests that prove my fix is effective or that my feature works

COMMITS:
- [X] My commits organize changes in coherent units
- [X] There are no commits which should be combined into others
- [X] My commits are ordered in a way that ease understanding
- [X] My commit messages are well formatted and concisely describe what was changed and why it was changed

PR TITLE & DESCRIPTION:
- [X] My PR title includes an issue number and a descriptive title
- [X] My PR description explains the motivation for this change
- [X] My PR description explains the proposed solution
- [X] My PR description includes the steps to verify the change