### PR TITLE
LPS-176667 Replace alert divs with clay:alert taglib in iframe-web

### DIFF
--- a/modules/apps/iframe/iframe-web/build.gradle
+++ b/modules/apps/iframe/iframe-web/build.gradle
@@ -9,6 +9,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")
 	compileOnly project(":core:petra:petra-lang")

--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/configuration.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/configuration.jsp
@@ -79,7 +79,10 @@ sb.append("\n");
 			<aui:input inlineLabel="right" label="authenticate" labelCssClass="simple-toggle-switch" name="preferences--auth--" type="toggle-switch" value="<%= iFramePortletInstanceConfiguration.auth() %>" />
 
 			<div id="<portlet:namespace />authenticationOptions">
-				<div class="alert alert-info" id="<portlet:namespace />currentLoginMsg">
+				<clay:alert
+					displayType="info"
+					id='<%= liferayPortletResponse.getNamespace() + "currentLoginMsg" %>'
+				>
 					<c:choose>
 						<c:when test="<%= IFrameUtil.isPasswordTokenEnabled(renderRequest) %>">
 							<liferay-ui:message key="you-may-use-the-tokens-email-address-screen-name-userid-and-password" />
@@ -88,7 +91,7 @@ sb.append("\n");
 							<liferay-ui:message key="you-may-use-the-tokens-email-address-screen-name-userid" />
 						</c:otherwise>
 					</c:choose>
-				</div>
+				</clay:alert>
 
 				<aui:select label="authentication-type" name="preferences--authType--" value="<%= iFrameDisplayContext.getAuthType() %>">
 					<aui:option label="basic" />

--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/init.jsp
@@ -19,6 +19,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/portlet_not_setup.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/portlet_not_setup.jsp
@@ -20,8 +20,14 @@
 renderRequest.setAttribute(WebKeys.PORTLET_CONFIGURATOR_VISIBILITY, Boolean.TRUE);
 %>
 
-<div class="alert alert-info portlet-configuration">
-	<a href="<%= portletDisplay.getURLConfiguration() %>" onClick="<%= portletDisplay.getURLConfigurationJS() %>">
-		<liferay-ui:message key="please-configure-this-portlet-to-make-it-visible-to-all-users" />
-	</a>
-</div>
+<clay:alert
+	cssClass="portlet-configuration"
+	displayType="info"
+>
+	<clay:button
+		displayType="link"
+		label="please-configure-this-portlet-to-make-it-visible-to-all-users"
+		onClick="<%= portletDisplay.getURLConfigurationJS() %>"
+		small="<%= true %>"
+	/>
+</clay:alert>

--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
@@ -18,9 +18,15 @@
 
 <c:choose>
 	<c:when test="<%= iFramePortletInstanceConfiguration.auth() && Validator.isNull(iFrameDisplayContext.getUserName()) && !themeDisplay.isSignedIn() %>">
-		<div class="alert alert-info">
-			<a href="<%= themeDisplay.getURLSignIn() %>" target="_top"><liferay-ui:message key="please-sign-in-to-access-this-application" /></a>
-		</div>
+		<clay:alert
+			displayType="info"
+		>
+			<clay:link
+				href="<%= themeDisplay.getURLSignIn() %>"
+				label="please-sign-in-to-access-this-application"
+				target="_top"
+			/>
+		</clay:alert>
 	</c:when>
 	<c:otherwise>
 		<div class="iframe-container">


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-176667)

## Test Scenarios

**Case 1**
- Go to Site Builder > Pages > Create a Content page 
- Add an “Iframe” widget > see alert 
![Screenshot 2023-07-04 at 13 07 31](https://github.com/liferay-echo/liferay-portal/assets/91208451/df6a7ba5-54f0-40ab-b020-d30f6ea504bc)

**Case 2**
- Go to Site Builder > Pages > Create a Content page 
- Add an “Iframe” widget > click on three dots at the right to enter configuration
- Go to Authenticate > check the option > see alert
![Screenshot 2023-07-04 at 13 07 15](https://github.com/liferay-echo/liferay-portal/assets/91208451/1b231c49-ec30-4b9b-9213-a5e3610131ed)

**Case 3**
- Go to Site Builder > Pages > Create a Content page 
- Add an “Iframe” widget > click on three dots at the right to enter configuration
- Add an URL to URL Source
- Go to Authenticate > check the option 
- Save the configuration
- Publish page
- Sign out the session
- Go to the page created
![Screenshot 2023-07-04 at 12 47 03](https://github.com/liferay-echo/liferay-portal/assets/91208451/c76bc75b-5559-4fa2-8477-737b3c9b6b96)
