### PR TITLE
[TS] LPS-191026 Fix navigation issues with Structure Filter

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
@@ -231,6 +231,8 @@ public class JournalManagementToolbarDisplayContext
 				getPortletURL()
 			).setNavigation(
 				"structure"
+			).setParameter(
+				"ddmStructureId", (String)null
 			).buildString()
 		).build();
 	}
@@ -243,6 +245,8 @@ public class JournalManagementToolbarDisplayContext
 			StringPool.BLANK
 		).setNavigation(
 			StringPool.BLANK
+		).setParameter(
+			"ddmStructureId", (String)null
 		).setParameter(
 			"orderByCol", StringPool.BLANK
 		).setParameter(
@@ -350,6 +354,8 @@ public class JournalManagementToolbarDisplayContext
 							currentURLObj, liferayPortletResponse)
 					).setNavigation(
 						(String)null
+					).setParameter(
+						"ddmStructureId", (String)null
 					).buildString());
 
 				labelItem.setCloseable(true);
@@ -471,6 +477,8 @@ public class JournalManagementToolbarDisplayContext
 				getPortletURL()
 			).setKeywords(
 				StringPool.BLANK
+			).setParameter(
+				"ddmStructureId", (String)null
 			).buildPortletURL(),
 			getNavigationParam(), getNavigation());
 


### PR DESCRIPTION
Motivation
=======
When viewing the Web Content Filter, navigation gets messed up if you apply a Structure filter. This is because the "ddmStructureId" parameter gets stuck in the URL, and never gets removed. For example, if you click the "x" on the "Structures: [Structure Name]" label, the page does not change at all. The expected behavior is that it would restore the original folder view. This does not happen; nothing changes.

I discovered that the same bug also occurs when clicking another "Filter By Navigation" filter (such as "All", "Mine", or "Recent"), clicking the Clear button, or trying to apply a new Structure filter (the new Structure filter simply doesn't take). So I fixed it in all these locations

See more details on [LPS-191026](https://issues.liferay.com/browse/LPS-191026)

Proposed Solution
========
Explicitly remove the "ddmStructureId" parameter from the relevant URLs, since its presence in the URL was causing the Structure filter to still be applied in cases where it shouldn't.

Steps to Verify
========
1. Start up Liferay and log in as the admin user.
2. Go to Content & Data > Web Content > Structures > +.
3. Set any name, add a Text field and Save.
4. Go to Web Content > +.
5. Create a new Basic Web Content.
6. Create a new content based on the structure created.
7. Note the 2 web contents are displayed in the list of web contents.
8. Click on Filter and Order > Structures.
9. Select "Basic Web Content".

**Checkpoint:** Only one content should be displayed, the one that is a Basic Web Content.

10. Remove the filter by clicking on the X in the blue bar

 **Expected Result:** Both web contents should be displayed again.
 **Actual Result:** Nothing changes. The Basic Web Content is still the only web content that is displayed.

11. Click on Filter and Order > Structures.
12. Select the created structure

 **Expected Result:** Only the web content for the created structure is displayed. The Basic Web Content is not displayed.
 **Actual Result:** Nothing changes. The Basic Web Content is still the only web content that is displayed.

13. Remove the filter by clicking on the X in the blue bar
14. Click on [Filter and Order > All]

 **Expected Result:** Both web contents should be displayed again.
 **Actual Result:** Nothing changes. The Basic Web Content is still the only web content that is displayed.

