### PR TITLE
LPS-190347 Use ClayDropdown for preview by selector

### DIFF
--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/js/components/PageContentSelectors.tsx
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/js/components/PageContentSelectors.tsx
@@ -13,7 +13,8 @@
  */
 
 import ClayAlert from '@clayui/alert';
-import {ClaySelectWithOption} from '@clayui/form';
+import ClayButton from '@clayui/button';
+import ClayDropDown, {Align} from '@clayui/drop-down';
 import ClayLink from '@clayui/link';
 import {fetch, openSelectionModal, sub} from 'frontend-js-web';
 import React, {useCallback, useEffect, useRef, useState} from 'react';
@@ -36,11 +37,12 @@ interface Props {
 	simulateSegmentsEntriesURL: string;
 }
 
+const DEFAULT_PREVIEW_OPTION = {
+	label: Liferay.Language.get('segments'),
+	value: 'segments',
+};
 const PREVIEW_OPTIONS = [
-	{
-		label: Liferay.Language.get('segments'),
-		value: 'segments',
-	},
+	DEFAULT_PREVIEW_OPTION,
 	{
 		label: Liferay.Language.get('experiences'),
 		value: 'experiences',
@@ -61,9 +63,13 @@ function PageContentSelectors({
 	selectSegmentsExperienceURL,
 	simulateSegmentsEntriesURL,
 }: Props) {
+	const [
+		isSegmentOrExperienceSelectorActive,
+		setIsSegmentOrExperienceSelectorActive,
+	] = useState(false);
 	const [alertVisible, setAlertVisible] = useState(!segmentationEnabled);
 	const [selectedPreviewOption, setSelectedPreviewOption] = useState(
-		'segments'
+		DEFAULT_PREVIEW_OPTION
 	);
 	const [selectedSegmentEntry, setSelectedSegmentEntry] = useState(
 		segmentsEntries?.[0]
@@ -205,7 +211,7 @@ function PageContentSelectors({
 			return;
 		}
 
-		if (selectedPreviewOption === 'segments') {
+		if (selectedPreviewOption.value === 'segments') {
 			const url = new URL(iframe.contentWindow.location.href);
 			url.searchParams.delete('segmentsExperienceId');
 
@@ -268,17 +274,55 @@ function PageContentSelectors({
 					{Liferay.Language.get('preview-by')}
 				</label>
 
-				<ClaySelectWithOption
+				<input
 					id={`${namespace}segmentsOrExperiences`}
-					onChange={({target}) => {
-						setSelectedPreviewOption(target.value);
-					}}
-					options={PREVIEW_OPTIONS}
-					value={selectedPreviewOption}
+					name={`${namespace}segmentsOrExperiences`}
+					type="hidden"
+					value={selectedPreviewOption.value}
 				/>
+
+				<ClayDropDown
+					active={isSegmentOrExperienceSelectorActive}
+					alignmentPosition={Align.BottomLeft}
+					menuElementAttrs={{
+						containerProps: {
+							className: 'cadmin',
+						},
+					}}
+					onActiveChange={setIsSegmentOrExperienceSelectorActive}
+					trigger={
+						<ClayButton
+							className="form-control-select text-left w-100"
+							displayType="secondary"
+							size="sm"
+							type="button"
+						>
+							{selectedPreviewOption.label}
+						</ClayButton>
+					}
+				>
+					<ClayDropDown.ItemList>
+						{PREVIEW_OPTIONS.map((option) => (
+							<ClayDropDown.Item
+								active={
+									option.value === selectedPreviewOption.value
+								}
+								key={option.value}
+								onClick={() => {
+									setIsSegmentOrExperienceSelectorActive(
+										false
+									);
+									setSelectedPreviewOption(option);
+								}}
+							>
+								{option.label}
+							</ClayDropDown.Item>
+						))}
+					</ClayDropDown.ItemList>
+				</ClayDropDown>
 			</div>
 
-			{selectedPreviewOption === 'segments' && (
+			{selectedPreviewOption.value === 'segments' && (
 				<SegmentSelector
 					maximumDropdownEntries={MAXIMUM_DROPDOWN_ENTRIES}
 					namespace={namespace}
@@ -291,7 +335,7 @@ function PageContentSelectors({
 				/>
 			)}
 
-			{selectedPreviewOption === 'experiences' && (
+			{selectedPreviewOption.value === 'experiences' && (
 				<ExperienceSelector
 					maximumDropdownEntries={MAXIMUM_DROPDOWN_ENTRIES}
 					namespace={namespace}

--- a/modules/apps/segments/segments-simulation-web/test/js/components/PageContentSelectors.test.js
+++ b/modules/apps/segments/segments-simulation-web/test/js/components/PageContentSelectors.test.js
@@ -12,7 +12,7 @@
  * details.
  */
 
-import {fireEvent, render} from '@testing-library/react';
+import {render} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {openSelectionModal} from 'frontend-js-web';
 import React from 'react';
@@ -74,10 +74,24 @@ describe('PageContentSelectors', () => {
 			<PageContentSelectors {...mockProps} />
 		);
 
+		const previewBySelector = getByRole('button', {name: /segments/i});
 		expect(getByText('preview-by')).toBeInTheDocument();
-		expect(getByRole('combobox')).toHaveValue('segments');
-		expect(getByRole('option', {name: 'segments'}).selected).toBe(true);
-		expect(getByRole('option', {name: 'experiences'}).selected).toBe(false);
+		expect(previewBySelector).toBeInTheDocument();
+		expect(previewBySelector).toHaveTextContent('segments');
+
+		userEvent.click(previewBySelector);
+
+		expect(
+			getByRole('menuitem', {
+				name: /segments/i,
+			})
+		).toBeInTheDocument();
+
+		expect(
+			getByRole('menuitem', {
+				name: /experiences/i,
+			})
+		).toBeInTheDocument();
 	});
 
 	it('If no segments available renders empty segments message', () => {
@@ -97,9 +111,13 @@ describe('PageContentSelectors', () => {
 			/>
 		);
 
-		fireEvent.change(getByRole('combobox'), {
-			target: {value: 'experiences'},
-		});
+		const previewBySelector = getByRole('button', {name: /segments/i});
+		userEvent.click(previewBySelector);
+		userEvent.click(
+			getByRole('menuitem', {
+				name: /experiences/i,
+			})
+		);
 
 		expect(
 			getByText('no-experiences-have-been-added-yet')
@@ -111,10 +129,10 @@ describe('PageContentSelectors', () => {
 			<PageContentSelectors {...mockProps} />
 		);
 
-		expect(getByText('segments')).toBeInTheDocument();
+		expect(getByText('segment')).toBeInTheDocument();
 
-		const button = getByRole('button');
-		expect(button).toHaveTextContent('Anyone');
+		const button = getByRole('button', {name: /Anyone/i});
+		expect(button).toBeInTheDocument();
 
 		userEvent.click(button);
 		expect(getByText('Liferayers')).toBeInTheDocument();
@@ -144,7 +162,7 @@ describe('PageContentSelectors', () => {
 			/>
 		);
 
-		const button = getByRole('button');
+		const button = getByRole('button', {name: /Anyone/i});
 
 		userEvent.click(button);
 		expect(getByText('more-segments')).toBeInTheDocument();
@@ -158,12 +176,16 @@ describe('PageContentSelectors', () => {
 			<PageContentSelectors {...mockProps} />
 		);
 
-		fireEvent.change(getByRole('combobox'), {
-			target: {value: 'experiences'},
-		});
+		const previewBySelector = getByRole('button', {name: /segments/i});
+		userEvent.click(previewBySelector);
+		userEvent.click(
+			getByRole('menuitem', {
+				name: /experiences/i,
+			})
+		);
 
-		const button = getByRole('button');
-		expect(button).toHaveTextContent('Experience 1');
+		const button = getByRole('button', {name: /Experience 1/i});
+		expect(button).toBeInTheDocument();
 
 		userEvent.click(button);
 		expect(getByText('Default')).toBeInTheDocument();
@@ -247,11 +269,15 @@ describe('PageContentSelectors', () => {
 			/>
 		);
 
-		fireEvent.change(getByRole('combobox'), {
-			target: {value: 'experiences'},
-		});
+		const previewBySelector = getByRole('button', {name: /segments/i});
+		userEvent.click(previewBySelector);
+		userEvent.click(
+			getByRole('menuitem', {
+				name: /experiences/i,
+			})
+		);
 
-		const button = getByRole('button');
+		const button = getByRole('button', {name: /Experience 1/i});
 
 		userEvent.click(button);
 		expect(getByText('more-experiences')).toBeInTheDocument();


### PR DESCRIPTION
Motivation
=======
We want to unify the styles of the preview by, segments and experiences selectors. 
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-190347)

Proposed Solution
========
We have migrated the preview by selector from ClaySelect to ClayDropdown

Steps to Verify:
----------------
1. Set feature.flag.LPS-186558=true
1. Create one segment (People -> Segments)
1. Go to home page and create and experience for that segment and publish
1. Open the simulation panel and check that the styles of the preview by, segments and experiences are the same.
