### PR TITLE
[TS] LPS-192814 - only send groupIds that actually correspond to a tag

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/java/com/liferay/content/dashboard/web/internal/display/context/ContentDashboardAdminManagementToolbarDisplayContext.java
@@ -6,8 +6,10 @@
 package com.liferay.content.dashboard.web.internal.display.context;
 
 import com.liferay.asset.kernel.model.AssetCategory;
+import com.liferay.asset.kernel.model.AssetTag;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
+import com.liferay.asset.kernel.service.AssetTagLocalServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.tags.item.selector.AssetTagsItemSelectorReturnType;
 import com.liferay.asset.tags.item.selector.criterion.AssetTagsItemSelectorCriterion;
@@ -46,7 +48,6 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
-import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -54,6 +55,7 @@ import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -554,19 +556,12 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 	}
 
 	private PortletURL _getAssetTagSelectorURL() {
-		ThemeDisplay themeDisplay =
-			(ThemeDisplay)_liferayPortletRequest.getAttribute(
-				WebKeys.THEME_DISPLAY);
-
 		AssetTagsItemSelectorCriterion assetTagsItemSelectorCriterion =
 			new AssetTagsItemSelectorCriterion();
 
 		assetTagsItemSelectorCriterion.setDesiredItemSelectorReturnTypes(
 			new AssetTagsItemSelectorReturnType());
-		assetTagsItemSelectorCriterion.setGroupIds(
-			ArrayUtil.toLongArray(
-				_groupLocalService.getGroupIds(
-					themeDisplay.getCompanyId(), true)));
+		assetTagsItemSelectorCriterion.setGroupIds(_getGroupIds());
 		assetTagsItemSelectorCriterion.setMultiSelection(true);
 
 		return _itemSelector.getItemSelectorURL(
@@ -813,6 +808,16 @@ public class ContentDashboardAdminManagementToolbarDisplayContext
 				}
 			}
 		};
+	}
+
+	private long[] _getGroupIds() {
+		Set<Long> groupIdsSet = new HashSet<>();
+
+		for (AssetTag assetTag : AssetTagLocalServiceUtil.getTags()) {
+			groupIdsSet.add(assetTag.getGroupId());
+		}
+
+		return new long[groupIdsSet.size()];
 	}
 
 	private String _getLabel(String key, String value) {


### PR DESCRIPTION
Hi @liferay-echo,

This is a fix for a potential issue when filtering by tag for the Content Dashboard. Currently, when creating our URL, we add *all* active groups within a company. However, this number can easily outstrip a URL's size limit due to growing not just due to site creation, but user creation (due to user personal sites also having valid groupIds grabbed by our current logic). For example, a client might have 8000+ users alone and therefore would have that many groupIds in the URL -- this number not even including their actual sites. Since these personal user sites _can_ still technically have tags of their own, we do need to still potentially include them in the groupIds list as far as I'm aware. I've opted to reduce the number of groupIds instead by creating a set and grabbing groupIds from existing tags. Please let me know if you have any questions or concerns. Thanks!