### PR TITLE
[TS] [Urgent] LPS-191314  Navigation does not work while embedding Documents and Media portlet via Widget Template

### DIFF
--- a/modules/apps/portlet-display-template/portlet-display-template-impl/src/main/java/com/liferay/portlet/display/template/internal/PortletDisplayTemplateImpl.java
+++ b/modules/apps/portlet-display-template/portlet-display-template-impl/src/main/java/com/liferay/portlet/display/template/internal/PortletDisplayTemplateImpl.java
@@ -461,7 +461,8 @@ public class PortletDisplayTemplateImpl implements PortletDisplayTemplate {
 
 		return transformer.transform(
 			themeDisplay, contextObjects, ddmTemplate.getScript(),
-			ddmTemplate.getLanguage(), unsyncStringWriter, httpServletRequest,
+			ddmTemplate.getLanguage(), unsyncStringWriter,
+			themeDisplay.getRequest(),
 			new PipingServletResponse(httpServletResponse, unsyncStringWriter));
 	}
 


### PR DESCRIPTION
Motivation
=======
When trying to render an embedded portlet in a Widget Template, the original request parameters do not get propagated to the embedded portlet request. This causes some embedded portlets not to work properly. For example, folder navigation in an embedded Documents and Media portlet does not work correctly, because it is dependent on the `folderId` parameter, which does not get propagated to the embedded Documents and Media portlet.

Ticket: [LPS-191314](https://liferay.atlassian.net/browse/LPS-191314)

Proposed Solution
========
Use the `themeDisplay`'s request, rather than the modified httpServletRequest, when rendering the template, so that the original parameters are preserved. See [PTR-4103](https://liferay.atlassian.net/browse/PTR-4103), and especially Eric's detailed comment [here](https://liferay.atlassian.net/browse/PTR-4103?focusedCommentId=2178136), for more details about this solution.

Steps to Verify
========
1. Start up Liferay and log in as the admin user.
2. Navigate to Site > Templates > Widget Template > Plus Sign > Asset Publisher Template 
3. Name it “Test Template, then add the following code to the template and click Save:
```
 <@liferay_portlet["runtime"] portletName="com_liferay_document_library_web_portlet_DLPortlet"/> 
```
4. Create a new Widget Page an add an Asset Publisher portlet to it.
5. Click the Asset Publisher portlet’s Kebab Menu > Configuration > Display Settings > Display Template > Select “Test Template” and click Save.
6. Attempt to navigate inside the default “Provided by Liferay” folder.

**Expected Result:** The UI would display the contents of the folder.
**Actual Result:** Nothing changes at all. The user is still inside the root folder.