### PR TITLE
LPS-191691 Do not allow the user to edit the article if they cannot view the article's structure

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/clay/servlet/taglib/JournalArticleVerticalCard.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/frontend/taglib/clay/servlet/taglib/JournalArticleVerticalCard.java
@@ -20,6 +20,7 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItem;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.LabelItemListBuilder;
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.web.internal.security.permission.resource.DDMStructurePermission;
 import com.liferay.journal.web.internal.security.permission.resource.JournalArticlePermission;
 import com.liferay.journal.web.internal.servlet.taglib.util.JournalArticleActionDropdownItemsProvider;
 import com.liferay.petra.string.StringPool;
@@ -99,7 +100,10 @@ public class JournalArticleVerticalCard extends BaseVerticalCard {
 		try {
 			if (!JournalArticlePermission.contains(
 					themeDisplay.getPermissionChecker(), _article,
-					ActionKeys.UPDATE)) {
+					ActionKeys.UPDATE) ||
+				!DDMStructurePermission.contains(
+					themeDisplay.getPermissionChecker(),
+					_article.getDDMStructure(), ActionKeys.VIEW)) {
 
 				return StringPool.BLANK;
 			}

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/JournalArticleActionDropdownItemsProvider.java
@@ -38,6 +38,7 @@ import com.liferay.journal.web.internal.configuration.FFJournalAutoSaveDraftConf
 import com.liferay.journal.web.internal.configuration.JournalWebConfiguration;
 import com.liferay.journal.web.internal.item.selector.JournalArticleTranslationsItemSelectorCriterion;
 import com.liferay.journal.web.internal.portlet.JournalPortlet;
+import com.liferay.journal.web.internal.security.permission.resource.DDMStructurePermission;
 import com.liferay.journal.web.internal.security.permission.resource.JournalArticlePermission;
 import com.liferay.journal.web.internal.security.permission.resource.JournalFolderPermission;
 import com.liferay.journal.web.internal.util.JournalUtil;
@@ -146,7 +147,11 @@ public class JournalArticleActionDropdownItemsProvider {
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
 					DropdownItemListBuilder.add(
-						() -> hasUpdatePermission,
+						() ->
+							hasUpdatePermission &&
+							DDMStructurePermission.contains(
+								_themeDisplay.getPermissionChecker(),
+								_article.getDDMStructure(), ActionKeys.VIEW),
 						_getEditArticleActionUnsafeConsumer()
 					).add(
 						() ->

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -70,7 +70,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 
 				String editURL = StringPool.BLANK;
 
-				if (JournalArticlePermission.contains(permissionChecker, curArticle, ActionKeys.UPDATE)) {
+				if (JournalArticlePermission.contains(permissionChecker, curArticle, ActionKeys.UPDATE) && DDMStructurePermission.contains(permissionChecker, curArticle.getDDMStructure(), ActionKeys.VIEW)) {
 					editURL = PortletURLBuilder.createRenderURL(
 						liferayPortletResponse
 					).setMVCPath(


### PR DESCRIPTION
Motivation
=======
https://liferay.atlassian.net/browse/LPS-191691

The issue is that when a user has permission to edit an article but does not have permission to view the underlying structure the article does not display properly.

Proposed Solution
========
To solve this problem I introduced a new permission check to ensure the user has permission to view the structure. If they do not then the do not have the option to edit the article.

Steps to Verify
========
1. Go to the Global site
2. Go to Content & Data - Web Content - Structures
3. Add a new Structure
4. Go to Control Panel - Users and Organizations
5. Add a new user
6. Add the user as a member of the Liferay DXP site
7. Add the Site Administrator role to the user
8. On the default site add a new Web Content Article utilizing the new structure
9. Sign in as the new user
10. Go to Content & Data - Web Content
11. Edit the newly created article

Alternative Solutions that were discarded (if applies)
========
I wasn't 100% certain what the behavior should be in this situation. If you would rather allow the user to be able to edit the article please let me know.