### PR TITLE
LPS-190970 Add value field to Single selection

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/ContentFieldUtil.java
@@ -385,8 +385,12 @@ public class ContentFieldUtil {
 
 				return new ContentFieldValue() {
 					{
-						data = selectedOptionLabelLocalizedValue.getString(
-							locale);
+						setData(
+							selectedOptionLabelLocalizedValue.getString(
+								locale));
+						setValue(
+							ddmFormFieldOptions.getOptionReference(
+								valueString));
 					}
 				};
 			}


### PR DESCRIPTION
Motivation
=======
When testing a relates story as when the user customizes the option labels available in the single selection sections in a web content, those new names are not shown properly. (Please for more info go to the original [Story](https://liferay.atlassian.net/browse/LPS-190970) ) 

Proposed Solution
========
In order to keep showing accurate information when a graphQL query is executed, information like the customized field reference value (label) and the original reference will be added to the response.

Steps to Verify
========

1. Add a web content structure with a single selection field
2. Add options with customized field reference for single selection
3. Add a web content based on this new structure
4. Get the id of structuredContent via getSiteStructuredContentsPage
5. Navigate to the GraphQL -> http://localhost:8080/o/api
6. Get the structuredContent with contentFieldValue

 ```

{
  structuredContent(structuredContentId: {structuredContentId}) {
    contentFields {
			contentFieldValue {
			  data
			  value
			}
    }
  }
}
```
7. Expected result as follows:
<img width="1330" alt="RepeatableResult" src="https://github.com/liferay-echo/liferay-portal/assets/85171101/60ca7ebf-5c58-49c7-b316-69b091c8a450">


Expected result when repeatable option is marked 
<img width="1375" alt="SimpleResult" src="https://github.com/liferay-echo/liferay-portal/assets/85171101/8d413b4e-2d9e-4b00-ab4e-1bd142841a61">


COMMITS:
-------------------
LPS-190970 Add value field to Single selection (simple and repeatable)