### PR TITLE
LPS-176675 Substitute alert with <clay-alert> in .jsp

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/merge_alert.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/merge_alert.jsp
@@ -24,35 +24,23 @@ int mergeFailCount = SitesUtil.getMergeFailCount(layoutPrototype);
 %>
 
 <c:if test="<%= mergeFailCount > PropsValues.LAYOUT_PROTOTYPE_MERGE_FAIL_THRESHOLD %>">
+	<portlet:actionURL name="/layout_page_template_admin/reset_merge_fail_count" var="resetMergeFailCountURL">
+		<portlet:param name="redirect" value="<%= redirect %>" />
+		<portlet:param name="layoutPrototypeId" value="<%= String.valueOf(layoutPrototype.getLayoutPrototypeId()) %>" />
+	</portlet:actionURL>
 
-	<%
-	String randomNamespace = PortalUtil.generateRandomKey(request, "portlet_layout_prototypes_merge_alert") + StringPool.UNDERLINE;
-	%>
-
-	<span class="alert alert-warning">
+	<clay:alert
+		displayType="warning"
+	>
 		<liferay-ui:message arguments='<%= new Object[] {mergeFailCount, LanguageUtil.get(request, "page-template")} %>' key="the-propagation-of-changes-from-the-x-has-been-disabled-temporarily-after-x-errors" translateArguments="<%= false %>" />
 
 		<liferay-ui:message arguments="page-template" key="click-reset-to-reset-the-failure-count-and-reenable-propagation" />
 
-		<aui:button id='<%= randomNamespace + "resetButton" %>' useNamespace="<%= false %>" value="reset" />
-	</span>
-
-	<script>
-		(function () {
-			var resetButton = document.getElementById(
-				'<%= randomNamespace %>resetButton'
-			);
-
-			if (resetButton) {
-				resetButton.addEventListener('click', (event) => {
-					<portlet:actionURL name="/layout_page_template_admin/reset_merge_fail_count" var="resetMergeFailCountURL">
-						<portlet:param name="redirect" value="<%= redirect %>" />
-						<portlet:param name="layoutPrototypeId" value="<%= String.valueOf(layoutPrototype.getLayoutPrototypeId()) %>" />
-					</portlet:actionURL>
-
-					submitForm(document.hrefFm, '<%= resetMergeFailCountURL %>');
-				});
-			}
-		})();
-	</script>
+		<clay:link
+			displayType="secondary"
+			href="<%= resetMergeFailCountURL %>"
+			label='<%= LanguageUtil.get(request, "reset") %>'
+			type="button"
+		/>
+	</clay:alert>
 </c:if>

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_import.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_import.jsp
@@ -54,12 +54,9 @@ ImportDisplayContext importDisplayContext = new ImportDisplayContext(request, re
 		%>
 
 		<c:if test="<%= MapUtil.isNotEmpty(layoutsImporterResultEntryMap) %>">
-
-			<%
-			String dialogType = importDisplayContext.getDialogType();
-			%>
-
-			<div class="alert alert-<%= dialogType %> <%= dialogType %>-dialog">
+			<clay:alert
+				displayType="<%= importDisplayContext.getDialogType() %>"
+			>
 				<span class="font-weight-bold"><%= importDisplayContext.getDialogMessage() %></span>
 
 				<ul>
@@ -146,7 +143,7 @@ ImportDisplayContext importDisplayContext = new ImportDisplayContext(request, re
 				<c:if test="<%= notImportedLayoutsImporterResultEntries.size() > 10 %>">
 					<span><%= LanguageUtil.format(request, "x-more-entries-could-also-not-be-imported", "<strong>" + (notImportedLayoutsImporterResultEntries.size() - i) + "</strong>", false) %></span>
 				</c:if>
-			</div>
+			</clay:alert>
 		</c:if>
 	</liferay-frontend:edit-form-body>
 

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/layout/view/display_page.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/layout/view/display_page.jsp
@@ -57,9 +57,10 @@ String ppid = ParamUtil.getString(request, "p_p_id");
 					<clay:container-fluid
 						cssClass="pt-3"
 					>
-						<div class="alert alert-danger">
-							<liferay-ui:message key="you-do-not-have-the-required-permissions-to-view-the-content-of-this-page" />
-						</div>
+						<clay:alert
+							displayType="danger"
+							message="you-do-not-have-the-required-permissions-to-view-the-content-of-this-page"
+						/>
 					</clay:container-fluid>
 				</div>
 			</c:when>

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-panel/src/main/resources/META-INF/resources/layout/edit/panel.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-panel/src/main/resources/META-INF/resources/layout/edit/panel.jsp
@@ -28,9 +28,9 @@ if (selLayout != null) {
 
 <aui:input cssClass="layout-description" id="descriptionPanel" label="description" name="TypeSettingsProperties--panelLayoutDescription--" type="textarea" value="<%= description %>" wrap="soft" />
 
-<div class="alert alert-info">
-	<liferay-ui:message key="select-the-applications-that-are-available-in-the-panel" />
-</div>
+<clay:alert
+	message="select-the-applications-that-are-available-in-the-panel"
+/>
 
 <%
 WidgetsTreeDisplayContext widgetsTreeDisplayContext = new WidgetsTreeDisplayContext(request, layoutTypePortlet, user);

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-panel/src/main/resources/META-INF/resources/layout/view/panel_description.jspf
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-panel/src/main/resources/META-INF/resources/layout/view/panel_description.jspf
@@ -53,9 +53,9 @@ else {
 		<%= HtmlUtil.escape(layout.getName(locale)) %>
 	</h2>
 
-	<div class="alert alert-info">
-		<%= HtmlUtil.escape(description) %>
-	</div>
+	<clay:alert
+		message="<%= HtmlUtil.escape(description) %>"
+	/>
 
 <%
 }

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/init.jsp
@@ -29,6 +29,7 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.item.selector.constants.ItemSelectorPortletKeys" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
+page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.theme.NavItem" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/view.jsp
@@ -38,9 +38,10 @@
 				/>
 			</c:when>
 			<c:otherwise>
-				<div class="alert alert-warning">
-					<liferay-ui:message key="the-selected-menu-does-not-exist" />
-				</div>
+				<clay:alert
+					displayType="warning"
+					message="the-selected-menu-does-not-exist"
+				/>
 			</c:otherwise>
 		</c:choose>
 	</c:when>
@@ -78,15 +79,24 @@
 				/>
 			</c:when>
 			<c:otherwise>
-				<div class="alert alert-warning">
-					<liferay-ui:message arguments="<%= siteNavigationMenuDisplayContext.getSelectSiteNavigationMenuTypeLabel() %>" key="there-is-no-x-available-for-the-current-site" />
-				</div>
+				<clay:alert
+					displayType="warning"
+					message='<%= LanguageUtil.format(request, "there-is-no-x-available-for-the-current-site", siteNavigationMenuDisplayContext.getSelectSiteNavigationMenuTypeLabel()) %>'
+				/>
 			</c:otherwise>
 		</c:choose>
 	</c:when>
 	<c:otherwise>
-		<div class="alert alert-info text-center">
-			<aui:a href="javascript:void(0);" onClick="<%= portletDisplay.getURLConfigurationJS() %>"><liferay-ui:message key="configure" /></aui:a>
-		</div>
+		<clay:alert
+			cssClass="text-center"
+			message='<%= LanguageUtil.format(request, "there-is-no-x-available-for-the-current-site", siteNavigationMenuDisplayContext.getSelectSiteNavigationMenuTypeLabel()) %>'
+		>
+			<clay:button
+				displayType="link"
+				label="configure"
+				onClick="<%= portletDisplay.getURLConfigurationJS() %>"
+				small="<%= true %>"
+			/>
+		</clay:alert>
 	</c:otherwise>
 </c:choose>


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to use clay utilities or clay classes in order to standardize the components in the portal.
[LPS-176675](https://liferay.atlassian.net/browse/LPS-176675)
[LPS-176676](https://liferay.atlassian.net/browse/LPS-176676)
[LPS-176677](https://liferay.atlassian.net/browse/LPS-176677)

Proposed Solution
========
The proposed solution consists in replace the <div alerts> elements with clay:alerts.