### PR TITLE
[TS] LPS-191622 - LinkToLayout.getData() return is diferent after upgrade to 7.4 when no layout is selected

### DIFF
--- a/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/LayoutSelector.js
+++ b/modules/apps/layout/layout-dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/LayoutSelector.js
@@ -42,14 +42,18 @@ const LayoutSelector = ({
 	onChange,
 	portletNamespace,
 }) => {
-	const [layout, setLayout] = useState(() => JSON.parse(inputValue || '{}'));
+	const [layout, setLayout] = useState(() =>
+		inputValue ? JSON.parse(inputValue) : null
+	);
 
 	useEffect(() => {
-		setLayout(JSON.parse(getInputValue(inputValue, '{}')));
+		setLayout(
+			inputValue ? JSON.parse(getInputValue(inputValue, '{}')) : null
+		);
 	}, [inputValue]);
 
 	const handleClearClick = () => {
-		setLayout({});
+		setLayout(null);
 		onChange('');
 	};
 
@@ -78,7 +82,7 @@ const LayoutSelector = ({
 					<input
 						name={name}
 						type="hidden"
-						value={JSON.stringify(layout)}
+						value={layout ? JSON.stringify(layout) : null}
 					/>
 
 					<ClayInput
@@ -89,7 +93,7 @@ const LayoutSelector = ({
 						onClick={handleItemSelectorTriggerClick}
 						readOnly
 						type="text"
-						value={layout.name || ''}
+						value={layout?.name || ''}
 					/>
 				</ClayInput.GroupItem>
 
@@ -104,7 +108,7 @@ const LayoutSelector = ({
 					</ClayButton>
 				</ClayInput.GroupItem>
 
-				{layout.layoutId && (
+				{layout?.layoutId && (
 					<ClayInput.GroupItem shrink>
 						<ClayButton
 							disabled={disabled}


### PR DESCRIPTION
Motivation
=======
If no layout is selected, `LinkToLayout.getData()` return values:
- <7.4: "" (blank, empty string)
- 7.4: "`{}`" (empty JSON, not empty string)

This behavior doesn't seem consistent. 
In addition, if you upgrade, you still get an empty string, which is ok. But if you edit the journal article (keeping clear the Link To Page field), then the value is overwritten and you will get `{}` from there on.

See [LPS-191622](https://liferay.atlassian.net/browse/LPS-191622) for details.

Proposed Solution
========
Use `null` instead of `{}`. This way, we store `null` in database, which is the value you get for an empty LinkToLayout field right after an upgrade from <7.4.

Note that there might be customers in 7.4 that already deal with/expect an empty JSON, and they would be affected by this solution. Although it is likely that they already control when the return value is an empty string and/or a valid JSON.

Steps to Verify
========
See [LPS-191622](https://liferay.atlassian.net/browse/LPS-191622).

References to existing code (if applies)
========
Not found

Alternative Solutions that were discarded (if applies)
========
Check for `{}` in [TemplateNode.getData()](https://github.com/liferay/liferay-portal/blob/379d5d45bc941efe624948991865b40fe63e5c14/portal-kernel/src/com/liferay/portal/kernel/templateparser/TemplateNode.java#L162) and return an empty string if so.

---

What are your views on this @liferay-echo ? Thanks!
