### PR TITLE
LPS-190828 Add colon after Info title

### DIFF
--- a/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/components/Preview.tsx
+++ b/modules/apps/product-navigation/product-navigation-simulation-device/src/main/resources/META-INF/resources/js/components/Preview.tsx
@@ -82,7 +82,7 @@ export default function Preview({activeSize, previewRef}: IPreviewProps) {
 				<ClayAlert
 					className="c-m-3"
 					displayType="info"
-					title={Liferay.Language.get('info')}
+					title={`${Liferay.Language.get('info')}:`}
 				>
 					{segmentMessage}
 				</ClayAlert>


### PR DESCRIPTION
Motivation
=======
Add a colon after Info title in the alert message
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-190828)

Steps to Verify:
----------------

1. Set feature.flag.LPS-186558=true in portal-ext.properties
2. Go to People -> Segments and create some segments
3. Go to Home page and open the simulation panel. Check that the alert has a colon after the Info title.