### PR TITLE
LPS-176670 Replace alert divs with clay:alert taglib in journal-web

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMTemplateDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditDDMTemplateDisplayContext.java
@@ -133,7 +133,8 @@ public class JournalEditDDMTemplateDisplayContext {
 		return _ddmTemplate;
 	}
 
-	public HashMap<String, Object> getDDMTemplateEditorContext()
+	public HashMap<String, Object> getDDMTemplateEditorContext(
+			long scopeGroupId)
 		throws Exception {
 
 		return HashMapBuilder.<String, Object>put(
@@ -166,6 +167,9 @@ public class JournalEditDDMTemplateDisplayContext {
 
 				return false;
 			}
+		).put(
+			"showTemplateWarning",
+			(_ddmTemplate != null) && (getGroupId() != scopeGroupId)
 		).put(
 			"templateVariableGroups", getTemplateVariableGroupJSONArray()
 		).build();

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/asset_display_page.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/asset_display_page.jsp
@@ -41,9 +41,10 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 <p class="text-secondary"><liferay-ui:message key="changing-the-display-page-template-will-affect-all-web-content-article-versions-even-when-saving-it-as-a-draft" /></p>
 
 <c:if test="<%= Validator.isNotNull(layoutUuid) && (articleLayout == null) %>">
-	<div class="alert alert-warning">
-		<liferay-ui:message arguments="<%= layoutUuid %>" key="this-article-is-configured-to-use-a-display-page-that-does-not-exist-on-the-current-site" />
-	</div>
+	<clay:alert
+		displayType="warning"
+		message='<%= LanguageUtil.format(request, "this-article-is-configured-to-use-a-display-page-that-does-not-exist-on-the-current-site", layoutUuid) %>'
+	/>
 </c:if>
 
 <div>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp
@@ -89,21 +89,24 @@ editDDMStructureURL.setParameter("structureKey", String.valueOf(ddmStructureKey)
 				<liferay-ui:error exception="<%= DDMStructureValidationModelListenerException.class %>" message="the-structure-key-cannot-be-modified" />
 
 				<c:if test="<%= (ddmStructure != null) && (DDMStorageLinkLocalServiceUtil.getStructureStorageLinksCount(journalEditDDMStructuresDisplayContext.getDDMStructureId()) > 0) %>">
-					<div class="alert alert-warning">
-						<liferay-ui:message key="there-are-content-references-to-this-structure.-you-may-lose-data-if-a-field-name-is-renamed-or-removed" />
-					</div>
+					<clay:alert
+						displayType="warning"
+						message="there-are-content-references-to-this-structure.-you-may-lose-data-if-a-field-name-is-renamed-or-removed"
+					/>
 				</c:if>
 
 				<c:if test="<%= (journalEditDDMStructuresDisplayContext.getDDMStructureId() > 0) && (DDMTemplateLocalServiceUtil.getTemplatesCount(null, PortalUtil.getClassNameId(DDMStructure.class), journalEditDDMStructuresDisplayContext.getDDMStructureId()) > 0) %>">
-					<div class="alert alert-info">
-						<liferay-ui:message key="there-are-template-references-to-this-structure.-please-update-them-if-a-field-name-is-renamed-or-removed" />
-					</div>
+					<clay:alert
+						displayType="info"
+						message="there-are-template-references-to-this-structure.-please-update-them-if-a-field-name-is-renamed-or-removed"
+					/>
 				</c:if>
 
 				<c:if test="<%= (ddmStructure != null) && (groupId != scopeGroupId) %>">
-					<div class="alert alert-warning">
-						<liferay-ui:message key="this-structure-does-not-belong-to-this-site.-you-may-affect-other-sites-if-you-edit-this-structure" />
-					</div>
+					<clay:alert
+						displayType="warning"
+						message="this-structure-does-not-belong-to-this-site.-you-may-affect-other-sites-if-you-edit-this-structure"
+					/>
 				</c:if>
 
 				<div class="contextual-sidebar-mr-n">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
@@ -67,12 +67,6 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 		</clay:container-fluid>
 	</nav>
 
-	<c:if test="<%= (ddmTemplate != null) && (journalEditDDMTemplateDisplayContext.getGroupId() != scopeGroupId) %>">
-		<div class="alert alert-warning">
-			<liferay-ui:message key="this-template-does-not-belong-to-this-site.-you-may-affect-other-sites-if-you-edit-this-template" />
-		</div>
-	</c:if>
-
 	<div>
 		<div id="<portlet:namespace />ddmTemplateEditor">
 			<div class="inline-item my-5 p-5 w-100">
@@ -82,7 +76,7 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 			<react:component
 				componentId="ddmTemplateEditor"
 				module="ddm_template_editor/components/TemplateEditor"
-				props="<%= journalEditDDMTemplateDisplayContext.getDDMTemplateEditorContext() %>"
+				props="<%= journalEditDDMTemplateDisplayContext.getDDMTemplateEditorContext(scopeGroupId) %>"
 			/>
 		</div>
 	</div>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/abstract.jsp
@@ -23,9 +23,10 @@ AssetRenderer<?> assetRenderer = (AssetRenderer)request.getAttribute(WebKeys.ASS
 
 <c:choose>
 	<c:when test="<%= (article != null) && article.isExpired() %>">
-		<div class="alert alert-warning">
-			<liferay-ui:message arguments="<%= HtmlUtil.escape(article.getTitle(locale)) %>" key="x-is-expired" />
-		</div>
+		<clay:alert
+			displayType="warning"
+			message='<%= LanguageUtil.format(request, "x-is-expired", HtmlUtil.escape(article.getTitle(locale))) %>'
+		/>
 	</c:when>
 	<c:otherwise>
 		<div class="asset-summary">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/init.jsp
@@ -18,12 +18,13 @@
 
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
-<%@ taglib uri="http://liferay.com/tld/journal" prefix="liferay-journal" %><%@
-taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
-taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
+<%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
+taglib uri="http://liferay.com/tld/journal" prefix="liferay-journal" %><%@
+taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %>
 
 <%@ page import="com.liferay.asset.kernel.model.AssetRenderer" %><%@
 page import="com.liferay.journal.model.JournalArticle" %><%@
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/title.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info/item/renderer/title.jsp
@@ -22,9 +22,10 @@ JournalArticle article = (JournalArticle)request.getAttribute(WebKeys.JOURNAL_AR
 
 <c:choose>
 	<c:when test="<%= (article != null) && article.isExpired() %>">
-		<div class="alert alert-warning">
-			<liferay-ui:message arguments="<%= HtmlUtil.escape(article.getTitle(locale)) %>" key="x-is-expired" />
-		</div>
+		<clay:alert
+			displayType="warning"
+			message='<%= LanguageUtil.format(request, "x-is-expired", HtmlUtil.escape(article.getTitle(locale))) %>'
+		/>
 	</c:when>
 	<c:otherwise>
 		<div class="asset-summary">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_article_history.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_article_history.jsp
@@ -20,179 +20,167 @@
 JournalArticle article = journalDisplayContext.getArticle();
 
 Map<String, Object> componentContext = journalDisplayContext.getComponentContext();
+
+JournalHistoryDisplayContext journalHistoryDisplayContext = new JournalHistoryDisplayContext(renderRequest, renderResponse, journalDisplayContext.getArticle());
+
+JournalHistoryManagementToolbarDisplayContext journalHistoryManagementToolbarDisplayContext = new JournalHistoryManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, article, journalHistoryDisplayContext);
+
+portletDisplay.setShowBackIcon(true);
+portletDisplay.setURLBack(journalHistoryDisplayContext.getBackURL());
+
+renderResponse.setTitle(article.getTitle(locale));
 %>
 
-<c:choose>
-	<c:when test="<%= article == null %>">
-		<div class="alert alert-danger">
-			<liferay-ui:message key="the-selected-web-content-no-longer-exists" />
-		</div>
-	</c:when>
-	<c:otherwise>
+<clay:navigation-bar
+	inverted="<%= true %>"
+	navigationItems="<%= journalHistoryDisplayContext.getNavigationItems() %>"
+/>
 
-		<%
-		JournalHistoryDisplayContext journalHistoryDisplayContext = new JournalHistoryDisplayContext(renderRequest, renderResponse, journalDisplayContext.getArticle());
+<clay:management-toolbar
+	managementToolbarDisplayContext="<%= journalHistoryManagementToolbarDisplayContext %>"
+	propsTransformer="js/ArticleHistoryManagementToolbarPropsTransformer"
+/>
 
-		JournalHistoryManagementToolbarDisplayContext journalHistoryManagementToolbarDisplayContext = new JournalHistoryManagementToolbarDisplayContext(request, liferayPortletRequest, liferayPortletResponse, article, journalHistoryDisplayContext);
+<aui:form action="<%= journalHistoryDisplayContext.getPortletURL() %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="fm">
+	<aui:input name="referringPortletResource" type="hidden" value="<%= journalHistoryDisplayContext.getReferringPortletResource() %>" />
+	<aui:input name="groupId" type="hidden" value="<%= String.valueOf(article.getGroupId()) %>" />
 
-		portletDisplay.setShowBackIcon(true);
-		portletDisplay.setURLBack(journalHistoryDisplayContext.getBackURL());
+	<liferay-ui:search-container
+		id="articleVersions"
+		searchContainer="<%= journalHistoryDisplayContext.getArticleSearchContainer() %>"
+	>
+		<liferay-ui:search-container-row
+			className="com.liferay.journal.model.JournalArticle"
+			modelVar="articleVersion"
+		>
 
-		renderResponse.setTitle(article.getTitle(locale));
-		%>
+			<%
+			row.setData(
+				HashMapBuilder.<String, Object>put(
+					"actions", journalHistoryManagementToolbarDisplayContext.getAvailableActions(articleVersion)
+				).build());
 
-		<clay:navigation-bar
-			inverted="<%= true %>"
-			navigationItems="<%= journalHistoryDisplayContext.getNavigationItems() %>"
+			row.setPrimaryKey(articleVersion.getArticleId() + JournalPortlet.VERSION_SEPARATOR + articleVersion.getVersion());
+			%>
+
+			<c:choose>
+				<c:when test='<%= Objects.equals(journalHistoryDisplayContext.getDisplayStyle(), "descriptive") %>'>
+					<liferay-ui:search-container-column-text>
+						<liferay-ui:user-portrait
+							userId="<%= articleVersion.getStatusByUserId() %>"
+						/>
+					</liferay-ui:search-container-column-text>
+
+					<liferay-ui:search-container-column-text
+						colspan="<%= 2 %>"
+					>
+
+						<%
+						Date createDate = articleVersion.getModifiedDate();
+
+						String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - createDate.getTime(), true);
+						%>
+
+						<h6 class="text-default">
+							<liferay-ui:message arguments="<%= new String[] {HtmlUtil.escape(articleVersion.getStatusByUserName()), modifiedDateDescription} %>" key="x-modified-x-ago" />
+						</h6>
+
+						<h5>
+							<%= HtmlUtil.escape(articleVersion.getTitle(locale)) %>
+						</h5>
+
+						<h6 class="text-default">
+							<liferay-portal-workflow:status
+								showStatusLabel="<%= false %>"
+								status="<%= articleVersion.getStatus() %>"
+								version="<%= String.valueOf(articleVersion.getVersion()) %>"
+							/>
+						</h6>
+					</liferay-ui:search-container-column-text>
+
+					<liferay-ui:search-container-column-text>
+						<clay:dropdown-actions
+							additionalProps='<%=
+								HashMapBuilder.<String, Object>put(
+									"trashEnabled", componentContext.get("trashEnabled")
+								).build()
+							%>'
+							aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
+							dropdownItems="<%= journalDisplayContext.getArticleHistoryActionDropdownItems(articleVersion) %>"
+							propsTransformer="js/ElementsDefaultPropsTransformer"
+						/>
+					</liferay-ui:search-container-column-text>
+				</c:when>
+				<c:when test='<%= Objects.equals(journalHistoryDisplayContext.getDisplayStyle(), "icon") %>'>
+					<liferay-ui:search-container-column-text>
+						<clay:vertical-card
+							verticalCard="<%= new JournalArticleHistoryVerticalCard(articleVersion, renderRequest, renderResponse, searchContainer.getRowChecker(), assetDisplayPageFriendlyURLProvider, trashHelper) %>"
+						/>
+					</liferay-ui:search-container-column-text>
+				</c:when>
+				<c:when test='<%= Objects.equals(journalHistoryDisplayContext.getDisplayStyle(), "list") %>'>
+					<liferay-ui:search-container-column-text
+						name="id"
+						value="<%= HtmlUtil.escape(articleVersion.getArticleId()) %>"
+					/>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand table-cell-minw-200 table-title"
+						name="title"
+						value="<%= HtmlUtil.escape(articleVersion.getTitle(locale)) %>"
+					/>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand-smallest table-cell-minw-100"
+						name="version"
+						orderable="<%= true %>"
+					/>
+
+					<liferay-ui:search-container-column-status
+						name="status"
+					/>
+
+					<liferay-ui:search-container-column-date
+						cssClass="table-cell-expand-smallest table-cell-ws-nowrap"
+						name="modified-date"
+						orderable="<%= true %>"
+						property="modifiedDate"
+					/>
+
+					<c:if test="<%= article.getDisplayDate() != null %>">
+						<liferay-ui:search-container-column-date
+							cssClass="table-cell-expand-smallest table-cell-ws-nowrap"
+							name="display-date"
+							orderable="<%= true %>"
+							property="displayDate"
+						/>
+					</c:if>
+
+					<liferay-ui:search-container-column-text
+						cssClass="table-cell-expand-smallest table-cell-minw-100"
+						name="author"
+						value="<%= HtmlUtil.escape(articleVersion.getStatusByUserName()) %>"
+					/>
+
+					<liferay-ui:search-container-column-text>
+						<clay:dropdown-actions
+							additionalProps='<%=
+								HashMapBuilder.<String, Object>put(
+									"trashEnabled", componentContext.get("trashEnabled")
+								).build()
+							%>'
+							aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
+							dropdownItems="<%= journalDisplayContext.getArticleHistoryActionDropdownItems(articleVersion) %>"
+							propsTransformer="js/ElementsDefaultPropsTransformer"
+						/>
+					</liferay-ui:search-container-column-text>
+				</c:when>
+			</c:choose>
+		</liferay-ui:search-container-row>
+
+		<liferay-ui:search-iterator
+			displayStyle="<%= journalHistoryDisplayContext.getDisplayStyle() %>"
+			markupView="lexicon"
 		/>
-
-		<clay:management-toolbar
-			managementToolbarDisplayContext="<%= journalHistoryManagementToolbarDisplayContext %>"
-			propsTransformer="js/ArticleHistoryManagementToolbarPropsTransformer"
-		/>
-
-		<aui:form action="<%= journalHistoryDisplayContext.getPortletURL() %>" cssClass="container-fluid container-fluid-max-xl" method="post" name="fm">
-			<aui:input name="referringPortletResource" type="hidden" value="<%= journalHistoryDisplayContext.getReferringPortletResource() %>" />
-			<aui:input name="groupId" type="hidden" value="<%= String.valueOf(article.getGroupId()) %>" />
-
-			<liferay-ui:search-container
-				id="articleVersions"
-				searchContainer="<%= journalHistoryDisplayContext.getArticleSearchContainer() %>"
-			>
-				<liferay-ui:search-container-row
-					className="com.liferay.journal.model.JournalArticle"
-					modelVar="articleVersion"
-				>
-
-					<%
-					row.setData(
-						HashMapBuilder.<String, Object>put(
-							"actions", journalHistoryManagementToolbarDisplayContext.getAvailableActions(articleVersion)
-						).build());
-
-					row.setPrimaryKey(articleVersion.getArticleId() + JournalPortlet.VERSION_SEPARATOR + articleVersion.getVersion());
-					%>
-
-					<c:choose>
-						<c:when test='<%= Objects.equals(journalHistoryDisplayContext.getDisplayStyle(), "descriptive") %>'>
-							<liferay-ui:search-container-column-text>
-								<liferay-ui:user-portrait
-									userId="<%= articleVersion.getStatusByUserId() %>"
-								/>
-							</liferay-ui:search-container-column-text>
-
-							<liferay-ui:search-container-column-text
-								colspan="<%= 2 %>"
-							>
-
-								<%
-								Date createDate = articleVersion.getModifiedDate();
-
-								String modifiedDateDescription = LanguageUtil.getTimeDescription(request, System.currentTimeMillis() - createDate.getTime(), true);
-								%>
-
-								<h6 class="text-default">
-									<liferay-ui:message arguments="<%= new String[] {HtmlUtil.escape(articleVersion.getStatusByUserName()), modifiedDateDescription} %>" key="x-modified-x-ago" />
-								</h6>
-
-								<h5>
-									<%= HtmlUtil.escape(articleVersion.getTitle(locale)) %>
-								</h5>
-
-								<h6 class="text-default">
-									<liferay-portal-workflow:status
-										showStatusLabel="<%= false %>"
-										status="<%= articleVersion.getStatus() %>"
-										version="<%= String.valueOf(articleVersion.getVersion()) %>"
-									/>
-								</h6>
-							</liferay-ui:search-container-column-text>
-
-							<liferay-ui:search-container-column-text>
-								<clay:dropdown-actions
-									additionalProps='<%=
-										HashMapBuilder.<String, Object>put(
-											"trashEnabled", componentContext.get("trashEnabled")
-										).build()
-									%>'
-									aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
-									dropdownItems="<%= journalDisplayContext.getArticleHistoryActionDropdownItems(articleVersion) %>"
-									propsTransformer="js/ElementsDefaultPropsTransformer"
-								/>
-							</liferay-ui:search-container-column-text>
-						</c:when>
-						<c:when test='<%= Objects.equals(journalHistoryDisplayContext.getDisplayStyle(), "icon") %>'>
-							<liferay-ui:search-container-column-text>
-								<clay:vertical-card
-									verticalCard="<%= new JournalArticleHistoryVerticalCard(articleVersion, renderRequest, renderResponse, searchContainer.getRowChecker(), assetDisplayPageFriendlyURLProvider, trashHelper) %>"
-								/>
-							</liferay-ui:search-container-column-text>
-						</c:when>
-						<c:when test='<%= Objects.equals(journalHistoryDisplayContext.getDisplayStyle(), "list") %>'>
-							<liferay-ui:search-container-column-text
-								name="id"
-								value="<%= HtmlUtil.escape(articleVersion.getArticleId()) %>"
-							/>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand table-cell-minw-200 table-title"
-								name="title"
-								value="<%= HtmlUtil.escape(articleVersion.getTitle(locale)) %>"
-							/>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand-smallest table-cell-minw-100"
-								name="version"
-								orderable="<%= true %>"
-							/>
-
-							<liferay-ui:search-container-column-status
-								name="status"
-							/>
-
-							<liferay-ui:search-container-column-date
-								cssClass="table-cell-expand-smallest table-cell-ws-nowrap"
-								name="modified-date"
-								orderable="<%= true %>"
-								property="modifiedDate"
-							/>
-
-							<c:if test="<%= article.getDisplayDate() != null %>">
-								<liferay-ui:search-container-column-date
-									cssClass="table-cell-expand-smallest table-cell-ws-nowrap"
-									name="display-date"
-									orderable="<%= true %>"
-									property="displayDate"
-								/>
-							</c:if>
-
-							<liferay-ui:search-container-column-text
-								cssClass="table-cell-expand-smallest table-cell-minw-100"
-								name="author"
-								value="<%= HtmlUtil.escape(articleVersion.getStatusByUserName()) %>"
-							/>
-
-							<liferay-ui:search-container-column-text>
-								<clay:dropdown-actions
-									additionalProps='<%=
-										HashMapBuilder.<String, Object>put(
-											"trashEnabled", componentContext.get("trashEnabled")
-										).build()
-									%>'
-									aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
-									dropdownItems="<%= journalDisplayContext.getArticleHistoryActionDropdownItems(articleVersion) %>"
-									propsTransformer="js/ElementsDefaultPropsTransformer"
-								/>
-							</liferay-ui:search-container-column-text>
-						</c:when>
-					</c:choose>
-				</liferay-ui:search-container-row>
-
-				<liferay-ui:search-iterator
-					displayStyle="<%= journalHistoryDisplayContext.getDisplayStyle() %>"
-					markupView="lexicon"
-				/>
-			</liferay-ui:search-container>
-		</aui:form>
-	</c:otherwise>
-</c:choose>
+	</liferay-ui:search-container>
+</aui:form>

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/App.js
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/js/ddm_template_editor/components/App.js
@@ -31,6 +31,7 @@ export default function App({
 	propertiesViewURL,
 	script: initialScript = '',
 	showCacheableWarning = false,
+	showTemplateWarning = false,
 	showPropertiesPanel = false,
 	templateVariableGroups = [],
 }) {
@@ -50,6 +51,13 @@ export default function App({
 						'ddm_template_editor__App-content--sidebar-open': selectedSidebarPanelId,
 					})}
 				>
+					<ClosableAlert
+						message={Liferay.Language.get(
+							'this-template-does-not-belong-to-this-site.-you-may-affect-other-sites-if-you-edit-this-template'
+						)}
+						visible={showTemplateWarning}
+					/>
+
 					<ClosableAlert
 						id={`${portletNamespace}-cacheableWarningMessage`}
 						message={Liferay.Language.get(


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-176670)

## Test Scenario 1

* Create a site, with a public page
* Add an Asset Publisher to the page
* Configure the Asset Publisher
    1. Navigate to Display Settings > Set and Enable
    2. Check "Set as the Default Asset Publisher for This Page"
    3. Save
* Create a new web content article
    1. Fill in a title and content
    2. Under Display Page settings, change "Default Display Page" to "Specific Display Page"
    3. Select the added public page
    4. Publish
* Export Web Content as a LAR (from the Web Content admin portlet; do not include pages)
* Create a new site, and import the Web Content LAR
<img width="290" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/9561039c-a715-40dd-bb8a-6e8deb250ff1">

## Test Scenario 2

* Create a new web content.
    1. Under Default Template click on edit for basic web content.
    2. After fix the behaviour in this pr you can see now the alert.
<img width="1331" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/c60e4f5f-6db4-4f76-bbdb-f98788caa581">

## Test Scenario 3

* Create a new structure.
* Create a new web content based on this structure
* Export Web Content as a LAR 
* Create a new site, and import the Web Content LAR
* Go to Edit the structure
<img width="933" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/ce611bb8-6aad-4df1-bc6c-6b2ff9fc39dd">

## Test Scenario 4
* Create a new web content.
* Create a content Page.
    1. Add a Content display and relate it to the web content
    2. In general change the Template to the Title.
* In other tab, expire the web content.
* Reload the content page in the edit view.
<img width="1408" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/a5420523-4b38-4da9-9e73-bf30ada56b99">


