### PR TITLE
LPS-191305

### DIFF
--- a/modules/apps/layout/layout-admin-api/bnd.bnd
+++ b/modules/apps/layout/layout-admin-api/bnd.bnd
@@ -1,4 +1,4 @@
 Bundle-Name: Liferay Layout Admin API
 Bundle-SymbolicName: com.liferay.layout.admin.api
-Bundle-Version: 4.2.1
+Bundle-Version: 4.3.0
 Export-Package: com.liferay.layout.admin.constants

--- a/modules/apps/layout/layout-admin-api/src/main/java/com/liferay/layout/admin/constants/LayoutScreenNavigationEntryConstants.java
+++ b/modules/apps/layout/layout-admin-api/src/main/java/com/liferay/layout/admin/constants/LayoutScreenNavigationEntryConstants.java
@@ -10,6 +10,8 @@ package com.liferay.layout.admin.constants;
  */
 public class LayoutScreenNavigationEntryConstants {
 
+	public static final String CATEGORY_KEY_DESIGN = "design";
+
 	public static final String CATEGORY_KEY_GENERAL = "general";
 
 	public static final String ENTRY_KEY_DESIGN = "design";

--- a/modules/apps/layout/layout-admin-api/src/main/java/com/liferay/layout/admin/constants/LayoutScreenNavigationEntryConstants.java
+++ b/modules/apps/layout/layout-admin-api/src/main/java/com/liferay/layout/admin/constants/LayoutScreenNavigationEntryConstants.java
@@ -16,6 +16,8 @@ public class LayoutScreenNavigationEntryConstants {
 
 	public static final String ENTRY_KEY_GENERAL = "general";
 
+	public static final String ENTRY_KEY_SEO = "seo";
+
 	public static final String SCREEN_NAVIGATION_KEY_LAYOUT = "layout.form";
 
 	public static final String SCREEN_NAVIGATION_KEY_LAYOUT_SET =

--- a/modules/apps/layout/layout-admin-api/src/main/resources/com/liferay/layout/admin/constants/packageinfo
+++ b/modules/apps/layout/layout-admin-api/src/main/resources/com/liferay/layout/admin/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminDisplayContext.java
@@ -1304,24 +1304,29 @@ public class LayoutsAdminDisplayContext {
 			return _selPlid;
 		}
 
-		Long selPlid = ParamUtil.getLong(
+		_selPlid = ParamUtil.getLong(
 			_liferayPortletRequest, "selPlid", LayoutConstants.DEFAULT_PLID);
 
-		if (Objects.equals(
+		if ((_selPlid == 0) ||
+			!Objects.equals(
 				ParamUtil.getString(
 					httpServletRequest, "screenNavigationEntryKey"),
 				LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN)) {
 
-			Layout layout = LayoutLocalServiceUtil.fetchLayout(selPlid);
-
-			Layout draftLayout = layout.fetchDraftLayout();
-
-			if (draftLayout != null) {
-				selPlid = draftLayout.getPlid();
-			}
+			return _selPlid;
 		}
 
-		_selPlid = selPlid;
+		Layout layout = LayoutLocalServiceUtil.fetchLayout(_selPlid);
+
+		if (layout == null) {
+			return _selPlid;
+		}
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		if (draftLayout != null) {
+			_selPlid = draftLayout.getPlid();
+		}
 
 		return _selPlid;
 	}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/LayoutSetDesignScreenNavigationCategory.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/LayoutSetDesignScreenNavigationCategory.java
@@ -23,13 +23,13 @@ public class LayoutSetDesignScreenNavigationCategory
 
 	@Override
 	public String getCategoryKey() {
-		return LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN;
+		return LayoutScreenNavigationEntryConstants.CATEGORY_KEY_DESIGN;
 	}
 
 	@Override
 	public String getLabel(Locale locale) {
 		return _language.get(
-			locale, LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN);
+			locale, LayoutScreenNavigationEntryConstants.CATEGORY_KEY_DESIGN);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/LayoutSetDesignScreenNavigationCategory.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/LayoutSetDesignScreenNavigationCategory.java
@@ -23,12 +23,13 @@ public class LayoutSetDesignScreenNavigationCategory
 
 	@Override
 	public String getCategoryKey() {
-		return "design";
+		return LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN;
 	}
 
 	@Override
 	public String getLabel(Locale locale) {
-		return _language.get(locale, "design");
+		return _language.get(
+			locale, LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN);
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/LayoutSetDesignScreenNavigationEntry.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/LayoutSetDesignScreenNavigationEntry.java
@@ -37,7 +37,7 @@ public class LayoutSetDesignScreenNavigationEntry
 
 	@Override
 	public String getCategoryKey() {
-		return LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN;
+		return LayoutScreenNavigationEntryConstants.CATEGORY_KEY_DESIGN;
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/LayoutSetDesignScreenNavigationEntry.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/LayoutSetDesignScreenNavigationEntry.java
@@ -37,12 +37,12 @@ public class LayoutSetDesignScreenNavigationEntry
 
 	@Override
 	public String getCategoryKey() {
-		return "design";
+		return LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN;
 	}
 
 	@Override
 	public String getEntryKey() {
-		return "design";
+		return LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN;
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/LayoutSetSEOScreenNavigationEntry.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/LayoutSetSEOScreenNavigationEntry.java
@@ -37,7 +37,7 @@ public class LayoutSetSEOScreenNavigationEntry
 
 	@Override
 	public String getCategoryKey() {
-		return LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN;
+		return LayoutScreenNavigationEntryConstants.CATEGORY_KEY_DESIGN;
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/LayoutSetSEOScreenNavigationEntry.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/servlet/taglib/LayoutSetSEOScreenNavigationEntry.java
@@ -37,12 +37,12 @@ public class LayoutSetSEOScreenNavigationEntry
 
 	@Override
 	public String getCategoryKey() {
-		return "design";
+		return LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN;
 	}
 
 	@Override
 	public String getEntryKey() {
-		return "seo";
+		return LayoutScreenNavigationEntryConstants.ENTRY_KEY_SEO;
 	}
 
 	@Override

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
@@ -68,10 +68,13 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 			actionRequest, "stagingGroupId");
 		boolean privateLayout = ParamUtil.getBoolean(
 			actionRequest, "privateLayout");
+		String tab = ParamUtil.getString(actionRequest, "tab");
 
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(layoutSetId);
 
-		_updateClientExtensions(actionRequest, layoutSet, themeDisplay);
+		if (tab.equals("design")) {
+			_updateClientExtensions(actionRequest, layoutSet, themeDisplay);
+		}
 
 		_updateLogo(actionRequest, liveGroupId, stagingGroupId, privateLayout);
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
@@ -66,11 +66,14 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 			actionRequest, "stagingGroupId");
 		boolean privateLayout = ParamUtil.getBoolean(
 			actionRequest, "privateLayout");
-		String tab = ParamUtil.getString(actionRequest, "tab");
+		String screenNavigationEntryKey = ParamUtil.getString(
+			actionRequest, "screenNavigationEntryKey");
 
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(layoutSetId);
 
-		if (tab.equals(LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN)) {
+		if (screenNavigationEntryKey.equals(
+				LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN)) {
+
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
@@ -58,9 +58,6 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
-
 		long layoutSetId = ParamUtil.getLong(actionRequest, "layoutSetId");
 
 		long liveGroupId = ParamUtil.getLong(actionRequest, "liveGroupId");
@@ -73,14 +70,19 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(layoutSetId);
 
 		if (tab.equals("design")) {
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
+
 			_updateClientExtensions(actionRequest, layoutSet, themeDisplay);
+
+			_updateLogo(
+				actionRequest, liveGroupId, stagingGroupId, privateLayout);
+
+			updateLookAndFeel(
+				actionRequest, themeDisplay.getCompanyId(), liveGroupId,
+				stagingGroupId, privateLayout,
+				layoutSet.getSettingsProperties());
 		}
-
-		_updateLogo(actionRequest, liveGroupId, stagingGroupId, privateLayout);
-
-		updateLookAndFeel(
-			actionRequest, themeDisplay.getCompanyId(), liveGroupId,
-			stagingGroupId, privateLayout, layoutSet.getSettingsProperties());
 
 		_updateMergePages(actionRequest, liveGroupId);
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java
@@ -10,6 +10,7 @@ import com.liferay.client.extension.model.ClientExtensionEntryRel;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.document.library.kernel.service.DLAppLocalService;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
+import com.liferay.layout.admin.constants.LayoutScreenNavigationEntryConstants;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.LayoutSet;
@@ -69,7 +70,7 @@ public class EditLayoutSetMVCActionCommand extends BaseMVCActionCommand {
 
 		LayoutSet layoutSet = _layoutSetLocalService.getLayoutSet(layoutSetId);
 
-		if (tab.equals("design")) {
+		if (tab.equals(LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN)) {
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/design.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/design.jsp
@@ -50,7 +50,7 @@ renderResponse.setTitle(selGroup.getLayoutRootNodeName(privateLayout, locale));
 	<aui:input name="selPlid" type="hidden" value="<%= layoutsAdminDisplayContext.getSelPlid() %>" />
 	<aui:input name="privateLayout" type="hidden" value="<%= privateLayout %>" />
 	<aui:input name="layoutSetId" type="hidden" value="<%= selLayoutSet.getLayoutSetId() %>" />
-	<aui:input name="tab" type="hidden" value="<%= LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN %>" />
+	<aui:input name="screenNavigationEntryKey" type="hidden" value="<%= LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN %>" />
 
 	<h2 class="c-mb-4 text-7"><liferay-ui:message key="design" /></h2>
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/design.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/design.jsp
@@ -50,6 +50,7 @@ renderResponse.setTitle(selGroup.getLayoutRootNodeName(privateLayout, locale));
 	<aui:input name="selPlid" type="hidden" value="<%= layoutsAdminDisplayContext.getSelPlid() %>" />
 	<aui:input name="privateLayout" type="hidden" value="<%= privateLayout %>" />
 	<aui:input name="layoutSetId" type="hidden" value="<%= selLayoutSet.getLayoutSetId() %>" />
+	<aui:input name="tab" type="hidden" value="design" />
 
 	<h2 class="c-mb-4 text-7"><liferay-ui:message key="design" /></h2>
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/design.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/design.jsp
@@ -50,7 +50,7 @@ renderResponse.setTitle(selGroup.getLayoutRootNodeName(privateLayout, locale));
 	<aui:input name="selPlid" type="hidden" value="<%= layoutsAdminDisplayContext.getSelPlid() %>" />
 	<aui:input name="privateLayout" type="hidden" value="<%= privateLayout %>" />
 	<aui:input name="layoutSetId" type="hidden" value="<%= selLayoutSet.getLayoutSetId() %>" />
-	<aui:input name="tab" type="hidden" value="design" />
+	<aui:input name="tab" type="hidden" value="<%= LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN %>" />
 
 	<h2 class="c-mb-4 text-7"><liferay-ui:message key="design" /></h2>
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/seo.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/seo.jsp
@@ -50,7 +50,7 @@ renderResponse.setTitle(selGroup.getLayoutRootNodeName(privateLayout, locale));
 	<aui:input name="selPlid" type="hidden" value="<%= layoutsAdminDisplayContext.getSelPlid() %>" />
 	<aui:input name="privateLayout" type="hidden" value="<%= privateLayout %>" />
 	<aui:input name="layoutSetId" type="hidden" value="<%= selLayoutSet.getLayoutSetId() %>" />
-	<aui:input name="tab" type="hidden" value="<%= LayoutScreenNavigationEntryConstants.ENTRY_KEY_SEO %>" />
+	<aui:input name="screenNavigationEntryKey" type="hidden" value="<%= LayoutScreenNavigationEntryConstants.ENTRY_KEY_SEO %>" />
 
 	<h2 class="c-mb-4 text-7"><liferay-ui:message key="seo" /></h2>
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/seo.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/seo.jsp
@@ -50,6 +50,7 @@ renderResponse.setTitle(selGroup.getLayoutRootNodeName(privateLayout, locale));
 	<aui:input name="selPlid" type="hidden" value="<%= layoutsAdminDisplayContext.getSelPlid() %>" />
 	<aui:input name="privateLayout" type="hidden" value="<%= privateLayout %>" />
 	<aui:input name="layoutSetId" type="hidden" value="<%= selLayoutSet.getLayoutSetId() %>" />
+	<aui:input name="tab" type="hidden" value="seo" />
 
 	<h2 class="c-mb-4 text-7"><liferay-ui:message key="seo" /></h2>
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/seo.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/screen/navigation/entries/seo.jsp
@@ -50,7 +50,7 @@ renderResponse.setTitle(selGroup.getLayoutRootNodeName(privateLayout, locale));
 	<aui:input name="selPlid" type="hidden" value="<%= layoutsAdminDisplayContext.getSelPlid() %>" />
 	<aui:input name="privateLayout" type="hidden" value="<%= privateLayout %>" />
 	<aui:input name="layoutSetId" type="hidden" value="<%= selLayoutSet.getLayoutSetId() %>" />
-	<aui:input name="tab" type="hidden" value="seo" />
+	<aui:input name="tab" type="hidden" value="<%= LayoutScreenNavigationEntryConstants.ENTRY_KEY_SEO %>" />
 
 	<h2 class="c-mb-4 text-7"><liferay-ui:message key="seo" /></h2>
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -34,7 +34,7 @@ import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelect
 import com.liferay.item.selector.criteria.url.criterion.URLItemSelectorCriterion;
 import com.liferay.item.selector.criteria.video.criterion.VideoItemSelectorCriterion;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
-import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.layout.admin.constants.LayoutScreenNavigationEntryConstants;import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.sidebar.panel.ContentPageEditorSidebarPanel;
 import com.liferay.layout.content.page.editor.web.internal.configuration.PageEditorConfiguration;
 import com.liferay.layout.content.page.editor.web.internal.constants.ContentPageEditorActionKeys;
@@ -1501,7 +1501,7 @@ public class ContentPageEditorDisplayContext {
 		).setParameter(
 			"privateLayout", layout.isPrivateLayout()
 		).setParameter(
-			"screenNavigationEntryKey", "design"
+			"screenNavigationEntryKey", LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN
 		).setParameter(
 			"selPlid",
 			() -> {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -34,7 +34,8 @@ import com.liferay.item.selector.criteria.info.item.criterion.InfoItemItemSelect
 import com.liferay.item.selector.criteria.url.criterion.URLItemSelectorCriterion;
 import com.liferay.item.selector.criteria.video.criterion.VideoItemSelectorCriterion;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
-import com.liferay.layout.admin.constants.LayoutScreenNavigationEntryConstants;import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
+import com.liferay.layout.admin.constants.LayoutScreenNavigationEntryConstants;
+import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.sidebar.panel.ContentPageEditorSidebarPanel;
 import com.liferay.layout.content.page.editor.web.internal.configuration.PageEditorConfiguration;
 import com.liferay.layout.content.page.editor.web.internal.constants.ContentPageEditorActionKeys;
@@ -1501,7 +1502,8 @@ public class ContentPageEditorDisplayContext {
 		).setParameter(
 			"privateLayout", layout.isPrivateLayout()
 		).setParameter(
-			"screenNavigationEntryKey", LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN
+			"screenNavigationEntryKey",
+			LayoutScreenNavigationEntryConstants.ENTRY_KEY_DESIGN
 		).setParameter(
 			"selPlid",
 			() -> {

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportsIssuesStrutsAction.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportsIssuesStrutsAction.java
@@ -5,7 +5,7 @@
 
 package com.liferay.layout.reports.web.internal.struts;
 
-import com.liferay.layout.reports.web.internal.configuration.provider.LayoutReportsGooglePageSpeedConfigurationProvider;
+import com.liferay.layout.admin.constants.LayoutScreenNavigationEntryConstants;import com.liferay.layout.reports.web.internal.configuration.provider.LayoutReportsGooglePageSpeedConfigurationProvider;
 import com.liferay.layout.reports.web.internal.data.provider.LayoutReportsDataProvider;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
@@ -191,7 +191,8 @@ public class GetLayoutReportsIssuesStrutsAction implements StrutsAction {
 						"/layout_reports/get_layout_reports_issues",
 					"redirect", completeURL, "backURL", completeURL, "groupId",
 					layout.getGroupId(), "privateLayout",
-					layout.isPrivateLayout(), "screenNavigationEntryKey", "seo",
+					layout.isPrivateLayout(), "screenNavigationEntryKey", 					layout.isPrivateLayout(), "screenNavigationEntryKey", LayoutScreenNavigationEntryConstants.ENTRY_KEY_SEO,
+					layout.isPrivateLayout(), "screenNavigationEntryKey", LayoutScreenNavigationEntryConstants.ENTRY_KEY_SEO,
 					"selPlid", layout.getPlid());
 			}
 		}

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportsIssuesStrutsAction.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportsIssuesStrutsAction.java
@@ -5,7 +5,8 @@
 
 package com.liferay.layout.reports.web.internal.struts;
 
-import com.liferay.layout.admin.constants.LayoutScreenNavigationEntryConstants;import com.liferay.layout.reports.web.internal.configuration.provider.LayoutReportsGooglePageSpeedConfigurationProvider;
+import com.liferay.layout.admin.constants.LayoutScreenNavigationEntryConstants;
+import com.liferay.layout.reports.web.internal.configuration.provider.LayoutReportsGooglePageSpeedConfigurationProvider;
 import com.liferay.layout.reports.web.internal.data.provider.LayoutReportsDataProvider;
 import com.liferay.portal.kernel.cache.PortalCache;
 import com.liferay.portal.kernel.cache.PortalCacheHelperUtil;
@@ -191,8 +192,11 @@ public class GetLayoutReportsIssuesStrutsAction implements StrutsAction {
 						"/layout_reports/get_layout_reports_issues",
 					"redirect", completeURL, "backURL", completeURL, "groupId",
 					layout.getGroupId(), "privateLayout",
-					layout.isPrivateLayout(), "screenNavigationEntryKey", 					layout.isPrivateLayout(), "screenNavigationEntryKey", LayoutScreenNavigationEntryConstants.ENTRY_KEY_SEO,
-					layout.isPrivateLayout(), "screenNavigationEntryKey", LayoutScreenNavigationEntryConstants.ENTRY_KEY_SEO,
+					layout.isPrivateLayout(), "screenNavigationEntryKey",
+					layout.isPrivateLayout(), "screenNavigationEntryKey",
+					LayoutScreenNavigationEntryConstants.ENTRY_KEY_SEO,
+					layout.isPrivateLayout(), "screenNavigationEntryKey",
+					LayoutScreenNavigationEntryConstants.ENTRY_KEY_SEO,
 					"selPlid", layout.getPlid());
 			}
 		}

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportsIssuesStrutsAction.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportsIssuesStrutsAction.java
@@ -193,9 +193,6 @@ public class GetLayoutReportsIssuesStrutsAction implements StrutsAction {
 					"redirect", completeURL, "backURL", completeURL, "groupId",
 					layout.getGroupId(), "privateLayout",
 					layout.isPrivateLayout(), "screenNavigationEntryKey",
-					layout.isPrivateLayout(), "screenNavigationEntryKey",
-					LayoutScreenNavigationEntryConstants.ENTRY_KEY_SEO,
-					layout.isPrivateLayout(), "screenNavigationEntryKey",
 					LayoutScreenNavigationEntryConstants.ENTRY_KEY_SEO,
 					"selPlid", layout.getPlid());
 			}


### PR DESCRIPTION
coming from : https://github.com/liferay-echo/liferay-portal/pull/12994
bug : https://liferay.atlassian.net/browse/LPS-191305

Motivation
=======
Currently, when saving the SEO Configuration of a LayoutSet, it always resets the Client Extensions settings of that LayoutSet. I believe that this is a bug and a poor user experience because this means that the user cannot update their SEO Settings without resetting their Client Extension settings, and they have to re-configure the Client Extension Settings afterwards. Moreover, there is no obvious indication in the UI that the Client Extension settings were reset, so they may not even be aware that they need to be reconfigured until it is too late.

Proposed Solution
========
Add a `tab` parameter to the `edit_layout_set` request to keep track of which screen the request came from, and only do the logic to update the Client Extensions settings if the request came from the Design screen (since the Design screen is the only one that sets the Client Extensions settings.

Steps to Verify
========
1. Start up Liferay and log in as the admin user.
2. Enable Private Pages
* Open the Global Menu (Global Menu), go to the Control Panel tab, and click System Settings.
* Go to Release Feature Flags.
* In the Disabled Features dropdown menu, select Disable Private Pages.
* Click Update.
3. Add a Theme CSS Client extension
* Open the Global Menu (Global Menu), go to the Applications tab, and click Client Extensions.
* Click the Add :plus: icon and select "Add Theme CSS"
* In the Name field, type "Test Theme CSS Client Extension".
* Click Publish.
4. Go to the Liferay DXP site.
5. Go to Site Builder > Pages.
6. Click the gear icon next to Public Pages.
7. On the Design tab, scroll down to the Customization section.
8. Select the "Test Theme CSS Client Extension" as the Theme CSS option.
9. Click Save.
10. Refresh the page and confirm that the "Test Theme CSS Client Extension" selection was saved.
11. Go to the SEO tab.
12. Without editing anything on the SEO page, click Save.
13. Go back to the Design tab.
14. Scroll down to the Customization section.

**Expected Result:** The "Test Theme CSS Client Extension" appears as the Theme CSS option.
**Actual Result:** The "Test Theme CSS Client Extension" does not appear as the Theme CSS option. Instead, we see "No theme CSS client extension was loaded".