### PR TITLE
LPS-189820 Asset categories ids are duplicated 

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetCategoriesSelectorTag.es.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_selector/AssetCategoriesSelectorTag.es.js
@@ -104,6 +104,7 @@ export default function (props) {
 
 					<AssetCategoriesSelectorTag
 						{...props}
+						id={`${publicVocabulariesId}_categories`}
 						initialVocabularies={initialPublicVocabularies}
 					/>
 				</div>
@@ -132,6 +133,7 @@ export default function (props) {
 
 						<AssetCategoriesSelectorTag
 							{...props}
+							id={`${internalVocabulariesId}_categories`}
 							initialVocabularies={initialInternalVocabularies}
 						/>
 					</div>


### PR DESCRIPTION
Issue https://liferay.atlassian.net/browse/LPS-189820. 

Please let me know if this approach is not the correct. Thanks! 
