### PR TITLE
LPS-192155 Remove the use of global functions in edit_feed.jsp

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
@@ -109,20 +109,28 @@ renderResponse.setTitle(editJournalFeedDisplayContext.getTitle());
 
 				<aui:input name="structure" type="resource" value="<%= editJournalFeedDisplayContext.getDDMStructureName() %>" />
 
-				<clay:button
-					displayType="secondary"
-					id='<%= liferayPortletResponse.getNamespace() + "selectDDMStructureButton" %>'
-					label="select"
-					onClick='<%= liferayPortletResponse.getNamespace() + "openDDMStructureSelector();" %>'
-				/>
+				<div class="c-gap-1 d-flex">
+					<clay:button
+						additionalProps='<%=
+							HashMapBuilder.<String, Object>put(
+								"description", JournalFeedConstants.WEB_CONTENT_DESCRIPTION
+							).put(
+								"selectDDMStructurePropsTransformerURL", journalDisplayContext.getSelectDDMStructureURL()
+							).build()
+						%>'
+						displayType="secondary"
+						label="select"
+						propsTransformer="js/SelectDDMStructureButtonPropsTransformer"
+					/>
 
-				<clay:button
-					disabled="<%= editJournalFeedDisplayContext.getDDMStructureId() == 0 %>"
-					displayType="secondary"
-					id='<%= liferayPortletResponse.getNamespace() + "removeDDMStructureButton" %>'
-					label="remove"
-					onClick='<%= liferayPortletResponse.getNamespace() + "removeDDMStructure();" %>'
-				/>
+					<clay:button
+						disabled="<%= editJournalFeedDisplayContext.getDDMStructureId() == 0 %>"
+						displayType="secondary"
+						id='<%= liferayPortletResponse.getNamespace() + "removeDDMStructureButton" %>'
+						label="remove"
+						onClick='<%= liferayPortletResponse.getNamespace() + "removeDDMStructure();" %>'
+					/>
+				</div>
 			</div>
 
 			<c:choose>
@@ -283,47 +291,6 @@ renderResponse.setTitle(editJournalFeedDisplayContext.getTitle());
 </liferay-frontend:edit-form>
 
 <aui:script>
-	function <portlet:namespace />openDDMStructureSelector() {
-		Liferay.Util.openSelectionModal({
-			onSelect: function (selectedItem) {
-				const itemValue = JSON.parse(selectedItem.value);
-
-				if (
-					document.<portlet:namespace />fm
-						.<portlet:namespace />ddmStructureId.value !=
-					itemValue.ddmstructureid
-				) {
-					Liferay.Util.openConfirmModal({
-						message:
-							'<%= UnicodeLanguageUtil.get(request, "selecting-a-new-structure-changes-the-available-templates-and-available-feed-item-content") %>',
-						onConfirm: (isConfirmed) => {
-							if (isConfirmed) {
-								document.<portlet:namespace />fm.<portlet:namespace />ddmStructureId.value =
-									itemValue.ddmstructureid;
-								document.<portlet:namespace />fm.<portlet:namespace />ddmTemplateKey.value =
-									'';
-								document.<portlet:namespace />fm.<portlet:namespace />ddmRendererTemplateKey.value =
-									'';
-								document.<portlet:namespace />fm.<portlet:namespace />contentField.value =
-									'<%= JournalFeedConstants.WEB_CONTENT_DESCRIPTION %>';
-
-								submitForm(
-									document.<portlet:namespace />fm,
-									null,
-									false,
-									false
-								);
-							}
-						},
-					});
-				}
-			},
-			selectEventName: '<portlet:namespace />selectDDMStructure',
-			title: '<%= UnicodeLanguageUtil.get(request, "structures") %>',
-			url: '<%= journalDisplayContext.getSelectDDMStructureURL() %>>',
-		});
-	}
-
 	function <portlet:namespace />removeAssetCategory() {
 		document.<portlet:namespace />fm.<portlet:namespace />assetCategoryIds.value =
 			'';

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
@@ -151,20 +151,26 @@ renderResponse.setTitle(editJournalFeedDisplayContext.getTitle());
 
 				<aui:input name="assetCategory" type="resource" value="<%= editJournalFeedDisplayContext.getAssetCategoryName() %>" />
 
-				<clay:button
-					displayType="secondary"
-					id='<%= liferayPortletResponse.getNamespace() + "selectAssetCategoryButton" %>'
-					label="select"
-					onClick='<%= liferayPortletResponse.getNamespace() + "openAssetCategorySelector();" %>'
-				/>
+				<div class="c-gap-1 d-flex">
+					<clay:button
+						additionalProps='<%=
+							HashMapBuilder.<String, Object>put(
+								"selectAssetCategoryPropsTransformerURL", editJournalFeedDisplayContext.getAssetCategoriesSelectorURL()
+							).build()
+						%>'
+						displayType="secondary"
+						label="select"
+						propsTransformer="js/SelectAssetCategoryButtonPropsTransformer"
+					/>
 
-				<clay:button
-					disabled="<%= editJournalFeedDisplayContext.getAssetCategoryId() == 0 %>"
-					displayType="secondary"
-					id='<%= liferayPortletResponse.getNamespace() + "removeAssetCategoryButton" %>'
-					label="remove"
-					onClick='<%= liferayPortletResponse.getNamespace() + "removeAssetCategory();" %>'
-				/>
+					<clay:button
+						disabled="<%= editJournalFeedDisplayContext.getAssetCategoryId() == 0 %>"
+						displayType="secondary"
+						id='<%= liferayPortletResponse.getNamespace() + "removeAssetCategoryButton" %>'
+						label="remove"
+						onClick='<%= liferayPortletResponse.getNamespace() + "removeAssetCategory();" %>'
+					/>
+				</div>
 			</div>
 		</liferay-frontend:fieldset>
 
@@ -277,24 +283,6 @@ renderResponse.setTitle(editJournalFeedDisplayContext.getTitle());
 </liferay-frontend:edit-form>
 
 <aui:script>
-	function <portlet:namespace />openAssetCategorySelector() {
-		Liferay.Util.openSelectionModal({
-			onSelect: function (selectedItems) {
-				const [selectedItem] = Object.values(selectedItems);
-
-				document.<portlet:namespace />fm.<portlet:namespace />assetCategoryIds.value =
-					selectedItem.classPK;
-				document.<portlet:namespace />fm.<portlet:namespace />assetCategory.value =
-					selectedItem.title;
-				document.<portlet:namespace />fm.<portlet:namespace />removeAssetCategoryButton.disabled = false;
-			},
-			selectEventName: '<portlet:namespace />selectAssetCategory',
-			title: '<%= UnicodeLanguageUtil.get(request, "select-category") %>',
-			url:
-				'<%= editJournalFeedDisplayContext.getAssetCategoriesSelectorURL() %>>',
-		});
-	}
-
 	function <portlet:namespace />openDDMStructureSelector() {
 		Liferay.Util.openSelectionModal({
 			onSelect: function (selectedItem) {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_feed.jsp
@@ -25,7 +25,6 @@ renderResponse.setTitle(editJournalFeedDisplayContext.getTitle());
 	enctype="multipart/form-data"
 	method="post"
 	name="fm"
-	onSubmit='<%= "event.preventDefault(); " + liferayPortletResponse.getNamespace() + "saveFeed();" %>'
 >
 	<aui:input name="<%= ActionRequest.ACTION_NAME %>" type="hidden" value="" />
 	<aui:input name="redirect" type="hidden" value="<%= editJournalFeedDisplayContext.getRedirect() %>" />
@@ -290,6 +289,17 @@ renderResponse.setTitle(editJournalFeedDisplayContext.getTitle());
 	</liferay-frontend:edit-form-footer>
 </liferay-frontend:edit-form>
 
+<liferay-frontend:component
+	context='<%=
+		HashMapBuilder.<String, Object>put(
+			"isNewJournalFeed", editJournalFeedDisplayContext.getJournalFeed() == null
+		).put(
+			"renderedWebContent", JournalFeedConstants.RENDERED_WEB_CONTENT
+		).build()
+	%>'
+	module="js/EditFeed"
+/>
+
 <aui:script>
 	function <portlet:namespace />removeAssetCategory() {
 		document.<portlet:namespace />fm.<portlet:namespace />assetCategoryIds.value =
@@ -310,69 +320,5 @@ renderResponse.setTitle(editJournalFeedDisplayContext.getTitle());
 			'<%= JournalFeedConstants.WEB_CONTENT_DESCRIPTION %>';
 
 		submitForm(document.<portlet:namespace />fm, null, false, false);
-	}
-
-	function <portlet:namespace />saveFeed() {
-		document.<portlet:namespace />fm[
-			'<portlet:namespace />javax-portlet-action'
-		].value =
-			'<%= (editJournalFeedDisplayContext.getJournalFeed() == null) ? "/journal/add_feed" : "/journal/update_feed" %>';
-
-		<c:if test="<%= editJournalFeedDisplayContext.getJournalFeed() == null %>">
-			document.<portlet:namespace />fm.<portlet:namespace />feedId.value =
-				document.<portlet:namespace />fm.<portlet:namespace />newFeedId.value;
-		</c:if>
-
-		submitForm(document.<portlet:namespace />fm);
-	}
-
-	var autoFeedInput = document.getElementById('<portlet:namespace />autoFeedId');
-	var newFeedCheckbox = document.getElementById('<portlet:namespace />newFeedId');
-
-	if (autoFeedInput && newFeedCheckbox) {
-		newFeedCheckbox.disabled = autoFeedInput.checked;
-
-		autoFeedInput.addEventListener('click', () => {
-			Liferay.Util.toggleDisabled(newFeedCheckbox, !newFeedCheckbox.disabled);
-		});
-	}
-</aui:script>
-
-<aui:script sandbox="<%= true %>">
-	var form = document.<portlet:namespace />fm;
-
-	var renderedWebContent = '<%= JournalFeedConstants.RENDERED_WEB_CONTENT %>';
-
-	var contentFieldSelector = Liferay.Util.getFormElement(
-		form,
-		'contentFieldSelector'
-	);
-
-	if (contentFieldSelector) {
-		contentFieldSelector.addEventListener('change', () => {
-			var contentFieldValue = '';
-			var ddmRendererTemplateKeyValue = '';
-
-			var selectedFeedItemOption =
-				contentFieldSelector.options[contentFieldSelector.selectedIndex];
-
-			if (selectedFeedItemOption) {
-				contentFieldValue = selectedFeedItemOption.value || '';
-
-				if (
-					selectedFeedItemOption.dataset.contentfield ===
-					renderedWebContent
-				) {
-					ddmRendererTemplateKeyValue = contentFieldValue;
-
-					contentFieldValue = renderedWebContent;
-				}
-			}
-
-			Liferay.Util.setFormValues(form, {
-				contentField: contentFieldValue,
-				ddmRendererTemplateKey: ddmRendererTemplateKeyValue,
-			});
-		});
 	}
 </aui:script>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/EditFeed.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/EditFeed.js
@@ -1,0 +1,86 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {getFormElement, setFormValues, toggleDisabled} from 'frontend-js-web';
+
+export default function ({isNewJournalFeed, namespace, renderedWebContent}) {
+	const form = document.getElementById(`${namespace}fm`);
+
+	const contentFieldSelector = getFormElement(form, 'contentFieldSelector');
+
+	const handleFieldSelector = () => {
+		let contentFieldValue = '';
+		let ddmRendererTemplateKeyValue = '';
+
+		const selectedFeedItemOption =
+			contentFieldSelector.options[contentFieldSelector.selectedIndex];
+
+		if (selectedFeedItemOption) {
+			contentFieldValue = selectedFeedItemOption.value || '';
+
+			if (
+				selectedFeedItemOption.dataset.contentfield ===
+				renderedWebContent
+			) {
+				ddmRendererTemplateKeyValue = contentFieldValue;
+
+				contentFieldValue = renderedWebContent;
+			}
+		}
+
+		setFormValues(form, {
+			contentField: contentFieldValue,
+			ddmRendererTemplateKey: ddmRendererTemplateKeyValue,
+		});
+	};
+
+	const saveFeed = () => {
+		const actionInput = document.getElementById(
+			`${namespace}javax-portlet-action`
+		);
+
+		let feed = '/journal/update_feed';
+
+		if (isNewJournalFeed) {
+			feed = '/journal/add_feed';
+
+			document.getElementById(
+				`${namespace}feedId`
+			).value = document.getElementById(`${namespace}newFeedId`).value;
+		}
+		actionInput.value = feed;
+		submitForm(form);
+	};
+
+	if (form) {
+		contentFieldSelector.addEventListener('change', handleFieldSelector);
+
+		form.addEventListener('submit', saveFeed);
+
+		const autoFeedInput = document.getElementById(`${namespace}autoFeedId`);
+		const newFeedCheckbox = document.getElementById(
+			`${namespace}newFeedId`
+		);
+
+		if (autoFeedInput && newFeedCheckbox) {
+			newFeedCheckbox.disabled = autoFeedInput.checked;
+
+			autoFeedInput.addEventListener('click', () => {
+				toggleDisabled(newFeedCheckbox, !newFeedCheckbox.disabled);
+			});
+		}
+	}
+
+	return {
+		dispose() {
+			contentFieldSelector.removeEventListener(
+				'change',
+				handleFieldSelector()
+			);
+
+			form.removeEventListener('submit', saveFeed);
+		},
+	};
+}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectAssetCategoryButtonPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectAssetCategoryButtonPropsTransformer.js
@@ -1,0 +1,45 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {openSelectionModal} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps,
+	portletNamespace,
+	...props
+}) {
+	return {
+		...props,
+		onClick() {
+			const {selectAssetCategoryPropsTransformerURL} = additionalProps;
+
+			openSelectionModal({
+				onSelect: (selectedItems) => {
+					const [selectedItem] = Object.values(selectedItems);
+
+					const assetCategoryIds = document.getElementById(
+						`${portletNamespace}assetCategoryIds`
+					);
+
+					const assetCategory = document.getElementById(
+						`${portletNamespace}assetCategory`
+					);
+
+					assetCategoryIds.value = selectedItem.classPK;
+					assetCategory.value = selectedItem.title;
+
+					const removeAssetCategoryButton = document.getElementById(
+						`${portletNamespace}removeAssetCategoryButton`
+					);
+
+					removeAssetCategoryButton.disabled = false;
+				},
+				selectEventName: `${portletNamespace}selectAssetCategory`,
+				title: Liferay.Language.get('select-category'),
+				url: `${selectAssetCategoryPropsTransformerURL}`,
+			});
+		},
+	};
+}

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectDDMStructureButtonPropsTransformer.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/SelectDDMStructureButtonPropsTransformer.js
@@ -1,0 +1,68 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {openConfirmModal, openSelectionModal} from 'frontend-js-web';
+
+export default function propsTransformer({
+	additionalProps: {description, selectDDMStructurePropsTransformerURL},
+	portletNamespace,
+	...props
+}) {
+	return {
+		...props,
+		onClick() {
+			openSelectionModal({
+				onSelect: (selectedItem) => {
+					const itemValue = JSON.parse(selectedItem.value);
+
+					const ddmStructureId = document.getElementById(
+						`${portletNamespace}ddmStructureId`
+					);
+
+					if (ddmStructureId.value !== itemValue.ddmstructureid) {
+						openConfirmModal({
+							message: Liferay.Language.get(
+								'selecting-a-new-structure-changes-the-available-templates-and-available-feed-item-content'
+							),
+							onConfirm: (isConfirmed) => {
+								if (isConfirmed) {
+									ddmStructureId.value =
+										itemValue.ddmstructureid;
+
+									const ddmTemplateKey = document.getElementById(
+										`${portletNamespace}ddmTemplateKey`
+									);
+
+									ddmTemplateKey.value = '';
+
+									const ddmRendererTemplateKey = document.getElementById(
+										`${portletNamespace}ddmRendererTemplateKey`
+									);
+
+									ddmRendererTemplateKey.value = '';
+
+									const contentField = document.getElementById(
+										`${portletNamespace}contentField`
+									);
+
+									contentField.value = description;
+
+									const form = document.getElementById(
+										`${portletNamespace}fm`
+									);
+
+									submitForm(form, null, false, false);
+								}
+							},
+						});
+					}
+				},
+				selectEventName: `${portletNamespace}selectDDMStructure`,
+				title: Liferay.Language.get('structures'),
+				url: selectDDMStructurePropsTransformerURL,
+			});
+		},
+	};
+}


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-192155)

After completing this issue (https://github.com/liferay-echo/liferay-portal/pull/12900) I created a task to improve the quality of the existing code and move all global functions to JS.


## Proposed solution

The solution was to move the code to `propsTransformers` to remove unnecessary global functions.

## Test Scenario 1
* Go to system settings > search journal > web content
* Go to system scope > Administration and click on show feed and save
* Create a content page
* Create a vocabulary with a category on it
* Go to Content and Data > Feed and create a new one
* Complete the Friendly URL with “/web/guest/[name of your content page]
* Click on web content constraints and check the behaviour of the buttons for Select structures and categories:

<img width="339" alt="Pasted Graphic 4" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/972cc337-e84d-42dc-9152-2445e3406211">

* Also check the behaviour of the presentation settings and save+cancel buttons:

<img width="782" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/97d9f507-cd18-490a-bac9-e328ad14d368">


### Note: 
We won't change the Remove cases until find a solution related with the `disabled` attribute and the behaviour when using a `propsTransformer` on clay buttons.