### PR TITLE
LPS-172659 Hide layouts tree icon if the user doesn't have permissions

### DIFF
--- a/modules/apps/product-navigation/product-navigation-product-menu-api/src/main/java/com/liferay/product/navigation/product/menu/display/context/ProductMenuDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-api/src/main/java/com/liferay/product/navigation/product/menu/display/context/ProductMenuDisplayContext.java
@@ -24,9 +24,12 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.module.configuration.ConfigurationException;
 import com.liferay.portal.kernel.module.configuration.ConfigurationProviderUtil;
+import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -189,6 +192,20 @@ public class ProductMenuDisplayContext {
 			(ppid.equals(_PORTLET_NAME) &&
 			 Validator.isNotNull(mvcRenderCommandName)) ||
 			(ppid.equals(_PORTLET_NAME) && Validator.isNotNull(mvcPath))) {
+
+			return false;
+		}
+
+		return true;
+	}
+
+	public boolean isShowLayoutsTree() throws PortalException {
+		Group group = _themeDisplay.getScopeGroup();
+
+		if ((group != null) && !group.isCompany() && !group.isDepot() &&
+			GroupPermissionUtil.contains(
+				_themeDisplay.getPermissionChecker(),
+				_themeDisplay.getScopeGroup(), ActionKeys.MANAGE_LAYOUTS)) {
 
 			return true;
 		}

--- a/modules/apps/product-navigation/product-navigation-product-menu-api/src/main/java/com/liferay/product/navigation/product/menu/display/context/ProductMenuDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-api/src/main/java/com/liferay/product/navigation/product/menu/display/context/ProductMenuDisplayContext.java
@@ -171,7 +171,7 @@ public class ProductMenuDisplayContext {
 		return false;
 	}
 
-	public boolean isShowLayoutsTree() {
+	public boolean isLayoutsTreeDisabled() {
 		HttpServletRequest originalHttpServletRequest =
 			PortalUtil.getOriginalServletRequest(_httpServletRequest);
 

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
@@ -54,7 +54,7 @@ ApplicationsMenuInstanceConfiguration applicationsMenuInstanceConfiguration = Co
 
 	<div class="sidebar-body">
 		<c:choose>
-			<c:when test='<%= !productMenuDisplayContext.isLayoutsTreeDisabled() || (Objects.equals(productMenuState, "open") && !Objects.equals(pagesTreeState, "open")) %>'>
+			<c:when test='<%= productMenuDisplayContext.isLayoutsTreeDisabled() || !productMenuDisplayContext.isShowLayoutsTree() || (Objects.equals(productMenuState, "open") && !Objects.equals(pagesTreeState, "open")) %>'>
 				<liferay-util:include page="/portlet/product_menu.jsp" servletContext="<%= application %>" />
 			</c:when>
 			<c:when test='<%= Objects.equals(productMenuState, "open") && Objects.equals(pagesTreeState, "open") %>'>

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/portlet/view.jsp
@@ -54,7 +54,7 @@ ApplicationsMenuInstanceConfiguration applicationsMenuInstanceConfiguration = Co
 
 	<div class="sidebar-body">
 		<c:choose>
-			<c:when test='<%= !productMenuDisplayContext.isShowLayoutsTree() || (Objects.equals(productMenuState, "open") && !Objects.equals(pagesTreeState, "open")) %>'>
+			<c:when test='<%= !productMenuDisplayContext.isLayoutsTreeDisabled() || (Objects.equals(productMenuState, "open") && !Objects.equals(pagesTreeState, "open")) %>'>
 				<liferay-util:include page="/portlet/product_menu.jsp" servletContext="<%= application %>" />
 			</c:when>
 			<c:when test='<%= Objects.equals(productMenuState, "open") && Objects.equals(pagesTreeState, "open") %>'>

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -421,11 +421,11 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 		return true;
 	}
 
-	public boolean isShowLayoutsTree() throws PortalException {
+	public boolean isLayoutsTreeDisabled() throws PortalException {
 		ProductMenuDisplayContext productMenuDisplayContext =
 			new ProductMenuDisplayContext(_portletRequest, _portletResponse);
 
-		return productMenuDisplayContext.isShowLayoutsTree();
+		return productMenuDisplayContext.isLayoutsTreeDisabled();
 	}
 
 	public boolean isShowSiteAdministration() throws PortalException {

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -428,6 +428,13 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 		return productMenuDisplayContext.isLayoutsTreeDisabled();
 	}
 
+	public boolean isShowLayoutsTree() throws PortalException {
+		ProductMenuDisplayContext productMenuDisplayContext =
+			new ProductMenuDisplayContext(_portletRequest, _portletResponse);
+
+		return productMenuDisplayContext.isShowLayoutsTree();
+	}
+
 	public boolean isShowSiteAdministration() throws PortalException {
 		Group group = getGroup();
 

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -97,7 +97,7 @@ Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 			<c:if test="<%= (group != null) && !group.isCompany() && !group.isDepot() %>">
 				<clay:button
 					cssClass="list-group-heading navigation-link panel-header-link"
-					disabled="<%= !siteAdministrationPanelCategoryDisplayContext.isShowLayoutsTree() %>"
+					disabled="<%= !siteAdministrationPanelCategoryDisplayContext.isLayoutsTreeDisabled() %>"
 					displayType="unstyled"
 					icon="pages-tree"
 					id='<%= liferayPortletResponse.getNamespace() + "pagesTreeSidenavToggleId" %>'

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -94,10 +94,10 @@ Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 				/>
 			</c:if>
 
-			<c:if test="<%= (group != null) && !group.isCompany() && !group.isDepot() %>">
+			<c:if test="<%= siteAdministrationPanelCategoryDisplayContext.isShowLayoutsTree() %>">
 				<clay:button
 					cssClass="list-group-heading navigation-link panel-header-link"
-					disabled="<%= !siteAdministrationPanelCategoryDisplayContext.isLayoutsTreeDisabled() %>"
+					disabled="<%= siteAdministrationPanelCategoryDisplayContext.isLayoutsTreeDisabled() %>"
 					displayType="unstyled"
 					icon="pages-tree"
 					id='<%= liferayPortletResponse.getNamespace() + "pagesTreeSidenavToggleId" %>'


### PR DESCRIPTION
Not sure about whether we should use `MANAGE_LAYOUTS` permissions or other, that one seemed good enough. Also I thought about unifying the case where we want to disable the pages tree and the case where it should be hidden, but It makes sense to keep both. The disabled state show the user that the button will be enabled eventually where as hiding it doesn't give any clue to the user