### PR TITLE
LPS-176671 Replace alert divs with clay:alert taglib in layout-admin-web

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/add_layout.jsp
@@ -93,9 +93,11 @@ List<SiteNavigationMenu> autoSiteNavigationMenus = layoutsAdminDisplayContext.ge
 							/>
 						</c:when>
 						<c:otherwise>
-							<div class="alert alert-warning text-justify">
-								<liferay-ui:message key="pages-have-required-vocabularies.-you-need-to-create-at-least-one-category-in-all-required-vocabularies-in-order-to-create-a-page" />
-							</div>
+							<clay:alert
+								cssClass="text-justify"
+								displayType="warning"
+								message="pages-have-required-vocabularies.-you-need-to-create-at-least-one-category-in-all-required-vocabularies-in-order-to-create-a-page"
+							/>
 						</c:otherwise>
 					</c:choose>
 				</aui:fieldset>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/error_layout_prototype_exception.jspf
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/error_layout_prototype_exception.jspf
@@ -15,9 +15,10 @@
 --%>
 
 <c:if test="<%= selGroup.hasLocalOrRemoteStagingGroup() && !selGroup.isStagingGroup() %>">
-	<div class="alert alert-warning">
-		<liferay-ui:message key="changes-are-immediately-available-to-end-users" />
-	</div>
+	<clay:alert
+		displayType="warning"
+		message="changes-are-immediately-available-to-end-users"
+	/>
 </c:if>
 
 <%

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/customization_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/customization_settings.jsp
@@ -65,9 +65,10 @@ if (selLayout != null) {
 
 <c:choose>
 	<c:when test="<%= prototypeGroup %>">
-		<div class="alert alert-warning">
-			<liferay-ui:message key="it-is-not-possible-to-specify-customization-settings-for-pages-in-site-templates-or-page-templates" />
-		</div>
+		<clay:alert
+			displayType="warning"
+			message="it-is-not-possible-to-specify-customization-settings-for-pages-in-site-templates-or-page-templates"
+		/>
 	</c:when>
 	<c:otherwise>
 		<aui:input aria-describedby='<%= liferayPortletResponse.getNamespace() + "customizableDescription" %>' label="customizable" labelCssClass="font-weight-normal" name='<%= "TypeSettingsProperties--" + LayoutConstants.CUSTOMIZABLE_LAYOUT + "--" %>' type="checkbox" value="<%= selLayout.isCustomizable() %>" wrapperCssClass="c-mb-2" />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/layout.jsp
@@ -42,9 +42,12 @@ Layout selLayout = layoutsAdminDisplayContext.getSelLayout();
 		<liferay-ui:message arguments="<%= HtmlUtil.escape(layoutPrototype.getName(user.getLocale())) %>" key="if-enabled-this-page-will-inherit-changes-made-to-the-x-page-template" />
 	</p>
 
-	<div class="alert alert-warning layout-prototype-info-message <%= selLayout.isLayoutPrototypeLinkActive() ? StringPool.BLANK : "hide" %>">
+	<clay:alert
+		cssClass='<%= selLayout.isLayoutPrototypeLinkActive() ? "layout-prototype-info-message" : "layout-prototype-info-message hide" %>'
+		displayType="warning"
+	>
 		<liferay-ui:message arguments='<%= new String[] {"inherit-changes", "general"} %>' key="some-page-settings-are-unavailable-because-x-is-enabled" translateArguments="<%= true %>" />
-	</div>
+	</clay:alert>
 
 	<div class="<%= selLayout.isLayoutPrototypeLinkEnabled() ? StringPool.BLANK : "hide" %>" id="<portlet:namespace />layoutPrototypeMergeAlert">
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/url.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/url.jsp
@@ -59,9 +59,12 @@ if (!group.isLayoutPrototype() && selLayoutType.isURLFriendliable() && !layoutsA
 	%>
 
 	<c:if test="<%= !group.isLayoutPrototype() %>">
-		<div class="alert alert-warning layout-prototype-info-message <%= selLayout.isLayoutPrototypeLinkActive() ? StringPool.BLANK : "hide" %>">
-			<liferay-ui:message arguments='<%= new String[] {LanguageUtil.get(request, "inherit-changes"), "General"} %>' key="some-page-settings-are-unavailable-because-x-is-enabled" translateArguments="<%= false %>" />
-		</div>
+		<clay:alert
+			cssClass='<%= selLayout.isLayoutPrototypeLinkActive() ? "layout-prototype-info-message" : "layout-prototype-info-message hide" %>'
+			displayType="warning"
+		>
+			<liferay-ui:message arguments='<%= new String[] {"inherit-changes", "general"} %>' key="some-page-settings-are-unavailable-because-x-is-enabled" translateArguments="<%= true %>" />
+		</clay:alert>
 
 		<aui:input cssClass="propagatable-field" disabled="<%= selLayout.isLayoutPrototypeLinkActive() %>" helpMessage="query-string-help" label="query-string" name="TypeSettingsProperties--query-string--" size="30" type="text" value='<%= GetterUtil.getString(layoutTypeSettingsUnicodeProperties.getProperty("query-string")) %>' />
 	</c:if>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_merge_alert.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_merge_alert.jsp
@@ -30,13 +30,21 @@ int mergeFailCount = SitesUtil.getMergeFailCount(layoutPrototype);
 	String randomNamespace = PortalUtil.generateRandomKey(request, "portlet_layout_prototypes_merge_alert") + StringPool.UNDERLINE;
 	%>
 
-	<span class="alert alert-warning">
+	<clay:alert
+		displayType="warning"
+	>
 		<liferay-ui:message arguments='<%= new Object[] {mergeFailCount, LanguageUtil.get(request, "page-template")} %>' key="the-propagation-of-changes-from-the-x-has-been-disabled-temporarily-after-x-errors" translateArguments="<%= false %>" />
 
 		<liferay-ui:message arguments="page-template" key="click-reset-and-propagate-to-reset-the-failure-count-and-propagate-changes-from-the-x" />
 
-		<aui:button id='<%= randomNamespace + "resetButton" %>' useNamespace="<%= false %>" value="reset-and-propagate" />
-	</span>
+		<clay:button
+			cssClass="alert-btn"
+			displayType="primary"
+			id='<%= randomNamespace + "resetButton" %>'
+			label="reset-and-propagate"
+			small="<%= true %>"
+		/>
+	</clay:alert>
 
 	<script>
 		(function () {

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/advanced.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/advanced.jsp
@@ -42,8 +42,9 @@ Group guestGroup = GroupLocalServiceUtil.getGroup(company.getCompanyId(), GroupC
 		</c:choose>
 	</c:when>
 	<c:otherwise>
-		<div class="alert alert-info">
-			<liferay-ui:message key="there-are-no-available-advanced-settings-for-these-pages" />
-		</div>
+		<clay:alert
+			displayType="info"
+			message="there-are-no-available-advanced-settings-for-these-pages"
+		/>
 	</c:otherwise>
 </c:choose>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/basic_settings.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/basic_settings.jsp
@@ -49,9 +49,10 @@
 		</liferay-ui:error>
 
 		<c:if test="<%= liveGroup.isLayoutSetPrototype() && !PropsValues.LAYOUT_SET_PROTOTYPE_PROPAGATE_LOGO %>">
-			<div class="alert alert-warning">
-				<liferay-ui:message key="modifying-the-site-template-logo-only-affects-sites-that-are-not-yet-created" />
-			</div>
+			<clay:alert
+				displayType="warning"
+				message="modifying-the-site-template-logo-only-affects-sites-that-are-not-yet-created"
+			/>
 		</c:if>
 
 		<%

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/robots.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/robots.jsp
@@ -34,8 +34,9 @@ String virtualHostname = layoutsAdminDisplayContext.getVirtualHostname();
 		<aui:input aria-describedby="<portlet:namespace />robotsDescription" label="robots" name='<%= "TypeSettingsProperties--" + layoutSet.isPrivateLayout() + "-robots.txt--" %>' placeholder="robots" type="textarea" value="<%= layoutsAdminDisplayContext.getRobots() %>" />
 	</c:when>
 	<c:otherwise>
-		<div class="alert alert-info">
-			<liferay-ui:message key="please-set-the-virtual-host-before-you-set-the-robots-txt" />
-		</div>
+		<clay:alert
+			displayType="info"
+			message="please-set-the-virtual-host-before-you-set-the-robots-txt"
+		/>
 	</c:otherwise>
 </c:choose>


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-176671)

For the _9a0b6f127809590d0336c1abe9159a32e1b001de_ this is the result:
 
![image](https://github.com/liferay-echo/liferay-portal/assets/93203423/b4e14d7e-bb15-4a2b-829f-833957175299)

I've changed the appearance of the button for a better fit with the clay style.