### PR TITLE
LPS-176668 Adjust clay alert styles of asset publisher and journal content

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/view.jsp
@@ -127,17 +127,15 @@ if (assetPublisherDisplayContext.isEnableTagBasedNavigation() && !assetPublisher
 			>
 				<c:choose>
 					<c:when test="<%= assetPublisherDisplayContext.isSelectionStyleAssetList() && (assetPublisherDisplayContext.fetchAssetListEntry() == null) && Validator.isNull(assetPublisherDisplayContext.getInfoListProviderKey()) && !portletName.equals(AssetPublisherPortletKeys.RELATED_ASSETS) %>">
-						<div class="align-items-center d-inline-flex">
-							<liferay-ui:message key="this-application-is-not-visible-to-users-yet" />
+						<liferay-ui:message key="this-application-is-not-visible-to-users-yet" />
 
-							<clay:button
-								cssClass="ml-1 p-0"
-								displayType="link"
-								label="select-a-collection-to-make-it-visible"
-								onClick="<%= portletDisplay.getURLConfigurationJS() %>"
-								small="<%= true %>"
-							/>
-						</div>
+						<clay:button
+							cssClass="align-text-bottom border-0 p-0"
+							displayType="link"
+							label="select-a-collection-to-make-it-visible"
+							onClick="<%= portletDisplay.getURLConfigurationJS() %>"
+							small="<%= true %>"
+						/>
 					</c:when>
 					<c:when test="<%= !portletName.equals(AssetPublisherPortletKeys.RELATED_ASSETS) %>">
 						<liferay-ui:message key="there-are-no-results" />

--- a/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/journal/journal-content-web/src/main/resources/META-INF/resources/view.jsp
@@ -38,17 +38,15 @@ if (journalContentDisplayContext.isShowArticle()) {
 				<clay:alert
 					displayType="info"
 				>
-					<div class="align-items-center d-inline-flex">
-						<liferay-ui:message key="this-application-is-not-visible-to-users-yet" />
+					<liferay-ui:message key="this-application-is-not-visible-to-users-yet" />
 
-						<clay:button
-							cssClass="ml-1 p-0"
-							displayType="link"
-							label="select-web-content-to-make-it-visible"
-							onClick="<%= portletDisplay.getURLConfigurationJS() %>"
-							small="<%= true %>"
-						/>
-					</div>
+					<clay:button
+						cssClass="align-text-bottom border-0 p-0"
+						displayType="link"
+						label="select-web-content-to-make-it-visible"
+						onClick="<%= portletDisplay.getURLConfigurationJS() %>"
+						small="<%= true %>"
+					/>
 				</clay:alert>
 			</c:when>
 			<c:otherwise>


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-176668)

**In this PR I have adjusted the styles of asset publisher widget and journal content widget, since in this PR (https://github.com/liferay-echo/liferay-portal/pull/12788) the styles where weird**
<img width="703" alt="Screenshot 2023-07-17 at 13 29 19" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/6a8a3f20-6457-48a4-bc0b-50c3d0408d7c">

