### PR TITLE
LPS-189834 Expire info is missing in Content Display

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/provider/JournalArticleInfoItemObjectProvider.java
@@ -129,8 +129,8 @@ public class JournalArticleInfoItemObjectProvider
 				"Unable to get journal article " + infoItemIdentifier);
 		}
 
-		if (article.isExpired() || article.isInTrash() ||
-			(article.isPending() && !_isSignedIn()) || article.isScheduled()) {
+		if (article.isInTrash() || (article.isPending() && !_isSignedIn()) ||
+			article.isScheduled()) {
 
 			return null;
 		}


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-189834)

## Test Scenario

1. Add a web content
2. Add a Content Display to a content page
3. Display the web content in Content Display
4. Expire the web content
5. Back to page editor

<img width="1308" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/9d14d2b4-3985-479e-aa6a-f06ddfe5bba9">
