### PR TITLE
LPS-192406 UI experience improvement in the Content Dashboard info panel

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
@@ -132,6 +132,12 @@ html#{$cadmin-selector} {
 				.sidebar-header {
 					top: 0;
 				}
+
+				.sidebar-section {
+					.nav {
+						border-bottom: 1px solid $cadmin-gray-300;
+					}
+				}
 			}
 		}
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/CollapsibleSection.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/CollapsibleSection.js
@@ -8,15 +8,11 @@ import ClayPanel from '@clayui/panel';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const SidebarPanelInfoCollapsibleSection = ({
-	children,
-	expanded = false,
-	title,
-}) => {
+const SidebarPanelInfoCollapsibleSection = ({children, title}) => {
 	return (
 		<ClayPanel
 			collapsable
-			defaultExpanded={expanded}
+			defaultExpanded
 			displayTitle={
 				<span className="c-inner" tabIndex="-1">
 					<ClayPanel.Title>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/DetailsContent.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/DetailsContent.js
@@ -46,7 +46,7 @@ const DetailsContent = ({
 				<Categorization tags={tags} vocabularies={vocabularies} />
 			</>
 
-			<CollapsibleSection title={Liferay.Language.get('details')}>
+			<CollapsibleSection title={Liferay.Language.get('properties')}>
 				<div className="sidebar-section">
 					<SpecificFields
 						fields={specificItems}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/DetailsContent.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/DetailsContent.js
@@ -6,7 +6,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Categorization from './Categorization';
 import CollapsibleSection from './CollapsibleSection';
 import ItemLanguages from './ItemLanguages';
 import PreviewActionsDescriptionSection from './PreviewActionsDescriptionSection';
@@ -24,10 +23,8 @@ const DetailsContent = ({
 	modifiedDate,
 	preview,
 	specificFields,
-	tags = [],
 	title,
 	viewURLs = [],
-	vocabularies,
 }) => {
 	const specificItems = Object.values(specificFields);
 
@@ -42,8 +39,6 @@ const DetailsContent = ({
 					preview={preview}
 					title={title}
 				/>
-
-				<Categorization tags={tags} vocabularies={vocabularies} />
 			</>
 
 			<CollapsibleSection title={Liferay.Language.get('properties')}>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 
 import Sidebar from '../Sidebar';
+import Categorization from './Categorization';
 import DetailsContent from './DetailsContent';
 import ManageCollaborators from './ManageCollaborators';
 import Subscribe from './Subscribe';
@@ -139,40 +140,53 @@ const SidebarPanelInfoView = ({
 								</>
 							)}
 						</div>
-
-						<div className="mb-0 sidebar-section">
-							{showTabs && activeTabKeyValue !== null && (
-								<ClayTabs modern>
-									<ClayTabs.Item
-										active={activeTabKeyValue === 0}
-										innerProps={{
-											'aria-controls': 'details',
-										}}
-										onClick={() => setActiveTabKeyValue(0)}
-									>
-										{Liferay.Language.get('details')}
-									</ClayTabs.Item>
-
-									<ClayTabs.Item
-										active={activeTabKeyValue === 1}
-										innerProps={{
-											'aria-controls': 'versions',
-										}}
-										onClick={() => setActiveTabKeyValue(1)}
-									>
-										{Liferay.Language.get('versions')}
-									</ClayTabs.Item>
-								</ClayTabs>
-							)}
-						</div>
 					</div>
 				</ClayLayout.ContentRow>
 			</Sidebar.Header>
 
+			<div className="mb-0 sidebar-section">
+				{showTabs && activeTabKeyValue !== null && (
+					<ClayTabs modern>
+						<ClayTabs.Item
+							active={activeTabKeyValue === 0}
+							innerProps={{
+								'aria-controls': 'details',
+							}}
+							onClick={() => setActiveTabKeyValue(0)}
+						>
+							{Liferay.Language.get('details')}
+						</ClayTabs.Item>
+
+						<ClayTabs.Item
+							active={activeTabKeyValue === 1}
+							innerProps={{
+								'aria-controls': 'versions',
+							}}
+							onClick={() => setActiveTabKeyValue(1)}
+						>
+							{Liferay.Language.get('versions')}
+						</ClayTabs.Item>
+
+						<ClayTabs.Item
+							active={activeTabKeyValue === 2}
+							innerProps={{
+								'aria-controls': 'categorization',
+							}}
+							onClick={() => setActiveTabKeyValue(2)}
+						>
+							{Liferay.Language.get('categorization')}
+						</ClayTabs.Item>
+					</ClayTabs>
+				)}
+			</div>
+
 			<Sidebar.Body>
 				<div>
 					<ClayTabs.Content activeIndex={activeTabKeyValue} fade>
-						<ClayTabs.TabPane aria-labelledby="tab-1">
+						<ClayTabs.TabPane
+							aria-labelledby="tab-1"
+							className="flex-shrink-0"
+						>
 							<DetailsContent
 								classPK={classPK}
 								createDate={createDate}
@@ -183,20 +197,33 @@ const SidebarPanelInfoView = ({
 								modifiedDate={modifiedDate}
 								preview={preview}
 								specificFields={specificFields}
-								tags={tags}
 								title={title}
 								viewURLs={viewURLs}
-								vocabularies={vocabularies}
 							/>
 						</ClayTabs.TabPane>
 
-						{showTabs && (
-							<ClayTabs.TabPane aria-labelledby="tab-2">
+						{showTabs && activeTabKeyValue === 1 && (
+							<ClayTabs.TabPane
+								aria-labelledby="tab-2"
+								className="flex-shrink-0"
+							>
 								<VersionsContent
 									active={activeTabKeyValue === 1}
 									getItemVersionsURL={getItemVersionsURL}
 									languageTag={languageTag}
 									onError={handleError}
+								/>
+							</ClayTabs.TabPane>
+						)}
+
+						{showTabs && activeTabKeyValue === 2 && (
+							<ClayTabs.TabPane
+								aria-labelledby="tab-2"
+								className="flex-shrink-0"
+							>
+								<Categorization
+									tags={tags}
+									vocabularies={vocabularies}
 								/>
 							</ClayTabs.TabPane>
 						)}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -9,7 +9,7 @@ import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import ClaySticker from '@clayui/sticker';
 import ClayTabs from '@clayui/tabs';
-import classnames from 'classnames';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 
@@ -53,6 +53,9 @@ const SidebarPanelInfoView = ({
 	const handleError = useCallback(() => {
 		setError(true);
 	}, []);
+
+	const hasCategorization =
+		!!tags.length || !!Object.keys(vocabularies).length;
 
 	return (
 		<>
@@ -116,7 +119,7 @@ const SidebarPanelInfoView = ({
 							) : (
 								<>
 									<ClaySticker
-										className={classnames(
+										className={classNames(
 											'sticker-user-icon',
 											{
 												[`user-icon-color-${stickerColor}`]: !user.url,
@@ -147,7 +150,9 @@ const SidebarPanelInfoView = ({
 			<div className="c-mb-4 sidebar-section">
 				{showTabs && activeTabKeyValue !== null && (
 					<ClayTabs
-						className="flex-nowrap justify-content-center"
+						className={classNames('d-flex flex-nowrap', {
+							'justify-content-center': hasCategorization,
+						})}
 						modern
 					>
 						<ClayTabs.Item
@@ -161,26 +166,28 @@ const SidebarPanelInfoView = ({
 							{Liferay.Language.get('details')}
 						</ClayTabs.Item>
 
-						<ClayTabs.Item
-							active={activeTabKeyValue === 1}
-							className="flex-shrink-0"
-							innerProps={{
-								'aria-controls': 'versions',
-							}}
-							onClick={() => setActiveTabKeyValue(1)}
-						>
-							{Liferay.Language.get('versions')}
-						</ClayTabs.Item>
+						{hasCategorization && (
+							<ClayTabs.Item
+								active={activeTabKeyValue === 1}
+								className="flex-shrink-0"
+								innerProps={{
+									'aria-controls': 'categorization',
+								}}
+								onClick={() => setActiveTabKeyValue(1)}
+							>
+								{Liferay.Language.get('categorization')}
+							</ClayTabs.Item>
+						)}
 
 						<ClayTabs.Item
 							active={activeTabKeyValue === 2}
 							className="flex-shrink-0"
 							innerProps={{
-								'aria-controls': 'categorization',
+								'aria-controls': 'versions',
 							}}
 							onClick={() => setActiveTabKeyValue(2)}
 						>
-							{Liferay.Language.get('categorization')}
+							{Liferay.Language.get('versions')}
 						</ClayTabs.Item>
 					</ClayTabs>
 				)}
@@ -208,7 +215,21 @@ const SidebarPanelInfoView = ({
 							/>
 						</ClayTabs.TabPane>
 
-						{showTabs && activeTabKeyValue === 1 && (
+						{hasCategorization &&
+							showTabs &&
+							activeTabKeyValue === 1 && (
+								<ClayTabs.TabPane
+									aria-labelledby="tab-2"
+									className="flex-shrink-0"
+								>
+									<Categorization
+										tags={tags}
+										vocabularies={vocabularies}
+									/>
+								</ClayTabs.TabPane>
+							)}
+
+						{showTabs && activeTabKeyValue === 2 && (
 							<ClayTabs.TabPane
 								aria-labelledby="tab-2"
 								className="flex-shrink-0"
@@ -218,18 +239,6 @@ const SidebarPanelInfoView = ({
 									getItemVersionsURL={getItemVersionsURL}
 									languageTag={languageTag}
 									onError={handleError}
-								/>
-							</ClayTabs.TabPane>
-						)}
-
-						{showTabs && activeTabKeyValue === 2 && (
-							<ClayTabs.TabPane
-								aria-labelledby="tab-2"
-								className="flex-shrink-0"
-							>
-								<Categorization
-									tags={tags}
-									vocabularies={vocabularies}
 								/>
 							</ClayTabs.TabPane>
 						)}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -105,7 +105,7 @@ const SidebarPanelInfoView = ({
 							))}
 						</div>
 
-						<div className="sidebar-section">
+						<div className="mb-1 sidebar-section">
 							{fetchSharingCollaboratorsURL ? (
 								<ManageCollaborators
 									fetchSharingCollaboratorsURL={
@@ -144,11 +144,15 @@ const SidebarPanelInfoView = ({
 				</ClayLayout.ContentRow>
 			</Sidebar.Header>
 
-			<div className="mb-0 sidebar-section">
+			<div className="c-mb-4 sidebar-section">
 				{showTabs && activeTabKeyValue !== null && (
-					<ClayTabs modern>
+					<ClayTabs
+						className="flex-nowrap justify-content-center"
+						modern
+					>
 						<ClayTabs.Item
 							active={activeTabKeyValue === 0}
+							className="flex-shrink-0"
 							innerProps={{
 								'aria-controls': 'details',
 							}}
@@ -159,6 +163,7 @@ const SidebarPanelInfoView = ({
 
 						<ClayTabs.Item
 							active={activeTabKeyValue === 1}
+							className="flex-shrink-0"
 							innerProps={{
 								'aria-controls': 'versions',
 							}}
@@ -169,6 +174,7 @@ const SidebarPanelInfoView = ({
 
 						<ClayTabs.Item
 							active={activeTabKeyValue === 2}
+							className="flex-shrink-0"
 							innerProps={{
 								'aria-controls': 'categorization',
 							}}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -20,6 +20,12 @@ import ManageCollaborators from './ManageCollaborators';
 import Subscribe from './Subscribe';
 import VersionsContent from './VersionsContent';
 
+const TABS = {
+	categorization: 1,
+	details: 0,
+	version: 2,
+};
+
 const SidebarPanelInfoView = ({
 	classPK,
 	createDate,
@@ -42,7 +48,7 @@ const SidebarPanelInfoView = ({
 	viewURLs = [],
 	vocabularies = {},
 }) => {
-	const [activeTabKeyValue, setActiveTabKeyValue] = useState(0);
+	const [activeTabKeyValue, setActiveTabKeyValue] = useState(TABS.details);
 
 	const showTabs = !!getItemVersionsURL;
 
@@ -156,36 +162,40 @@ const SidebarPanelInfoView = ({
 						modern
 					>
 						<ClayTabs.Item
-							active={activeTabKeyValue === 0}
+							active={activeTabKeyValue === TABS.details}
 							className="flex-shrink-0"
 							innerProps={{
 								'aria-controls': 'details',
 							}}
-							onClick={() => setActiveTabKeyValue(0)}
+							onClick={() => setActiveTabKeyValue(TABS.details)}
 						>
 							{Liferay.Language.get('details')}
 						</ClayTabs.Item>
 
 						{hasCategorization && (
 							<ClayTabs.Item
-								active={activeTabKeyValue === 1}
+								active={
+									activeTabKeyValue === TABS.categorization
+								}
 								className="flex-shrink-0"
 								innerProps={{
 									'aria-controls': 'categorization',
 								}}
-								onClick={() => setActiveTabKeyValue(1)}
+								onClick={() =>
+									setActiveTabKeyValue(TABS.categorization)
+								}
 							>
 								{Liferay.Language.get('categorization')}
 							</ClayTabs.Item>
 						)}
 
 						<ClayTabs.Item
-							active={activeTabKeyValue === 2}
+							active={activeTabKeyValue === TABS.version}
 							className="flex-shrink-0"
 							innerProps={{
 								'aria-controls': 'versions',
 							}}
-							onClick={() => setActiveTabKeyValue(2)}
+							onClick={() => setActiveTabKeyValue(TABS.version)}
 						>
 							{Liferay.Language.get('versions')}
 						</ClayTabs.Item>
@@ -217,7 +227,7 @@ const SidebarPanelInfoView = ({
 
 						{hasCategorization &&
 							showTabs &&
-							activeTabKeyValue === 1 && (
+							activeTabKeyValue === TABS.categorization && (
 								<ClayTabs.TabPane
 									aria-labelledby="tab-2"
 									className="flex-shrink-0"
@@ -229,13 +239,13 @@ const SidebarPanelInfoView = ({
 								</ClayTabs.TabPane>
 							)}
 
-						{showTabs && activeTabKeyValue === 2 && (
+						{showTabs && activeTabKeyValue === TABS.version && (
 							<ClayTabs.TabPane
 								aria-labelledby="tab-2"
 								className="flex-shrink-0"
 							>
 								<VersionsContent
-									active={activeTabKeyValue === 1}
+									active={activeTabKeyValue === TABS.version}
 									getItemVersionsURL={getItemVersionsURL}
 									languageTag={languageTag}
 									onError={handleError}


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to improve Content Dashboard info panels UI experience.
https://liferay.atlassian.net/browse/LPS-164349
https://liferay.atlassian.net/browse/LPS-164348

Proposed Solution
========
What I did to solve this problem is to change the Details key name to Properties in one of the info panels section and make that section expanded by default when the info panel is open. Also I moved the Categorization section to a new tab by using a new ClayTab.Item and ClayTab.Content when the item has linked vocabularies or tags.

Steps to Verify
========
1. Create some tags and vocabularies.
2. Create a Display Page Template for web contents.
3. Create a web content and add the tag and vocabularies to it and also attach it to the DPT created.
4. Go to the Content Dashboard.
5. Hover over the web content created and click on the info button in the right side
6. When the info panel is opened, check that the item contains three tabs and all work correctly
7. Also, check the same with some item that hasn't has categories
