### PR TITLE
LPS-191769 Redirect to the blocked page view when a user tries to access to a locked display page template or collection page

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-collection/build.gradle
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-collection/build.gradle
@@ -14,6 +14,7 @@ dependencies {
 	compileOnly project(":apps:info:info-list-provider-item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-api")
 	compileOnly project(":apps:item-selector:item-selector-criteria-api")
+	compileOnly project(":apps:layout:layout-admin-api")
 	compileOnly project(":apps:layout:layout-api")
 	compileOnly project(":apps:layout:layout-content-page-editor-api")
 	compileOnly project(":apps:layout:layout-page-template-api")

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-collection/src/main/java/com/liferay/layout/type/controller/collection/internal/layout/type/controller/CollectionPageLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-collection/src/main/java/com/liferay/layout/type/controller/collection/internal/layout/type/controller/CollectionPageLayoutTypeController.java
@@ -5,6 +5,7 @@
 
 package com.liferay.layout.type.controller.collection.internal.layout.type.controller;
 
+import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorWebKeys;
 import com.liferay.layout.type.controller.BaseLayoutTypeControllerImpl;
 import com.liferay.petra.io.unsync.UnsyncStringWriter;
@@ -15,6 +16,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypeController;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
@@ -29,6 +31,8 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+
+import javax.portlet.PortletRequest;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
@@ -103,6 +107,24 @@ public class CollectionPageLayoutTypeController
 					themeDisplay.getPermissionChecker(), layout)) {
 
 				layoutMode = Constants.VIEW;
+			}
+			else if (!layout.isUnlocked(layoutMode, themeDisplay.getUserId())) {
+				redirect = PortletURLBuilder.create(
+					_portal.getControlPanelPortletURL(
+						httpServletRequest, LayoutAdminPortletKeys.GROUP_PAGES,
+						PortletRequest.RENDER_PHASE)
+				).setMVCRenderCommandName(
+					"/layout_admin/locked_layout"
+				).setBackURL(
+					() -> {
+						HttpServletRequest originalHttpServletRequest =
+							_portal.getOriginalServletRequest(
+								httpServletRequest);
+
+						return ParamUtil.getString(
+							originalHttpServletRequest, "p_l_back_url", null);
+					}
+				).buildString();
 			}
 			else {
 				redirect = _getDraftLayoutFullURL(

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/display/context/DisplayPageLayoutTypeControllerDisplayContext.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/display/context/DisplayPageLayoutTypeControllerDisplayContext.java
@@ -26,6 +26,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 
 /**
  * @author Jürgen Kappler
@@ -146,6 +147,16 @@ public class DisplayPageLayoutTypeControllerDisplayContext {
 		}
 
 		return true;
+	}
+
+	public boolean isForbidden(HttpServletResponse httpServletResponse) {
+		if (httpServletResponse.getStatus() ==
+				HttpServletResponse.SC_FORBIDDEN) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private final Object _infoItem;

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/DisplayPageLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/DisplayPageLayoutTypeController.java
@@ -194,6 +194,21 @@ public class DisplayPageLayoutTypeController
 			RequestDispatcher.INCLUDE_SERVLET_PATH);
 
 		try {
+			if (!displayPageLayoutTypeControllerDisplayContext.hasPermission(
+					themeDisplay.getPermissionChecker(), ActionKeys.VIEW)) {
+
+				if (themeDisplay.isSignedIn()) {
+					httpServletResponse.setStatus(
+						HttpServletResponse.SC_FORBIDDEN);
+				}
+				else {
+					String signInURL = themeDisplay.getURLSignIn();
+
+					redirect = HttpComponentsUtil.setParameter(
+						signInURL, "redirect", themeDisplay.getURLCurrent());
+				}
+			}
+
 			if (Validator.isNotNull(redirect)) {
 				httpServletResponse.sendRedirect(redirect);
 			}
@@ -229,21 +244,6 @@ public class DisplayPageLayoutTypeController
 
 		if (contentType != null) {
 			httpServletResponse.setContentType(contentType);
-		}
-
-		if (!displayPageLayoutTypeControllerDisplayContext.hasPermission(
-				themeDisplay.getPermissionChecker(), ActionKeys.VIEW)) {
-
-			if (themeDisplay.isSignedIn()) {
-				httpServletResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
-			}
-			else {
-				String signInURL = themeDisplay.getURLSignIn();
-
-				httpServletResponse.sendRedirect(
-					HttpComponentsUtil.setParameter(
-						signInURL, "redirect", themeDisplay.getURLCurrent()));
-			}
 		}
 
 		return false;

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/DisplayPageLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/DisplayPageLayoutTypeController.java
@@ -194,19 +194,17 @@ public class DisplayPageLayoutTypeController
 			RequestDispatcher.INCLUDE_SERVLET_PATH);
 
 		try {
-			if (!displayPageLayoutTypeControllerDisplayContext.hasPermission(
-					themeDisplay.getPermissionChecker(), ActionKeys.VIEW)) {
+			boolean hasViewPermission =
+				displayPageLayoutTypeControllerDisplayContext.hasPermission(
+					themeDisplay.getPermissionChecker(), ActionKeys.VIEW);
 
-				if (themeDisplay.isSignedIn()) {
-					httpServletResponse.setStatus(
-						HttpServletResponse.SC_FORBIDDEN);
-				}
-				else {
-					String signInURL = themeDisplay.getURLSignIn();
-
-					redirect = HttpComponentsUtil.setParameter(
-						signInURL, "redirect", themeDisplay.getURLCurrent());
-				}
+			if (!hasViewPermission && themeDisplay.isSignedIn()) {
+				httpServletResponse.setStatus(HttpServletResponse.SC_FORBIDDEN);
+			}
+			else if (!hasViewPermission) {
+				redirect = HttpComponentsUtil.setParameter(
+					themeDisplay.getURLSignIn(), "redirect",
+					themeDisplay.getURLCurrent());
 			}
 
 			if (Validator.isNotNull(redirect)) {

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/init.jsp
@@ -20,7 +20,6 @@ page import="com.liferay.layout.type.controller.display.page.internal.constants.
 page import="com.liferay.layout.type.controller.display.page.internal.display.context.DisplayPageLayoutTypeControllerDisplayContext" %><%@
 page import="com.liferay.portal.kernel.layoutconfiguration.util.RuntimePageUtil" %><%@
 page import="com.liferay.portal.kernel.model.LayoutTemplateConstants" %><%@
-page import="com.liferay.portal.kernel.security.permission.ActionKeys" %><%@
 page import="com.liferay.portal.kernel.service.LayoutTemplateLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %>

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/init.jsp
@@ -10,12 +10,10 @@
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/layout" prefix="liferay-layout" %><%@
-taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.asset.kernel.model.AssetRendererFactory" %><%@
-page import="com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys" %><%@
 page import="com.liferay.layout.type.controller.display.page.internal.constants.DisplayPageLayoutTypeControllerWebKeys" %><%@
 page import="com.liferay.layout.type.controller.display.page.internal.display.context.DisplayPageLayoutTypeControllerDisplayContext" %><%@
 page import="com.liferay.portal.kernel.layoutconfiguration.util.RuntimePageUtil" %><%@

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/layout/edit/display_page.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/layout/edit/display_page.jsp
@@ -5,7 +5,7 @@
  */
 --%>
 
-<%@ include file="/init.jsp" %>
+<%@ include file="/layout/edit/init.jsp" %>
 
 <liferay-ui:success key="displayPageAdded" message="the-display-page-template-was-created-successfully" />
 

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/layout/edit/init.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/layout/edit/init.jsp
@@ -1,0 +1,12 @@
+<%--
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+--%>
+
+<%@ include file="/init.jsp" %>
+
+<%@ taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %>
+
+<%@ page import="com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys" %>

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/layout/view/display_page.jsp
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/resources/META-INF/resources/layout/view/display_page.jsp
@@ -43,7 +43,7 @@ String ppid = ParamUtil.getString(request, "p_p_id");
 		</c:if>
 
 		<c:choose>
-			<c:when test="<%= !displayPageLayoutTypeControllerDisplayContext.hasPermission(permissionChecker, ActionKeys.VIEW) %>">
+			<c:when test="<%= displayPageLayoutTypeControllerDisplayContext.isForbidden(response) %>">
 				<div class="layout-content" id="main-content" role="main">
 					<clay:container-fluid
 						cssClass="pt-3"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-191769

Dear reviewer 👋

Thanks in advance for your review ❤️

This PR implements the browse to the blocked page view when the user tries to access a locked draft of types display page template and collection page.

The lock acquire and release process is not implemented yet so we need to use scripts to lock and unlock the draft.

In addition, to be able to test it, the feature flag must be enabled:
feature.flag.LPS-180328=true

These scripts are useful to test this PR:

Script to lock a draft by a user
[LockLayout.txt](https://github.com/liferay-echo/liferay-portal/files/12240677/LockLayout.txt)


Script to see the status of a draft (locked/unlocked) with respect to all the users of the company
[isUnlockedLayout.txt](https://github.com/liferay-echo/liferay-portal/files/12240681/isUnlockedLayout.txt)


Script to unlock a draft
[UnlockLayout.txt](https://github.com/liferay-echo/liferay-portal/files/12240682/UnlockLayout.txt)

