### PR TITLE
[TS] LPS-192954 Background image for fragment not shown when context is not ROOT

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -685,7 +685,7 @@ public class RenderLayoutStructureDisplayContext {
 		String backgroundImageURL = jsonObject.getString("url");
 
 		if (Validator.isNotNull(backgroundImageURL)) {
-			return PortalUtil.getPathContext() + backgroundImageURL;
+			return backgroundImageURL;
 		}
 
 		return StringPool.BLANK;


### PR DESCRIPTION
Motivation
=======
When the context set for the application server is not the default ROOT the background image for a fragment won't be loaded because the context path is set twice. 

The background image for a fragment is selected via an item selector that will return a corresponding URL starting with the context path; e.g. `/mycontext/documents/d/site01/image01`. 

The background image is displayed correctly in the edit view of the page, but when visiting the page the background image is missing because it tries to get it from the URL `http://localhost:8080/mycontext/mycontext/documents/d/site01/image01`.

The extra path context is introduced in `RenderLayoutStructureDisplaycontext#_getBackgroundImage`. (And it's there where I fix the problem.)

Proposed Solution
========
Avoid prepending the path context when getting the background image to display because it already includes it.

Steps to Verify
========
See steps in [LPS-192954](https://liferay.atlassian.net/browse/LPS-192954).

References to existing code (if applies)
========
None

Screenshots (if applies)
========
None

Alternative Solutions that were discarded (if applies)
========
The other option to fix this issue would be to tell the item selector provide us the URL without the context path. (The URL is obtained from `DLURLHelperImpl#getPreviewURL`.)

Although I don't have a definitive argument against this alternative, I think the proposed solution is cleaner. 

Checklist (optional)
========

CODE:
- [x] I have considered breaking this PR into smaller PRs if the amount of changed code is too large
- [x] I have performed a self-review of my own code following Liferay's code conventions
- [x] I have checked other areas of the product for solutions to similar problems
- [ ] I have added tests that prove my fix is effective or that my feature works

COMMITS:
- [x] My commits organize changes in coherent units
- [x] There are no commits which should be combined into others
- [x] My commits are ordered in a way that ease understanding
- [x] My commit messages are well formatted and concisely describe what was changed and why it was changed

PR TITLE & DESCRIPTION:
- [x] My PR title includes an issue number and a descriptive title
- [x] My PR description explains the motivation for this change
- [x] My PR description explains the proposed solution
- [x] My PR description includes the steps to verify the change
- [ ] My PR description includes references to other places where this solution is used (if applies) (doesn't apply)
- [ ] My PR description includes visual aids to understand what has changed (if applies)
- [x] My PR description explains alternative approaches considered and why they were discarded (if applies)