### PR TITLE
LPS-188909 - Remove the update number, build and date from the Hello world box

### DIFF
--- a/modules/apps/site-initializer/site-initializer-welcome/src/main/resources/site-initializer/layouts/home/page-definition.json
+++ b/modules/apps/site-initializer/site-initializer-welcome/src/main/resources/site-initializer/layouts/home/page-definition.json
@@ -204,7 +204,7 @@
 																},
 																"text": {
 																	"value": {
-																		"title": "[$RELEASE_INFO:RELEASE_INFO$]"
+																		"title": "[$RELEASE_INFO:SERVER_INFO$]<br>([$RELEASE_INFO:CODE_NAME$])"
 																	}
 																}
 															}


### PR DESCRIPTION
Due to security issues update number, build and date should be removed from the Hello Word Box (more info in the [Story](https://liferay.atlassian.net/browse/LPS-188909))