### PR TITLE
LPS-190825 Show customized field reference value instead of the default one

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
@@ -52,6 +52,7 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 
 import java.text.ParseException;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -330,12 +331,17 @@ public class ContentFieldUtil {
 				DDMFormFieldOptions ddmFormFieldOptions =
 					ddmFormField.getDDMFormFieldOptions();
 
-				List<String> values = TransformUtil.transform(
+				List<String> values = new ArrayList<>();
+
+				List<String> dataList = TransformUtil.transform(
 					JSONUtil.toStringList(
 						JSONFactoryUtil.createJSONArray(valueString)),
 					value -> {
 						LocalizedValue localizedValue =
 							ddmFormFieldOptions.getOptionLabels(value);
+
+						values.add(
+							ddmFormFieldOptions.getOptionReference(value));
 
 						return localizedValue.getString(locale);
 					});
@@ -343,6 +349,17 @@ public class ContentFieldUtil {
 				return new ContentFieldValue() {
 					{
 						setData(
+							() -> {
+								if (!ddmFormField.isMultiple() &&
+									(dataList.size() == 1)) {
+
+									return dataList.get(0);
+								}
+
+								return String.valueOf(
+									JSONFactoryUtil.createJSONArray(dataList));
+							});
+						setValue(
 							() -> {
 								if (!ddmFormField.isMultiple() &&
 									(values.size() == 1)) {
@@ -353,7 +370,6 @@ public class ContentFieldUtil {
 								return String.valueOf(
 									JSONFactoryUtil.createJSONArray(values));
 							});
-						setValue(valueString);
 					}
 				};
 			}


### PR DESCRIPTION


Motivation
=======
An impedibug was raised when testing a relates story as when the user customizes the option labels available in the select sections in a web content, those new names are not shown properly. (Please for more info go to the original [Story](https://liferay.atlassian.net/browse/LPS-190825) ) 

Proposed Solution
========
In order to keep showing accurate information when a graphQL query is executed, information like the customized field reference value (label) and the original reference will be added to the response.

Steps to Verify
========

1. Add a web content structure with a Select from List field
2. Add two options with customized field reference for Select from List
3. Add a web content based on new structure
4. Get the id of structuredContent via getSiteStructuredContentsPage
5. Navigate to the  GraphQL GUI -> http://localhost:8080/o/api
6. Get the structuredContent with contentFieldValue

 ```

{
  structuredContent(structuredContentId: {structuredContentId}) {
    contentFields {
			contentFieldValue {
			  data
			  value
			}
    }
  }
}
```
7. Expected result as follows:
<img width="1040" alt="SelectExpectedResult" src="https://github.com/liferay-echo/liferay-portal/assets/85171101/db9b0980-1590-4960-88e9-a75286ec67f2">


COMMITS:
-------------------
LPS-190825 Show customized field reference value instead of the default one

