### PR TITLE
LPS-176663 Replace alert divs with clay:alert taglib in asset-categories-item-selector-web

### DIFF
--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/select_asset_category_tree_node.jsp
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/select_asset_category_tree_node.jsp
@@ -21,9 +21,10 @@ SelectAssetCategoryTreeNodeDisplayContext selectAssetCategoryTreeNodeDisplayCont
 %>
 
 <div class="container-fluid container-fluid-max-xl p-4" id="<portlet:namespace />assetCategoryTreeNodeSelector">
-	<div class="alert alert-info">
-		<liferay-ui:message key="select-the-vocabulary-or-category-to-be-displayed" />
-	</div>
+	<clay:alert
+		displayType="info"
+		message="select-the-vocabulary-or-category-to-be-displayed"
+	/>
 
 	<div class="align-items-center d-flex justify-content-between">
 		<liferay-site-navigation:breadcrumb

--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/select_asset_vocabulary.jsp
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/select_asset_vocabulary.jsp
@@ -26,9 +26,10 @@ SelectAssetVocabularyDisplayContext selectAssetVocabularyDisplayContext = (Selec
 	</c:when>
 	<c:otherwise>
 		<div class="container-fluid container-fluid-max-xl p-4">
-			<div class="alert alert-info">
-				<liferay-ui:message key="select-the-vocabulary-or-category-to-be-displayed" />
-			</div>
+			<clay:alert
+				displayType="info"
+				message="select-the-vocabulary-or-category-to-be-displayed"
+			/>
 
 			<div class="align-items-center d-flex justify-content-between">
 				<liferay-site-navigation:breadcrumb


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-176663)

## Test Scenarios

- Go to Site Builder > Collections > Create a Manual Collection (any type)
- Go to Site Builder > Pages > Create a Collection Page with the Manual Collection created
- Add a “Collection Filter” fragment
- Click on the fragment to enter Collection Filter options
- In Filter, choose Category 
- Then click in Source 
![Screenshot 2023-07-04 at 10 37 46](https://github.com/liferay-echo/liferay-portal/assets/91208451/19b199d1-6479-475e-8fef-fe1f8406aad9)
