### PR TITLE
LPS-192103

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
@@ -21,6 +21,9 @@ import com.liferay.portal.kernel.search.IndexerRegistry;
 import com.liferay.portal.kernel.search.SearchContext;
 import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.transaction.Propagation;
+import com.liferay.portal.kernel.transaction.TransactionConfig;
+import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -73,9 +76,9 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 				message.getLong("companyId"), segmentsEntryId, type,
 				newClassPKs, indexer);
 		}
-		catch (PortalException portalException) {
+		catch (Throwable throwable) {
 			if (_log.isWarnEnabled()) {
-				_log.warn("Unable to index segment members", portalException);
+				_log.warn("Unable to index segment members", throwable);
 			}
 		}
 	}
@@ -126,8 +129,35 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 		return classPKsSet;
 	}
 
-	private void _updateDatabase(long segmentsEntryId, Set<Long> newClassPKs)
+	private Void _updateDatabase(
+			long segmentsEntryId, SegmentsEntry segmentsEntry,
+			Set<Long> addClassPKs, Set<Long> deleteClassPKs)
 		throws PortalException {
+
+		long classNameId = _portal.getClassNameId(segmentsEntry.getType());
+
+		if (!deleteClassPKs.isEmpty()) {
+			_segmentsEntryRelLocalService.deleteSegmentsEntryRels(
+				segmentsEntryId, classNameId,
+				ArrayUtil.toLongArray(deleteClassPKs));
+		}
+
+		if (!addClassPKs.isEmpty()) {
+			ServiceContext serviceContext = new ServiceContext();
+
+			serviceContext.setScopeGroupId(segmentsEntry.getGroupId());
+			serviceContext.setUserId(segmentsEntry.getUserId());
+
+			_segmentsEntryRelLocalService.addSegmentsEntryRels(
+				segmentsEntryId, classNameId,
+				ArrayUtil.toLongArray(addClassPKs), serviceContext);
+		}
+
+		return null;
+	}
+
+	private void _updateDatabase(long segmentsEntryId, Set<Long> newClassPKs)
+		throws Throwable {
 
 		SegmentsEntry segmentsEntry =
 			_segmentsEntryLocalService.fetchSegmentsEntry(segmentsEntryId);
@@ -149,20 +179,14 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 			}
 		}
 
-		long classNameId = _portal.getClassNameId(segmentsEntry.getType());
+		if (deleteClassPKs.isEmpty() && addClassPKs.isEmpty()) {
+			return;
+		}
 
-		_segmentsEntryRelLocalService.deleteSegmentsEntryRels(
-			segmentsEntryId, classNameId,
-			ArrayUtil.toLongArray(deleteClassPKs));
-
-		ServiceContext serviceContext = new ServiceContext();
-
-		serviceContext.setScopeGroupId(segmentsEntry.getGroupId());
-		serviceContext.setUserId(segmentsEntry.getUserId());
-
-		_segmentsEntryRelLocalService.addSegmentsEntryRels(
-			segmentsEntryId, classNameId, ArrayUtil.toLongArray(addClassPKs),
-			serviceContext);
+		TransactionInvokerUtil.invoke(
+			_transactionConfig,
+			() -> _updateDatabase(
+				segmentsEntryId, segmentsEntry, addClassPKs, deleteClassPKs));
 	}
 
 	private void _updateIndex(
@@ -181,6 +205,10 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		SegmentsEntryReindexMessageListener.class);
+
+	private static final TransactionConfig _transactionConfig =
+		TransactionConfig.Factory.create(
+			Propagation.REQUIRED, new Class<?>[] {PortalException.class});
 
 	@Reference
 	private IndexerRegistry _indexerRegistry;

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/internal/messaging/SegmentsEntryReindexMessageListener.java
@@ -6,6 +6,8 @@
 package com.liferay.segments.internal.messaging;
 
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.dao.orm.FinderCache;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
@@ -31,6 +33,7 @@ import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.segments.internal.constants.SegmentsDestinationNames;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.model.SegmentsEntryRelTable;
+import com.liferay.segments.model.impl.SegmentsEntryRelImpl;
 import com.liferay.segments.provider.SegmentsEntryProviderRegistry;
 import com.liferay.segments.service.SegmentsEntryLocalService;
 import com.liferay.segments.service.SegmentsEntryRelLocalService;
@@ -153,6 +156,9 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 				ArrayUtil.toLongArray(addClassPKs), serviceContext);
 		}
 
+		_entityCache.clearCache(SegmentsEntryRelImpl.class);
+		_finderCache.clearCache(SegmentsEntryRelImpl.class);
+
 		return null;
 	}
 
@@ -209,6 +215,12 @@ public class SegmentsEntryReindexMessageListener extends BaseMessageListener {
 	private static final TransactionConfig _transactionConfig =
 		TransactionConfig.Factory.create(
 			Propagation.REQUIRED, new Class<?>[] {PortalException.class});
+
+	@Reference
+	private EntityCache _entityCache;
+
+	@Reference
+	private FinderCache _finderCache;
 
 	@Reference
 	private IndexerRegistry _indexerRegistry;


### PR DESCRIPTION
## Motivation

We have a customer on an earlier version of 7.4.13 who experiences outages due to their cluster being flooded with with cache replication messages stemming from the `SegmentsEntryReindexMessageListener`.

## Proposed solution

The idea is to work around the issue by wrapping the `SegmentsEntryReindexMessageListener` code inside of a transaction, thus allowing us to do a single `REMOVE_ALL` in order to suppress the thousands of PUT and REMOVE messages. (In the steps to reproduce, there are about 20, but that's due to there being a small number of users involved in the segments reindex.)

Investigating this issue also revealed a more general issue with FinderCacheImpl, and an additional commit to address that was included in a pull request to the core infrastructure team, but this pull request excludes it so we can focus on the changes that are specific to segments.

https://github.com/liferay-core-infra/liferay-portal/pull/5145

## Steps to verify

Please see the steps described in https://liferay.atlassian.net/browse/LPS-192103