### PR TITLE
LPS-190004 Replace aui:button with clay:button in asset-publisher-web

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/add_asset_selector.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/add_asset_selector.jsp
@@ -108,9 +108,18 @@ String redirect = PortalUtil.getLayoutFullURL(layout, themeDisplay);
 	</div>
 
 	<aui:button-row>
-		<aui:button onClick='<%= liferayPortletResponse.getNamespace() + "addAssetEntry();" %>' primary="<%= true %>" value="add" />
+		<clay:button
+			displayType="primary"
+			label="add"
+			onClick='<%= liferayPortletResponse.getNamespace() + "addAssetEntry();" %>'
+		/>
 
-		<aui:button href="<%= redirect %>" type="cancel" />
+		<clay:link
+			displayType="secondary"
+			href="<%= redirect %>"
+			label="cancel"
+			type="button"
+		/>
 	</aui:button-row>
 </clay:container-fluid>
 

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_list.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/asset_list.jsp
@@ -38,9 +38,18 @@ AssetListEntry assetListEntry = assetPublisherDisplayContext.fetchAssetListEntry
 </div>
 
 <div class="button-row">
-	<aui:button cssClass="mr-2" name="selectAssetListButton" value="select" />
+	<clay:button
+		cssClass="mr-2"
+		displayType="secondary"
+		id='<%= liferayPortletResponse.getNamespace() + "selectAssetListButton" %>'
+		label="select"
+	/>
 
-	<aui:button name="clearAssetListButton" value="clear" />
+	<clay:button
+		displayType="secondary"
+		id='<%= liferayPortletResponse.getNamespace() + "clearAssetListButton" %>'
+		label="clear"
+	/>
 </div>
 
 <aui:script sandbox="<%= true %>">

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/source.jsp
@@ -183,7 +183,12 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 							</liferay-portlet:renderURL>
 
 							<span class="asset-subtypefields-popup" id="<portlet:namespace /><%= classType.getClassTypeId() %>_<%= className %>PopUpButton">
-								<aui:button data-href="<%= selectStructureFieldURL.toString() %>" disabled="<%= !assetPublisherDisplayContext.isSubtypeFieldsFilterEnabled() %>" value="select" />
+								<clay:button
+									data-href="<%= selectStructureFieldURL.toString() %>"
+									disabled="<%= !assetPublisherDisplayContext.isSubtypeFieldsFilterEnabled() %>"
+									displayType="secondary"
+									label="select"
+								/>
 							</span>
 						</span>
 


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-190004)

In this issue we want to replace all usages of aui:button with clay:button in asset-publisher-web module, ideally it is going to allow us improve the accessibility.

## Test Scenario 1 (add_asset_selector.jsp)

* Create a new basic web content.
* Create a widget page
* Add an asset publisher to this page and configure it
* Select manual collection
* Add another scope
* Save and close the modal
* Click on the addd button of the asset publisher and select “Add content (Select Scope and type)”
* Check the buttons

<img width="946" alt="Pasted Graphic 10" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/dc2ffb10-caee-4d5e-8e3f-97a53680cb38">

## Test Scenario 2 (asset_list.jsp)

* Create a new basic web content.
* Create a widget page
* Add an asset publisher to this page and configure it
* Select manual collection
* Go to select colección and check the buttons

<img width="353" alt="Pasted Graphic 11" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/afe91f44-fa9a-4cc4-a931-f3030a845197">

## Test Scenario 2 (source.jsp)

* Create a new basic web content.
* Create a widget page
* Add an asset publisher to this page and configure it
* Select dynamic collection
* Go to source and check the button

<img width="1321" alt="Pasted Graphic 12" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/e5bf976e-9b9c-4a0f-83f0-34986b536dd4">

