### PR TITLE
LPS-190010 Replace button with clay:button in site-admin-web and layout-type-controller-collection modules

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-collection/src/main/resources/META-INF/resources/entries/collection_items_detail.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-collection/src/main/resources/META-INF/resources/entries/collection_items_detail.jsp
@@ -12,9 +12,12 @@ CollectionItemsDetailDisplayContext collectionItemsDetailDisplayContext = (Colle
 %>
 
 <li class="control-menu-nav-item">
-	<button class="btn btn-unstyled text-muted" id="<%= collectionItemsDetailDisplayContext.getNamespace() %>viewCollectionItems" />
-		(<%= LanguageUtil.format(resourceBundle, "x-items", collectionItemsDetailDisplayContext.getCollectionItemsCount(), false) %>)
-	</button>
+	<clay:button
+		cssClass="text-muted"
+		displayType="unstyled"
+		id='<%= collectionItemsDetailDisplayContext.getNamespace() + "viewCollectionItems" %>'
+		label='<%= "(" + LanguageUtil.format(resourceBundle, "x-items", collectionItemsDetailDisplayContext.getCollectionItemsCount(), false) + ")" %>'
+	/>
 </li>
 
 <aui:script>

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/build.gradle
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
 	compileOnly project(":apps:layout:layout-item-selector-api")

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/resources/META-INF/resources/init.jsp
@@ -8,6 +8,7 @@
 <%@ taglib uri="http://java.sun.com/portlet_2_0" prefix="portlet" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/resources/META-INF/resources/layout/edit/link_to_layout.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-link-to-page/src/main/resources/META-INF/resources/layout/edit/link_to_layout.jsp
@@ -14,7 +14,11 @@
 	<aui:input label="link-to-layout" name="linkToLayoutName" type="resource" value="<%= linkToPageLayoutTypeControllerDisplayContext.getLinkToLayoutName() %>" />
 	<aui:input name="linkToLayoutUuid" type="hidden" value="<%= linkToPageLayoutTypeControllerDisplayContext.getLinkToLayoutUuid() %>" />
 
-	<aui:button name="selectLayoutButton" value="select" />
+	<clay:button
+		displayType="secondary"
+		id='<%= liferayPortletResponse.getNamespace() + "selectLayoutButton" %>'
+		label="select"
+	/>
 
 	<aui:script sandbox="<%= true %>">
 		var selectLayoutButton = document.getElementById(

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/frontend/taglib/clay/servlet/taglib/SelectSiteInitializerVerticalCard.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/frontend/taglib/clay/servlet/taglib/SelectSiteInitializerVerticalCard.java
@@ -38,7 +38,8 @@ public class SelectSiteInitializerVerticalCard implements VerticalCard {
 
 	@Override
 	public String getCssClass() {
-		return "add-site-action-card mb-0";
+		return "add-site-action-card card-interactive " +
+			"card-interactive-primary c-mb-2";
 	}
 
 	@Override
@@ -65,9 +66,6 @@ public class SelectSiteInitializerVerticalCard implements VerticalCard {
 			).setWindowState(
 				LiferayWindowState.POP_UP
 			).buildString()
-		).put(
-			"data-layout-set-prototype-id",
-			String.valueOf(_siteInitializerItem.getLayoutSetPrototypeId())
 		).build();
 	}
 

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/configuration/screen/entry.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/configuration/screen/entry.jsp
@@ -57,11 +57,20 @@ else {
 		<clay:sheet-footer>
 			<div class="btn-group mt-4">
 				<div class="btn-group-item">
-					<aui:button type="submit" value="save" />
+					<clay:button
+						displayType="primary"
+						label="save"
+						type="submit"
+					/>
 				</div>
 
 				<div class="btn-group-item">
-					<aui:button href="<%= redirect %>" name="cancel" type="cancel" />
+					<clay:link
+						displayType="secondary"
+						href="<%= redirect %>"
+						label="cancel"
+						type="button"
+					/>
 				</div>
 			</div>
 		</clay:sheet-footer>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/SelectSiteInitializerVerticalCardPropsTransformer.js
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/js/SelectSiteInitializerVerticalCardPropsTransformer.js
@@ -1,0 +1,27 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {openModal} from 'frontend-js-web';
+
+export default function SelectSiteInitializerVerticalCardPropsTransformer({
+	portletNamespace: namespace,
+	...otherProps
+}) {
+	return {
+		...otherProps,
+		onClick: (event) => {
+			event.preventDefault();
+
+			openModal({
+				disableAutoClose: true,
+				height: '60vh',
+				id: `${namespace}addSiteDialog`,
+				size: 'md',
+				title: Liferay.Language.get('add-site'),
+				url: event.currentTarget.dataset.addSiteUrl,
+			});
+		},
+	};
+}

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
@@ -30,11 +30,10 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 			modelVar="siteInitializerItem"
 		>
 			<liferay-ui:search-container-column-text>
-				<button class="add-site-action-button align-items-stretch btn btn-unstyled form-check-card mb-4 w-100" type="button">
-					<clay:vertical-card
-						verticalCard="<%= new SelectSiteInitializerVerticalCard(siteInitializerItem, renderRequest, renderResponse) %>"
-					/>
-				</button>
+				<clay:vertical-card
+					propsTransformer="js/SelectSiteInitializerVerticalCardPropsTransformer"
+					verticalCard="<%= new SelectSiteInitializerVerticalCard(siteInitializerItem, renderRequest, renderResponse) %>"
+				/>
 			</liferay-ui:search-container-column-text>
 		</liferay-ui:search-container-row>
 
@@ -48,36 +47,4 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 		<portlet:param name="mvcPath" value="/select_layout_set_prototype_entry.jsp" />
 		<portlet:param name="parentGroupId" value="<%= String.valueOf(selectSiteInitializerDisplayContext.getParentGroupId()) %>" />
 	</portlet:actionURL>
-
-	<aui:script require="frontend-js-web/index as frontendJsWeb">
-		var {delegate, openSimpleInputModal} = frontendJsWeb;
-
-		var addSiteActionOptionQueryClickHandler = delegate(
-			document.body,
-			'click',
-			'.add-site-action-button',
-			(event) => {
-				var data = event.delegateTarget.querySelector('.add-site-action-card')
-					.dataset;
-
-				Liferay.Util.openModal({
-					disableAutoClose: true,
-					height: '60vh',
-					id: '<portlet:namespace />addSiteDialog',
-					iframeBodyCssClass: '',
-					size: 'md',
-					title: '<liferay-ui:message key="add-site" />',
-					url: data.addSiteUrl,
-				});
-			}
-		);
-
-		function handleDestroyPortlet() {
-			addSiteActionOptionQueryClickHandler.dispose();
-
-			Liferay.detach('destroyPortlet', handleDestroyPortlet);
-		}
-
-		Liferay.on('destroyPortlet', handleDestroyPortlet);
-	</aui:script>
 </aui:form>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
@@ -42,9 +42,4 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 			markupView="lexicon"
 		/>
 	</liferay-ui:search-container>
-
-	<portlet:actionURL name="/site_admin/add_group" var="addSiteURL">
-		<portlet:param name="mvcPath" value="/select_layout_set_prototype_entry.jsp" />
-		<portlet:param name="parentGroupId" value="<%= String.valueOf(selectSiteInitializerDisplayContext.getParentGroupId()) %>" />
-	</portlet:actionURL>
 </aui:form>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/details.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/details.jsp
@@ -116,13 +116,18 @@ if (parentGroupId != GroupConstants.DEFAULT_PARENT_GROUP_ID) {
 		</div>
 
 		<div class="input-group-item input-group-item-shrink">
-			<button class="btn btn-secondary mr-1" id="<portlet:namespace />clearParentSiteLink" type="button">
-				<liferay-ui:message key="clear" />
-			</button>
+			<clay:button
+				cssClass="c-mr-1"
+				displayType="secondary"
+				id='<%= liferayPortletResponse.getNamespace() + "clearParentSiteLink" %>'
+				label="clear"
+			/>
 
-			<button class="btn btn-secondary" id="<portlet:namespace />changeParentSiteLink" type="button">
-				<liferay-ui:message key="change" />
-			</button>
+			<clay:button
+				displayType="secondary"
+				id='<%= liferayPortletResponse.getNamespace() + "changeParentSiteLink" %>'
+				label="change"
+			/>
 		</div>
 	</div>
 


### PR DESCRIPTION
Motivation
=======
The motivation behind this PR stadirize the usages of buttons in the portal by using for clay:button or clay:icon.
https://liferay.atlassian.net/browse/LPS-190010
https://liferay.atlassian.net/browse/LPS-190011

Proposed Solution
========
The proposed solution consist in substitute the usages of aui:button and <button> for clay:button or clay:icon.

Steps to Verify
========
For the one in the layout-type-controller-collection module:
     - Add a collection page using a collection provider (Site Builder -> Pages -> (+)from a page and add a Collection Page -> Click on Collection Provider tab and select one
     - Go to the view of that collection page and check that x-items button (in the control menu header) works correctly
For the one in layout-type-controller-link:
    - Create a link-page (Site Builder -> Pages -> new page -> select page type link page -> create one -> after creating it go and configure it by clicking on the ellipsis button -> in the configuration go to Layout -> Check that the Select button works fine
For the ones in site-admin-module
     Go to Configuration -> Site Settings -> Site Configuration -> Check that save, cancel, clear and change buttons work correctly
