### PR TITLE
LPS-176666 Replace alert divs with clay:alert taglib in asset-taglib

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/init.jsp
@@ -18,9 +18,9 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.asset.taglib.internal.display.context.AssetCategoriesNavigationDisplayContext" %><%@
 page import="com.liferay.asset.taglib.internal.util.AssetCategoryUtil" %><%@

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/page.jsp
@@ -30,9 +30,10 @@ AssetCategoriesNavigationDisplayContext assetCategoriesNavigationDisplayContext 
 
 		</c:if>
 
-		<div class="alert alert-info">
-			<liferay-ui:message key="there-are-no-categories" />
-		</div>
+		<clay:alert
+			displayType="info"
+			message="there-are-no-categories"
+		/>
 	</c:when>
 	<c:otherwise>
 		<div class="categories-tree container-fluid container-fluid-max-xl" id="<%= assetCategoriesNavigationDisplayContext.getNamespace() %>categoriesContainer">

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_navigation/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_navigation/init.jsp
@@ -18,7 +18,8 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_navigation/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_tags_navigation/page.jsp
@@ -47,9 +47,10 @@ String tagsNavigation = _buildTagsNavigation(scopeGroupId, tag, classNameId, dis
 		}
 		%>
 
-		<div class="alert alert-info">
-			<liferay-ui:message key="there-are-no-tags" />
-		</div>
+		<clay:alert
+			displayType="info"
+			message="there-are-no-tags"
+		/>
 	</c:otherwise>
 </c:choose>
 


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-176666)

## Test Scenario

* Navigate to Site Builder > Pages
* Create a new Widget Page.
* Add one category filter and one tag filter.

<img width="1303" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/abfa8377-f025-4005-ae93-5007e75c690a">
