### PR TITLE
LPS-190735 Exclude props with default value from export

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/ContainerLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/ContainerLayoutStructureItemMapper.java
@@ -24,13 +24,14 @@ import com.liferay.layout.converter.JustifyConverter;
 import com.liferay.layout.converter.MarginConverter;
 import com.liferay.layout.converter.PaddingConverter;
 import com.liferay.layout.converter.ShadowConverter;
-import com.liferay.layout.util.structure.CommonStylesUtil;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -116,13 +117,7 @@ public class ContainerLayoutStructureItemMapper
 	private Object _getStyleProperty(
 		JSONObject stylesJSONObject, String propertyKey) {
 
-		Object styleValue = stylesJSONObject.get(propertyKey);
-
-		if (styleValue != null) {
-			return styleValue;
-		}
-
-		return CommonStylesUtil.getDefaultStyleValue(propertyKey);
+		return stylesJSONObject.get(propertyKey);
 	}
 
 	private FragmentLink _toFragmentLink(
@@ -250,7 +245,9 @@ public class ContainerLayoutStructureItemMapper
 						Object borderWidth = _getStyleProperty(
 							stylesJSONObject, "borderWidth");
 
-						if (Validator.isNull(borderWidth)) {
+						if (Validator.isNull(borderWidth) ||
+							(GetterUtil.getInteger(borderWidth) == 0)) {
+
 							return null;
 						}
 
@@ -299,7 +296,11 @@ public class ContainerLayoutStructureItemMapper
 						Object marginBottom = _getStyleProperty(
 							stylesJSONObject, "marginBottom");
 
-						if (Validator.isNull(marginBottom)) {
+						if (Validator.isNull(marginBottom) ||
+							Validator.isNull(
+								MarginConverter.convertToExternalValue(
+									GetterUtil.getString(marginBottom)))) {
+
 							return null;
 						}
 
@@ -312,7 +313,11 @@ public class ContainerLayoutStructureItemMapper
 						Object marginLeft = _getStyleProperty(
 							stylesJSONObject, "marginLeft");
 
-						if (Validator.isNull(marginLeft)) {
+						if (Validator.isNull(marginLeft) ||
+							Validator.isNull(
+								MarginConverter.convertToExternalValue(
+									GetterUtil.getString(marginLeft)))) {
+
 							return null;
 						}
 
@@ -325,7 +330,11 @@ public class ContainerLayoutStructureItemMapper
 						Object marginRight = _getStyleProperty(
 							stylesJSONObject, "marginRight");
 
-						if (Validator.isNull(marginRight)) {
+						if (Validator.isNull(marginRight) ||
+							Validator.isNull(
+								MarginConverter.convertToExternalValue(
+									GetterUtil.getString(marginRight)))) {
+
 							return null;
 						}
 
@@ -338,7 +347,11 @@ public class ContainerLayoutStructureItemMapper
 						Object marginTop = _getStyleProperty(
 							stylesJSONObject, "marginTop");
 
-						if (Validator.isNull(marginTop)) {
+						if (Validator.isNull(marginTop) ||
+							Validator.isNull(
+								MarginConverter.convertToExternalValue(
+									GetterUtil.getString(marginTop)))) {
+
 							return null;
 						}
 
@@ -351,7 +364,9 @@ public class ContainerLayoutStructureItemMapper
 						Object opacity = _getStyleProperty(
 							stylesJSONObject, "opacity");
 
-						if (Validator.isNull(opacity)) {
+						if (Validator.isNull(opacity) ||
+							Objects.equals(opacity, "100")) {
+
 							return null;
 						}
 
@@ -362,7 +377,11 @@ public class ContainerLayoutStructureItemMapper
 						Object paddingBottom = _getStyleProperty(
 							stylesJSONObject, "paddingBottom");
 
-						if (Validator.isNull(paddingBottom)) {
+						if (Validator.isNull(paddingBottom) ||
+							Validator.isNull(
+								MarginConverter.convertToExternalValue(
+									GetterUtil.getString(paddingBottom)))) {
+
 							return null;
 						}
 
@@ -375,7 +394,11 @@ public class ContainerLayoutStructureItemMapper
 						Object paddingLeft = _getStyleProperty(
 							stylesJSONObject, "paddingLeft");
 
-						if (Validator.isNull(paddingLeft)) {
+						if (Validator.isNull(paddingLeft) ||
+							Validator.isNull(
+								MarginConverter.convertToExternalValue(
+									GetterUtil.getString(paddingLeft)))) {
+
 							return null;
 						}
 
@@ -388,7 +411,11 @@ public class ContainerLayoutStructureItemMapper
 						Object paddingRight = _getStyleProperty(
 							stylesJSONObject, "paddingRight");
 
-						if (Validator.isNull(paddingRight)) {
+						if (Validator.isNull(paddingRight) ||
+							Validator.isNull(
+								MarginConverter.convertToExternalValue(
+									GetterUtil.getString(paddingRight)))) {
+
 							return null;
 						}
 
@@ -401,7 +428,11 @@ public class ContainerLayoutStructureItemMapper
 						Object paddingTop = _getStyleProperty(
 							stylesJSONObject, "paddingTop");
 
-						if (Validator.isNull(paddingTop)) {
+						if (Validator.isNull(paddingTop) ||
+							Validator.isNull(
+								MarginConverter.convertToExternalValue(
+									GetterUtil.getString(paddingTop)))) {
+
 							return null;
 						}
 
@@ -427,7 +458,9 @@ public class ContainerLayoutStructureItemMapper
 						String widthType =
 							containerStyledLayoutStructureItem.getWidthType();
 
-						if (Validator.isNotNull(widthType)) {
+						if (Validator.isNotNull(widthType) &&
+							!Objects.equals(widthType, "fluid")) {
+
 							return WidthType.create(
 								StringUtil.upperCaseFirstLetter(widthType));
 						}

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/ContainerLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/ContainerLayoutStructureItemMapper.java
@@ -24,6 +24,7 @@ import com.liferay.layout.converter.JustifyConverter;
 import com.liferay.layout.converter.MarginConverter;
 import com.liferay.layout.converter.PaddingConverter;
 import com.liferay.layout.converter.ShadowConverter;
+import com.liferay.layout.util.constants.StyledLayoutStructureConstants;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -459,7 +460,9 @@ public class ContainerLayoutStructureItemMapper
 							containerStyledLayoutStructureItem.getWidthType();
 
 						if (Validator.isNotNull(widthType) &&
-							!Objects.equals(widthType, "fluid")) {
+							!Objects.equals(
+								widthType,
+								StyledLayoutStructureConstants.WIDTH_TYPE)) {
 
 							return WidthType.create(
 								StringUtil.upperCaseFirstLetter(widthType));

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/FormLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/FormLayoutStructureItemMapper.java
@@ -22,6 +22,7 @@ import com.liferay.layout.converter.AlignConverter;
 import com.liferay.layout.converter.ContentDisplayConverter;
 import com.liferay.layout.converter.FlexWrapConverter;
 import com.liferay.layout.converter.JustifyConverter;
+import com.liferay.layout.util.constants.StyledLayoutStructureConstants;
 import com.liferay.layout.util.structure.FormStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -276,7 +277,9 @@ public class FormLayoutStructureItemMapper
 							formStyledLayoutStructureItem.getWidthType();
 
 						if (Validator.isNotNull(widthType) &&
-							!Objects.equals(widthType, "fluid")) {
+							!Objects.equals(
+								widthType,
+								StyledLayoutStructureConstants.WIDTH_TYPE)) {
 
 							return WidthType.create(
 								StringUtil.upperCaseFirstLetter(widthType));

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/FormLayoutStructureItemMapper.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/dto/v1_0/mapper/FormLayoutStructureItemMapper.java
@@ -275,7 +275,9 @@ public class FormLayoutStructureItemMapper
 						String widthType =
 							formStyledLayoutStructureItem.getWidthType();
 
-						if (Validator.isNotNull(widthType)) {
+						if (Validator.isNotNull(widthType) &&
+							!Objects.equals(widthType, "fluid")) {
+
 							return WidthType.create(
 								StringUtil.upperCaseFirstLetter(widthType));
 						}

--- a/modules/apps/layout/layout-api/bnd.bnd
+++ b/modules/apps/layout/layout-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout API
 Bundle-SymbolicName: com.liferay.layout.api
-Bundle-Version: 35.0.2
+Bundle-Version: 35.1.0
 Export-Package:\
 	com.liferay.layout.adaptive.media,\
 	com.liferay.layout.configuration,\

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/constants/StyledLayoutStructureConstants.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/constants/StyledLayoutStructureConstants.java
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.util.constants;
+
+/**
+ * @author Diego Hu
+ */
+public class StyledLayoutStructureConstants {
+
+	public static final String VERTICAL_ALIGNMENT_START = "start";
+
+	public static final String VERTICAL_ALIGNMENT_TOP = "top";
+
+	public static final String WIDTH_TYPE = "fluid";
+
+}

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/CollectionStyledLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/CollectionStyledLayoutStructureItem.java
@@ -8,6 +8,7 @@ package com.liferay.layout.util.structure;
 import com.liferay.layout.responsive.ViewportSize;
 import com.liferay.layout.util.CollectionPaginationUtil;
 import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
+import com.liferay.layout.util.constants.StyledLayoutStructureConstants;
 import com.liferay.layout.util.structure.collection.EmptyCollectionOptions;
 import com.liferay.petra.lang.HashUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
@@ -516,7 +517,8 @@ public class CollectionStyledLayoutStructureItem
 		CollectionPaginationUtil.PAGINATION_TYPE_NUMERIC;
 	private boolean _showAllItems;
 	private String _templateKey;
-	private String _verticalAlignment = "start";
+	private String _verticalAlignment =
+		StyledLayoutStructureConstants.VERTICAL_ALIGNMENT_START;
 	private final Map<String, JSONObject> _viewportConfigurationJSONObjects =
 		new HashMap<>();
 

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/ContainerStyledLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/ContainerStyledLayoutStructureItem.java
@@ -6,6 +6,7 @@
 package com.liferay.layout.util.structure;
 
 import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
+import com.liferay.layout.util.constants.StyledLayoutStructureConstants;
 import com.liferay.petra.lang.HashUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -370,6 +371,6 @@ public class ContainerStyledLayoutStructureItem
 	private boolean _indexed = true;
 	private String _justify = "";
 	private JSONObject _linkJSONObject;
-	private String _widthType = "fluid";
+	private String _widthType = StyledLayoutStructureConstants.WIDTH_TYPE;
 
 }

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/FormStyledLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/FormStyledLayoutStructureItem.java
@@ -6,6 +6,7 @@
 package com.liferay.layout.util.structure;
 
 import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
+import com.liferay.layout.util.constants.StyledLayoutStructureConstants;
 import com.liferay.petra.lang.HashUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.util.Validator;
@@ -271,6 +272,6 @@ public class FormStyledLayoutStructureItem extends StyledLayoutStructureItem {
 	private boolean _indexed = true;
 	private String _justify = "";
 	private JSONObject _successMessageJSONObject;
-	private String _widthType = "fluid";
+	private String _widthType = StyledLayoutStructureConstants.WIDTH_TYPE;
 
 }

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/RowStyledLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/RowStyledLayoutStructureItem.java
@@ -7,6 +7,7 @@ package com.liferay.layout.util.structure;
 
 import com.liferay.layout.responsive.ViewportSize;
 import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
+import com.liferay.layout.util.constants.StyledLayoutStructureConstants;
 import com.liferay.petra.lang.HashUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -279,7 +280,8 @@ public class RowStyledLayoutStructureItem extends StyledLayoutStructureItem {
 	private Integer _modulesPerRow;
 	private int _numberOfColumns;
 	private boolean _reverseOrder;
-	private String _verticalAlignment = "top";
+	private String _verticalAlignment =
+		StyledLayoutStructureConstants.VERTICAL_ALIGNMENT_TOP;
 	private final Map<String, JSONObject> _viewportConfigurationJSONObjects =
 		new HashMap<>();
 

--- a/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/util/constants/packageinfo
+++ b/modules/apps/layout/layout-api/src/main/resources/com/liferay/layout/util/constants/packageinfo
@@ -1,1 +1,1 @@
-version 2.1.0
+version 2.2.0

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_fragment_image/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -22,18 +22,7 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"shadow": "None",
-						"widthType": "Fluid"
+						"shadow": "None"
 					}
 				},
 				"pageElements": [
@@ -63,18 +52,7 @@
 							},
 							"indexed": true,
 							"layout": {
-								"borderWidth": 0,
-								"marginBottom": 0,
-								"marginLeft": 0,
-								"marginRight": 0,
-								"marginTop": 0,
-								"opacity": 100,
-								"paddingBottom": 0,
-								"paddingLeft": 0,
-								"paddingRight": 0,
-								"paddingTop": 0,
-								"shadow": "None",
-								"widthType": "Fluid"
+								"shadow": "None"
 							}
 						},
 						"type": "Section"
@@ -111,18 +89,7 @@
 							},
 							"indexed": true,
 							"layout": {
-								"borderWidth": 0,
-								"marginBottom": 0,
-								"marginLeft": 0,
-								"marginRight": 0,
-								"marginTop": 0,
-								"opacity": 100,
-								"paddingBottom": 0,
-								"paddingLeft": 0,
-								"paddingRight": 0,
-								"paddingTop": 0,
-								"shadow": "None",
-								"widthType": "Fluid"
+								"shadow": "None"
 							}
 						},
 						"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_image/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/background_image/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -22,18 +22,7 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"shadow": "None",
-						"widthType": "Fluid"
+						"shadow": "None"
 					}
 				},
 				"pageElements": [
@@ -63,18 +52,7 @@
 							},
 							"indexed": true,
 							"layout": {
-								"borderWidth": 0,
-								"marginBottom": 0,
-								"marginLeft": 0,
-								"marginRight": 0,
-								"marginTop": 0,
-								"opacity": 100,
-								"paddingBottom": 0,
-								"paddingLeft": 0,
-								"paddingRight": 0,
-								"paddingTop": 0,
-								"shadow": "None",
-								"widthType": "Fluid"
+								"shadow": "None"
 							}
 						},
 						"type": "Section"
@@ -111,18 +89,7 @@
 							},
 							"indexed": true,
 							"layout": {
-								"borderWidth": 0,
-								"marginBottom": 0,
-								"marginLeft": 0,
-								"marginRight": 0,
-								"marginTop": 0,
-								"opacity": 100,
-								"paddingBottom": 0,
-								"paddingLeft": 0,
-								"paddingRight": 0,
-								"paddingTop": 0,
-								"shadow": "None",
-								"widthType": "Fluid"
+								"shadow": "None"
 							}
 						},
 						"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/complete/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/complete/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -26,21 +26,10 @@
 					"indexed": true,
 					"layout": {
 						"align": "Stretch",
-						"borderWidth": 0,
 						"contentDisplay": "FlexRow",
 						"flexWrap": "WrapReverse",
 						"justify": "Start",
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"shadow": "None",
-						"widthType": "Fluid"
+						"shadow": "None"
 					}
 				},
 				"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/content_visibility/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/content_visibility/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -27,18 +27,7 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"shadow": "None",
-						"widthType": "Fluid"
+						"shadow": "None"
 					}
 				},
 				"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/css_classes/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/css_classes/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -26,18 +26,7 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"shadow": "None",
-						"widthType": "Fluid"
+						"shadow": "None"
 					}
 				},
 				"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/custom_css/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/custom_css/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -37,18 +37,7 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"shadow": "None",
-						"widthType": "Fluid"
+						"shadow": "None"
 					}
 				},
 				"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/default/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/default/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -22,18 +22,7 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"shadow": "None",
-						"widthType": "Fluid"
+						"shadow": "None"
 					}
 				},
 				"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/empty/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/empty/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -22,18 +22,7 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"shadow": "None",
-						"widthType": "Fluid"
+						"shadow": "None"
 					}
 				},
 				"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/layout/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/layout/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -22,18 +22,7 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"shadow": "None",
-						"widthType": "Fluid"
+						"shadow": "None"
 					}
 				},
 				"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/link/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/link/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -22,18 +22,7 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"shadow": "None",
-						"widthType": "Fluid"
+						"shadow": "None"
 					}
 				},
 				"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/link_mapped_journal_article_display_page_url/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/link_mapped_journal_article_display_page_url/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -36,18 +36,7 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"shadow": "None",
-						"widthType": "Fluid"
+						"shadow": "None"
 					}
 				},
 				"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/link_mapped_layout/friendly_url/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/link_mapped_layout/friendly_url/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -31,17 +31,6 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"widthType": "Fluid"
 					}
 				},
 				"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/link_mapped_layout/friendly_url_site_key/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/link_mapped_layout/friendly_url_site_key/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -31,17 +31,6 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"widthType": "Fluid"
 					}
 				},
 				"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/link_mapped_layout/plid/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/link_mapped_layout/plid/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -31,17 +31,6 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"widthType": "Fluid"
 					}
 				},
 				"type": "Section"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/name/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/container/name/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -22,18 +22,7 @@
 					},
 					"indexed": true,
 					"layout": {
-						"borderWidth": 0,
-						"marginBottom": 0,
-						"marginLeft": 0,
-						"marginRight": 0,
-						"marginTop": 0,
-						"opacity": 100,
-						"paddingBottom": 0,
-						"paddingLeft": 0,
-						"paddingRight": 0,
-						"paddingTop": 0,
-						"shadow": "None",
-						"widthType": "Fluid"
+						"shadow": "None"
 					},
 					"name": "customName"
 				},

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/name/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/name/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -11,7 +11,6 @@
 					},
 					"indexed": true,
 					"layout": {
-						"widthType": "Fluid"
 					},
 					"name": "customName"
 				},

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_embedded/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -20,7 +20,6 @@
 					},
 					"indexed": true,
 					"layout": {
-						"widthType": "Fluid"
 					}
 				},
 				"type": "Form"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_layout/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -30,7 +30,6 @@
 					},
 					"indexed": true,
 					"layout": {
-						"widthType": "Fluid"
 					}
 				},
 				"type": "Form"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_none/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_none/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -21,7 +21,6 @@
 					},
 					"indexed": true,
 					"layout": {
-						"widthType": "Fluid"
 					}
 				},
 				"type": "Form"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/form/success_message_url/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -19,7 +19,6 @@
 					},
 					"indexed": true,
 					"layout": {
-						"widthType": "Fluid"
 					}
 				},
 				"type": "Form"

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/row/container/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/row/container/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -88,18 +88,7 @@
 									},
 									"indexed": true,
 									"layout": {
-										"borderWidth": 0,
-										"marginBottom": 0,
-										"marginLeft": 0,
-										"marginRight": 0,
-										"marginTop": 0,
-										"opacity": 100,
-										"paddingBottom": 0,
-										"paddingLeft": 0,
-										"paddingRight": 0,
-										"paddingTop": 0,
-										"shadow": "None",
-										"widthType": "Fluid"
+										"shadow": "None"
 									}
 								},
 								"pageElements": [

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/css_classes/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/css_classes/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,21 +1,5 @@
 {
 	"pageElement": {
-		"pageElements": [
-			{
-				"definition": {
-					"cssClasses": [
-						"customClass1",
-						"customClass2"
-					],
-					"widgetInstance": {
-						"widgetConfig": {
-						},
-						"widgetName": "com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet"
-					}
-				},
-				"type": "Widget"
-			}
-		],
 		"type": "Root"
 	},
 	"settings": {

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/css_classes/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/css_classes/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,21 +1,5 @@
 {
 	"pageElement": {
-		"pageElements": [
-			{
-				"definition": {
-					"cssClasses": [
-						"customClass1",
-						"customClass2"
-					],
-					"widgetInstance": {
-						"widgetConfig": {
-						},
-						"widgetName": "com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet"
-					}
-				},
-				"type": "Widget"
-			}
-		],
 		"type": "Root"
 	},
 	"settings": {

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/custom_css/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/custom_css/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,32 +1,5 @@
 {
 	"pageElement": {
-		"pageElements": [
-			{
-				"definition": {
-					"customCSS": ".[$FRAGMENT_CLASS$] {\n color: red;\n}",
-					"customCSSViewports": [
-						{
-							"customCSS": ".[$FRAGMENT_CLASS$] { color: red; }",
-							"id": "landscapeMobile"
-						},
-						{
-							"customCSS": ".[$FRAGMENT_CLASS$] { color: pink; }",
-							"id": "portraitMobile"
-						},
-						{
-							"customCSS": ".[$FRAGMENT_CLASS$] { color: aquamarine; }",
-							"id": "tablet"
-						}
-					],
-					"widgetInstance": {
-						"widgetConfig": {
-						},
-						"widgetName": "com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet"
-					}
-				},
-				"type": "Widget"
-			}
-		],
 		"type": "Root"
 	},
 	"settings": {

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/custom_css/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/custom_css/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,32 +1,5 @@
 {
 	"pageElement": {
-		"pageElements": [
-			{
-				"definition": {
-					"customCSS": ".[$FRAGMENT_CLASS$] {\n color: red;\n}",
-					"customCSSViewports": [
-						{
-							"customCSS": ".[$FRAGMENT_CLASS$] { color: red; }",
-							"id": "landscapeMobile"
-						},
-						{
-							"customCSS": ".[$FRAGMENT_CLASS$] { color: pink; }",
-							"id": "portraitMobile"
-						},
-						{
-							"customCSS": ".[$FRAGMENT_CLASS$] { color: aquamarine; }",
-							"id": "tablet"
-						}
-					],
-					"widgetInstance": {
-						"widgetConfig": {
-						},
-						"widgetName": "com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet"
-					}
-				},
-				"type": "Widget"
-			}
-		],
 		"type": "Root"
 	},
 	"settings": {

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/hidden/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/hidden/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,20 +1,5 @@
 {
 	"pageElement": {
-		"pageElements": [
-			{
-				"definition": {
-					"fragmentStyle": {
-						"hidden": true
-					},
-					"widgetInstance": {
-						"widgetConfig": {
-						},
-						"widgetName": "com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet"
-					}
-				},
-				"type": "Widget"
-			}
-		],
 		"type": "Root"
 	},
 	"settings": {

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/hidden/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/hidden/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,20 +1,5 @@
 {
 	"pageElement": {
-		"pageElements": [
-			{
-				"definition": {
-					"fragmentStyle": {
-						"hidden": true
-					},
-					"widgetInstance": {
-						"widgetConfig": {
-						},
-						"widgetName": "com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet"
-					}
-				},
-				"type": "Widget"
-			}
-		],
 		"type": "Root"
 	},
 	"settings": {

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/name/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/name/expected/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,18 +1,5 @@
 {
 	"pageElement": {
-		"pageElements": [
-			{
-				"definition": {
-					"name": "customName",
-					"widgetInstance": {
-						"widgetConfig": {
-						},
-						"widgetName": "com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet"
-					}
-				},
-				"type": "Widget"
-			}
-		],
 		"type": "Root"
 	},
 	"settings": {

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/name/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/resources/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/dependencies/import_export/page_templates/widget/name/input/page-templates/test-page-template-collection/test-page-template/page-definition.json
@@ -1,18 +1,5 @@
 {
 	"pageElement": {
-		"pageElements": [
-			{
-				"definition": {
-					"name": "customName",
-					"widgetInstance": {
-						"widgetConfig": {
-						},
-						"widgetName": "com_liferay_site_navigation_menu_web_portlet_SiteNavigationMenuPortlet"
-					}
-				},
-				"type": "Widget"
-			}
-		],
 		"type": "Root"
 	},
 	"settings": {

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/headless/delivery/dto/v1_0/test/PageDefinitionDTOConverterTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/headless/delivery/dto/v1_0/test/PageDefinitionDTOConverterTest.java
@@ -538,7 +538,7 @@ public class PageDefinitionDTOConverterTest {
 		com.liferay.headless.delivery.dto.v1_0.Layout sectionLayout =
 			pageSectionDefinition1.getLayout();
 
-		Assert.assertEquals("Fluid", sectionLayout.getWidthTypeAsString());
+		Assert.assertNull(sectionLayout.getWidthTypeAsString());
 		Assert.assertEquals(
 			Integer.valueOf(10), sectionLayout.getPaddingBottom());
 		Assert.assertEquals(Integer.valueOf(4), sectionLayout.getPaddingLeft());


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-190735)

Motivation
=======
When exporting pages, there are some default or empty props that are stored the json created when exporting the page. We want to avoid those default props to be exported.

**NOTE: I will include two screenshots, at left the screenshot without the default props and at right the screenshot with the props configured and exported well.**

## Steps
- Go to Design > Page Templates > Page Templates > Create a Content Page Template 

**Case 1: Container**
  - Add a Container to a content page template
  - Select the Container and see Container configurations at right side 
  - In general tab > Container Width > Fixed
  - In Styles tab configure the opacity to 99 and the following properties to 1px:
  - "borderWidth",
     "marginBottom",
     "marginLeft",
     "marginRight",
     "marginTop",
     "paddingBottom",
     "paddingLeft",
     "paddingRight",
     "paddingTop",
<img width="234" alt="containerWithoutDefaultProps1" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/f97f6c7c-c172-439d-abb2-374958241f49">
<img width="240" alt="containerWithPropsConfigured1" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/cc67b36a-36fc-4c30-b05b-28a6ad6a8812">

**Case 3: Form**
  - Go to Control Menu > Control Panel > Objects
  - Create a new Object 
  - View the new Object 
  - Go to fields > add a new field
  - Publish the Object
  - Add a Form Container to a content page template 
  - Map the container to the form created
  - Go to Form Container configuration 
  - In general tab > Container Width > Fixed
  
<img width="309" alt="formWithoutDefault" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/3bfef115-9225-4b1b-8277-1c6f0fc45b1a">
<img width="282" alt="formConfigured" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/7d7badea-de28-492f-8bdc-f2006981ae76">

@DiegoHu97 