### PR TITLE
LPS-189886 Styles in Asset Publisher configuration -> filter are broken

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/css/main.scss
@@ -34,25 +34,6 @@
 		border-radius: 0;
 	}
 
-	.timeline-increment-icon.add-condition:before {
-		background-color: #869cad;
-		bottom: 37px;
-		content: '';
-		display: block;
-		left: 20px;
-		position: absolute;
-		top: -10px;
-		width: 2px;
-	}
-
-	.timeline-increment-icon.add-condition {
-		.form-builder-timeline-add-item {
-			border-radius: 100%;
-			margin-left: 10px;
-			margin-top: -72px;
-		}
-	}
-
 	.timeline-item {
 		&:first-child {
 			.timeline-icon {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/css/main.scss
@@ -56,7 +56,6 @@
 		.form-group {
 			display: inline-block;
 			margin: 0 8px 8px 0;
-			vertical-align: middle;
 		}
 
 		.container-trash {

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/components/AssetFilterBuilder/index.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/components/AssetFilterBuilder/index.js
@@ -154,8 +154,12 @@ function Rule({
 	return (
 		<>
 			<div className="panel panel-default">
-				<div className="panel-body">
-					<ClayForm.Group>
+				<div className="c-mt-2 timeline-increment">
+					<span className="timeline-icon"></span>
+				</div>
+
+				<div className="mb-0 panel-body">
+					<ClayForm.Group className="c-mr-3">
 						<ClaySelectWithOption
 							aria-label={Liferay.Language.get('query-contains')}
 							data-index={index}
@@ -169,7 +173,7 @@ function Rule({
 						/>
 					</ClayForm.Group>
 
-					<ClayForm.Group>
+					<ClayForm.Group className="c-mr-3">
 						<ClaySelectWithOption
 							aria-label={Liferay.Language.get('and-operator')}
 							data-index={index}
@@ -183,7 +187,7 @@ function Rule({
 						/>
 					</ClayForm.Group>
 
-					<ClayForm.Group>
+					<ClayForm.Group className="c-mr-3">
 						<label
 							className="control-label"
 							htmlFor={`${namespace}queryName${index}`}
@@ -192,7 +196,7 @@ function Rule({
 						</label>
 					</ClayForm.Group>
 
-					<ClayForm.Group>
+					<ClayForm.Group className="c-mr-3">
 						<ClaySelectWithOption
 							data-index={index}
 							data-property="type"
@@ -233,10 +237,6 @@ function Rule({
 							rule={rule}
 						/>
 					)}
-
-					<div className="timeline-increment">
-						<span className="timeline-icon"></span>
-					</div>
 				</div>
 			</div>
 
@@ -317,13 +317,13 @@ function AssetFilterBuilder({
 			<ul className="timeline">
 				<li className="timeline-item">
 					<div className="panel panel-default">
-						<div className="d-flex flex-wrap mb-0 panel-body py-2">
-							<div className="h4 panel-title">
-								{Liferay.Language.get('rules')}
-							</div>
+						<div className="timeline-increment">
+							<span className="timeline-icon"></span>
+						</div>
 
-							<div className="timeline-increment">
-								<span className="timeline-icon"></span>
+						<div className="my-1 panel-body">
+							<div className="c-mb-0 h4 panel-title">
+								{Liferay.Language.get('rules')}
 							</div>
 						</div>
 					</div>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/components/AssetFilterBuilder/index.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/components/AssetFilterBuilder/index.js
@@ -344,21 +344,24 @@ function AssetFilterBuilder({
 						/>
 					</li>
 				))}
-			</ul>
 
-			<div className="position-relative">
-				<div className="add-condition timeline-increment-icon">
-					<ClayButton
-						aria-label={Liferay.Language.get('add-condition')}
-						className="form-builder-rule-add-condition form-builder-timeline-add-item"
-						monospaced
-						onClick={handleAddRule}
-						size="sm"
-					>
-						<ClayIcon symbol="plus" />
-					</ClayButton>
-				</div>
-			</div>
+				<li className="timeline-item">
+					<div className="position-relative">
+						<div className="timeline-increment">
+							<ClayButton
+								aria-label={Liferay.Language.get(
+									'add-condition'
+								)}
+								monospaced
+								onClick={handleAddRule}
+								size="sm"
+							>
+								<ClayIcon symbol="plus" />
+							</ClayButton>
+						</div>
+					</div>
+				</li>
+			</ul>
 		</>
 	);
 }


### PR DESCRIPTION
Motivation
=======
The motivation behind this PR is to fix some style issues in the Asset Publisher for the Edit View.

Proposed Solution
========
What I did to solve this problem is to add the necessary spacing between elements and also remove some unnecessary styling code from it.

Steps to Verify
========
1. Go to Edit view for a page
2. Add an Asset Publisher from the left sidebar Widget Section
3. Click on the Options ellipsis button -> Configuration
4. Select Dynamic for Asset Selection and then go to the Filter section

Screenshots
========
BEFORE
<img width="1665" alt="Screenshot 2023-07-17 at 11 06 01" src="https://github.com/liferay-echo/liferay-portal/assets/91207948/4e63f44c-2073-49d8-b039-9fa1351e4908">

AFTER
<img width="1459" alt="Screenshot 2023-07-17 at 11 07 51" src="https://github.com/liferay-echo/liferay-portal/assets/91207948/44bc21cb-10dd-47f4-9f80-bb8dc48fd858">


