### PR TITLE
[TS] LPS-191305 Bugfix - When saving a LayoutSet's SEO settings, its Client Extensions settings are reset

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
@@ -77,10 +77,13 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 			actionRequest, "stagingGroupId");
 		boolean privateLayout = ParamUtil.getBoolean(
 			actionRequest, "privateLayout");
+		String tab = ParamUtil.getString(actionRequest, "tab");
 
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(layoutSetId);
 
-		_updateClientExtensions(actionRequest, layoutSet, themeDisplay);
+		if (tab.equals("design")) {
+			_updateClientExtensions(actionRequest, layoutSet, themeDisplay);
+		}
 
 		_updateLogo(actionRequest, liveGroupId, stagingGroupId, privateLayout);
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/design.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/design.jsp
@@ -59,6 +59,7 @@ renderResponse.setTitle(selGroup.getLayoutRootNodeName(privateLayout, locale));
 	<aui:input name="selPlid" type="hidden" value="<%= layoutsAdminDisplayContext.getSelPlid() %>" />
 	<aui:input name="privateLayout" type="hidden" value="<%= privateLayout %>" />
 	<aui:input name="layoutSetId" type="hidden" value="<%= selLayoutSet.getLayoutSetId() %>" />
+	<aui:input name="tab" type="hidden" value="design" />
 
 	<h2 class="c-mb-4 text-7"><liferay-ui:message key="design" /></h2>
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/seo.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/seo.jsp
@@ -59,6 +59,7 @@ renderResponse.setTitle(selGroup.getLayoutRootNodeName(privateLayout, locale));
 	<aui:input name="selPlid" type="hidden" value="<%= layoutsAdminDisplayContext.getSelPlid() %>" />
 	<aui:input name="privateLayout" type="hidden" value="<%= privateLayout %>" />
 	<aui:input name="layoutSetId" type="hidden" value="<%= selLayoutSet.getLayoutSetId() %>" />
+	<aui:input name="tab" type="hidden" value="seo" />
 
 	<h2 class="c-mb-4 text-7"><liferay-ui:message key="seo" /></h2>
 


### PR DESCRIPTION
Motivation
=======
Currently, when saving the SEO Configuration of a LayoutSet, it always resets the Client Extensions settings of that LayoutSet. I believe that this is a bug and a poor user experience because this means that the user cannot update their SEO Settings without resetting their Client Extension settings, and they have to re-configure the Client Extension Settings afterwards. Moreover, there is no obvious indication in the UI that the Client Extension settings were reset, so they may not even be aware that they need to be reconfigured until it is too late.

Proposed Solution
========
Add a `tab` parameter to the `edit_layout_set` request to keep track of which screen the request came from, and only do the logic to update the Client Extensions settings if the request came from the Design screen (since the Design screen is the only one that sets the Client Extensions settings.

Steps to Verify
========
1. Start up Liferay and log in as the admin user.
2. Enable Private Pages
* Open the Global Menu (Global Menu), go to the Control Panel tab, and click System Settings.
* Go to Release Feature Flags.
* In the Disabled Features dropdown menu, select Disable Private Pages.
* Click Update.
3. Add a Theme CSS Client extension
* Open the Global Menu (Global Menu), go to the Applications tab, and click Client Extensions.
* Click the Add :plus: icon and select "Add Theme CSS"
* In the Name field, type "Test Theme CSS Client Extension".
* Click Publish.
4. Go to the Liferay DXP site.
5. Go to Site Builder > Pages.
6. Click the gear icon next to Public Pages.
7. On the Design tab, scroll down to the Customization section.
8. Select the "Test Theme CSS Client Extension" as the Theme CSS option.
9. Click Save.
10. Refresh the page and confirm that the "Test Theme CSS Client Extension" selection was saved.
11. Go to the SEO tab.
12. Without editing anything on the SEO page, click Save.
13. Go back to the Design tab.
14. Scroll down to the Customization section.

**Expected Result:** The "Test Theme CSS Client Extension" appears as the Theme CSS option.
**Actual Result:** The "Test Theme CSS Client Extension" does not appear as the Theme CSS option. Instead, we see "No theme CSS client extension was loaded".