### PR TITLE
LPS-189594 - Show the error message of the Object Action on Preview Error toggle

### DIFF
--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/item/action/executor/InfoItemActionExecutor.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/item/action/executor/InfoItemActionExecutor.java
@@ -16,6 +16,7 @@ package com.liferay.info.item.action.executor;
 
 import com.liferay.info.exception.InfoItemActionExecutionException;
 import com.liferay.info.item.InfoItemIdentifier;
+import com.liferay.portal.kernel.exception.PortalException;
 
 /**
  * @author Rubén Pulido
@@ -25,5 +26,8 @@ public interface InfoItemActionExecutor<T> {
 	public void executeInfoItemAction(
 			InfoItemIdentifier infoItemIdentifier, String fieldId)
 		throws InfoItemActionExecutionException;
+
+	public String getInfoItemActionErrorMessage(String fieldId)
+		throws PortalException;
 
 }

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/exception/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/exception/packageinfo
@@ -1,1 +1,1 @@
-version 3.0.0
+version 3.1.0

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/item/action/executor/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/item/action/executor/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 2.0.0

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -481,6 +481,11 @@ public class ContentPageEditorDisplayContext {
 						layoutURL, "disableCommonStyles", Boolean.TRUE);
 				}
 			).put(
+				"getInfoItemActionErrorMessageURL",
+				_getResourceURL(
+					"/layout_content_page_editor" +
+						"/get_info_item_action_error_message")
+			).put(
 				"getInfoItemFieldValueURL",
 				_getResourceURL(
 					"/layout_content_page_editor/get_info_item_field_value")

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetInfoItemActionErrorMessageMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetInfoItemActionErrorMessageMVCResourceCommand.java
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.layout.content.page.editor.web.internal.portlet.action;
+
+import com.liferay.info.item.InfoItemServiceRegistry;
+import com.liferay.info.item.action.executor.InfoItemActionExecutor;
+import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCResourceCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCResourceCommand;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+
+import javax.portlet.ResourceRequest;
+import javax.portlet.ResourceResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Rubén Pulido
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + ContentPageEditorPortletKeys.CONTENT_PAGE_EDITOR_PORTLET,
+		"mvc.command.name=/layout_content_page_editor/get_info_item_action_error_message"
+	},
+	service = MVCResourceCommand.class
+)
+public class GetInfoItemActionErrorMessageMVCResourceCommand
+	extends BaseMVCResourceCommand {
+
+	@Override
+	protected void doServeResource(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPS-169992")) {
+			return;
+		}
+
+		try {
+			InfoItemActionExecutor<Object> infoItemActionExecutor =
+				_infoItemServiceRegistry.getFirstInfoItemService(
+					InfoItemActionExecutor.class,
+					_portal.getClassName(
+						ParamUtil.getLong(resourceRequest, "classNameId")));
+
+			if (infoItemActionExecutor == null) {
+				_writeErrorJSON(resourceRequest, resourceResponse);
+
+				return;
+			}
+
+			JSONPortletResponseUtil.writeJSON(
+				resourceRequest, resourceResponse,
+				JSONUtil.put(
+					"message",
+					infoItemActionExecutor.getInfoItemActionErrorMessage(
+						ParamUtil.getString(resourceRequest, "fieldId"))));
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			_writeErrorJSON(resourceRequest, resourceResponse);
+		}
+	}
+
+	private void _writeErrorJSON(
+			ResourceRequest resourceRequest, ResourceResponse resourceResponse)
+		throws Exception {
+
+		JSONPortletResponseUtil.writeJSON(
+			resourceRequest, resourceResponse,
+			JSONUtil.put(
+				"error",
+				_language.get(
+					resourceRequest.getLocale(),
+					"your-request-failed-to-complete")));
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GetInfoItemActionErrorMessageMVCResourceCommand.class);
+
+	@Reference
+	private InfoItemServiceRegistry _infoItemServiceRegistry;
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/InfoItemService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/InfoItemService.js
@@ -102,6 +102,25 @@ export default {
 	},
 
 	/**
+	 * Get the error message of an action
+	 * @param {object} options
+	 * @param {string} options.classNameId Asset's className
+	 * @param {string} options.fieldId
+	 */
+	getInfoItemActionErrorMessage({classNameId, fieldId}) {
+		return serviceFetch(
+			config.getInfoItemActionErrorMessageURL,
+			{
+				body: {
+					classNameId,
+					fieldId,
+				},
+			},
+			() => {}
+		);
+	},
+
+	/**
 	 * Get an item's value
 	 * @param {object} options
 	 * @param {string} options.classNameId Asset's className

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/cache.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/cache.js
@@ -15,6 +15,7 @@
 let cache = null;
 
 export const CACHE_KEYS = {
+	actionError: 'actionError',
 	allowedInputTypes: 'allowedInputTypes',
 	collectionConfigurationUrl: 'collectionConfigurationUrl',
 	collectionVariations: 'collectionVariations',

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/EditableActionPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/EditableActionPanel.js
@@ -201,7 +201,7 @@ function InteractionSelector({config, data, fragmentId, onValueSelect}) {
 	const hidePreview = () => {
 		const previewElement = document.getElementById(previewId);
 
-		previewElement.remove();
+		previewElement?.remove();
 	};
 
 	return (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/EditableActionPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/EditableActionPanel.js
@@ -31,8 +31,11 @@ import {
 import selectEditableValue from '../../../../../../app/selectors/selectEditableValue';
 import selectEditableValues from '../../../../../../app/selectors/selectEditableValues';
 import selectLanguageId from '../../../../../../app/selectors/selectLanguageId';
+import InfoItemService from '../../../../../../app/services/InfoItemService';
 import updateEditableValues from '../../../../../../app/thunks/updateEditableValues';
+import {CACHE_KEYS} from '../../../../../../app/utils/cache';
 import {updateIn} from '../../../../../../app/utils/updateIn';
+import useCache from '../../../../../../app/utils/useCache';
 import CurrentLanguageFlag from '../../../../../../common/components/CurrentLanguageFlag';
 import {LayoutSelector} from '../../../../../../common/components/LayoutSelector';
 import MappingSelector from '../../../../../../common/components/MappingSelector';
@@ -113,6 +116,17 @@ export default function EditableActionPanel({item}) {
 		);
 	};
 
+	const {classNameId, fieldId} = editableValue;
+
+	const defaultError = useCache({
+		fetcher: () =>
+			InfoItemService.getInfoItemActionErrorMessage({
+				classNameId,
+				fieldId,
+			}).then(({error, message}) => message || error),
+		key: [CACHE_KEYS.actionError, classNameId, fieldId],
+	});
+
 	return (
 		<>
 			<MappingSelector
@@ -136,7 +150,10 @@ export default function EditableActionPanel({item}) {
 
 					<InteractionSelector
 						config={editableValue.config}
-						data={INTERACTION_DATA.error}
+						data={{
+							...INTERACTION_DATA.error,
+							defaultMessage: defaultError,
+						}}
 						fragmentId={item.parentId}
 						onValueSelect={onValueSelect}
 					/>
@@ -151,7 +168,7 @@ EditableActionPanel.propTypes = {
 };
 
 function InteractionSelector({config, data, fragmentId, onValueSelect}) {
-	const {field, label, type} = data;
+	const {defaultMessage, field, label, type} = data;
 
 	const interactionConfig = config[field];
 
@@ -289,7 +306,8 @@ function InteractionSelector({config, data, fragmentId, onValueSelect}) {
 
 							if (checked) {
 								openToast({
-									message: textValue[languageId],
+									message:
+										textValue[languageId] || defaultMessage,
 									onClose: () => onPreviewToggle(false),
 									toastProps: {
 										id: previewId,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/config.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/config.d.ts
@@ -54,7 +54,6 @@ export interface Config {
 
 	changeMasterLayoutURL: string;
 	changeStyleBookEntryURL: string;
-	contentPagePersonalizationLearnURL: string;
 	collectionSelectorURL: string;
 
 	commonStyles: Array<{
@@ -83,6 +82,7 @@ export interface Config {
 			defaultValue: string;
 		};
 	};
+	contentPagePersonalizationLearnURL: string;
 
 	createLayoutPageTemplateEntryURL: string;
 
@@ -111,13 +111,15 @@ export interface Config {
 		getAvailableImageConfigurationsURL: string;
 		getAvailableListItemRenderersURL: string;
 		getAvailableListRenderersURL: string;
-		[key: string]: {
-			cssVariable: string;
-			editorType: string;
-			label: string;
-			name: string;
-			value: string;
-		} | string;
+		[key: string]:
+			| {
+					cssVariable: string;
+					editorType: string;
+					label: string;
+					name: string;
+					value: string;
+			  }
+			| string;
 	};
 	getAvailableTemplatesURL: string;
 	getCollectionConfigurationURL: string;
@@ -129,6 +131,7 @@ export interface Config {
 	getExperienceDataURL: string;
 	getIframeContentCssURL: string;
 	getIframeContentURL: string;
+	getInfoItemActionErrorMessageURL: string;
 	getInfoItemFieldValueURL: string;
 	getLayoutFriendlyURL: string;
 	getLayoutPageTemplateCollectionsURL: string;
@@ -168,11 +171,11 @@ export interface Config {
 	searchContainerPageMaxDelta: number;
 
 	selectedMappingTypes?: {
-		type: {
+		subtype: {
 			id: string;
 			label: string;
 		};
-		subtype: {
+		type: {
 			id: string;
 			label: string;
 		};

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/deployer/ObjectDefinitionDeployerImpl.java
@@ -202,8 +202,8 @@ public class ObjectDefinitionDeployerImpl implements ObjectDefinitionDeployer {
 			_bundleContext.registerService(
 				InfoItemActionExecutor.class,
 				new ObjectEntryInfoItemActionExecutor(
-					_objectActionLocalService, objectDefinition,
-					_objectEntryManagerRegistry),
+					infoItemFormProvider, _objectActionLocalService,
+					objectDefinition, _objectEntryManagerRegistry),
 				HashMapDictionaryBuilder.<String, Object>put(
 					"company.id", objectDefinition.getCompanyId()
 				).put(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/action/ObjectEntryInfoItemActionExecutor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/action/ObjectEntryInfoItemActionExecutor.java
@@ -15,9 +15,12 @@
 package com.liferay.object.web.internal.info.item.action;
 
 import com.liferay.info.exception.InfoItemActionExecutionException;
+import com.liferay.info.field.InfoField;
+import com.liferay.info.form.InfoForm;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemIdentifier;
 import com.liferay.info.item.action.executor.InfoItemActionExecutor;
+import com.liferay.info.item.provider.InfoItemFormProvider;
 import com.liferay.object.constants.ObjectActionTriggerConstants;
 import com.liferay.object.model.ObjectAction;
 import com.liferay.object.model.ObjectDefinition;
@@ -43,10 +46,12 @@ public class ObjectEntryInfoItemActionExecutor
 	implements InfoItemActionExecutor<ObjectEntry> {
 
 	public ObjectEntryInfoItemActionExecutor(
+		InfoItemFormProvider<ObjectEntry> infoItemFormProvider,
 		ObjectActionLocalService objectActionLocalService,
 		ObjectDefinition objectDefinition,
 		ObjectEntryManagerRegistry objectEntryManagerRegistry) {
 
+		_infoItemFormProvider = infoItemFormProvider;
 		_objectActionLocalService = objectActionLocalService;
 		_objectDefinition = objectDefinition;
 		_objectEntryManagerRegistry = objectEntryManagerRegistry;
@@ -137,19 +142,22 @@ public class ObjectEntryInfoItemActionExecutor
 				throw new PortalException();
 			}
 
-			String objectActionName = fieldId;
+			InfoForm infoForm = _infoItemFormProvider.getInfoForm();
 
-			String objectActionPrefix =
-				ObjectAction.class.getSimpleName() + StringPool.UNDERLINE;
+			if (infoForm == null) {
+				throw new PortalException();
+			}
 
-			if (objectActionName.startsWith(objectActionPrefix)) {
-				objectActionName = objectActionName.substring(
-					objectActionPrefix.length());
+			InfoField<?> infoField = infoForm.getInfoField(fieldId);
+
+			if (infoField == null) {
+				throw new PortalException();
 			}
 
 			ObjectAction objectAction =
 				_objectActionLocalService.getObjectAction(
-					_objectDefinition.getObjectDefinitionId(), objectActionName,
+					_objectDefinition.getObjectDefinitionId(),
+					infoField.getName(),
 					ObjectActionTriggerConstants.KEY_STANDALONE);
 
 			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
@@ -168,6 +176,7 @@ public class ObjectEntryInfoItemActionExecutor
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryInfoItemActionExecutor.class);
 
+	private final InfoItemFormProvider<ObjectEntry> _infoItemFormProvider;
 	private final ObjectActionLocalService _objectActionLocalService;
 	private final ObjectDefinition _objectDefinition;
 	private final ObjectEntryManagerRegistry _objectEntryManagerRegistry;

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/action/ObjectEntryInfoItemActionExecutor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/action/ObjectEntryInfoItemActionExecutor.java
@@ -29,7 +29,6 @@ import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManager;
 import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManagerProvider;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
 import com.liferay.object.service.ObjectActionLocalService;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -90,19 +89,22 @@ public class ObjectEntryInfoItemActionExecutor
 					null, _objectDefinition.getObjectDefinitionId(),
 					themeDisplay.getLocale(), null, themeDisplay.getUser());
 
-			String objectActionName = fieldId;
+			InfoForm infoForm = _infoItemFormProvider.getInfoForm();
 
-			String objectActionPrefix =
-				ObjectAction.class.getSimpleName() + StringPool.UNDERLINE;
+			if (infoForm == null) {
+				throw new InfoItemActionExecutionException();
+			}
 
-			if (objectActionName.startsWith(objectActionPrefix)) {
-				objectActionName = objectActionName.substring(
-					objectActionPrefix.length());
+			InfoField<?> infoField = infoForm.getInfoField(fieldId);
+
+			if (infoField == null) {
+				throw new InfoItemActionExecutionException();
 			}
 
 			ObjectAction objectAction =
 				_objectActionLocalService.getObjectAction(
-					_objectDefinition.getObjectDefinitionId(), objectActionName,
+					_objectDefinition.getObjectDefinitionId(),
+					infoField.getName(),
 					ObjectActionTriggerConstants.KEY_STANDALONE);
 
 			errorMessage = objectAction.getErrorMessage(
@@ -112,7 +114,7 @@ public class ObjectEntryInfoItemActionExecutor
 				(ClassPKInfoItemIdentifier)infoItemIdentifier;
 
 			defaultObjectEntryManager.executeObjectAction(
-				dtoConverterContext, objectActionName, _objectDefinition,
+				dtoConverterContext, infoField.getName(), _objectDefinition,
 				classPKInfoItemIdentifier.getClassPK());
 		}
 		catch (Exception exception) {

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/action/ObjectEntryInfoItemActionExecutor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/action/ObjectEntryInfoItemActionExecutor.java
@@ -77,18 +77,6 @@ public class ObjectEntryInfoItemActionExecutor
 				throw new InfoItemActionExecutionException();
 			}
 
-			DefaultObjectEntryManager defaultObjectEntryManager =
-				DefaultObjectEntryManagerProvider.provide(
-					_objectEntryManagerRegistry.getObjectEntryManager(
-						_objectDefinition.getStorageType()));
-
-			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
-
-			DTOConverterContext dtoConverterContext =
-				new DefaultDTOConverterContext(
-					null, _objectDefinition.getObjectDefinitionId(),
-					themeDisplay.getLocale(), null, themeDisplay.getUser());
-
 			InfoForm infoForm = _infoItemFormProvider.getInfoForm();
 
 			if (infoForm == null) {
@@ -100,6 +88,18 @@ public class ObjectEntryInfoItemActionExecutor
 			if (infoField == null) {
 				throw new InfoItemActionExecutionException();
 			}
+
+			DefaultObjectEntryManager defaultObjectEntryManager =
+				DefaultObjectEntryManagerProvider.provide(
+					_objectEntryManagerRegistry.getObjectEntryManager(
+						_objectDefinition.getStorageType()));
+
+			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+			DTOConverterContext dtoConverterContext =
+				new DefaultDTOConverterContext(
+					null, _objectDefinition.getObjectDefinitionId(),
+					themeDisplay.getLocale(), null, themeDisplay.getUser());
 
 			ObjectAction objectAction =
 				_objectActionLocalService.getObjectAction(

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/action/ObjectEntryInfoItemActionExecutor.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/action/ObjectEntryInfoItemActionExecutor.java
@@ -27,6 +27,7 @@ import com.liferay.object.rest.manager.v1_0.DefaultObjectEntryManagerProvider;
 import com.liferay.object.rest.manager.v1_0.ObjectEntryManagerRegistry;
 import com.liferay.object.service.ObjectActionLocalService;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -119,6 +120,48 @@ public class ObjectEntryInfoItemActionExecutor
 			}
 
 			throw new InfoItemActionExecutionException();
+		}
+	}
+
+	@Override
+	public String getInfoItemActionErrorMessage(String fieldId)
+		throws PortalException {
+
+		try {
+			ServiceContext serviceContext =
+				ServiceContextThreadLocal.getServiceContext();
+
+			if ((serviceContext == null) ||
+				(serviceContext.getThemeDisplay() == null)) {
+
+				throw new PortalException();
+			}
+
+			String objectActionName = fieldId;
+
+			String objectActionPrefix =
+				ObjectAction.class.getSimpleName() + StringPool.UNDERLINE;
+
+			if (objectActionName.startsWith(objectActionPrefix)) {
+				objectActionName = objectActionName.substring(
+					objectActionPrefix.length());
+			}
+
+			ObjectAction objectAction =
+				_objectActionLocalService.getObjectAction(
+					_objectDefinition.getObjectDefinitionId(), objectActionName,
+					ObjectActionTriggerConstants.KEY_STANDALONE);
+
+			ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+			return objectAction.getErrorMessage(themeDisplay.getLocale());
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			throw new PortalException(exception);
 		}
 	}
 


### PR DESCRIPTION
Incorporated feedback from @victorg1991 in https://github.com/liferay-echo/liferay-portal/pull/12728

Marking it "on hold" because:
- If mapping only the action (but not the text of the button), the toggle displays an empty message.
- When using the toggle to display the message in one language (English), then switching to another language (Spanish), the value of the message is dispalayed on the first language (English) instead of the current one (Spanish)

//cc @ealonso @sandrodw3 @victorg1991