### PR TITLE
LPS-192285 Draggable area active just when item from the accordions is selected

### DIFF
--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/EmptyDropZone.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_builder/EmptyDropZone.js
@@ -44,8 +44,9 @@ function EmptyDropZone({canDrop, connectDropTarget, emptyContributors, hover}) {
 	return (
 		<div
 			className={classNames('empty-drop-zone-root', {
-				'empty-drop-zone-dashed border-primary rounded':
-					displayEmptyDropZone && (!canDrop || !hover),
+				'border-primary': !hover && canDrop,
+				'border-secondary': !hover && !canDrop,
+				'empty-drop-zone-dashed rounded': !hover,
 			})}
 		>
 			{connectDropTarget(

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/CriteriaBuilder.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/CriteriaBuilder.test.js.snap
@@ -14,7 +14,7 @@ exports[`CriteriaBuilder renders 1`] = `
       class="color--user criteria-group-item-root"
     >
       <div
-        class="empty-drop-zone-root empty-drop-zone-dashed border-primary rounded"
+        class="empty-drop-zone-root border-secondary empty-drop-zone-dashed rounded"
       >
         <div
           class="drop-zone-target p-5"

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/CriteriaGroup.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/CriteriaGroup.test.js.snap
@@ -6,7 +6,7 @@ exports[`CriteriaGroup renders 1`] = `
     class="color--user criteria-group-item"
   >
     <div
-      class="empty-drop-zone-root empty-drop-zone-dashed border-primary rounded"
+      class="empty-drop-zone-root border-secondary empty-drop-zone-dashed rounded"
     >
       <div
         class="drop-zone-target p-5"

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/EmptyDropZone.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/EmptyDropZone.test.js.snap
@@ -3,7 +3,7 @@
 exports[`EmptyDropZone renders 1`] = `
 <DocumentFragment>
   <div
-    class="empty-drop-zone-root empty-drop-zone-dashed border-primary rounded"
+    class="empty-drop-zone-root border-secondary empty-drop-zone-dashed rounded"
   >
     <div
       class="drop-zone-target p-5"
@@ -19,7 +19,7 @@ exports[`EmptyDropZone renders 1`] = `
 exports[`EmptyDropZone renders illustration when empty contributors 1`] = `
 <DocumentFragment>
   <div
-    class="empty-drop-zone-root"
+    class="empty-drop-zone-root border-secondary empty-drop-zone-dashed rounded"
   >
     <div>
       <div


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to improve Segments Editor usability and accessibility by adding different styles in the drag and drop process.
https://liferay.atlassian.net/browse/LPS-192285

Proposed Solution
========
What I did to solve this problem is to use the canDrop variable to know if an element is being dragged to change the style of the dropTarget.

Steps to Verify
========
1. Go to Product Menu -> People -> Segments -> Create a new Segment and save it
2. Edit the segment and start to add a new property from a different Contributor. (e.g if the created segment contains a property of type Session, this one must be Organization, User or Segment type)
3. Start dragging the one property to the dropTarget and check that:
   - When the new Contributors panel is expanded, the border of the drop target is default (grey) and dashed
   - When an element is being dragged the border turns to blue and dashed
   - When the element is over the drop target it turns blue and solid

