### PR TITLE
[TS] LPS-190729 Add setLocaleTransformerListener and utilizing the @Refere…

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -24,7 +24,6 @@ import com.liferay.friendly.url.model.FriendlyURLEntryLocalization;
 import com.liferay.friendly.url.service.FriendlyURLEntryLocalServiceUtil;
 import com.liferay.journal.constants.JournalConstants;
 import com.liferay.journal.constants.JournalFolderConstants;
-import com.liferay.journal.internal.transformer.LocaleTransformerListener;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.model.JournalArticleResource;
 import com.liferay.journal.model.JournalFolder;
@@ -50,6 +49,7 @@ import com.liferay.portal.kernel.service.ClassNameLocalServiceUtil;
 import com.liferay.portal.kernel.service.ImageLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.templateparser.TransformerListener;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
@@ -107,7 +107,7 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 	}
 
 	public static void setLocaleTransformerListener(
-		LocaleTransformerListener localeTransformerListener) {
+		TransformerListener localeTransformerListener) {
 
 		_localeTransformerListener = localeTransformerListener;
 	}
@@ -815,8 +815,7 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 	private static volatile DDMFormValuesToFieldsConverter
 		_ddmFormValuesToFieldsConverter;
 	private static volatile JournalConverter _journalConverter;
-	private static volatile LocaleTransformerListener
-		_localeTransformerListener;
+	private static volatile TransformerListener _localeTransformerListener;
 
 	private Map<Locale, String> _descriptionMap;
 	private Document _document;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5874,6 +5874,8 @@ public class JournalArticleLocalServiceImpl
 		JournalArticleImpl.setDDMFormValuesToFieldsConverter(
 			_ddmFormValuesToFieldsConverter);
 		JournalArticleImpl.setJournalConverter(_journalConverter);
+		JournalArticleImpl.setLocaleTransformerListener(
+			_localeTransformerListener);
 
 		_serviceTrackerList = ServiceTrackerListFactory.open(
 			bundleContext, TransformerListener.class,
@@ -6217,6 +6219,7 @@ public class JournalArticleLocalServiceImpl
 
 		JournalArticleImpl.setDDMFormValuesToFieldsConverter(null);
 		JournalArticleImpl.setJournalConverter(null);
+		JournalArticleImpl.setLocaleTransformerListener(null);
 
 		_serviceTrackerList.close();
 	}
@@ -8132,6 +8135,11 @@ public class JournalArticleLocalServiceImpl
 	@Reference
 	private LayoutPageTemplateEntryLocalService
 		_layoutPageTemplateEntryLocalService;
+
+	@Reference(
+		target = "(component.name=com.liferay.journal.internal.transformer.LocaleTransformerListener)"
+	)
+	private TransformerListener _localeTransformerListener;
 
 	@Reference
 	private Localization _localization;


### PR DESCRIPTION
Hi Team,

May I ask if you could review my PR?

Opened the PR to fix: https://liferay.atlassian.net/browse/LPS-190729 
Caused by: https://liferay.atlassian.net/browse/LPS-165626
Solution guidance: https://liferay.atlassian.net/browse/PTR-4133

Root casue: 

https://github.com/liferay/liferay-portal/blob/2f26b1877faf8cf517f5d5c8477fcf3ebb70da29/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java#L97 getContentByLocale() method gives back all the values, not only the locale. The problem is _localeTransformerListener is null, because the LocaleTransformerListener not getting activated.

Solution: calling the JournalArticleImpl::setLocaleTransformerListener at https://github.com/liferay/liferay-portal/blob/7.4.13-u86/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java#L5881-L5890
and
inject service dependencies: Reference annotation  [JournalArticleLocalServiceImpl.java#L8067C2-L8068C73](https://github.com/liferay/liferay-portal/blob/7.4.13-u86/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java#L8067C2-L8068C73)

Tested it locally and it solves the issue.

Thank you in advance!

BR,
Gege