### PR TITLE
LPS-191767 Adds service validation to prevent a user to modify a draft locked by another user

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -21,6 +21,7 @@ import com.liferay.fragment.service.persistence.FragmentCollectionPersistence;
 import com.liferay.fragment.service.persistence.FragmentEntryPersistence;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.aop.AopService;
+import com.liferay.portal.kernel.exception.LockedLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONException;
 import com.liferay.portal.kernel.json.JSONFactory;
@@ -31,12 +32,14 @@ import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -78,6 +81,8 @@ public class FragmentEntryLinkLocalServiceImpl
 			String editableValues, String namespace, int position,
 			String rendererKey, int type, ServiceContext serviceContext)
 		throws PortalException {
+
+		_checkUnlockedLayout(plid, userId);
 
 		User user = _userLocalService.getUser(userId);
 
@@ -536,6 +541,9 @@ public class FragmentEntryLinkLocalServiceImpl
 		FragmentEntryLink fragmentEntryLink =
 			fragmentEntryLinkPersistence.findByPrimaryKey(fragmentEntryLinkId);
 
+		_checkUnlockedLayout(
+			fragmentEntryLink.getPlid(), GuestOrUserUtil.getUserId());
+
 		fragmentEntryLink.setDeleted(deleted);
 
 		return fragmentEntryLinkPersistence.update(fragmentEntryLink);
@@ -548,6 +556,9 @@ public class FragmentEntryLinkLocalServiceImpl
 
 		FragmentEntryLink fragmentEntryLink = fetchFragmentEntryLink(
 			fragmentEntryLinkId);
+
+		_checkUnlockedLayout(
+			fragmentEntryLink.getPlid(), GuestOrUserUtil.getUserId());
 
 		fragmentEntryLink.setPosition(position);
 
@@ -564,6 +575,8 @@ public class FragmentEntryLinkLocalServiceImpl
 		throws PortalException {
 
 		User user = _userLocalService.getUser(userId);
+
+		_checkUnlockedLayout(plid, userId);
 
 		FragmentEntryLink fragmentEntryLink = fetchFragmentEntryLink(
 			fragmentEntryLinkId);
@@ -602,6 +615,9 @@ public class FragmentEntryLinkLocalServiceImpl
 		FragmentEntryLink fragmentEntryLink = fetchFragmentEntryLink(
 			fragmentEntryLinkId);
 
+		_checkUnlockedLayout(
+			fragmentEntryLink.getPlid(), GuestOrUserUtil.getUserId());
+
 		fragmentEntryLink.setEditableValues(editableValues);
 
 		return fragmentEntryLinkPersistence.update(fragmentEntryLink);
@@ -615,6 +631,9 @@ public class FragmentEntryLinkLocalServiceImpl
 
 		FragmentEntryLink fragmentEntryLink = fetchFragmentEntryLink(
 			fragmentEntryLinkId);
+
+		_checkUnlockedLayout(
+			fragmentEntryLink.getPlid(), GuestOrUserUtil.getUserId());
 
 		fragmentEntryLink.setEditableValues(editableValues);
 
@@ -731,6 +750,16 @@ public class FragmentEntryLinkLocalServiceImpl
 				fragmentEntryLink.getFragmentEntryId());
 
 		updateLatestChanges(fragmentEntry, fragmentEntryLink);
+	}
+
+	private void _checkUnlockedLayout(long plid, long userId)
+		throws PortalException {
+
+		Layout layout = _layoutLocalService.getLayout(plid);
+
+		if (!layout.isUnlocked(Constants.EDIT, userId)) {
+			throw new LockedLayoutException();
+		}
 	}
 
 	private String _getProcessedHTML(

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateStructureLocalServiceImpl.java
@@ -12,15 +12,19 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
 import com.liferay.layout.page.template.service.base.LayoutPageTemplateStructureLocalServiceBaseImpl;
 import com.liferay.portal.aop.AopService;
+import com.liferay.portal.kernel.exception.LockedLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
 
@@ -146,6 +150,8 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 			long groupId, long plid, long segmentsExperienceId, String data)
 		throws PortalException {
 
+		_checkUnlockedLayout(plid);
+
 		// Layout page template structure
 
 		LayoutPageTemplateStructure layoutPageTemplateStructure =
@@ -193,6 +199,8 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 			long groupId, long plid, String data)
 		throws PortalException {
 
+		_checkUnlockedLayout(plid);
+
 		long defaultSegmentsExperienceId =
 			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
 				plid);
@@ -200,6 +208,14 @@ public class LayoutPageTemplateStructureLocalServiceImpl
 		return layoutPageTemplateStructureLocalService.
 			updateLayoutPageTemplateStructureData(
 				groupId, plid, defaultSegmentsExperienceId, data);
+	}
+
+	private void _checkUnlockedLayout(long plid) throws PortalException {
+		Layout layout = _layoutLocalService.getLayout(plid);
+
+		if (!layout.isUnlocked(Constants.EDIT, GuestOrUserUtil.getUserId())) {
+			throw new LockedLayoutException();
+		}
 	}
 
 	private void _updateLayoutStatus(long userId, long plid)

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceLocalServiceImpl.java
@@ -6,17 +6,20 @@
 package com.liferay.segments.service.impl;
 
 import com.liferay.portal.aop.AopService;
+import com.liferay.portal.kernel.exception.LockedLayoutException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ResourceLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.systemevent.SystemEvent;
+import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -110,6 +113,8 @@ public class SegmentsExperienceLocalServiceImpl
 			UnicodeProperties typeSettingsUnicodeProperties,
 			ServiceContext serviceContext)
 		throws PortalException {
+
+		_checkUnlockedLayout(plid, userId);
 
 		// Segments experience
 
@@ -206,6 +211,9 @@ public class SegmentsExperienceLocalServiceImpl
 			segmentsExperiencePersistence.findByPrimaryKey(
 				segmentsExperienceId);
 
+		_checkUnlockedLayout(
+			segmentsExperience.getPlid(), GuestOrUserUtil.getUserId());
+
 		return segmentsExperienceLocalService.deleteSegmentsExperience(
 			segmentsExperience);
 	}
@@ -225,6 +233,9 @@ public class SegmentsExperienceLocalServiceImpl
 				MustNotDeleteSegmentsExperienceReferencedBySegmentsExperiments(
 					segmentsExperience.getSegmentsExperienceId());
 		}
+
+		_checkUnlockedLayout(
+			segmentsExperience.getPlid(), GuestOrUserUtil.getUserId());
 
 		segmentsExperiencePersistence.remove(segmentsExperience);
 
@@ -438,6 +449,9 @@ public class SegmentsExperienceLocalServiceImpl
 					" has a locked segments experiment");
 		}
 
+		_checkUnlockedLayout(
+			segmentsExperience.getPlid(), GuestOrUserUtil.getUserId());
+
 		segmentsExperience.setSegmentsEntryId(segmentsEntryId);
 		segmentsExperience.setNameMap(nameMap);
 		segmentsExperience.setActive(active);
@@ -455,6 +469,9 @@ public class SegmentsExperienceLocalServiceImpl
 		SegmentsExperience segmentsExperience =
 			segmentsExperiencePersistence.findByPrimaryKey(
 				segmentsExperienceId);
+
+		_checkUnlockedLayout(
+			segmentsExperience.getPlid(), GuestOrUserUtil.getUserId());
 
 		segmentsExperience.setActive(active);
 
@@ -475,6 +492,9 @@ public class SegmentsExperienceLocalServiceImpl
 				"Segments experience " + segmentsExperienceId +
 					" has a locked segments experiment");
 		}
+
+		_checkUnlockedLayout(
+			segmentsExperience.getPlid(), GuestOrUserUtil.getUserId());
 
 		boolean swap = true;
 
@@ -523,6 +543,16 @@ public class SegmentsExperienceLocalServiceImpl
 
 		return segmentsExperiencePersistence.findByPrimaryKey(
 			segmentsExperience.getSegmentsExperienceId());
+	}
+
+	private void _checkUnlockedLayout(long plid, long userId)
+		throws PortalException {
+
+		Layout layout = _layoutLocalService.getLayout(plid);
+
+		if (!layout.isUnlocked(Constants.EDIT, userId)) {
+			throw new LockedLayoutException();
+		}
 	}
 
 	private void _compactSegmentsExperiencesPriorities(

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -32,6 +32,7 @@ import com.liferay.portal.kernel.exception.SitemapIncludeException;
 import com.liferay.portal.kernel.exception.SitemapPagePriorityException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.language.LanguageUtil;
+import com.liferay.portal.kernel.lock.LockManagerUtil;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.CustomizedPages;
@@ -796,6 +797,8 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 		for (Layout childLayout : childLayouts) {
 			layoutLocalService.deleteLayout(childLayout, serviceContext);
 		}
+
+		LockManagerUtil.unlock(Layout.class.getName(), layout.getPlid());
 
 		// Layout friendly URLs
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-191767

Dear reviewer 👋 

Thanks in advance for your review ❤️ 

This PR implements that when a layout is locked by a user if another user tries to modify its structure data, its fragment links, or the segment's experiences then the service will throw a LockedLayoutException.

The lock acquire process isn't implemented yet so we need to use scripts to lock/unlock the draft. In addition, to be able to test it, the feature flag must be enabled:
`feature.flag.LPS-180328=true`

These scripts are useful to test this PR:

* Script to lock a draft by a user

[LockLayout.txt](https://github.com/liferay-echo/liferay-portal/files/12184835/LockLayout.txt)

* Script to see the status of a draft (locked/unlocked) with respect to all the users of the company

[isUnlockedLayout.txt](https://github.com/liferay-echo/liferay-portal/files/12184843/isUnlockedLayout.txt)

* Script to unlock a draft

[UnlockLayout.txt](https://github.com/liferay-echo/liferay-portal/files/12184851/UnlockLayout.txt)
