### PR TITLE
LPS-190591 Manage Pages makes wrong pages visible on Page Tree

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
@@ -877,8 +877,18 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 	public int getLayoutsCount(
 		long groupId, boolean privateLayout, long parentLayoutId) {
 
-		return layoutPersistence.filterCountByG_P_P(
-			groupId, privateLayout, parentLayoutId);
+		try {
+			return getLayouts(
+				groupId, privateLayout, parentLayoutId
+			).size();
+		}
+		catch (PortalException portalException) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(portalException);
+			}
+		}
+
+		return 0;
 	}
 
 	@Override


### PR DESCRIPTION
bug : https://liferay.atlassian.net/browse/LPS-190591

Fix description
----------
The method getLayoutsCount of LayoutServiceImple was not taking into account the MANAGE_LAYOUT permission, so, I have change it to check that permission.
