### PR TITLE
LPS-185796 Add span with sr-only so that the screen reader correctly reads the node name

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
@@ -413,6 +413,8 @@ export default function PageStructureSidebar() {
 									hoverItem(item.id);
 								}}
 							>
+								<span className="sr-only">{item.name}</span>
+
 								<StructureTreeNode
 									node={item}
 									setEditingNodeId={setEditingNodeId}
@@ -424,6 +426,10 @@ export default function PageStructureSidebar() {
 									<ClayTreeView.Item
 										actions={<ItemActions item={item} />}
 									>
+										<span className="sr-only">
+											{item.name}
+										</span>
+
 										<StructureTreeNode
 											node={item}
 											setEditingNodeId={setEditingNodeId}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page_structure/components/PageStructureSidebar.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page_structure/components/PageStructureSidebar.test.js
@@ -291,7 +291,9 @@ describe('PageStructureSidebar', () => {
 			activeItemId: '04-fragment',
 		});
 
-		expect(screen.getByText('Fragment 1')).toBeInTheDocument();
+		expect(
+			screen.getByText('Fragment 1', {selector: 'span'})
+		).toBeInTheDocument();
 	});
 
 	it('uses default labels for containers, columns, rows', () => {
@@ -397,7 +399,9 @@ describe('PageStructureSidebar', () => {
 			rootItemChildren: ['04-fragment'],
 		});
 
-		expect(screen.getByText('Text Field 1')).toBeInTheDocument();
+		expect(
+			screen.getByText('Fragment 1', {selector: 'span'})
+		).toBeInTheDocument();
 	});
 
 	it('render custom fragment names as labels', () => {
@@ -406,7 +410,9 @@ describe('PageStructureSidebar', () => {
 			rootItemChildren: ['04-fragment'],
 		});
 
-		expect(screen.getByText('Fragment 1')).toBeInTheDocument();
+		expect(
+			screen.getByText('Fragment 1', {selector: 'span'})
+		).toBeInTheDocument();
 	});
 
 	it('allow changing fragment name', () => {
@@ -443,7 +449,9 @@ describe('PageStructureSidebar', () => {
 				rootItemChildren: ['06-form'],
 			});
 
-			expect(screen.getByText('form-container')).toBeInTheDocument();
+			expect(
+				screen.getByText('form-container', {selector: 'span'})
+			).toBeInTheDocument();
 			expect(
 				screen.queryByText(
 					'this-content-cannot-be-displayed-due-to-permission-restrictions'
@@ -461,7 +469,9 @@ describe('PageStructureSidebar', () => {
 				rootItemChildren: ['06-form'],
 			});
 
-			expect(screen.getByText('form-container')).toBeInTheDocument();
+			expect(
+				screen.getByText('form-container', {selector: 'span'})
+			).toBeInTheDocument();
 
 			expect(
 				screen.getByText(
@@ -481,7 +491,9 @@ describe('PageStructureSidebar', () => {
 				rootItemChildren: ['04-fragment'],
 			});
 
-			expect(screen.getByText('Fragment 1')).toBeInTheDocument();
+			expect(
+				screen.getByText('Fragment 1', {selector: 'span'})
+			).toBeInTheDocument();
 
 			expect(
 				screen.getByText(


### PR DESCRIPTION
This fix has to do with this task: https://liferay.atlassian.net/browse/LPS-185796

Currently when the screen reader reaches the node it reads something like the following:
`Select container move container container hide container options open`

With this change, only the name of the node is read.