### PR TITLE
LPS-190008 Replace aui:button with clay:button in journal-web

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/basic_info.jsp
@@ -46,7 +46,11 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 	</div>
 
 	<div class="form-group">
-		<aui:button name="selectFolderButton" value="select" />
+		<clay:button
+			displayType="secondary"
+			id='<%= liferayPortletResponse.getNamespace() + "selectFolderButton" %>'
+			label="select"
+		/>
 	</div>
 
 	<liferay-frontend:component

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/template.jsp
@@ -49,14 +49,26 @@ DDMTemplate ddmTemplate = journalEditArticleDisplayContext.getDDMTemplate();
 		</div>
 
 		<div class="form-group">
-			<aui:button id="selectDDMTemplate" value="select" />
+			<clay:button
+				displayType="secondary"
+				id='<%= liferayPortletResponse.getNamespace() + "selectDDMTemplate" %>'
+				label="select"
+			/>
 
 			<c:if test="<%= (ddmTemplate != null) && DDMTemplatePermission.contains(permissionChecker, ddmTemplate, ActionKeys.UPDATE) %>">
-				<aui:button id="editDDMTemplate" value="edit" />
+				<clay:button
+					displayType="secondary"
+					id='<%= liferayPortletResponse.getNamespace() + "editDDMTemplate" %>'
+					label="edit"
+				/>
 			</c:if>
 
 			<c:if test="<%= ddmTemplate != null %>">
-				<aui:button id="clearDDMTemplate" value="clear" />
+				<clay:button
+					displayType="secondary"
+					id='<%= liferayPortletResponse.getNamespace() + "clearDDMTemplate" %>'
+					label="clear"
+				/>
 			</c:if>
 		</div>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/view_source.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/configuration/icon/view_source.jsp
@@ -17,13 +17,15 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String redirect = ParamUtil.getString(request, "redirect");
-
 JournalArticle article = journalDisplayContext.getArticle();
 %>
 
 <pre class="m-4"><%= HtmlUtil.escape(article.getContent()) %></pre>
 
 <aui:button-row>
-	<aui:button href="<%= redirect %>" type="cancel" value="close" />
+	<clay:button
+		displayType="secondary"
+		label="close"
+		onClick="Liferay.Util.getOpener().Liferay.fire('closeModal')"
+	/>
 </aui:button-row>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -66,7 +66,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 					<aui:input cssClass="form-control-inline" defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>" label='<%= LanguageUtil.get(request, "name") %>' labelCssClass="sr-only" languagesDropdownDirection="down" localized="<%= true %>" name="titleMapAsXML" placeholder='<%= LanguageUtil.format(request, "untitled-x", HtmlUtil.escape(ddmStructure.getName(locale))) %>' required="<%= journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT %>" selectedLanguageId="<%= journalEditArticleDisplayContext.getSelectedLanguageId() %>" type="text" wrapperCssClass="article-content-title mb-0" />
 				</li>
 				<li class="tbar-item">
-					<div class="journal-article-button-row tbar-section text-right">
+					<div class="c-gap-3 form-group-sm journal-article-button-row tbar-section text-right">
 						<c:choose>
 							<c:when test="<%= journalEditArticleDisplayContext.isJournalArticleAutoSaveDraftEnabled() %>">
 								<div class="align-items-center d-none mx-3 small" id="<portlet:namespace />savingChangesIndicator">
@@ -85,7 +85,13 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 								</div>
 							</c:when>
 							<c:otherwise>
-								<aui:button cssClass="btn-outline-borderless btn-outline-secondary btn-sm mr-3" href="<%= journalEditArticleDisplayContext.getRedirect() %>" type="cancel" />
+								<clay:link
+									borderless="<%= true %>"
+									displayType="secondary"
+									href="<%= journalEditArticleDisplayContext.getRedirect() %>"
+									label="cancel"
+									type="button"
+								/>
 							</c:otherwise>
 						</c:choose>
 
@@ -98,15 +104,32 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 								<portlet:param name="ddmStructureId" value="<%= String.valueOf(ddmStructure.getStructureId()) %>" />
 							</portlet:actionURL>
 
-							<aui:button cssClass="btn-sm mr-3" data-url="<%= resetValuesDDMStructureURL %>" name="resetValuesButton" value="reset-values" />
+							<clay:button
+								data-url="<%= resetValuesDDMStructureURL %>"
+								displayType="secondary"
+								id='<%= liferayPortletResponse.getNamespace() + "resetValuesButton" %>'
+								label="reset-values"
+							/>
 						</c:if>
 
 						<c:if test="<%= journalEditArticleDisplayContext.hasSavePermission() %>">
 							<c:if test="<%= !journalEditArticleDisplayContext.isJournalArticleAutoSaveDraftEnabled() && (journalEditArticleDisplayContext.getClassNameId() == JournalArticleConstants.CLASS_NAME_ID_DEFAULT) %>">
-								<aui:button cssClass="btn-sm mr-3" data-actionname='<%= ((article == null) || Validator.isNull(article.getArticleId())) ? "/journal/add_article" : "/journal/update_article" %>' name="saveButton" primary="<%= false %>" type="submit" value="<%= journalEditArticleDisplayContext.getSaveButtonLabel() %>" />
+								<clay:button
+									data-actionname='<%= ((article == null) || Validator.isNull(article.getArticleId())) ? "/journal/add_article" : "/journal/update_article" %>'
+									displayType="secondary"
+									id='<%= liferayPortletResponse.getNamespace() + "saveButton" %>'
+									label="<%= journalEditArticleDisplayContext.getSaveButtonLabel() %>"
+									type="submit"
+								/>
 							</c:if>
 
-							<aui:button cssClass="btn-sm mr-3" data-actionname="<%= Constants.PUBLISH %>" disabled="<%= journalEditArticleDisplayContext.isPending() %>" name="publishButton" type="submit" value="<%= journalEditArticleDisplayContext.getPublishButtonLabel() %>" />
+							<clay:button
+								data-actionname="<%= Constants.PUBLISH %>"
+								displayType="primary"
+								id='<%= liferayPortletResponse.getNamespace() + "publishButton" %>'
+								label="<%= journalEditArticleDisplayContext.getPublishButtonLabel() %>"
+								type="submit"
+							/>
 						</c:if>
 
 						<div role="tablist">

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_data_definition.jsp
@@ -71,10 +71,21 @@ editDDMStructureURL.setParameter("structureKey", String.valueOf(ddmStructureKey)
 					<aui:input activeLanguageIds="<%= journalEditDDMStructuresDisplayContext.getAvailableLanguageIds() %>" adminMode="<%= true %>" cssClass="form-control-inline" defaultLanguageId="<%= (ddmForm == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): LocaleUtil.toLanguageId(ddmForm.getDefaultLocale()) %>" label='<%= LanguageUtil.get(request, "name") %>' labelCssClass="sr-only" languagesDropdownDirection="down" localized="<%= true %>" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "structure") %>' required="<%= true %>" type="text" wrapperCssClass="article-content-title c-mb-0" />
 				</li>
 				<li class="tbar-item">
-					<div class="journal-article-button-row tbar-section text-right">
-						<aui:button cssClass="btn-sm c-mr-3" href="<%= redirect %>" type="cancel" />
+					<div class="c-gap-3 form-group-sm journal-article-button-row tbar-section text-right">
+						<clay:link
+							borderless="<%= true %>"
+							displayType="secondary"
+							href="<%= redirect %>"
+							label="cancel"
+							type="button"
+						/>
 
-						<aui:button cssClass="btn-sm c-mr-3" id="submitButton" type="submit" value="save" />
+						<clay:button
+							displayType="primary"
+							id='<%= liferayPortletResponse.getNamespace() + "submitButton" %>'
+							label="save"
+							type="submit"
+						/>
 					</div>
 				</li>
 			</ul>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
@@ -57,10 +57,28 @@ renderResponse.setTitle(journalEditDDMTemplateDisplayContext.getTitle());
 					<aui:input cssClass="form-control-inline" defaultLanguageId="<%= (ddmTemplate == null) ? LocaleUtil.toLanguageId(LocaleUtil.getSiteDefault()): ddmTemplate.getDefaultLanguageId() %>" label='<%= LanguageUtil.get(request, "name") %>' labelCssClass="sr-only" name="name" placeholder='<%= LanguageUtil.format(request, "untitled-x", "template") %>' wrapperCssClass="article-content-title mb-0" />
 				</li>
 				<li class="tbar-item">
-					<div class="journal-article-button-row tbar-section text-right">
-						<aui:button cssClass="btn-sm mr-3" href="<%= journalEditDDMTemplateDisplayContext.getRedirect() %>" type="cancel" />
-						<aui:button cssClass="btn-sm mr-3 save-and-continue-button" primary="<%= false %>" type="submit" value="save-and-continue" />
-						<aui:button cssClass="btn-sm mr-3 save-button" type="submit" value="save" />
+					<div class="c-gap-3 form-group-sm journal-article-button-row tbar-section text-right">
+						<clay:link
+							borderless="<%= true %>"
+							displayType="secondary"
+							href="<%= journalEditDDMTemplateDisplayContext.getRedirect() %>"
+							label="cancel"
+							type="button"
+						/>
+
+						<clay:button
+							cssClass="save-and-continue-button"
+							displayType="secondary"
+							label="save-and-continue"
+							type="submit"
+						/>
+
+						<clay:button
+							cssClass="save-button"
+							displayType="primary"
+							label="save"
+							type="submit"
+						/>
 					</div>
 				</li>
 			</ul>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
@@ -118,9 +118,20 @@ renderResponse.setTitle(editJournalFeedDisplayContext.getTitle());
 
 				<aui:input name="structure" type="resource" value="<%= editJournalFeedDisplayContext.getDDMStructureName() %>" />
 
-				<aui:button name="selectDDMStructureButton" onClick='<%= liferayPortletResponse.getNamespace() + "openDDMStructureSelector();" %>' value="select" />
+				<clay:button
+					displayType="secondary"
+					id='<%= liferayPortletResponse.getNamespace() + "selectDDMStructureButton" %>'
+					label="select"
+					onClick='<%= liferayPortletResponse.getNamespace() + "openDDMStructureSelector();" %>'
+				/>
 
-				<aui:button disabled="<%= editJournalFeedDisplayContext.getDDMStructureId() == 0 %>" name="removeDDMStructureButton" onClick='<%= liferayPortletResponse.getNamespace() + "removeDDMStructure();" %>' value="remove" />
+				<clay:button
+					disabled="<%= editJournalFeedDisplayContext.getDDMStructureId() == 0 %>"
+					displayType="secondary"
+					id='<%= liferayPortletResponse.getNamespace() + "removeDDMStructureButton" %>'
+					label="remove"
+					onClick='<%= liferayPortletResponse.getNamespace() + "removeDDMStructure();" %>'
+				/>
 			</div>
 
 			<c:choose>
@@ -149,9 +160,20 @@ renderResponse.setTitle(editJournalFeedDisplayContext.getTitle());
 
 				<aui:input name="assetCategory" type="resource" value="<%= editJournalFeedDisplayContext.getAssetCategoryName() %>" />
 
-				<aui:button name="selectAssetCategoryButton" onClick='<%= liferayPortletResponse.getNamespace() + "openAssetCategorySelector();" %>' value="select" />
+				<clay:button
+					displayType="secondary"
+					id='<%= liferayPortletResponse.getNamespace() + "selectAssetCategoryButton" %>'
+					label="select"
+					onClick='<%= liferayPortletResponse.getNamespace() + "openAssetCategorySelector();" %>'
+				/>
 
-				<aui:button disabled="<%= editJournalFeedDisplayContext.getAssetCategoryId() == 0 %>" name="removeAssetCategoryButton" onClick='<%= liferayPortletResponse.getNamespace() + "removeAssetCategory();" %>' value="remove" />
+				<clay:button
+					disabled="<%= editJournalFeedDisplayContext.getAssetCategoryId() == 0 %>"
+					displayType="secondary"
+					id='<%= liferayPortletResponse.getNamespace() + "removeAssetCategoryButton" %>'
+					label="remove"
+					onClick='<%= liferayPortletResponse.getNamespace() + "removeAssetCategory();" %>'
+				/>
 			</div>
 		</liferay-frontend:fieldset>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -144,7 +144,11 @@ renderResponse.setTitle(title);
 				<div class="form-group">
 					<aui:input name="parentFolderName" type="resource" value="<%= parentFolderName %>" />
 
-					<aui:button name="selectFolderButton" value="select" />
+					<clay:button
+						displayType="secondary"
+						id='<%= liferayPortletResponse.getNamespace() + "selectFolderButton" %>'
+						label="select"
+					/>
 
 					<aui:script sandbox="<%= true %>">
 						var selectFolderButton = document.getElementById(
@@ -183,7 +187,13 @@ renderResponse.setTitle(title);
 					String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('parentFolderId', 'parentFolderName', this, '" + liferayPortletResponse.getNamespace() + "');";
 					%>
 
-					<aui:button disabled="<%= parentFolderId <= 0 %>" name="removeFolderButton" onClick="<%= taglibRemoveFolder %>" value="remove" />
+					<clay:button
+						disabled="<%= parentFolderId <= 0 %>"
+						displayType="secondary"
+						id='<%= liferayPortletResponse.getNamespace() + "removeFolderButton" %>'
+						label="remove"
+						onClick="<%= taglibRemoveFolder %>"
+					/>
 				</div>
 			</liferay-frontend:fieldset>
 		</c:if>
@@ -295,7 +305,11 @@ renderResponse.setTitle(title);
 							/>
 						</liferay-ui:search-container>
 
-						<aui:button id="selectDDMStructure" value="choose-structure" />
+						<clay:button
+							displayType="secondary"
+							id='<%= liferayPortletResponse.getNamespace() + "selectDDMStructure" %>'
+							label="choose-structure"
+						/>
 					</div>
 				</c:if>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/move_articles_and_folders.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/move_articles_and_folders.jsp
@@ -164,7 +164,11 @@ JournalMoveEntriesDisplayContext journalMoveEntriesDisplayContext = new JournalM
 
 			<aui:input label="new-folder" name="folderName" title="new-folder" type="resource" value="<%= journalMoveEntriesDisplayContext.getNewFolderName() %>" />
 
-			<aui:button name="selectFolderButton" value="select" />
+			<clay:button
+				displayType="secondary"
+				id='<%= liferayPortletResponse.getNamespace() + "selectFolderButton" %>'
+				label="select"
+			/>
 		</liferay-frontend:fieldset>
 	</liferay-frontend:edit-form-body>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content_template.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/preview_article_content_template.jsp
@@ -40,15 +40,17 @@ JournalPreviewArticleContentTemplateDisplayContext journalPreviewArticleContentT
 				</aui:select>
 			</li>
 			<li class="tbar-item">
-				<div class="journal-article-button-row tbar-section text-right">
-					<aui:button
-						cssClass="btn-sm selector-button"
-						data='<%=
+				<div class="form-group-sm journal-article-button-row tbar-section text-right">
+					<clay:button
+						cssClass="selector-button"
+						data-id='<%=
 							HashMapBuilder.<String, Object>put(
 								"ddmtemplateid", journalPreviewArticleContentTemplateDisplayContext.getDDMTemplateId()
 							).build()
 						%>'
-						value="apply"
+						displayType="secondary"
+						label="apply"
+						type="submit"
 					/>
 				</div>
 			</li>


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-190008)

In this issue we want to replace all usages of aui:button with clay:button in journal-web module, ideally it is going to allow us improve the accessibility.

## Test Scenario 1 (edit_data_definition.jsp)

* Create a new estructure
* Check the next buttons 

<img width="262" alt="Pasted Graphic" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/01bcd2c7-1e5e-47fa-be17-3a85e13aaef9">

## Test Scenario 2 (edit_ddm_template.jsp)

* Create a new template
* Check the next buttons 

<img width="393" alt="Pasted Graphic 1" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/87308bfe-ac7a-4ae2-9625-da8006c1f8d2">

## Test Scenario 3 (edit_article.jsp)

* Create a new structure an edit the default values
* Check the next buttons 

<img width="358" alt="Pasted Graphic 1" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/363635ec-6f76-4941-97a4-c82c48b479be">

## Test Scenario 4 (edit_article.jsp)

* Create a new web content
* Check the next buttons  

<img width="426" alt="Pasted Graphic" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/2cb72092-232f-4768-83cb-9b7a1b8daff7">

## Test Scenario 5 (basic_info.jsp)

* Create a new web content
* Create a Widget page with an asset publisher
* Configure the asset publisher to the dynamic for web content
* Try to add a new web content in the asset publisher by using the add button
* Check the select button un basic information 

<img width="306" alt="Pasted Graphic 3" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/8ffc43d6-7225-4ca3-9d77-a85cf2f7a500">

## Test Scenario 6 (move_articles_and_folders.jsp)

* Create a new web content
* Go to the kebab action menu for the web content and select move
* Check the select button 

<img width="781" alt="Pasted Graphic 4" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/c32cb55f-5e63-462a-b8b1-034a1411d048">
 

## Test Scenario 7 (edit_feed.jsp)

* Create a new web content
* Go to system settings > search journal > web content
* Go to system scope > Administration and click on show feed and save
* Create a content page 
* Create a vocabulary with a category on it
* Go to Content and Data > Feed and create a new one
* Complete the Friendly URL with “/web/guest/[name of your content page]
* Save and then edit to check this buttons 

<img width="781" alt="Pasted Graphic 5" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/880f98ef-8cb4-487f-a9fc-d42f01810949">

## Test Scenario 8 (preview_article_content_template.jsp)

* Create a new structure and a template for this structure
* Create a new web content and clear the default template
* Save
* Edit the web content, click in the preview of the template
* Check the apply button 

<img width="249" alt="Pasted Graphic 6" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/2acf6aaa-8e76-4f25-a966-d474f1a9628e">

## Test Scenario 9 (edit_folder.jsp)

* Create a folder and then edit it to check this buttons: 

<img width="288" alt="Pasted Graphic 7" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/92f09b58-eec8-4acf-8d94-50da818f6210">

<img width="514" alt="Pasted Graphic 8" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/9d409a6d-d40d-4461-a350-29205bd7d3d4">

## Test Scenario 10 (template.jsp)

* Create a new structure and a template for this structure
* Create a new web content and check the buttons for the default template

<img width="292" alt="Pasted Graphic 9" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/e3fcbeeb-98e6-40c1-9e3a-31dbc9ddc61c">
