### PR TITLE
LPS-190001 Replace aui:button with clay:button

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/resources/META-INF/resources/category/details.jsp
@@ -193,11 +193,26 @@ renderResponse.setTitle(title);
 	<c:choose>
 		<c:when test="<%= !assetCategoriesDisplayContext.isItemSelector() %>">
 			<liferay-frontend:edit-form-footer>
-				<aui:button disabled="<%= assetCategoriesDisplayContext.isSaveButtonDisabled() %>" type="submit" />
+				<clay:button
+					disabled="<%= assetCategoriesDisplayContext.isSaveButtonDisabled() %>"
+					label="save"
+					type="submit"
+				/>
 
-				<aui:button disabled="<%= assetCategoriesDisplayContext.isSaveAndAddNewButtonDisabled() %>" onClick='<%= liferayPortletResponse.getNamespace() + "saveAndAddNew();" %>' value="save-and-add-a-new-one" />
+				<clay:button
+					disabled="<%= assetCategoriesDisplayContext.isSaveAndAddNewButtonDisabled() %>"
+					displayType="secondary"
+					label="save-and-add-a-new-one"
+					onClick='<%= liferayPortletResponse.getNamespace() + "saveAndAddNew();" %>'
+				/>
 
-				<aui:button href="<%= redirect %>" type="cancel" />
+				<clay:link
+					borderless="<%= false %>"
+					displayType="secondary"
+					href="<%= redirect %>"
+					label="cancel"
+					type="button"
+				/>
 			</liferay-frontend:edit-form-footer>
 		</c:when>
 		<c:otherwise>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/source.jsp
@@ -195,7 +195,14 @@ List<Map<String, Object>> classTypesList = new ArrayList<>();
 							</portlet:renderURL>
 
 							<span class="asset-subtypefields-popup" id="<portlet:namespace /><%= classType.getClassTypeId() %>_<%= className %>PopUpButton">
-								<aui:button data-href="<%= selectStructureFieldURL.toString() %>" disabled="<%= !editAssetListDisplayContext.isSubtypeFieldsFilterEnabled() %>" value="select" />
+								<clay:button
+									borderless="<%= false %>"
+									disabled="<%= !editAssetListDisplayContext.isSubtypeFieldsFilterEnabled() %>"
+									displayType="secondary"
+									data-href="<%= selectStructureFieldURL.toString() %>"
+									label="select"
+									type="button"
+								/>
 							</span>
 						</span>
 


### PR DESCRIPTION
Motivation
=======
The motivation behind this PR stadirize the usages of buttons in the portal by using for clay:button or clay:icon.
https://liferay.atlassian.net/browse/LPS-190001
https://liferay.atlassian.net/browse/LPS-190002

Proposed Solution
========
The proposed solution consist in substitute the usages of aui:button for clay:button o clay:icon.

Steps to Verify
========
asset-categories button:
Product Menu -> Categorization -> Categories -> Create a Vocabulary -> Create a new Category -> buttons at the bottom

asset-list-button
Product Menu -> Collection -> Create a Dynamic Collection -> Select Web content and basic web content subtype -> Click on filter by field -> the select button there