### PR TITLE
[TS] LPS-190044 Ensure friendly URL entries are deleted on the live site when publishing

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -1151,6 +1151,30 @@ public class LayoutStagedModelDataHandler
 		return portletIds;
 	}
 
+	private void _deleteMissingFriendlyURLEntries(
+		Layout layout, PortletDataContext portletDataContext) {
+
+		Map<Long, Long> friendlyURLEntryIds =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				FriendlyURLEntry.class);
+
+		List<FriendlyURLEntry> friendlyURLEntries =
+			_friendlyURLEntryLocalService.getFriendlyURLEntries(
+				layout.getGroupId(),
+				_layoutFriendlyURLEntryHelper.getClassNameId(
+					portletDataContext.isPrivateLayout()),
+				layout.getPlid());
+
+		for (FriendlyURLEntry friendlyURLEntry : friendlyURLEntries) {
+			if (!friendlyURLEntryIds.containsValue(
+					friendlyURLEntry.getFriendlyURLEntryId())) {
+
+				_friendlyURLEntryLocalService.deleteFriendlyURLEntry(
+					friendlyURLEntry);
+			}
+		}
+	}
+
 	private void _deleteMissingLayoutFriendlyURLs(
 		Layout layout, PortletDataContext portletDataContext) {
 
@@ -2058,6 +2082,8 @@ public class LayoutStagedModelDataHandler
 			StagedModelDataHandlerUtil.importStagedModel(
 				portletDataContext, friendlyURLEntryElement);
 		}
+
+		_deleteMissingFriendlyURLEntries(importedLayout, portletDataContext);
 	}
 
 	private void _importLayoutClassedModelUsages(


### PR DESCRIPTION
Motivation
=======
This change ensures the deletion of friendly URLs on the Live side when publishing changes. This fixes https://liferay.atlassian.net/browse/LPS-190044.

Proposed Solution
========
To solve this problem I introduced a new method that is highly similar to _deleteMissingLayoutFriendlyURLs - https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java#L1154C15-L1154C47

It fetches the currently friendly URLs on the Live side and compares them against the ones being published. If one exists but is not being published then it is removed.

Steps to Verify
========
Please see the steps on https://liferay.atlassian.net/browse/LPS-190044

Notes
========
This has already been reviewed by the Staging team here - https://github.com/liferay-staging/liferay-portal/pull/354