### PR TITLE
LPS-190225

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -1255,15 +1255,26 @@ public class ContentPageEditorDisplayContext {
 		Map<Long, LayoutStructureItem> fragmentLayoutStructureItems =
 			layoutStructure.getFragmentLayoutStructureItems();
 
-		for (long fragmentEntryLinkId : fragmentLayoutStructureItems.keySet()) {
+		for (Map.Entry<Long, LayoutStructureItem> fragmentLayoutStructureItem :
+				fragmentLayoutStructureItems.entrySet()) {
+
 			if (fragmentEntryLinksMap.containsKey(
-					String.valueOf(fragmentEntryLinkId))) {
+					String.valueOf(fragmentLayoutStructureItem.getKey()))) {
+
+				continue;
+			}
+
+			LayoutStructureItem layoutStructureItem =
+				fragmentLayoutStructureItem.getValue();
+
+			if (layoutStructure.isItemMarkedForDeletion(
+					layoutStructureItem.getItemId())) {
 
 				continue;
 			}
 
 			fragmentEntryLinksMap.put(
-				String.valueOf(fragmentEntryLinkId),
+				String.valueOf(fragmentLayoutStructureItem.getKey()),
 				JSONUtil.put(
 					"configuration", _jsonFactory.createJSONObject()
 				).put(
@@ -1276,7 +1287,8 @@ public class ContentPageEditorDisplayContext {
 				).put(
 					"error", Boolean.TRUE
 				).put(
-					"fragmentEntryLinkId", String.valueOf(fragmentEntryLinkId)
+					"fragmentEntryLinkId",
+					String.valueOf(fragmentLayoutStructureItem.getKey())
 				));
 		}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -1225,7 +1225,7 @@ public class ContentPageEditorDisplayContext {
 			_fragmentEntryLinkLocalService.
 				getFragmentEntryLinksBySegmentsExperienceId(
 					getGroupId(), getSegmentsExperienceId(),
-					themeDisplay.getPlid());
+					themeDisplay.getPlid(), false);
 
 		LayoutStructure layoutStructure = _getLayoutStructure();
 


### PR DESCRIPTION
from: https://github.com/liferay-echo/liferay-portal/pull/12962

Motivation
=======
As part of [story](https://liferay.atlassian.net/browse/LPS-190225) related with undo/redo we mark fragments as deleted, to make it easier the redo. Since, when we reload the page the undo/redo is lost, we are loading deleted FragmentEntryLinks and it is not necessary.


Proposed Solution
========
The idea of this task is doesn’t load deleted fragments in `_getFragmentEntryLinks().`

Steps to Verify
========
- Add a breakpoint in ContentPageEditorDisplayContext.java line 722 and connect the debugger.

```
).put(
	"fragmentEntryLinks", _getFragmentEntryLinks().  <--- Here
).put(

```

- Go to the portal and create a new content page.
- Add 3 buttons and remove 2 of them using the **UNDO** arrows on the top right part of the page.
- Without saving or publishing the changes, reload the page using the **reload button in your browser**.
- Then you debugger should stop at the break point and when evaluating result of the` _getFragmentEntryLinks()` method, only one _FragmentEntryLink_ should be showed. (if you repeat this code in master, without this changes, you'll be able to see multiple _FragmentEntryLinks_ in te response as the deleted ones are included as well).

** please let me know if you need any help to verify it