### PR TITLE
LPS-190005 Replace aui:button with clay:button in asset-taglib module

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_display/init.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_display/init.jsp
@@ -10,7 +10,6 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/asset" prefix="liferay-asset" %><%@
-taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
@@ -18,13 +17,8 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.asset.kernel.model.AssetRenderer" %><%@
 page import="com.liferay.petra.string.CharPool" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.portlet.PortletProvider" %><%@
-page import="com.liferay.portal.kernel.portlet.PortletProviderUtil" %><%@
-page import="com.liferay.portal.kernel.security.permission.ActionKeys" %><%@
-page import="com.liferay.portal.kernel.service.permission.PortletPermissionUtil" %><%@
 page import="com.liferay.portal.kernel.util.FastDateFormatFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.GetterUtil" %><%@
-page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_display/preview.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_display/preview.jsp
@@ -62,28 +62,4 @@ AssetRenderer<?> assetRenderer = (AssetRenderer<?>)request.getAttribute(WebKeys.
 			/>
 		</div>
 	</div>
-
-	<%
-	String portletId = PortletProviderUtil.getPortletId(assetEntry.getClassName(), PortletProvider.Action.ADD);
-	%>
-
-	<c:if test="<%= PortletPermissionUtil.contains(permissionChecker, layout, portletId, ActionKeys.ADD_TO_PAGE) %>">
-		<aui:button
-			cssClass="add-button-preview"
-			data='<%=
-				HashMapBuilder.<String, Object>put(
-					"class-name", assetEntry.getClassName()
-				).put(
-					"class-pk", assetEntry.getClassPK()
-				).put(
-					"instanceable", Boolean.TRUE
-				).put(
-					"portlet-id", portletId
-				).put(
-					"title", HtmlUtil.escape(assetRenderer.getTitle(themeDisplay.getLocale()))
-				).build()
-			%>'
-			value="add"
-		/>
-	</c:if>
 </div>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/select_asset_display_page/page.jsp
@@ -67,9 +67,11 @@
 		</c:if>
 	</div>
 
-	<div class="btn-group">
-		<aui:button name="chooseSpecificDisplayPage" value="select" />
-	</div>
+	<clay:button
+		displayType="secondary"
+		id='<%= liferayPortletResponse.getNamespace() + "chooseSpecificDisplayPage" %>'
+		label="select"
+	/>
 </div>
 
 <aui:script sandbox="<%= true %>">


### PR DESCRIPTION
Motivation
=======
The motivation behind this PR stadirize the usages of buttons in the portal by using for clay:button or clay:icon.
https://liferay.atlassian.net/browse/LPS-190005

Proposed Solution
========
The proposed solution consist in substitute the usages of aui:button for clay:button o clay:icon.

Steps to Verify
========
First create a DPT for Blogs: 
Design -> Page Templates -> Display Page Templates -> create one for blogs

Second create a blog and add it to the DPT:
Product Menu -> Content & Data -> Blogs -> create a new blog -> Display Page Template section -> choose specific and a select button appears -> check that the button is working correctly