### PR TITLE
[TS] LPS-189437 Fragment with url configuration type doesn't work after imported in a different site or environment

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesURLLayoutMappingExportImportContentProcessor.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesURLLayoutMappingExportImportContentProcessor.java
@@ -1,0 +1,216 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.fragment.internal.exportimport.content.processor;
+
+import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
+import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
+import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.util.configuration.FragmentConfigurationField;
+import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.xml.Element;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Ricardo Couso
+ */
+@Component(
+	property = "content.processor.type=FragmentEntryLinkEditableValues",
+	service = ExportImportContentProcessor.class
+)
+public class EditableValuesURLLayoutMappingExportImportContentProcessor
+	implements ExportImportContentProcessor<JSONObject> {
+
+	@Override
+	public JSONObject replaceExportContentReferences(
+			PortletDataContext portletDataContext, StagedModel stagedModel,
+			JSONObject editableValuesJSONObject,
+			boolean exportReferencedContent, boolean escapeContent)
+		throws Exception {
+
+		List<FragmentConfigurationField> fragmentConfigurationFields =
+			_getFragmentConfigurationFields((FragmentEntryLink)stagedModel);
+
+		if (ListUtil.isEmpty(fragmentConfigurationFields)) {
+			return editableValuesJSONObject;
+		}
+
+		JSONObject editableProcessorJSONObject =
+			editableValuesJSONObject.getJSONObject(
+				FragmentEntryProcessorConstants.
+					KEY_FREEMARKER_FRAGMENT_ENTRY_PROCESSOR);
+
+		if (editableProcessorJSONObject == null) {
+			return editableValuesJSONObject;
+		}
+
+		for (FragmentConfigurationField fragmentConfigurationField :
+				fragmentConfigurationFields) {
+
+			JSONObject configJSONObject =
+				editableProcessorJSONObject.getJSONObject(
+					fragmentConfigurationField.getName());
+
+			if ((configJSONObject != null) && configJSONObject.has("layout")) {
+				_exportLayoutReferences(
+					portletDataContext, stagedModel,
+					configJSONObject.getJSONObject("layout"),
+					exportReferencedContent);
+			}
+		}
+
+		return editableValuesJSONObject;
+	}
+
+	@Override
+	public JSONObject replaceImportContentReferences(
+			PortletDataContext portletDataContext, StagedModel stagedModel,
+			JSONObject editableValuesJSONObject)
+		throws Exception {
+
+		List<FragmentConfigurationField> fragmentConfigurationFields =
+			_getFragmentConfigurationFields((FragmentEntryLink)stagedModel);
+
+		if (ListUtil.isEmpty(fragmentConfigurationFields)) {
+			return editableValuesJSONObject;
+		}
+
+		JSONObject editableProcessorJSONObject =
+			editableValuesJSONObject.getJSONObject(
+				FragmentEntryProcessorConstants.
+					KEY_FREEMARKER_FRAGMENT_ENTRY_PROCESSOR);
+
+		if (editableProcessorJSONObject == null) {
+			return editableValuesJSONObject;
+		}
+
+		for (FragmentConfigurationField fragmentConfigurationField :
+				fragmentConfigurationFields) {
+
+			JSONObject configJSONObject =
+				editableProcessorJSONObject.getJSONObject(
+					fragmentConfigurationField.getName());
+
+			if ((configJSONObject != null) && configJSONObject.has("layout")) {
+				_replaceImportLayoutReferences(
+					configJSONObject.getJSONObject("layout"),
+					portletDataContext);
+			}
+		}
+
+		return editableValuesJSONObject;
+	}
+
+	@Override
+	public void validateContentReferences(long groupId, JSONObject jsonObject) {
+	}
+
+	private void _exportLayoutReferences(
+			PortletDataContext portletDataContext,
+			StagedModel referrerStagedModel, JSONObject layoutJSONObject,
+			boolean exportReferencedContent)
+		throws Exception {
+
+		if (layoutJSONObject.length() == 0) {
+			return;
+		}
+
+		Layout layout = _layoutLocalService.fetchLayout(
+			layoutJSONObject.getLong("groupId"),
+			layoutJSONObject.getBoolean("privateLayout"),
+			layoutJSONObject.getLong("layoutId"));
+
+		if (layout == null) {
+			return;
+		}
+
+		layoutJSONObject.put("plid", layout.getPlid());
+
+		if (exportReferencedContent) {
+			StagedModelDataHandlerUtil.exportReferenceStagedModel(
+				portletDataContext, referrerStagedModel, layout,
+				PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
+		}
+		else {
+			Element entityElement = portletDataContext.getExportDataElement(
+				referrerStagedModel);
+
+			portletDataContext.addReferenceElement(
+				referrerStagedModel, entityElement, layout,
+				PortletDataContext.REFERENCE_TYPE_DEPENDENCY, true);
+		}
+	}
+
+	private List<FragmentConfigurationField> _getFragmentConfigurationFields(
+		FragmentEntryLink fragmentEntryLink) {
+
+		return ListUtil.filter(
+			_fragmentEntryConfigurationParser.getFragmentConfigurationFields(
+				fragmentEntryLink.getConfiguration()),
+			fragmentConfigurationField -> Objects.equals(
+				fragmentConfigurationField.getType(), "url"));
+	}
+
+	private void _replaceImportLayoutReferences(
+		JSONObject layoutJSONObject, PortletDataContext portletDataContext) {
+
+		if (layoutJSONObject.length() == 0) {
+			return;
+		}
+
+		long plid = GetterUtil.getLong(layoutJSONObject.remove("plid"));
+
+		Map<Long, Long> layoutNewPrimaryKeys =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				Layout.class.getName());
+
+		Layout layout = _layoutLocalService.fetchLayout(
+			layoutNewPrimaryKeys.getOrDefault(plid, 0L));
+
+		if (layout == null) {
+			return;
+		}
+
+		layoutJSONObject.put(
+			"groupId", layout.getGroupId()
+		).put(
+			"layoutId", layout.getLayoutId()
+		).put(
+			"layoutUuid", layout.getUuid()
+		).put(
+			"privateLayout", layout.isPrivateLayout()
+		);
+	}
+
+	@Reference
+	private FragmentEntryConfigurationParser _fragmentEntryConfigurationParser;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+}


### PR DESCRIPTION
Motivation
=======
The configuration type "url" for fragments was introduced in [LPS-164081](https://liferay.atlassian.net/browse/LPS-164081) and [LPS-164123](https://liferay.atlassian.net/browse/LPS-164123) (see [documentation](https://learn.liferay.com/w/dxp/site-building/developer-guide/reference/fragments/fragment-configuration-types-reference#url-configuration)).

This configuration allows to map an URL or an existing page to a part of a fragment. 

Unfortunately, exporting/importing a fragment like this is not aware of the corresponding new layout. So the imported fragment will point to the old layout in the source environment.

Proposed Solution
========
The export/import processing could have been automatic if the `editableValues` were defined under `EditableFragmentEntryProcessor` and the `layout` information were placed under `"config"` instead of a custom configuration name (e.g., `"myURL"` in the documentation linked above). 

The actual `editableValues` are defined under `FreeMarkerFragmentEntryProcessor`. 

To fix the problem I created a new `ExportImportContentProcessor` that is similar to :
- `EditableValuesLayoutMappingExportImportContentProcessor`: in that it expects a `"layout"` jsonObject with information to map to/from a layout.
- `BaseEditableValuesConfigurationExportImportContentProcessor`: in that it gets the available configurations from the `fragmentEntryLink` from which to get `fragmentConfigurationField.getName()`. 

Feel free to refactor if you think the code should be organized differently. 

Steps to Verify
========
See detailed steps in [LPS-189437](https://liferay.atlassian.net/browse/LPS-189437).

References to existing code (if applies)
========
- https://github.com/liferay-echo/liferay-portal/blob/master/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/EditableValuesLayoutMappingExportImportContentProcessor.java
- https://github.com/liferay-echo/liferay-portal/blob/master/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/content/processor/BaseEditableValuesConfigurationExportImportContentProcessor.java

Checklist (optional)
========

CODE:
- [x] I have considered breaking this PR into smaller PRs if the amount of changed code is too large
- [x] I have performed a self-review of my own code following Liferay's code conventions
- [x] I have checked other areas of the product for solutions to similar problems
- [ ] I have added tests that prove my fix is effective or that my feature works

COMMITS:
- [x] My commits organize changes in coherent units
- [x] There are no commits which should be combined into others
- [x] My commits are ordered in a way that ease understanding
- [x] My commit messages are well formatted and concisely describe what was changed and why it was changed

PR TITLE & DESCRIPTION:
- [x] My PR title includes an issue number and a descriptive title
- [x] My PR description explains the motivation for this change
- [x] My PR description explains the proposed solution
- [x] My PR description includes the steps to verify the change
- [ ] My PR description includes references to other places where this solution is used (if applies)
- [ ] My PR description includes visual aids to understand what has changed (if applies)
- [ ] My PR description explains alternative approaches considered and why they were discarded (if applies)