### PR TITLE
LPS-190089 Fix simulation autosize

### DIFF
--- a/modules/apps/product-navigation/product-navigation-simulation-device/package.json
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/package.json
@@ -1,5 +1,6 @@
 {
 	"dependencies": {
+		"@liferay/frontend-js-react-web": "*",
 		"frontend-js-web": "*"
 	},
 	"name": "product-navigation-simulation-device",

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/components/Preview.tsx
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/components/Preview.tsx
@@ -13,9 +13,11 @@
  */
 
 import ClayAlert from '@clayui/alert';
+import {useEventListener} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
+import {debounce} from 'frontend-js-web';
 import PropTypes from 'prop-types';
-import React, {useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import {SIZES, Size} from '../constants/sizes';
 
@@ -74,13 +76,8 @@ export default function Preview({activeSize, previewRef}: IPreviewProps) {
 		};
 	}, []);
 
-	useEffect(() => {
-		if (
-			visible &&
-			activeSize.id === SIZES.autosize.id &&
-			previewRef.current &&
-			previewWrapperRef?.current
-		) {
+	const updateAutosizePreview = useCallback(() => {
+		if (previewRef.current && previewWrapperRef.current) {
 			previewRef.current.style.width = `${
 				previewWrapperRef.current.getBoundingClientRect().width
 			}px`;
@@ -88,7 +85,30 @@ export default function Preview({activeSize, previewRef}: IPreviewProps) {
 				previewWrapperRef.current.getBoundingClientRect().height - 6
 			}px`;
 		}
-	}, [activeSize, previewRef, visible]);
+	}, [previewRef]);
+
+	useEffect(() => {
+		if (!visible) {
+			return;
+		}
+		if (activeSize.id === SIZES.autosize.id) {
+			updateAutosizePreview();
+		}
+	}, [activeSize, previewRef, updateAutosizePreview, visible]);
+
+	const handleWindowResize = debounce(() => {
+		if (!visible) {
+			return;
+		}
+
+		if (activeSize.id === SIZES.autosize.id) {
+			updateAutosizePreview();
+		}
+	}, 250);
+
+	// @ts-ignore
+
+	useEventListener('resize', handleWindowResize, false, window);
 
 	if (!visible) {
 		return null;

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/components/Preview.tsx
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/components/Preview.tsx
@@ -115,7 +115,12 @@ export default function Preview({activeSize, previewRef}: IPreviewProps) {
 	}
 
 	return (
-		<div className="d-flex flex-column simulation-preview" ref={previewWrapperRef}>
+		<div
+			className={classNames('d-flex flex-column simulation-preview', {
+				'justify-content-center': !Liferay.FeatureFlags['LPS-186558'],
+			})}
+			ref={previewWrapperRef}
+		>
 			{Liferay.FeatureFlags['LPS-186558'] && segmentMessage && (
 				<ClayAlert
 					className="c-m-3"

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/components/Preview.tsx
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/components/Preview.tsx
@@ -15,7 +15,7 @@
 import ClayAlert from '@clayui/alert';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React, {useEffect, useState} from 'react';
+import React, {useEffect, useRef, useState} from 'react';
 
 import {SIZES, Size} from '../constants/sizes';
 
@@ -29,6 +29,8 @@ const SEGMENT_SIMULATION_EVENT = 'SegmentSimulation:changeSegment';
 export default function Preview({activeSize, previewRef}: IPreviewProps) {
 	const [visible, setVisible] = useState<boolean>(true);
 	const [segmentMessage, setSegmentMessage] = useState<string | null>(null);
+
+	const previewWrapperRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
 		const wrapper = document.getElementById('wrapper');
@@ -72,12 +74,28 @@ export default function Preview({activeSize, previewRef}: IPreviewProps) {
 		};
 	}, []);
 
-	if (!visible || activeSize.id === SIZES.autosize.id) {
+	useEffect(() => {
+		if (
+			visible &&
+			activeSize.id === SIZES.autosize.id &&
+			previewRef.current &&
+			previewWrapperRef?.current
+		) {
+			previewRef.current.style.width = `${
+				previewWrapperRef.current.getBoundingClientRect().width
+			}px`;
+			previewRef.current.style.height = `${
+				previewWrapperRef.current.getBoundingClientRect().height - 6
+			}px`;
+		}
+	}, [activeSize, previewRef, visible]);
+
+	if (!visible) {
 		return null;
 	}
 
 	return (
-		<div className="d-flex flex-column simulation-preview">
+		<div className="d-flex flex-column simulation-preview" ref={previewWrapperRef}>
 			{Liferay.FeatureFlags['LPS-186558'] && segmentMessage && (
 				<ClayAlert
 					className="c-m-3"

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/components/Preview.tsx
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/components/Preview.tsx
@@ -19,7 +19,7 @@ import {debounce} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 
-import {SIZES, Size} from '../constants/sizes';
+import {SIZES, ScreenSize, Size} from '../constants/sizes';
 
 interface IPreviewProps {
 	activeSize: Size;
@@ -31,6 +31,9 @@ const SEGMENT_SIMULATION_EVENT = 'SegmentSimulation:changeSegment';
 export default function Preview({activeSize, previewRef}: IPreviewProps) {
 	const [visible, setVisible] = useState<boolean>(true);
 	const [segmentMessage, setSegmentMessage] = useState<string | null>(null);
+	const [size, setSize] = useState<ScreenSize | undefined>(
+		activeSize.screenSize
+	);
 
 	const previewWrapperRef = useRef<HTMLDivElement>(null);
 
@@ -77,33 +80,29 @@ export default function Preview({activeSize, previewRef}: IPreviewProps) {
 	}, []);
 
 	const updateAutosizePreview = useCallback(() => {
-		if (previewRef.current && previewWrapperRef.current) {
-			previewRef.current.style.width = `${
-				previewWrapperRef.current.getBoundingClientRect().width
-			}px`;
-			previewRef.current.style.height = `${
-				previewWrapperRef.current.getBoundingClientRect().height - 6
-			}px`;
+		if (!visible || !previewWrapperRef.current) {
+			return;
 		}
-	}, [previewRef]);
+
+		setSize(
+			activeSize.id === SIZES.autosize.id
+				? {
+						height:
+							previewWrapperRef.current.getBoundingClientRect()
+								.height - 6,
+						width: previewWrapperRef.current.getBoundingClientRect()
+							.width,
+				  }
+				: activeSize.screenSize
+		);
+	}, [activeSize.id, activeSize.screenSize, visible]);
 
 	useEffect(() => {
-		if (!visible) {
-			return;
-		}
-		if (activeSize.id === SIZES.autosize.id) {
-			updateAutosizePreview();
-		}
-	}, [activeSize, previewRef, updateAutosizePreview, visible]);
+		updateAutosizePreview();
+	}, [activeSize, updateAutosizePreview]);
 
 	const handleWindowResize = debounce(() => {
-		if (!visible) {
-			return;
-		}
-
-		if (activeSize.id === SIZES.autosize.id) {
-			updateAutosizePreview();
-		}
+		updateAutosizePreview();
 	}, 250);
 
 	// @ts-ignore
@@ -143,7 +142,7 @@ export default function Preview({activeSize, previewRef}: IPreviewProps) {
 					}
 				)}
 				ref={previewRef}
-				style={activeSize.screenSize}
+				style={size}
 			>
 				<iframe
 					className="border-0 h-100 w-100"

--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/constants/sizes.ts
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/constants/sizes.ts
@@ -15,6 +15,11 @@
 const ROTATED_SIZE_PADDING = 100;
 const NORMAL_SIZE_PADDING = 40;
 
+export interface ScreenSize {
+	height: number;
+	width: number;
+}
+
 export type Size = {
 	cssClass?: string;
 	icon: string;
@@ -22,10 +27,7 @@ export type Size = {
 	label: string;
 	responsive?: boolean;
 	rotatedId?: keyof typeof SIZES;
-	screenSize?: {
-		height: number;
-		width: number;
-	};
+	screenSize?: ScreenSize;
 };
 
 export const SIZES = {

--- a/modules/apps/product-navigation/product-navigation-simulation-device/tsconfig.json
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "ef1cd2c35d9ff2d6f173ecd8973f049606ee42cd",
+	"@generated": "45e40a8544aeb6d79f28e33c41eb1caed24afe07",
 	"@overrides": {
 	},
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
@@ -13,6 +13,9 @@
 		"moduleResolution": "node",
 		"outDir": "./types",
 		"paths": {
+			"@liferay/frontend-js-react-web": [
+				"../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
 			"frontend-js-web": [
 				"../../frontend-js/frontend-js-web/src/main/resources/META-INF/resources/index.d.ts"
 			]
@@ -35,6 +38,9 @@
 		"../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../frontend-js/frontend-js-react-web"
+		},
 		{
 			"path": "../../frontend-js/frontend-js-web"
 		}

--- a/modules/apps/product-navigation/product-navigation-simulation-device/types/src/main/resources/META-INF/resources/js/constants/sizes.d.ts
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/types/src/main/resources/META-INF/resources/js/constants/sizes.d.ts
@@ -12,6 +12,10 @@
  * details.
  */
 
+export interface ScreenSize {
+	height: number;
+	width: number;
+}
 export declare type Size = {
 	cssClass?: string;
 	icon: string;
@@ -19,10 +23,7 @@ export declare type Size = {
 	label: string;
 	responsive?: boolean;
 	rotatedId?: keyof typeof SIZES;
-	screenSize?: {
-		height: number;
-		width: number;
-	};
+	screenSize?: ScreenSize;
 };
 export declare const SIZES: {
 	readonly autosize: {


### PR DESCRIPTION
Motivation
=======
The simulation os segments and experiences doesn't work in the simulation panel. 
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-190089)

Proposed Solution
========
For fixing the autosize que now display the iframe when autosize is selected and readjust its size when the window is resized. 

Steps to Verify:
----------------
1. Add the feature.flag.LPS-186558=true into portal-ext.properties
2. Add a segment
3. In the home page, add an experience of that segment
4. Add a Button fragment for that experience
5. Publish the content page
6. Go to Simulation panel
7. Select autosize
8. Switch between the Anyone segment and the segment created in step 2 and check that it works ok.
9. In a small screen select Desktop option and check that the device does not overflow on top.
