### PR TITLE
LPS-188354 Replace custom code by clay:vertical-nav in layout-page-template-admin-web

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplateDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/LayoutPageTemplateDisplayContext.java
@@ -16,6 +16,7 @@ package com.liferay.layout.page.template.admin.web.internal.display.context;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuilder;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList;
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.admin.web.internal.security.permission.resource.LayoutPageTemplateCollectionPermission;
 import com.liferay.layout.page.template.admin.web.internal.security.permission.resource.LayoutPageTemplatePermission;
@@ -32,6 +33,7 @@ import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -321,6 +323,47 @@ public class LayoutPageTemplateDisplayContext {
 				return null;
 			}
 		).buildPortletURL();
+	}
+
+	public VerticalNavItemList getVerticalNavItemList(
+		LayoutPageTemplateDisplayContext layoutPageTemplateDisplayContext,
+		RenderResponse renderResponse) {
+
+		VerticalNavItemList verticalNavItemList = new VerticalNavItemList();
+
+		for (LayoutPageTemplateCollection layoutPageTemplateCollection :
+				getLayoutPageTemplateCollections()) {
+
+			verticalNavItemList.add(
+				verticalNavItem -> {
+					String name = HtmlUtil.escape(
+						layoutPageTemplateCollection.getName());
+
+					long id =
+						layoutPageTemplateCollection.
+							getLayoutPageTemplateCollectionId();
+
+					verticalNavItem.setActive(
+						id ==
+							layoutPageTemplateDisplayContext.
+								getLayoutPageTemplateCollectionId());
+
+					verticalNavItem.setHref(
+						PortletURLBuilder.createRenderURL(
+							renderResponse
+						).setTabs1(
+							"page-templates"
+						).setParameter(
+							"layoutPageTemplateCollectionId",
+							layoutPageTemplateCollection.
+								getLayoutPageTemplateCollectionId()
+						).buildString());
+					verticalNavItem.setId(name);
+					verticalNavItem.setLabel(name);
+				});
+		}
+
+		return verticalNavItemList;
 	}
 
 	public boolean isSearch() {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -26,8 +26,7 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
-<%@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList" %><%@
-page import="com.liferay.frontend.taglib.servlet.taglib.util.EmptyResultMessageKeys" %><%@
+<%@ page import="com.liferay.frontend.taglib.servlet.taglib.util.EmptyResultMessageKeys" %><%@
 page import="com.liferay.layout.importer.LayoutsImporterResultEntry" %><%@
 page import="com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys" %><%@
 page import="com.liferay.layout.page.template.admin.web.internal.constants.LayoutPageTemplateAdminWebKeys" %><%@
@@ -94,8 +93,7 @@ page import="java.util.Map" %><%@
 page import="java.util.Objects" %>
 
 <%@ page import="javax.portlet.PortletRequest" %><%@
-page import="javax.portlet.PortletURL" %><%@
-page import="javax.portlet.RenderResponse" %>
+page import="javax.portlet.PortletURL" %>
 
 <liferay-frontend:defineObjects />
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -26,7 +26,8 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 
-<%@ page import="com.liferay.frontend.taglib.servlet.taglib.util.EmptyResultMessageKeys" %><%@
+<%@ page import="com.liferay.frontend.taglib.clay.servlet.taglib.util.VerticalNavItemList" %><%@
+page import="com.liferay.frontend.taglib.servlet.taglib.util.EmptyResultMessageKeys" %><%@
 page import="com.liferay.layout.importer.LayoutsImporterResultEntry" %><%@
 page import="com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys" %><%@
 page import="com.liferay.layout.page.template.admin.web.internal.constants.LayoutPageTemplateAdminWebKeys" %><%@
@@ -63,7 +64,6 @@ page import="com.liferay.layout.page.template.model.LayoutPageTemplateEntry" %><
 page import="com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalServiceUtil" %><%@
 page import="com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalServiceUtil" %><%@
 page import="com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil" %><%@
-page import="com.liferay.petra.string.StringPool" %><%@
 page import="com.liferay.portal.kernel.dao.orm.QueryUtil" %><%@
 page import="com.liferay.portal.kernel.exception.PortalException" %><%@
 page import="com.liferay.portal.kernel.exception.RequiredLayoutPrototypeException" %><%@
@@ -94,7 +94,8 @@ page import="java.util.Map" %><%@
 page import="java.util.Objects" %>
 
 <%@ page import="javax.portlet.PortletRequest" %><%@
-page import="javax.portlet.PortletURL" %>
+page import="javax.portlet.PortletURL" %><%@
+page import="javax.portlet.RenderResponse" %>
 
 <liferay-frontend:defineObjects />
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
@@ -100,38 +100,9 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 						</clay:content-col>
 					</clay:content-row>
 
-					<%
-					for (LayoutPageTemplateCollection layoutPageTemplateCollection : layoutPageTemplateCollections) {
-						VerticalNavItemList verticalNavItemList = new VerticalNavItemList();
-
-						final RenderResponse renderResponse1 = renderResponse;
-
-						verticalNavItemList.add(
-							verticalNavItem -> {
-								String name = HtmlUtil.escape(layoutPageTemplateCollection.getName());
-
-								verticalNavItem.setHref(
-									PortletURLBuilder.createRenderURL(
-										renderResponse1
-									).setTabs1(
-										"page-templates"
-									).setParameter(
-										"layoutPageTemplateCollectionId", layoutPageTemplateCollection.getLayoutPageTemplateCollectionId()
-									).buildString());
-								verticalNavItem.setLabel(name);
-								verticalNavItem.setId(name);
-								verticalNavItem.setActive(layoutPageTemplateCollection.getLayoutPageTemplateCollectionId() == layoutPageTemplateDisplayContext.getLayoutPageTemplateCollectionId());
-							});
-					%>
-
-						<clay:vertical-nav
-							verticalNavItems="<%= verticalNavItemList %>"
-						/>
-
-					<%
-					}
-					%>
-
+					<clay:vertical-nav
+						verticalNavItems="<%= layoutPageTemplateDisplayContext.getVerticalNavItemList(layoutPageTemplateDisplayContext, renderResponse) %>"
+					/>
 				</c:when>
 				<c:otherwise>
 					<p class="text-uppercase">

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
@@ -36,118 +36,116 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 		<clay:col
 			lg="3"
 		>
-			<nav class="menubar menubar-transparent menubar-vertical-expand-lg">
-				<ul class="nav nav-nested">
-					<li class="nav-item">
-						<portlet:renderURL var="editLayoutPageTemplateCollectionURL">
-							<portlet:param name="mvcRenderCommandName" value="/layout_page_template_admin/edit_layout_page_template_collection" />
-							<portlet:param name="redirect" value="<%= currentURL %>" />
-						</portlet:renderURL>
+			<portlet:renderURL var="editLayoutPageTemplateCollectionURL">
+				<portlet:param name="mvcRenderCommandName" value="/layout_page_template_admin/edit_layout_page_template_collection" />
+				<portlet:param name="redirect" value="<%= currentURL %>" />
+			</portlet:renderURL>
 
-						<c:choose>
-							<c:when test="<%= ListUtil.isNotEmpty(layoutPageTemplateCollections) %>">
-								<clay:content-row
-									verticalAlign="center"
-								>
-									<clay:content-col
-										expand="<%= true %>"
-									>
-										<strong class="text-uppercase">
-											<liferay-ui:message key="page-template-sets" />
-										</strong>
-									</clay:content-col>
+			<c:choose>
+				<c:when test="<%= ListUtil.isNotEmpty(layoutPageTemplateCollections) %>">
+					<clay:content-row
+						verticalAlign="center"
+					>
+						<clay:content-col
+							expand="<%= true %>"
+						>
+							<strong class="text-uppercase">
+								<liferay-ui:message key="page-template-sets" />
+							</strong>
+						</clay:content-col>
 
-									<clay:content-col
-										verticalAlign="end"
-									>
-										<ul class="navbar-nav">
-											<c:if test="<%= layoutPageTemplateDisplayContext.isShowAddButton(LayoutPageTemplateActionKeys.ADD_LAYOUT_PAGE_TEMPLATE_COLLECTION) %>">
-												<li>
-													<clay:link
-														borderless="<%= true %>"
-														cssClass="component-action"
-														href="<%= editLayoutPageTemplateCollectionURL.toString() %>"
-														icon="plus"
-														type="button"
-													/>
-												</li>
-											</c:if>
+						<clay:content-col
+							verticalAlign="end"
+						>
+							<ul class="navbar-nav">
+								<c:if test="<%= layoutPageTemplateDisplayContext.isShowAddButton(LayoutPageTemplateActionKeys.ADD_LAYOUT_PAGE_TEMPLATE_COLLECTION) %>">
+									<li>
+										<clay:link
+											borderless="<%= true %>"
+											cssClass="component-action"
+											href="<%= editLayoutPageTemplateCollectionURL.toString() %>"
+											icon="plus"
+											type="button"
+										/>
+									</li>
+								</c:if>
 
-											<li>
-												<portlet:renderURL var="viewLayoutPageTemplateCollectionURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-													<portlet:param name="mvcRenderCommandName" value="/layout_page_template_admin/select_layout_page_template_collections" />
-												</portlet:renderURL>
+								<li>
+									<portlet:renderURL var="viewLayoutPageTemplateCollectionURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
+										<portlet:param name="mvcRenderCommandName" value="/layout_page_template_admin/select_layout_page_template_collections" />
+									</portlet:renderURL>
 
-												<portlet:renderURL var="redirectURL">
-													<portlet:param name="tabs1" value="page-templates" />
-												</portlet:renderURL>
+									<portlet:renderURL var="redirectURL">
+										<portlet:param name="tabs1" value="page-templates" />
+									</portlet:renderURL>
 
-												<liferay-portlet:actionURL copyCurrentRenderParameters="<%= false %>" name="/layout_page_template_admin/delete_layout_page_template_collection" var="deleteLayoutPageTemplateCollectionURL">
-													<portlet:param name="redirect" value="<%= redirectURL %>" />
-												</liferay-portlet:actionURL>
+									<liferay-portlet:actionURL copyCurrentRenderParameters="<%= false %>" name="/layout_page_template_admin/delete_layout_page_template_collection" var="deleteLayoutPageTemplateCollectionURL">
+										<portlet:param name="redirect" value="<%= redirectURL %>" />
+									</liferay-portlet:actionURL>
 
-												<clay:dropdown-actions
-													additionalProps='<%=
-														HashMapBuilder.<String, Object>put(
-															"deleteLayoutPageTemplateCollectionURL", deleteLayoutPageTemplateCollectionURL.toString()
-														).put(
-															"viewLayoutPageTemplateCollectionURL", viewLayoutPageTemplateCollectionURL.toString()
-														).build()
-													%>'
-													aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
-													dropdownItems="<%= layoutPageTemplateDisplayContext.getCollectionsDropdownItems() %>"
-													propsTransformer="js/ActionsComponentPropsTransformer"
-												/>
-											</li>
-										</ul>
-									</clay:content-col>
-								</clay:content-row>
+									<clay:dropdown-actions
+										additionalProps='<%=
+											HashMapBuilder.<String, Object>put(
+												"deleteLayoutPageTemplateCollectionURL", deleteLayoutPageTemplateCollectionURL.toString()
+											).put(
+												"viewLayoutPageTemplateCollectionURL", viewLayoutPageTemplateCollectionURL.toString()
+											).build()
+										%>'
+										aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
+										dropdownItems="<%= layoutPageTemplateDisplayContext.getCollectionsDropdownItems() %>"
+										propsTransformer="js/ActionsComponentPropsTransformer"
+									/>
+								</li>
+							</ul>
+						</clay:content-col>
+					</clay:content-row>
 
-								<ul class="nav nav-stacked">
+					<%
+					for (LayoutPageTemplateCollection layoutPageTemplateCollection : layoutPageTemplateCollections) {
+						VerticalNavItemList verticalNavItemList = new VerticalNavItemList();
 
-									<%
-									for (LayoutPageTemplateCollection layoutPageTemplateCollection : layoutPageTemplateCollections) {
-									%>
+						final RenderResponse renderResponse1 = renderResponse;
 
-										<li class="nav-item">
-											<a
-												class="nav-link text-truncate <%= (layoutPageTemplateCollection.getLayoutPageTemplateCollectionId() == layoutPageTemplateDisplayContext.getLayoutPageTemplateCollectionId()) ? "active" : StringPool.BLANK %>"
-												href="<%=
-													PortletURLBuilder.createRenderURL(
-														renderResponse
-													).setTabs1(
-														"page-templates"
-													).setParameter(
-														"layoutPageTemplateCollectionId", layoutPageTemplateCollection.getLayoutPageTemplateCollectionId()
-													).buildString()
-												%>"
-											>
-												<%= HtmlUtil.escape(layoutPageTemplateCollection.getName()) %>
-											</a>
-										</li>
+						verticalNavItemList.add(
+							verticalNavItem -> {
+								String name = HtmlUtil.escape(layoutPageTemplateCollection.getName());
 
-									<%
-									}
-									%>
+								verticalNavItem.setHref(
+									PortletURLBuilder.createRenderURL(
+										renderResponse1
+									).setTabs1(
+										"page-templates"
+									).setParameter(
+										"layoutPageTemplateCollectionId", layoutPageTemplateCollection.getLayoutPageTemplateCollectionId()
+									).buildString());
+								verticalNavItem.setLabel(name);
+								verticalNavItem.setId(name);
+								verticalNavItem.setActive(layoutPageTemplateCollection.getLayoutPageTemplateCollectionId() == layoutPageTemplateDisplayContext.getLayoutPageTemplateCollectionId());
+							});
+					%>
 
-								</ul>
-							</c:when>
-							<c:otherwise>
-								<p class="text-uppercase">
-									<strong><liferay-ui:message key="page-template-sets" /></strong>
-								</p>
+						<clay:vertical-nav
+							verticalNavItems="<%= verticalNavItemList %>"
+						/>
 
-								<liferay-frontend:empty-result-message
-									actionDropdownItems="<%= layoutPageTemplateDisplayContext.isShowAddButton(LayoutPageTemplateActionKeys.ADD_LAYOUT_PAGE_TEMPLATE_COLLECTION) ? layoutPageTemplateDisplayContext.getActionDropdownItems() : null %>"
-									animationType="<%= EmptyResultMessageKeys.AnimationType.NONE %>"
-									description='<%= LanguageUtil.get(request, "page-template-sets-are-needed-to-create-page-templates") %>'
-									elementType='<%= LanguageUtil.get(request, "page-template-sets") %>'
-								/>
-							</c:otherwise>
-						</c:choose>
-					</li>
-				</ul>
-			</nav>
+					<%
+					}
+					%>
+
+				</c:when>
+				<c:otherwise>
+					<p class="text-uppercase">
+						<strong><liferay-ui:message key="page-template-sets" /></strong>
+					</p>
+
+					<liferay-frontend:empty-result-message
+						actionDropdownItems="<%= layoutPageTemplateDisplayContext.isShowAddButton(LayoutPageTemplateActionKeys.ADD_LAYOUT_PAGE_TEMPLATE_COLLECTION) ? layoutPageTemplateDisplayContext.getActionDropdownItems() : null %>"
+						animationType="<%= EmptyResultMessageKeys.AnimationType.NONE %>"
+						description='<%= LanguageUtil.get(request, "page-template-sets-are-needed-to-create-page-templates") %>'
+						elementType='<%= LanguageUtil.get(request, "page-template-sets") %>'
+					/>
+				</c:otherwise>
+			</c:choose>
 		</clay:col>
 
 		<clay:col


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to use the clay:vertical-nav tag in order to standarize the usage of vertical navigation elements.
https://liferay.atlassian.net/browse/LPS-188311

Proposed Solution
========
The proposed solution consists in creating a list of verticalNavItemList and pass it to the clay:vertical-nav.

Steps to Verify
========
1. Go to Design -> Page Templates -> Page Template (tab).
2. Check that the left vertical navigation panel looks and works fine.
3. Add various page templates sets and change from one to another.