### PR TITLE
LPS-190221 Add cached label to contributed fragments when defined as cacheabled

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/frontend/taglib/clay/servlet/taglib/ContributedFragmentEntryVerticalCard.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/frontend/taglib/clay/servlet/taglib/ContributedFragmentEntryVerticalCard.java
@@ -19,10 +19,14 @@ import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.web.internal.security.permission.resource.FragmentPermission;
 import com.liferay.fragment.web.internal.servlet.taglib.util.ContributedFragmentEntryActionDropdownItemsProvider;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder;
 import com.liferay.portal.kernel.dao.search.RowChecker;
+import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.util.List;
 
@@ -91,6 +95,16 @@ public class ContributedFragmentEntryVerticalCard
 	@Override
 	public String getInputValue() {
 		return fragmentEntry.getFragmentEntryKey();
+	}
+
+	@Override
+	public List<LabelItem> getLabels() {
+		return LabelItemListBuilder.add(
+			fragmentEntry::isCacheable,
+			labelItem -> labelItem.setLabel(
+				LanguageUtil.get(
+					PortalUtil.getHttpServletRequest(_renderRequest), "cached"))
+		).build();
 	}
 
 	@Override


### PR DESCRIPTION
[Story](https://liferay.atlassian.net/browse/LPS-190221)

Currently Contributed Fragments don't show the "cached" label when defined as so. 
To keep the fragments behaviour consistent within the Portal, we added this feature like in the personalized ones.

<img width="1750" alt="CachedLabelInContributedFragments" src="https://github.com/liferay-echo/liferay-portal/assets/85171101/cd83fa79-3941-4b8e-9aa4-b97dcc6e7884">
