### PR TITLE
LPS-191642 Remove the use of global functions in edit_folder.jsp using JS

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -133,7 +133,7 @@ renderResponse.setTitle(title);
 				%>
 
 				<div class="form-group">
-					<aui:input name="parentFolderName" type="resource" value="<%= parentFolderName %>" />
+					<aui:input name="folderName" type="resource" value="<%= parentFolderName %>" />
 
 					<clay:button
 						displayType="secondary"
@@ -141,41 +141,30 @@ renderResponse.setTitle(title);
 						label="select"
 					/>
 
-					<aui:script sandbox="<%= true %>">
-						var selectFolderButton = document.getElementById(
-							'<portlet:namespace />selectFolderButton'
-						);
-
-						selectFolderButton.addEventListener('click', (event) => {
-							Liferay.Util.openSelectionModal({
-								onSelect: function (selectedItem) {
-									if (selectedItem) {
-										var folderData = {
-											idString: 'parentFolderId',
-											idValue: selectedItem.folderId,
-											nameString: 'parentFolderName',
-											nameValue: selectedItem.folderName,
-										};
-
-										Liferay.Util.selectFolder(folderData, '<portlet:namespace />');
-									}
-								},
-								selectEventName: '<portlet:namespace />selectFolder',
-								title: '<liferay-ui:message arguments="folder" key="select-x" />',
-
-								<portlet:renderURL var="selectFolderURL" windowState="<%= LiferayWindowState.POP_UP.toString() %>">
-									<portlet:param name="mvcPath" value="/select_folder.jsp" />
-									<portlet:param name="folderId" value="<%= String.valueOf(folderId) %>" />
-									<portlet:param name="parentFolderId" value="<%= String.valueOf(parentFolderId) %>" />
-								</portlet:renderURL>
-
-								url: '<%= selectFolderURL.toString() %>',
-							});
-						});
-					</aui:script>
+					<liferay-frontend:component
+						context='<%=
+							HashMapBuilder.<String, Object>put(
+								"inputName", "parentFolderId"
+							).put(
+								"selectFolderURL",
+								PortletURLBuilder.createRenderURL(
+									renderResponse
+								).setMVCPath(
+									"/select_folder.jsp"
+								).setParameter(
+									"folderId", folderId
+								).setParameter(
+									"parentFolderId", parentFolderId
+								).setWindowState(
+									LiferayWindowState.POP_UP
+								).buildString()
+							).build()
+						%>'
+						module="js/SelectFolderButton"
+					/>
 
 					<%
-					String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('parentFolderId', 'parentFolderName', this, '" + liferayPortletResponse.getNamespace() + "');";
+					String taglibRemoveFolder = "Liferay.Util.removeEntitySelection('parentFolderId', 'folderName', this, '" + liferayPortletResponse.getNamespace() + "');";
 					%>
 
 					<clay:button

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -53,11 +53,40 @@ renderResponse.setTitle(title);
 </portlet:actionURL>
 
 <liferay-util:buffer
-	var="removeDDMStructureIcon"
+	var="removeButton"
 >
-	<clay:icon
-		symbol="times-circle"
-	/>
+	<button
+		aria-label='<%= LanguageUtil.get(request, "remove") %>'
+		class="btn btn-monospaced btn-outline-borderless btn-outline-secondary float-right modify-link"
+		data-rowId="REMOVE_BUTTON_ROW_ID"
+		title='<%= LanguageUtil.get(request, "remove") %>'
+		type="button"
+	>
+		<clay:icon
+			symbol="times-circle"
+		/>
+	</button>
+</liferay-util:buffer>
+
+<liferay-util:buffer
+	var="workflowDefinitionsBuffer"
+>
+	<c:if test="<%= workflowEnabled %>">
+		<aui:select label="" name="WORKFLOW_NAME" title="workflow-definition" wrapperCssClass="mb-0">
+			<aui:option label="no-workflow" value="" />
+
+			<%
+			for (WorkflowDefinition workflowDefinition : workflowDefinitions) {
+			%>
+
+				<aui:option label="<%= HtmlUtil.escape(workflowDefinition.getTitle(languageId)) %>" value="<%= HtmlUtil.escapeAttribute(workflowDefinition.getName()) + StringPool.AT + workflowDefinition.getVersion() %>" />
+
+			<%
+			}
+			%>
+
+		</aui:select>
+	</c:if>
 </liferay-util:buffer>
 
 <liferay-frontend:edit-form
@@ -290,6 +319,21 @@ renderResponse.setTitle(title);
 							id='<%= liferayPortletResponse.getNamespace() + "selectDDMStructure" %>'
 							label="choose-structure"
 						/>
+
+						<liferay-frontend:component
+							context='<%=
+								HashMapBuilder.<String, Object>put(
+									"removeButton", removeButton
+								).put(
+									"selectDDMStructureURL", journalDisplayContext.getSelectDDMStructureURL()
+								).put(
+									"workflowDefinitions", workflowDefinitionsBuffer
+								).put(
+									"workflowEnabled", workflowEnabled
+								).build()
+							%>'
+							module="js/SelectDDMStructureButton"
+						/>
 					</div>
 				</c:if>
 
@@ -349,91 +393,6 @@ renderResponse.setTitle(title);
 		/>
 	</liferay-frontend:edit-form-footer>
 </liferay-frontend:edit-form>
-
-<liferay-util:buffer
-	var="workflowDefinitionsBuffer"
->
-	<c:if test="<%= workflowEnabled %>">
-		<aui:select label="" name="LIFERAY_WORKFLOW_DEFINITION_DDM_STRUCTURE" title="workflow-definition" wrapperCssClass="mb-0">
-			<aui:option label="no-workflow" value="" />
-
-			<%
-			for (WorkflowDefinition workflowDefinition : workflowDefinitions) {
-			%>
-
-				<aui:option label="<%= HtmlUtil.escape(workflowDefinition.getTitle(languageId)) %>" value="<%= HtmlUtil.escapeAttribute(workflowDefinition.getName()) + StringPool.AT + workflowDefinition.getVersion() %>" />
-
-			<%
-			}
-			%>
-
-		</aui:select>
-	</c:if>
-</liferay-util:buffer>
-
-<aui:script use="liferay-search-container">
-	var searchContainer = Liferay.SearchContainer.get(
-		'<portlet:namespace />ddmStructuresSearchContainer'
-	);
-
-	var selectDDMStructureButton = document.getElementById(
-		'<portlet:namespace />selectDDMStructure'
-	);
-
-	if (selectDDMStructureButton) {
-		selectDDMStructureButton.addEventListener('click', (event) => {
-			Liferay.Util.openSelectionModal({
-				onSelect: function (selectedItem) {
-					const itemValue = JSON.parse(selectedItem.value);
-
-					var ddmStructureLink = `
-							<button aria-label="<%= LanguageUtil.get(request, "remove") %>" class="btn btn-monospaced btn-outline-borderless btn-outline-secondary float-right modify-link" data-rowId="${itemValue.ddmstructureid }" title="<%= LanguageUtil.get(request, "remove") %>">
-								<%= UnicodeFormatter.toString(removeDDMStructureIcon) %></button>`;
-
-					<c:choose>
-						<c:when test="<%= workflowEnabled %>">
-							var workflowDefinitions =
-								'<%= UnicodeFormatter.toString(workflowDefinitionsBuffer) %>';
-
-							workflowDefinitions = workflowDefinitions.replace(
-								/LIFERAY_WORKFLOW_DEFINITION_DDM_STRUCTURE/g,
-								'workflowDefinition' + itemValue.ddmstructureid
-							);
-
-							searchContainer.addRow(
-								[itemValue.name, workflowDefinitions, ddmStructureLink],
-								itemValue.ddmstructureid
-							);
-						</c:when>
-						<c:otherwise>
-							searchContainer.addRow(
-								[itemValue.name, ddmStructureLink],
-								itemValue.ddmstructureid
-							);
-						</c:otherwise>
-					</c:choose>
-
-					searchContainer.updateDataStore();
-				},
-				selectEventName: '<portlet:namespace />selectDDMStructure',
-				title: '<%= UnicodeLanguageUtil.get(request, "structures") %>',
-				url: '<%= journalDisplayContext.getSelectDDMStructureURL() %>>',
-			});
-		});
-	}
-
-	searchContainer.get('contentBox').delegate(
-		'click',
-		(event) => {
-			var link = event.currentTarget;
-
-			var tr = link.ancestor('tr');
-
-			searchContainer.deleteRow(tr, link.attr('data-rowId'));
-		},
-		'.modify-link'
-	);
-</aui:script>
 
 <aui:script>
 	Liferay.Util.toggleRadio('<portlet:namespace />restrictionTypeInherit', '', [

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/init.jsp
@@ -179,7 +179,6 @@ page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.SetUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@
 page import="com.liferay.portal.kernel.util.TextFormatter" %><%@
-page import="com.liferay.portal.kernel.util.UnicodeFormatter" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.kernel.webdav.WebDAVUtil" %><%@

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectDDMStructureButton.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectDDMStructureButton.js
@@ -1,0 +1,91 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {openSelectionModal} from 'frontend-js-web';
+
+export default function ({
+	namespace,
+	removeButton,
+	selectDDMStructureURL,
+	workflowDefinitions,
+	workflowEnabled,
+}) {
+	const searchContainer = Liferay.SearchContainer.get(
+		`${namespace}ddmStructuresSearchContainer`
+	);
+
+	const selectDDMStructureButton = document.getElementById(
+		`${namespace}selectDDMStructure`
+	);
+
+	const handleSelectDDMStructureButtonClick = () => {
+		openSelectionModal({
+			height: '70vh',
+			iframeBodyCssClass: '',
+			onSelect: (selectedItem) => {
+				if (selectedItem) {
+					const itemValue = JSON.parse(selectedItem.value);
+
+					const removeStructureButton = removeButton.replace(
+						/REMOVE_BUTTON_ROW_ID/g,
+						itemValue.ddmstructureid
+					);
+
+					if (workflowEnabled) {
+						searchContainer.addRow(
+							[
+								itemValue.name,
+								workflowDefinitions.replace(
+									/WORKFLOW_NAME/g,
+									'workflowDefinition' +
+										itemValue.ddmstructureid
+								),
+								removeStructureButton,
+							],
+							itemValue.ddmstructureid
+						);
+					}
+					else {
+						searchContainer.addRow(
+							[itemValue.name, removeStructureButton],
+							itemValue.ddmstructureid
+						);
+					}
+
+					searchContainer.updateDataStore();
+				}
+			},
+			selectEventName: `${namespace}selectDDMStructure`,
+			title: Liferay.Language.get('structures'),
+			url: selectDDMStructureURL,
+		});
+	};
+
+	searchContainer.get('contentBox').delegate(
+		'click',
+		(event) => {
+			const link = event.currentTarget;
+
+			const tr = link.ancestor('tr');
+
+			searchContainer.deleteRow(tr, link.attr('data-rowId'));
+		},
+		'.modify-link'
+	);
+
+	selectDDMStructureButton.addEventListener(
+		'click',
+		handleSelectDDMStructureButtonClick
+	);
+
+	return {
+		dispose() {
+			selectDDMStructureButton.removeEventListener(
+				'click',
+				handleSelectDDMStructureButtonClick
+			);
+		},
+	};
+}


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-191642)

After completing this issue https://github.com/liferay-echo/liferay-portal/pull/12900 I created a task to improve the quality of the existing code and move all global functions to JS, specifically to Liferay components.


## Proposed solution

The solution was to move the code to Liferay components and even reuse some existing ones.

## Test Scenario 1

* Create two new folders for web content: “Folder 1” and “Folder 2”.
* Edit Folder 2 and go to Parent folder. Check the behaviour of this buttons trying yo make Folder 1 the parent folder of Folder 2: 

<img width="773" alt="Pasted Graphic" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/d800941d-51e4-4c3f-a0bd-5a901714898d">

## Test Scenario 2

* Edit any folder and go to Structure restrictions and workflow. Check the behaviour of this button: 

<img width="780" alt="Pasted Graphic 1" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/fc5e22fb-6e33-4337-9557-3934afcbc03f">

### Note: 
We won't move the `taglibRemoveFolder` until find a solution related with the `disabled` attribute and the behaviour when using a `propsTransformer` on clay buttons.