### PR TITLE
LPS-191678 - Rename DateTextEditableElementParser to DateTimeEditableElementParser so it is consistent with type property value (date-time)

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/DateTimeEditableElementParser.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable/src/main/java/com/liferay/fragment/entry/processor/editable/internal/parser/DateTimeEditableElementParser.java
@@ -24,7 +24,7 @@ import org.osgi.service.component.annotations.Reference;
  * @author Diego Hu
  */
 @Component(property = "type=date-time", service = EditableElementParser.class)
-public class DateTextEditableElementParser implements EditableElementParser {
+public class DateTimeEditableElementParser implements EditableElementParser {
 
 	@Override
 	public String getValue(Element element) {


### PR DESCRIPTION
//cc @ealonso @jkappler