### PR TITLE
LPS-189946 Reduce XML deserialization when rendering web content

### DIFF
--- a/modules/apps/journal/journal-api/bnd.bnd
+++ b/modules/apps/journal/journal-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal API
 Bundle-SymbolicName: com.liferay.journal.api
-Bundle-Version: 31.3.1
+Bundle-Version: 31.4.0
 Export-Package:\
 	com.liferay.journal.configuration,\
 	com.liferay.journal.constants,\

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/util/JournalConverter.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/util/JournalConverter.java
@@ -17,6 +17,7 @@ package com.liferay.journal.util;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.storage.Fields;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.xml.Document;
 
 import org.osgi.annotation.versioning.ProviderType;
 
@@ -33,5 +34,9 @@ public interface JournalConverter {
 
 	public Fields getDDMFields(DDMStructure ddmStructure, String content)
 		throws PortalException;
+
+	public Document getDocument(
+			DDMStructure ddmStructure, Fields ddmFields, long groupId)
+		throws Exception;
 
 }

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/util/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/util/packageinfo
@@ -1,1 +1,1 @@
-version 6.0.0
+version 6.1.0

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -75,32 +75,7 @@ public class JournalConverterImpl implements JournalConverter {
 			DDMStructure ddmStructure, Fields ddmFields, long groupId)
 		throws Exception {
 
-		Document document = SAXReaderUtil.createDocument();
-
-		Element rootElement = document.addElement("root");
-
-		rootElement.addAttribute(
-			"available-locales", _getAvailableLocales(ddmFields));
-
-		Locale defaultLocale = ddmFields.getDefaultLocale();
-
-		if (!_language.isAvailableLocale(groupId, defaultLocale)) {
-			defaultLocale = LocaleUtil.getSiteDefault();
-		}
-
-		rootElement.addAttribute(
-			"default-locale", LocaleUtil.toLanguageId(defaultLocale));
-
-		rootElement.addAttribute("version", "1.0");
-
-		DDMFieldsCounter ddmFieldsCounter = new DDMFieldsCounter();
-
-		DDMForm ddmForm = ddmStructure.getDDMForm();
-
-		for (DDMFormField ddmFormField : ddmForm.getDDMFormFields()) {
-			_updateDynamicElementElement(
-				ddmFields, ddmFieldsCounter, ddmFormField, rootElement, -1);
-		}
+		Document document = getDocument(ddmStructure, ddmFields, groupId);
 
 		try {
 			return XMLUtil.stripInvalidChars(document.formattedString());
@@ -145,6 +120,41 @@ public class JournalConverterImpl implements JournalConverter {
 		catch (DocumentException documentException) {
 			throw new PortalException(documentException);
 		}
+	}
+
+	@Override
+	public Document getDocument(
+			DDMStructure ddmStructure, Fields ddmFields, long groupId)
+		throws Exception {
+
+		Document document = SAXReaderUtil.createDocument();
+
+		Element rootElement = document.addElement("root");
+
+		rootElement.addAttribute(
+			"available-locales", _getAvailableLocales(ddmFields));
+
+		Locale defaultLocale = ddmFields.getDefaultLocale();
+
+		if (!_language.isAvailableLocale(groupId, defaultLocale)) {
+			defaultLocale = LocaleUtil.getSiteDefault();
+		}
+
+		rootElement.addAttribute(
+			"default-locale", LocaleUtil.toLanguageId(defaultLocale));
+
+		rootElement.addAttribute("version", "1.0");
+
+		DDMFieldsCounter ddmFieldsCounter = new DDMFieldsCounter();
+
+		DDMForm ddmForm = ddmStructure.getDDMForm();
+
+		for (DDMFormField ddmFormField : ddmForm.getDDMFormFields()) {
+			_updateDynamicElementElement(
+				ddmFields, ddmFieldsCounter, ddmFormField, rootElement, -1);
+		}
+
+		return document;
 	}
 
 	private void _addDDMFields(


### PR DESCRIPTION
## Motivation

https://liferay.atlassian.net/browse/LPS-189946

In analyzing a customer's 7.4.13-u74 performance test, we found that the customer was experiencing issues due to garbage collection.

This change aims to reduce the number of objects that are created when viewing web content in order to make garbage collection tuning a little easier for our customer.

## Proposed solution

Some parts of the code (`getDocument` and `getDocumentByLocale`) have a code pattern where they retrieve an XML string from `JournalConverter`, only to deserialize that XML string back into a `Document`.

If we have `JournalConverter` return a `Document` directly, we can eliminate the unnecessary conversion, thus saving a little on object creation.

## Steps to verify

N/A, this is just a code optimization