### PR TITLE
LPS-189601 Adapt front-end to use ClayPanel and clean css

### DIFF
--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/_criteria_sidebar.scss
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/_criteria_sidebar.scss
@@ -15,7 +15,6 @@
 
 	.sidebar-header,
 	.sidebar-search,
-	.panel-header,
 	.empty-message {
 		padding: 1rem 1.5rem;
 	}
@@ -25,40 +24,6 @@
 		flex-grow: 1;
 		flex-shrink: 1;
 		overflow-x: hidden;
-	}
-
-	.sidebar-collapse-item {
-		cursor: pointer;
-		transition: flex-grow $segmentsTransition;
-		will-change: flex-grow;
-
-		&.active {
-			flex-grow: 1;
-		}
-	}
-
-	.panel-header {
-		color: $dark;
-		font-size: 0.875rem;
-		word-wrap: break-word;
-
-		.lexicon-icon {
-			transition: transform $segmentsTransition;
-			will-change: transform;
-
-			&.expanded {
-				transform: rotate(90deg);
-			}
-		}
-
-		&:after {
-			border-top: 1px solid $secondary-l1;
-			bottom: 0;
-			content: '';
-			left: 1.5rem;
-			position: absolute;
-			right: 1.25rem;
-		}
 	}
 
 	.criteria-sidebar-item-root {

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebar.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebar.js
@@ -44,7 +44,7 @@ export default function CriteriaSidebar({
 				/>
 			</div>
 
-			<div className="overflow-y-auto position-relative sidebar-collapse">
+			<div className="c-p-4 overflow-y-auto position-relative sidebar-collapse">
 				<CriteriaSidebarCollapse
 					onCollapseClick={onTitleClicked}
 					propertyGroups={propertyGroups}

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarCollapse.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarCollapse.js
@@ -110,7 +110,6 @@ const CriteriaSidebarCollapse = ({
 
 									{searchValue && (
 										<ClayBadge
-											className="mr-4 my-0"
 											displayType="secondary"
 											label={filteredProperties.length}
 										/>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarCollapse.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarCollapse.js
@@ -87,7 +87,7 @@ const CriteriaSidebarCollapse = ({
 	const _handleClick = (key, editing) => () => onCollapseClick(key, editing);
 
 	return (
-		<ClayPanel.Group className="c-ml-1 c-mr-1 c-mt-1">
+		<ClayPanel.Group>
 			{propertyGroups.map((propertyGroup) => {
 				const key = propertyGroup.propertyKey;
 
@@ -118,6 +118,7 @@ const CriteriaSidebarCollapse = ({
 								</ClayPanel.Title>
 							</div>
 						}
+						displayType="unstyled"
 						expanded={active}
 						key={key}
 						onExpandedChange={_handleClick(key, active)}

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarItem.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarItem.js
@@ -42,7 +42,7 @@ function CriteriaSidebarItem({
 	return connectDragSource(
 		<li
 			className={classNames(
-				'align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex ',
+				'align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex ',
 				{dragging},
 				className
 			)}

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/ContributorsBuilder.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/ContributorsBuilder.test.js.snap
@@ -60,15 +60,15 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
           </div>
         </div>
         <div
-          class="overflow-y-auto position-relative sidebar-collapse"
+          class="c-p-4 overflow-y-auto position-relative sidebar-collapse"
         >
           <div
             aria-orientation="vertical"
-            class="panel-group c-ml-1 c-mr-1 c-mt-1"
+            class="panel-group"
             role="tablist"
           >
             <div
-              class="panel"
+              class="panel panel-unstyled"
               role="tablist"
             >
               <button
@@ -128,7 +128,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     class="c-pl-0"
                   >
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -163,7 +163,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Ancestor Organization IDs
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -198,7 +198,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Class PK
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -233,7 +233,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Company ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -268,7 +268,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Date Modified
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -303,7 +303,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Email Address
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -338,7 +338,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       First Name
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -373,7 +373,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Group ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -408,7 +408,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Group IDs
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -443,7 +443,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Job Title
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -478,7 +478,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Last Name
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -513,7 +513,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Organization IDs
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -548,7 +548,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Role IDs
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -583,7 +583,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Scope Group ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -618,7 +618,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Screen Name
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -653,7 +653,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Team IDs
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -688,7 +688,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       User Group IDs
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -723,7 +723,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       User ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -762,7 +762,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
               </div>
             </div>
             <div
-              class="panel"
+              class="panel panel-unstyled"
               role="tablist"
             >
               <button
@@ -822,7 +822,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     class="c-pl-0"
                   >
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -857,7 +857,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Class PK
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -892,7 +892,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Company ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -927,7 +927,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Date Modified
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -962,7 +962,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Name
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -997,7 +997,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Name Tree Path
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1032,7 +1032,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Organization ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1067,7 +1067,7 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                       Parent Organization ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1230,15 +1230,15 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
           </div>
         </div>
         <div
-          class="overflow-y-auto position-relative sidebar-collapse"
+          class="c-p-4 overflow-y-auto position-relative sidebar-collapse"
         >
           <div
             aria-orientation="vertical"
-            class="panel-group c-ml-1 c-mr-1 c-mt-1"
+            class="panel-group"
             role="tablist"
           >
             <div
-              class="panel"
+              class="panel panel-unstyled"
               role="tablist"
             >
               <button
@@ -1298,7 +1298,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     class="c-pl-0"
                   >
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1333,7 +1333,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Ancestor Organization IDs
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1368,7 +1368,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Class PK
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1403,7 +1403,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Company ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1438,7 +1438,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Date Modified
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1473,7 +1473,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Email Address
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1508,7 +1508,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       First Name
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1543,7 +1543,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Group ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1578,7 +1578,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Group IDs
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1613,7 +1613,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Job Title
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1648,7 +1648,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Last Name
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1683,7 +1683,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Organization IDs
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1718,7 +1718,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Role IDs
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1753,7 +1753,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Scope Group ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1788,7 +1788,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Screen Name
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1823,7 +1823,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Team IDs
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1858,7 +1858,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       User Group IDs
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1893,7 +1893,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       User ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user"
                       draggable="true"
                       tabindex="0"
                     >
@@ -1932,7 +1932,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
               </div>
             </div>
             <div
-              class="panel"
+              class="panel panel-unstyled"
               role="tablist"
             >
               <button
@@ -1992,7 +1992,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     class="c-pl-0"
                   >
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -2027,7 +2027,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Class PK
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -2062,7 +2062,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Company ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -2097,7 +2097,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Date Modified
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -2132,7 +2132,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Name
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -2167,7 +2167,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Name Tree Path
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -2202,7 +2202,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Organization ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >
@@ -2237,7 +2237,7 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                       Parent Organization ID
                     </li>
                     <li
-                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--user-organization"
+                      class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--user-organization"
                       draggable="true"
                       tabindex="0"
                     >

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebar.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebar.test.js.snap
@@ -54,11 +54,11 @@ exports[`CriteriaSidebar renders 1`] = `
       </div>
     </div>
     <div
-      class="overflow-y-auto position-relative sidebar-collapse"
+      class="c-p-4 overflow-y-auto position-relative sidebar-collapse"
     >
       <div
         aria-orientation="vertical"
-        class="panel-group c-ml-1 c-mr-1 c-mt-1"
+        class="panel-group"
         role="tablist"
       />
     </div>

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebarItem.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebarItem.test.js.snap
@@ -3,7 +3,7 @@
 exports[`CriteriaSidebarItem renders 1`] = `
 <DocumentFragment>
   <li
-    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex "
+    class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex "
     tabindex="0"
   >
     <span

--- a/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.test.js.snap
@@ -481,15 +481,15 @@ exports[`SegmentEdit renders with given values 1`] = `
               </div>
             </div>
             <div
-              class="overflow-y-auto position-relative sidebar-collapse"
+              class="c-p-4 overflow-y-auto position-relative sidebar-collapse"
             >
               <div
                 aria-orientation="vertical"
-                class="panel-group c-ml-1 c-mr-1 c-mt-1"
+                class="panel-group"
                 role="tablist"
               >
                 <div
-                  class="panel"
+                  class="panel panel-unstyled"
                   role="tablist"
                 >
                   <button
@@ -549,7 +549,7 @@ exports[`SegmentEdit renders with given values 1`] = `
                         class="c-pl-0"
                       >
                         <li
-                          class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-0 d-flex  color--first-test-values-group"
+                          class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-3 c-my-1 c-mx-n4 d-flex  color--first-test-values-group"
                           draggable="true"
                           tabindex="0"
                         >


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to clean some css code related to the segments editor since now the ClayPanel component is being used.
https://liferay.atlassian.net/browse/LPS-189601

Proposed Solution
========
The proposed solution consists in removing some of the css code that can be replaced with clay utilities.


