### PR TITLE
LPS-188311 Use clay:vertical-nav for configuration-admin-web

### DIFF
--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/display/ConfigurationCategoryMenuDisplay.java
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/java/com/liferay/configuration/admin/web/internal/display/ConfigurationCategoryMenuDisplay.java
@@ -14,6 +14,7 @@
 
 package com.liferay.configuration.admin.web.internal.display;
 
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition;
 import com.liferay.portal.kernel.util.LinkedHashMapBuilder;
 
@@ -22,6 +23,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
 
 /**
  * @author Jorge Ferrer
@@ -62,6 +66,34 @@ public class ConfigurationCategoryMenuDisplay {
 		}
 
 		return null;
+	}
+
+	public VerticalNavItemList getVerticalNavItemList(
+		ConfigurationScopeDisplay configurationScopeDisplay,
+		ConfigurationEntry configurationEntry, RenderRequest renderRequest,
+		RenderResponse renderResponse) {
+
+		List<ConfigurationEntry> configurationEntries =
+			configurationScopeDisplay.getConfigurationEntries();
+
+		VerticalNavItemList verticalNavItemList = new VerticalNavItemList();
+
+		for (ConfigurationEntry curConfigurationEntry : configurationEntries) {
+			verticalNavItemList.add(
+				verticalNavItem -> {
+					String name = curConfigurationEntry.getName();
+
+					verticalNavItem.setHref(
+						curConfigurationEntry.getEditURL(
+							renderRequest, renderResponse));
+					verticalNavItem.setLabel(name);
+					verticalNavItem.setId(name);
+					verticalNavItem.setActive(
+						configurationEntry.equals(curConfigurationEntry));
+				});
+		}
+
+		return verticalNavItemList;
 	}
 
 	public boolean isEmpty() {

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/configuration_category_menu.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/configuration_category_menu.jsp
@@ -22,8 +22,6 @@ ConfigurationEntry configurationEntry = (ConfigurationEntry)request.getAttribute
 ConfigurationCategoryMenuDisplay configurationCategoryMenuDisplay = (ConfigurationCategoryMenuDisplay)request.getAttribute(ConfigurationAdminWebKeys.CONFIGURATION_CATEGORY_MENU_DISPLAY);
 
 for (ConfigurationScopeDisplay configurationScopeDisplay : configurationCategoryMenuDisplay.getConfigurationScopeDisplays()) {
-	VerticalNavItemList verticalNavItemList = new VerticalNavItemList();
-
 	if (configurationScopeDisplay.isEmpty()) {
 		continue;
 	}
@@ -33,29 +31,9 @@ for (ConfigurationScopeDisplay configurationScopeDisplay : configurationCategory
 		<liferay-ui:message key='<%= "scope." + configurationScopeDisplay.getScope() %>' />
 	</div>
 
-	<%
-	List<ConfigurationEntry> configurationEntries = configurationScopeDisplay.getConfigurationEntries();
-
-	final RenderRequest renderRequest1 = renderRequest;
-
-	final RenderResponse renderResponse1 = renderResponse;
-
-	for (ConfigurationEntry curConfigurationEntry : configurationEntries) {
-		verticalNavItemList.add(
-			verticalNavItem -> {
-				String name = curConfigurationEntry.getName();
-
-				verticalNavItem.setHref(curConfigurationEntry.getEditURL(renderRequest1, renderResponse1));
-				verticalNavItem.setLabel(name);
-				verticalNavItem.setId(name);
-				verticalNavItem.setActive(configurationEntry.equals(curConfigurationEntry));
-			});
-	}
-	%>
-
 	<div class="c-ml-3">
 		<clay:vertical-nav
-			verticalNavItems="<%= verticalNavItemList %>"
+			verticalNavItems="<%= configurationCategoryMenuDisplay.getVerticalNavItemList(configurationScopeDisplay, configurationEntry, renderRequest, renderResponse) %>"
 		/>
 	</div>
 

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/configuration_category_menu.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/configuration_category_menu.jsp
@@ -17,60 +17,48 @@
 <%@ include file="/init.jsp" %>
 
 <%
-String id = PortalUtil.generateRandomKey(request, "configuration_category_menu.jsp");
-
 ConfigurationEntry configurationEntry = (ConfigurationEntry)request.getAttribute(ConfigurationAdminWebKeys.CONFIGURATION_ENTRY);
 
 ConfigurationCategoryMenuDisplay configurationCategoryMenuDisplay = (ConfigurationCategoryMenuDisplay)request.getAttribute(ConfigurationAdminWebKeys.CONFIGURATION_CATEGORY_MENU_DISPLAY);
+
+for (ConfigurationScopeDisplay configurationScopeDisplay : configurationCategoryMenuDisplay.getConfigurationScopeDisplays()) {
+	VerticalNavItemList verticalNavItemList = new VerticalNavItemList();
+
+	if (configurationScopeDisplay.isEmpty()) {
+		continue;
+	}
 %>
 
-<nav class="menubar menubar-transparent menubar-vertical-expand-md">
-	<a aria-controls="<%= id %>" aria-expanded="false" class="menubar-toggler" data-toggle="liferay-collapse" href="#<%= id %>" role="button">
-		<liferay-ui:message key="<%= configurationEntry.getName() %>" />
-
-		<aui:icon image="caret-bottom" markupView="lexicon" />
-	</a>
-
-	<div class="collapse menubar-collapse" id="<%= id %>">
-		<ul class="nav nav-nested">
-
-			<%
-			for (ConfigurationScopeDisplay configurationScopeDisplay : configurationCategoryMenuDisplay.getConfigurationScopeDisplays()) {
-				if (configurationScopeDisplay.isEmpty()) {
-					continue;
-				}
-
-				List<ConfigurationEntry> configurationEntries = configurationScopeDisplay.getConfigurationEntries();
-			%>
-
-				<li class="nav-item">
-					<a class="nav-link text-uppercase">
-						<liferay-ui:message key='<%= "scope." + configurationScopeDisplay.getScope() %>' />
-					</a>
-
-					<div>
-						<ul class="nav nav-stacked">
-
-							<%
-							for (ConfigurationEntry curConfigurationEntry : configurationEntries) {
-							%>
-
-								<li class="nav-item">
-									<aui:a cssClass='<%= configurationEntry.equals(curConfigurationEntry) ? "active nav-link" : "nav-link" %>' href="<%= curConfigurationEntry.getEditURL(renderRequest, renderResponse) %>"><%= curConfigurationEntry.getName() %></aui:a>
-								</li>
-
-							<%
-							}
-							%>
-
-						</ul>
-					</div>
-				</li>
-
-			<%
-			}
-			%>
-
-		</ul>
+	<div class="c-ml-3 c-my-2 h6 text-uppercase">
+		<liferay-ui:message key='<%= "scope." + configurationScopeDisplay.getScope() %>' />
 	</div>
-</nav>
+
+	<%
+	List<ConfigurationEntry> configurationEntries = configurationScopeDisplay.getConfigurationEntries();
+
+	final RenderRequest renderRequest1 = renderRequest;
+
+	final RenderResponse renderResponse1 = renderResponse;
+
+	for (ConfigurationEntry curConfigurationEntry : configurationEntries) {
+		verticalNavItemList.add(
+			verticalNavItem -> {
+				String name = curConfigurationEntry.getName();
+
+				verticalNavItem.setHref(curConfigurationEntry.getEditURL(renderRequest1, renderResponse1));
+				verticalNavItem.setLabel(name);
+				verticalNavItem.setId(name);
+				verticalNavItem.setActive(configurationEntry.equals(curConfigurationEntry));
+			});
+	}
+	%>
+
+	<div class="c-ml-3">
+		<clay:vertical-nav
+			verticalNavItems="<%= verticalNavItemList %>"
+		/>
+	</div>
+
+<%
+}
+%>

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -47,7 +47,6 @@ page import="com.liferay.configuration.admin.web.internal.util.ConfigurationEntr
 page import="com.liferay.configuration.admin.web.internal.util.ConfigurationEntryRetriever" %><%@
 page import="com.liferay.configuration.admin.web.internal.util.ConfigurationModelIterator" %><%@
 page import="com.liferay.configuration.admin.web.internal.util.ResourceBundleLoaderProvider" %><%@
-page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList" %><%@
 page import="com.liferay.frontend.taglib.servlet.taglib.util.EmptyResultMessageKeys" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition" %><%@
@@ -66,9 +65,7 @@ page import="com.liferay.taglib.servlet.PipingServletResponseFactory" %>
 <%@ page import="java.util.List" %><%@
 page import="java.util.ResourceBundle" %>
 
-<%@ page import="javax.portlet.PortletURL" %><%@
-page import="javax.portlet.RenderRequest" %><%@
-page import="javax.portlet.RenderResponse" %>
+<%@ page import="javax.portlet.PortletURL" %>
 
 <%@ page import="org.osgi.service.cm.Configuration" %><%@
 page import="org.osgi.service.metatype.AttributeDefinition" %>

--- a/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/configuration-admin/configuration-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -47,6 +47,7 @@ page import="com.liferay.configuration.admin.web.internal.util.ConfigurationEntr
 page import="com.liferay.configuration.admin.web.internal.util.ConfigurationEntryRetriever" %><%@
 page import="com.liferay.configuration.admin.web.internal.util.ConfigurationModelIterator" %><%@
 page import="com.liferay.configuration.admin.web.internal.util.ResourceBundleLoaderProvider" %><%@
+page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList" %><%@
 page import="com.liferay.frontend.taglib.servlet.taglib.util.EmptyResultMessageKeys" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.configuration.metatype.annotations.ExtendedObjectClassDefinition" %><%@
@@ -65,7 +66,9 @@ page import="com.liferay.taglib.servlet.PipingServletResponseFactory" %>
 <%@ page import="java.util.List" %><%@
 page import="java.util.ResourceBundle" %>
 
-<%@ page import="javax.portlet.PortletURL" %>
+<%@ page import="javax.portlet.PortletURL" %><%@
+page import="javax.portlet.RenderRequest" %><%@
+page import="javax.portlet.RenderResponse" %>
 
 <%@ page import="org.osgi.service.cm.Configuration" %><%@
 page import="org.osgi.service.metatype.AttributeDefinition" %>


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to use the clay:vertical-nav tag in order to standarize the usage of vertical navigation elements.
https://liferay.atlassian.net/browse/LPS-188311

Proposed Solution
========
The proposed solution consists in creating a list of verticalNavItemList and pass it to the clay:vertical-nav tag besides of some style adjustments.

Steps to Verify
========
1. Go to ControlPanel -> System Settings -> Select one of the settings.
2. Check that the left vertical navigation panel looks and works fine.

<img width="1792" alt="Screenshot 2023-07-19 at 14 54 04" src="https://github.com/liferay-echo/liferay-portal/assets/91207948/98e90d81-ab9a-4e5e-8d1f-7f8740e0e0f2">


