### PR TITLE
LPS-176665 Replace alert divs with clay:alert taglib in asset-publisher-web

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_entries.jsp
@@ -92,9 +92,10 @@ List<AssetEntry> assetEntries = assetPublisherHelper.getAssetEntries(renderReque
 </liferay-ui:search-container>
 
 <c:if test='<%= SessionMessages.contains(renderRequest, "deletedMissingAssetEntries") %>'>
-	<div class="alert alert-info">
-		<liferay-ui:message key="the-selected-assets-have-been-removed-from-the-list-because-they-do-not-belong-in-the-scope-of-this-widget" />
-	</div>
+	<clay:alert
+		displayType="info"
+		message="the-selected-assets-have-been-removed-from-the-list-because-they-do-not-belong-in-the-scope-of-this-widget"
+	/>
 </c:if>
 
 <%

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/select_structure_field.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/select_structure_field.jsp
@@ -20,9 +20,12 @@
 SelectStructureFieldDisplayContext selectStructureFieldDisplayContext = new SelectStructureFieldDisplayContext(request, liferayPortletResponse);
 %>
 
-<div class="alert alert-danger hide" id="<portlet:namespace />message">
-	<span class="error-message"><liferay-ui:message key="the-field-value-is-invalid" /></span>
-</div>
+<clay:alert
+	cssClass="hide"
+	displayType="danger"
+	id='<%= liferayPortletResponse.getNamespace() + "message" %>'
+	message="the-field-value-is-invalid"
+/>
 
 <clay:container-fluid
 	id='<%= liferayPortletResponse.getNamespace() + "selectDDMStructureFieldForm" %>'

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
@@ -122,7 +122,10 @@ if (assetPublisherDisplayContext.isEnableTagBasedNavigation() && !assetPublisher
 
 			</c:if>
 
-			<div class="alert alert-info text-center">
+			<clay:alert
+				cssClass="text-center"
+				displayType="info"
+			>
 				<c:choose>
 					<c:when test="<%= assetPublisherDisplayContext.isSelectionStyleAssetList() && (assetPublisherDisplayContext.fetchAssetListEntry() == null) && Validator.isNull(assetPublisherDisplayContext.getInfoListProviderKey()) && !portletName.equals(AssetPublisherPortletKeys.RELATED_ASSETS) %>">
 						<div>
@@ -140,7 +143,7 @@ if (assetPublisherDisplayContext.isEnableTagBasedNavigation() && !assetPublisher
 						<liferay-ui:message key="there-are-no-related-assets" />
 					</c:otherwise>
 				</c:choose>
-			</div>
+			</clay:alert>
 		</liferay-ddm:template-renderer>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
@@ -133,7 +133,13 @@ if (assetPublisherDisplayContext.isEnableTagBasedNavigation() && !assetPublisher
 						</div>
 
 						<div>
-							<aui:a href="javascript:void(0);" onClick="<%= portletDisplay.getURLConfigurationJS() %>"><liferay-ui:message key="select-a-collection-to-make-it-visible" /></aui:a>
+							<clay:button
+								cssClass="p-0"
+								displayType="link"
+								label="select-a-collection-to-make-it-visible"
+								onClick="<%= portletDisplay.getURLConfigurationJS() %>"
+								small="<%= true %>"
+							/>
 						</div>
 					</c:when>
 					<c:when test="<%= !portletName.equals(AssetPublisherPortletKeys.RELATED_ASSETS) %>">


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-176665)

## Test Scenarios

**Case 1**
- Go to Site Builder > Pages > go to a content page 
- Add an Related Assets widget > see the message
- Add an Asset Publisher widget > see the message
- Go to the Asset Publisher widget's configuration > asset selection > select Manual 
- Go back to the widget view > see message 
<img width="748" alt="Screenshot 2023-07-03 at 17 02 10" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/bb5e5436-72a0-4cb2-8c09-b8413d8675d8">
![Screenshot 2023-07-04 at 10 15 55](https://github.com/liferay-echo/liferay-portal/assets/91208451/fc40a6e9-9d58-42c1-be7d-f0af7a062b5f)

**Case 2**
- Go to Content and data > create a Web Content
- Go to Site Builder > Pages > go to a content page 
- Add an Asset Publisher widget 
- Go to the Asset Publisher widget's configuration > asset selection > select Manual 
- Go to asset entries section > select basic web content > save
- Go to Content and data > delete the web content and remove it from the recycle bin
- Go back to Asset Publisher widget's configuration > asset entries > see message 
<img width="813" alt="Screenshot 2023-07-03 at 16 44 34" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/4b2fca27-8cc5-4d7d-bbaa-629db1c23e44">

**Case 3**
**Tested in code, cannot be tested on UI**
<img width="638" alt="Screenshot 2023-07-03 at 17 07 32" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/f8b183ac-eb19-4064-9e3c-658ad75ec4b8">
