### PR TITLE
LPS-192406 UI experience improvement in the Content Dashboard info panel

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/css/main.scss
@@ -132,6 +132,12 @@ html#{$cadmin-selector} {
 				.sidebar-header {
 					top: 0;
 				}
+
+				.sidebar-section {
+					.nav {
+						border-bottom: 1px solid $cadmin-gray-300;
+					}
+				}
 			}
 		}
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/Categorization.tsx
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/Categorization.tsx
@@ -36,10 +36,7 @@ const Categorization = ({tags, vocabularies}: IProps): JSX.Element | null => {
 	}
 
 	return (
-		<CollapsibleSection
-			expanded
-			title={Liferay.Language.get('categorization')}
-		>
+		<>
 			{!!publicCategoriesCount && (
 				<ItemVocabularies
 					title={Liferay.Language.get('public-categories')}
@@ -49,18 +46,16 @@ const Categorization = ({tags, vocabularies}: IProps): JSX.Element | null => {
 
 			{!!internalCategoriesCount && (
 				<ItemVocabularies
-					cssClassNames="c-mt-4"
 					title={Liferay.Language.get('internal-categories')}
 					vocabularies={internalVocabularies}
 				/>
 			)}
 
 			{!!tags.length && (
-				<div className="c-mb-4 sidebar-section">
-					<h5 className="c-mb-1 font-weight-semi-bold">
-						{Liferay.Language.get('tags')}
-					</h5>
-
+				<CollapsibleSection
+					expanded
+					title={Liferay.Language.get('tags')}
+				>
 					<p>
 						{tags.map((tag) => (
 							<ClayLabel
@@ -73,9 +68,9 @@ const Categorization = ({tags, vocabularies}: IProps): JSX.Element | null => {
 							</ClayLabel>
 						))}
 					</p>
-				</div>
+				</CollapsibleSection>
 			)}
-		</CollapsibleSection>
+		</>
 	);
 };
 

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/CollapsibleSection.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/CollapsibleSection.js
@@ -8,15 +8,11 @@ import ClayPanel from '@clayui/panel';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-const SidebarPanelInfoCollapsibleSection = ({
-	children,
-	expanded = false,
-	title,
-}) => {
+const SidebarPanelInfoCollapsibleSection = ({children, title}) => {
 	return (
 		<ClayPanel
 			collapsable
-			defaultExpanded={expanded}
+			defaultExpanded
 			displayTitle={
 				<span className="c-inner" tabIndex="-1">
 					<ClayPanel.Title>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/CollapsibleSection.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/CollapsibleSection.js
@@ -11,6 +11,7 @@ import React from 'react';
 const SidebarPanelInfoCollapsibleSection = ({children, title}) => {
 	return (
 		<ClayPanel
+			className="c-mb-1"
 			collapsable
 			defaultExpanded
 			displayTitle={

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/DetailsContent.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/DetailsContent.js
@@ -46,7 +46,7 @@ const DetailsContent = ({
 				<Categorization tags={tags} vocabularies={vocabularies} />
 			</>
 
-			<CollapsibleSection title={Liferay.Language.get('details')}>
+			<CollapsibleSection title={Liferay.Language.get('properties')}>
 				<div className="sidebar-section">
 					<SpecificFields
 						fields={specificItems}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/DetailsContent.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/DetailsContent.js
@@ -6,7 +6,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import Categorization from './Categorization';
 import CollapsibleSection from './CollapsibleSection';
 import ItemLanguages from './ItemLanguages';
 import PreviewActionsDescriptionSection from './PreviewActionsDescriptionSection';
@@ -24,10 +23,8 @@ const DetailsContent = ({
 	modifiedDate,
 	preview,
 	specificFields,
-	tags = [],
 	title,
 	viewURLs = [],
-	vocabularies,
 }) => {
 	const specificItems = Object.values(specificFields);
 
@@ -42,8 +39,6 @@ const DetailsContent = ({
 					preview={preview}
 					title={title}
 				/>
-
-				<Categorization tags={tags} vocabularies={vocabularies} />
 			</>
 
 			<CollapsibleSection title={Liferay.Language.get('properties')}>

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/ItemVocabularies.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/ItemVocabularies.js
@@ -7,9 +7,10 @@ import ClayLabel from '@clayui/label';
 import PropTypes from 'prop-types';
 import React, {Fragment} from 'react';
 
+import CollapsibleSection from './CollapsibleSection';
 import {groupVocabulariesBy, sortByStrings} from './utils/taxonomiesUtils';
 
-const ItemVocabularies = ({cssClassNames = '', title, vocabularies}) => {
+const ItemVocabularies = ({title, vocabularies}) => {
 	const [global, nonGlobal] = groupVocabulariesBy({
 		array: vocabularies,
 		key: 'groupName',
@@ -25,13 +26,7 @@ const ItemVocabularies = ({cssClassNames = '', title, vocabularies}) => {
 	const groupedAndSortedVocabularies = nonGlobalSorted.concat(globalSorted);
 
 	return (
-		<div
-			className={`c-mb-4 item-vocabularies sidebar-section ${cssClassNames}`}
-		>
-			<h6 className="font-weight-semi-bold sidebar-section-subtitle-sm text-2 text-secondary text-uppercase">
-				{title}
-			</h6>
-
+		<CollapsibleSection expanded title={title}>
 			<div>
 				{groupedAndSortedVocabularies.map(
 					({categories, groupName, vocabularyName}) => (
@@ -60,7 +55,7 @@ const ItemVocabularies = ({cssClassNames = '', title, vocabularies}) => {
 					)
 				)}
 			</div>
-		</div>
+		</CollapsibleSection>
 	);
 };
 ItemVocabularies.defaultProps = {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/ItemVocabularies.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/ItemVocabularies.js
@@ -41,7 +41,7 @@ const ItemVocabularies = ({title, vocabularies}) => {
 								{sortByStrings({array: categories}).map(
 									(category) => (
 										<ClayLabel
-											className="c-mb-2 c-mr-2"
+											className="c-mr-2"
 											displayType="secondary"
 											key={category}
 											large

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/ItemVocabularies.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/ItemVocabularies.js
@@ -31,7 +31,7 @@ const ItemVocabularies = ({title, vocabularies}) => {
 				{groupedAndSortedVocabularies.map(
 					({categories, groupName, vocabularyName}) => (
 						<Fragment key={vocabularyName}>
-							<h5 className="c-mb-2 font-weight-semi-bold">
+							<h5 className="c-mb-2 font-weight-semi-bold vocabulary">
 								{vocabularyName}
 
 								{groupName ? ` (${groupName})` : ''}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -14,6 +14,7 @@ import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 
 import Sidebar from '../Sidebar';
+import Categorization from './Categorization';
 import DetailsContent from './DetailsContent';
 import ManageCollaborators from './ManageCollaborators';
 import Subscribe from './Subscribe';
@@ -139,40 +140,53 @@ const SidebarPanelInfoView = ({
 								</>
 							)}
 						</div>
-
-						<div className="mb-0 sidebar-section">
-							{showTabs && activeTabKeyValue !== null && (
-								<ClayTabs modern>
-									<ClayTabs.Item
-										active={activeTabKeyValue === 0}
-										innerProps={{
-											'aria-controls': 'details',
-										}}
-										onClick={() => setActiveTabKeyValue(0)}
-									>
-										{Liferay.Language.get('details')}
-									</ClayTabs.Item>
-
-									<ClayTabs.Item
-										active={activeTabKeyValue === 1}
-										innerProps={{
-											'aria-controls': 'versions',
-										}}
-										onClick={() => setActiveTabKeyValue(1)}
-									>
-										{Liferay.Language.get('versions')}
-									</ClayTabs.Item>
-								</ClayTabs>
-							)}
-						</div>
 					</div>
 				</ClayLayout.ContentRow>
 			</Sidebar.Header>
 
+			<div className="mb-0 sidebar-section">
+				{showTabs && activeTabKeyValue !== null && (
+					<ClayTabs modern>
+						<ClayTabs.Item
+							active={activeTabKeyValue === 0}
+							innerProps={{
+								'aria-controls': 'details',
+							}}
+							onClick={() => setActiveTabKeyValue(0)}
+						>
+							{Liferay.Language.get('details')}
+						</ClayTabs.Item>
+
+						<ClayTabs.Item
+							active={activeTabKeyValue === 1}
+							innerProps={{
+								'aria-controls': 'versions',
+							}}
+							onClick={() => setActiveTabKeyValue(1)}
+						>
+							{Liferay.Language.get('versions')}
+						</ClayTabs.Item>
+
+						<ClayTabs.Item
+							active={activeTabKeyValue === 2}
+							innerProps={{
+								'aria-controls': 'categorization',
+							}}
+							onClick={() => setActiveTabKeyValue(2)}
+						>
+							{Liferay.Language.get('categorization')}
+						</ClayTabs.Item>
+					</ClayTabs>
+				)}
+			</div>
+
 			<Sidebar.Body>
 				<div>
 					<ClayTabs.Content activeIndex={activeTabKeyValue} fade>
-						<ClayTabs.TabPane aria-labelledby="tab-1">
+						<ClayTabs.TabPane
+							aria-labelledby="tab-1"
+							className="flex-shrink-0"
+						>
 							<DetailsContent
 								classPK={classPK}
 								createDate={createDate}
@@ -183,20 +197,33 @@ const SidebarPanelInfoView = ({
 								modifiedDate={modifiedDate}
 								preview={preview}
 								specificFields={specificFields}
-								tags={tags}
 								title={title}
 								viewURLs={viewURLs}
-								vocabularies={vocabularies}
 							/>
 						</ClayTabs.TabPane>
 
-						{showTabs && (
-							<ClayTabs.TabPane aria-labelledby="tab-2">
+						{showTabs && activeTabKeyValue === 1 && (
+							<ClayTabs.TabPane
+								aria-labelledby="tab-2"
+								className="flex-shrink-0"
+							>
 								<VersionsContent
 									active={activeTabKeyValue === 1}
 									getItemVersionsURL={getItemVersionsURL}
 									languageTag={languageTag}
 									onError={handleError}
+								/>
+							</ClayTabs.TabPane>
+						)}
+
+						{showTabs && activeTabKeyValue === 2 && (
+							<ClayTabs.TabPane
+								aria-labelledby="tab-2"
+								className="flex-shrink-0"
+							>
+								<Categorization
+									tags={tags}
+									vocabularies={vocabularies}
 								/>
 							</ClayTabs.TabPane>
 						)}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -9,7 +9,7 @@ import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import ClaySticker from '@clayui/sticker';
 import ClayTabs from '@clayui/tabs';
-import classnames from 'classnames';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 
@@ -53,6 +53,9 @@ const SidebarPanelInfoView = ({
 	const handleError = useCallback(() => {
 		setError(true);
 	}, []);
+
+	const hasCategorization =
+		!!tags.length || !!Object.keys(vocabularies).length;
 
 	return (
 		<>
@@ -116,7 +119,7 @@ const SidebarPanelInfoView = ({
 							) : (
 								<>
 									<ClaySticker
-										className={classnames(
+										className={classNames(
 											'sticker-user-icon',
 											{
 												[`user-icon-color-${stickerColor}`]: !user.url,
@@ -147,7 +150,9 @@ const SidebarPanelInfoView = ({
 			<div className="c-mb-4 sidebar-section">
 				{showTabs && activeTabKeyValue !== null && (
 					<ClayTabs
-						className="flex-nowrap justify-content-center"
+						className={classNames('d-flex flex-nowrap', {
+							'justify-content-center': hasCategorization,
+						})}
 						modern
 					>
 						<ClayTabs.Item
@@ -161,26 +166,28 @@ const SidebarPanelInfoView = ({
 							{Liferay.Language.get('details')}
 						</ClayTabs.Item>
 
-						<ClayTabs.Item
-							active={activeTabKeyValue === 1}
-							className="flex-shrink-0"
-							innerProps={{
-								'aria-controls': 'versions',
-							}}
-							onClick={() => setActiveTabKeyValue(1)}
-						>
-							{Liferay.Language.get('versions')}
-						</ClayTabs.Item>
+						{hasCategorization && (
+							<ClayTabs.Item
+								active={activeTabKeyValue === 1}
+								className="flex-shrink-0"
+								innerProps={{
+									'aria-controls': 'categorization',
+								}}
+								onClick={() => setActiveTabKeyValue(1)}
+							>
+								{Liferay.Language.get('categorization')}
+							</ClayTabs.Item>
+						)}
 
 						<ClayTabs.Item
 							active={activeTabKeyValue === 2}
 							className="flex-shrink-0"
 							innerProps={{
-								'aria-controls': 'categorization',
+								'aria-controls': 'versions',
 							}}
 							onClick={() => setActiveTabKeyValue(2)}
 						>
-							{Liferay.Language.get('categorization')}
+							{Liferay.Language.get('versions')}
 						</ClayTabs.Item>
 					</ClayTabs>
 				)}
@@ -208,7 +215,21 @@ const SidebarPanelInfoView = ({
 							/>
 						</ClayTabs.TabPane>
 
-						{showTabs && activeTabKeyValue === 1 && (
+						{hasCategorization &&
+							showTabs &&
+							activeTabKeyValue === 1 && (
+								<ClayTabs.TabPane
+									aria-labelledby="tab-2"
+									className="flex-shrink-0"
+								>
+									<Categorization
+										tags={tags}
+										vocabularies={vocabularies}
+									/>
+								</ClayTabs.TabPane>
+							)}
+
+						{showTabs && activeTabKeyValue === 2 && (
 							<ClayTabs.TabPane
 								aria-labelledby="tab-2"
 								className="flex-shrink-0"
@@ -218,18 +239,6 @@ const SidebarPanelInfoView = ({
 									getItemVersionsURL={getItemVersionsURL}
 									languageTag={languageTag}
 									onError={handleError}
-								/>
-							</ClayTabs.TabPane>
-						)}
-
-						{showTabs && activeTabKeyValue === 2 && (
-							<ClayTabs.TabPane
-								aria-labelledby="tab-2"
-								className="flex-shrink-0"
-							>
-								<Categorization
-									tags={tags}
-									vocabularies={vocabularies}
 								/>
 							</ClayTabs.TabPane>
 						)}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -153,7 +153,7 @@ const SidebarPanelInfoView = ({
 				</ClayLayout.ContentRow>
 			</Sidebar.Header>
 
-			<div className="c-mb-4 sidebar-section">
+			<div className="c-mb-3 sidebar-section">
 				{showTabs && activeTabKeyValue !== null && (
 					<ClayTabs
 						className={classNames('d-flex flex-nowrap', {

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -105,7 +105,7 @@ const SidebarPanelInfoView = ({
 							))}
 						</div>
 
-						<div className="sidebar-section">
+						<div className="mb-1 sidebar-section">
 							{fetchSharingCollaboratorsURL ? (
 								<ManageCollaborators
 									fetchSharingCollaboratorsURL={
@@ -144,11 +144,15 @@ const SidebarPanelInfoView = ({
 				</ClayLayout.ContentRow>
 			</Sidebar.Header>
 
-			<div className="mb-0 sidebar-section">
+			<div className="c-mb-4 sidebar-section">
 				{showTabs && activeTabKeyValue !== null && (
-					<ClayTabs modern>
+					<ClayTabs
+						className="flex-nowrap justify-content-center"
+						modern
+					>
 						<ClayTabs.Item
 							active={activeTabKeyValue === 0}
+							className="flex-shrink-0"
 							innerProps={{
 								'aria-controls': 'details',
 							}}
@@ -159,6 +163,7 @@ const SidebarPanelInfoView = ({
 
 						<ClayTabs.Item
 							active={activeTabKeyValue === 1}
+							className="flex-shrink-0"
 							innerProps={{
 								'aria-controls': 'versions',
 							}}
@@ -169,6 +174,7 @@ const SidebarPanelInfoView = ({
 
 						<ClayTabs.Item
 							active={activeTabKeyValue === 2}
+							className="flex-shrink-0"
 							innerProps={{
 								'aria-controls': 'categorization',
 							}}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -20,6 +20,12 @@ import ManageCollaborators from './ManageCollaborators';
 import Subscribe from './Subscribe';
 import VersionsContent from './VersionsContent';
 
+const TABS = {
+	categorization: 1,
+	details: 0,
+	version: 2,
+};
+
 const SidebarPanelInfoView = ({
 	classPK,
 	createDate,
@@ -42,7 +48,7 @@ const SidebarPanelInfoView = ({
 	viewURLs = [],
 	vocabularies = {},
 }) => {
-	const [activeTabKeyValue, setActiveTabKeyValue] = useState(0);
+	const [activeTabKeyValue, setActiveTabKeyValue] = useState(TABS.details);
 
 	const showTabs = !!getItemVersionsURL;
 
@@ -156,36 +162,40 @@ const SidebarPanelInfoView = ({
 						modern
 					>
 						<ClayTabs.Item
-							active={activeTabKeyValue === 0}
+							active={activeTabKeyValue === TABS.details}
 							className="flex-shrink-0"
 							innerProps={{
 								'aria-controls': 'details',
 							}}
-							onClick={() => setActiveTabKeyValue(0)}
+							onClick={() => setActiveTabKeyValue(TABS.details)}
 						>
 							{Liferay.Language.get('details')}
 						</ClayTabs.Item>
 
 						{hasCategorization && (
 							<ClayTabs.Item
-								active={activeTabKeyValue === 1}
+								active={
+									activeTabKeyValue === TABS.categorization
+								}
 								className="flex-shrink-0"
 								innerProps={{
 									'aria-controls': 'categorization',
 								}}
-								onClick={() => setActiveTabKeyValue(1)}
+								onClick={() =>
+									setActiveTabKeyValue(TABS.categorization)
+								}
 							>
 								{Liferay.Language.get('categorization')}
 							</ClayTabs.Item>
 						)}
 
 						<ClayTabs.Item
-							active={activeTabKeyValue === 2}
+							active={activeTabKeyValue === TABS.version}
 							className="flex-shrink-0"
 							innerProps={{
 								'aria-controls': 'versions',
 							}}
-							onClick={() => setActiveTabKeyValue(2)}
+							onClick={() => setActiveTabKeyValue(TABS.version)}
 						>
 							{Liferay.Language.get('versions')}
 						</ClayTabs.Item>
@@ -217,7 +227,7 @@ const SidebarPanelInfoView = ({
 
 						{hasCategorization &&
 							showTabs &&
-							activeTabKeyValue === 1 && (
+							activeTabKeyValue === TABS.categorization && (
 								<ClayTabs.TabPane
 									aria-labelledby="tab-2"
 									className="flex-shrink-0"
@@ -229,13 +239,13 @@ const SidebarPanelInfoView = ({
 								</ClayTabs.TabPane>
 							)}
 
-						{showTabs && activeTabKeyValue === 2 && (
+						{showTabs && activeTabKeyValue === TABS.version && (
 							<ClayTabs.TabPane
 								aria-labelledby="tab-2"
 								className="flex-shrink-0"
 							>
 								<VersionsContent
-									active={activeTabKeyValue === 1}
+									active={activeTabKeyValue === TABS.version}
 									getItemVersionsURL={getItemVersionsURL}
 									languageTag={languageTag}
 									onError={handleError}

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/SidebarPanelInfoView.test.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/SidebarPanelInfoView.test.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {fireEvent, render, waitFor} from '@testing-library/react';
+import {render, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import '@testing-library/jest-dom/extend-expect';
@@ -86,7 +87,7 @@ describe('SidebarPanelInfoView', () => {
 		expect(getByText('38070')).toBeInTheDocument();
 
 		expect(getByText('categorization')).toBeInTheDocument();
-		expect(getByLabelText(/^(view Details)$/i)).toBeInTheDocument();
+		expect(getByLabelText(/^(view Properties)$/i)).toBeInTheDocument();
 	});
 
 	it('renders sidebar panel with proper dates for a basic web content', () => {
@@ -122,6 +123,8 @@ describe('SidebarPanelInfoView', () => {
 	it('renders sidebar panel with proper tags for a basic web content', () => {
 		const {getByText} = render(_getSidebarComponent(mockedProps));
 
+		userEvent.click(getByText('categorization'));
+
 		expect(getByText('tags')).toBeInTheDocument();
 		expect(getByText('tag1')).toBeInTheDocument();
 		expect(getByText('tag2')).toBeInTheDocument();
@@ -129,6 +132,8 @@ describe('SidebarPanelInfoView', () => {
 
 	it('renders sidebar panel with proper vocabularies and categories for a basic web content', () => {
 		const {getByText} = render(_getSidebarComponent(mockedProps));
+
+		userEvent.click(getByText('categorization'));
 
 		expect(getByText('public-categories')).toBeInTheDocument();
 		expect(getByText('internal-categories')).toBeInTheDocument();
@@ -183,22 +188,26 @@ describe('SidebarPanelInfoView', () => {
 	});
 
 	it('renders sidebar panel with vocabularies subtitles in the proper order for a basic web content', () => {
-		const {container} = render(_getSidebarComponent(mockedProps));
-
-		const subtitles = container.querySelectorAll(
-			'.item-vocabularies h6.sidebar-section-subtitle-sm'
+		const {container, getByText} = render(
+			_getSidebarComponent(mockedProps)
 		);
-		expect(subtitles.length).toBe(2);
-		expect(subtitles[0].textContent).toBe('public-categories');
-		expect(subtitles[1].textContent).toBe('internal-categories');
+
+		userEvent.click(getByText('categorization'));
+
+		const subtitles = container.querySelectorAll('.panel-header');
+		expect(subtitles.length).toBe(4);
+		expect(subtitles[1].textContent).toBe('public-categories');
+		expect(subtitles[2].textContent).toBe('internal-categories');
 	});
 
 	it('renders sidebar panel with vocabularies names grouped and sorted for a basic web content', () => {
-		const {container} = render(_getSidebarComponent(mockedProps));
-
-		const vocabularies = container.querySelectorAll(
-			'.item-vocabularies h5.font-weight-semi-bold'
+		const {container, getByText} = render(
+			_getSidebarComponent(mockedProps)
 		);
+
+		userEvent.click(getByText('categorization'));
+
+		const vocabularies = container.querySelectorAll('.vocabulary');
 		expect(vocabularies.length).toBe(
 			Object.keys(mockedProps.vocabularies).length
 		);
@@ -518,15 +527,7 @@ describe('SidebarPanelInfoView', () => {
 			})
 		);
 
-		const button = getByTitle('Subscribe');
-
-		fireEvent(
-			button,
-			new MouseEvent('click', {
-				bubbles: true,
-				cancelable: true,
-			})
-		);
+		userEvent.click(getByTitle('Subscribe'));
 
 		await waitFor(() =>
 			expect(fetch).toHaveBeenCalledWith(mockedProps.subscribe.url)
@@ -555,15 +556,7 @@ describe('SidebarPanelInfoView', () => {
 			})
 		);
 
-		const button = getByTitle('Subscribe');
-
-		fireEvent(
-			button,
-			new MouseEvent('click', {
-				bubbles: true,
-				cancelable: true,
-			})
-		);
+		userEvent.click(getByTitle('Subscribe'));
 
 		expect(fetch).toHaveBeenCalledWith(mockedProps.subscribe.url);
 		await waitFor(() =>
@@ -606,7 +599,8 @@ describe('SidebarPanelInfoView', () => {
 		const tabs = getAllByRole('tab');
 
 		expect(tabs[0].innerHTML).toContain('details');
-		expect(tabs[1].innerHTML).toContain('versions');
+		expect(tabs[1].innerHTML).toContain('categorization');
+		expect(tabs[2].innerHTML).toContain('versions');
 	});
 
 	it('renders Details tab active by default', () => {

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/__snapshots__/SidebarPanelInfoView.test.js.snap
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/__snapshots__/SidebarPanelInfoView.test.js.snap
@@ -123,7 +123,7 @@ exports[`SidebarPanelInfoView renders 1`] = `
               </div>
             </div>
             <div
-              class="sidebar-section"
+              class="mb-1 sidebar-section"
             >
               <span
                 class="sticker sticker-user-icon user-icon-color-6 sticker-circle"
@@ -147,12 +147,63 @@ exports[`SidebarPanelInfoView renders 1`] = `
                 Kate Williams
               </span>
             </div>
-            <div
-              class="mb-0 sidebar-section"
-            />
           </div>
         </div>
       </section>
+      <div
+        class="c-mb-3 sidebar-section"
+      >
+        <ul
+          class="nav nav-tabs d-flex flex-nowrap justify-content-center"
+          role="tablist"
+        >
+          <li
+            class="nav-item flex-shrink-0"
+            role="none"
+          >
+            <button
+              aria-controls="details"
+              aria-selected="true"
+              class="nav-link active btn btn-unstyled"
+              role="tab"
+              tabindex="0"
+              type="button"
+            >
+              details
+            </button>
+          </li>
+          <li
+            class="nav-item flex-shrink-0"
+            role="none"
+          >
+            <button
+              aria-controls="categorization"
+              aria-selected="false"
+              class="nav-link btn btn-unstyled"
+              role="tab"
+              tabindex="-1"
+              type="button"
+            >
+              categorization
+            </button>
+          </li>
+          <li
+            class="nav-item flex-shrink-0"
+            role="none"
+          >
+            <button
+              aria-controls="versions"
+              aria-selected="false"
+              class="nav-link btn btn-unstyled"
+              role="tab"
+              tabindex="-1"
+              type="button"
+            >
+              versions
+            </button>
+          </li>
+        </ul>
+      </div>
       <div
         class="sidebar-body"
       >
@@ -162,12 +213,12 @@ exports[`SidebarPanelInfoView renders 1`] = `
           >
             <div
               aria-labelledby="tab-1"
-              class="tab-pane active fade show"
+              class="tab-pane active fade show flex-shrink-0"
               role="tabpanel"
               tabindex="0"
             >
               <div
-                class="panel panel-unstyled"
+                class="panel c-mb-1 panel-unstyled"
                 role="tablist"
               >
                 <button
@@ -188,9 +239,9 @@ exports[`SidebarPanelInfoView renders 1`] = `
                           class="align-self-center panel-title autofit-col autofit-col-expand"
                         >
                           <span
-                            aria-label="view categorization"
+                            aria-label="view properties"
                           >
-                            categorization
+                            properties
                           </span>
                         </div>
                       </div>
@@ -223,829 +274,6 @@ exports[`SidebarPanelInfoView renders 1`] = `
                 </button>
                 <div
                   class="panel-collapse"
-                  role="tabpanel"
-                >
-                  <div
-                    class="panel-body"
-                  >
-                    <div
-                      class="c-mb-4 item-vocabularies sidebar-section "
-                    >
-                      <h6
-                        class="font-weight-semi-bold sidebar-section-subtitle-sm text-2 text-secondary text-uppercase"
-                      >
-                        public-categories
-                      </h6>
-                      <div>
-                        <h5
-                          class="c-mb-2 font-weight-semi-bold"
-                        >
-                          AA Another Fake vocabulary (Liferay)
-                        </h5>
-                        <p>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Another Fake 1
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Another Fake 2
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Another Fake 3
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Another Fake 4
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Another Fake 5
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Another Fake 6
-                            </span>
-                          </span>
-                        </p>
-                        <h5
-                          class="c-mb-2 font-weight-semi-bold"
-                        >
-                          Clothes (Demo Site)
-                        </h5>
-                        <p>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Clothe 1
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Clothe 2
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Clothe 3
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Clothe 4
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Clothe 5
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Clothe 6
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Clothe 7
-                            </span>
-                          </span>
-                        </p>
-                        <h5
-                          class="c-mb-2 font-weight-semi-bold"
-                        >
-                          Developers (Liferay)
-                        </h5>
-                        <p>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Backend
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Data Scientist
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Design
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Devops
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Frontend
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              QA
-                            </span>
-                          </span>
-                        </p>
-                        <h5
-                          class="c-mb-2 font-weight-semi-bold"
-                        >
-                          Travel (Demo Site)
-                        </h5>
-                        <p>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Travel 1
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Travel 2
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Travel 3
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Travel 4
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Travel 5
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Travel 6
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Travel 7
-                            </span>
-                          </span>
-                        </p>
-                        <h5
-                          class="c-mb-2 font-weight-semi-bold"
-                        >
-                          ZZ Fake vocabulary (Liferay)
-                        </h5>
-                        <p>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Fake 1
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Fake 2
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Fake 3
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Fake 4
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Fake 5
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Fake 6
-                            </span>
-                          </span>
-                        </p>
-                        <h5
-                          class="c-mb-2 font-weight-semi-bold"
-                        >
-                          AA Another Global Random Vocabulary (Global)
-                        </h5>
-                        <p>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Another Global Random 1
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Another Global Random 2
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Another Global Random 3
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Another Global Random 4
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Another Global Random 5
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Another Global Random 6
-                            </span>
-                          </span>
-                        </p>
-                        <h5
-                          class="c-mb-2 font-weight-semi-bold"
-                        >
-                          Foods (Global)
-                        </h5>
-                        <p>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Chinese
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Indian
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Italian
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Mexican
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Spanish
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Thai
-                            </span>
-                          </span>
-                        </p>
-                        <h5
-                          class="c-mb-2 font-weight-semi-bold"
-                        >
-                          Topic (Global)
-                        </h5>
-                        <p>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Topic 1
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Topic 2
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Topic 3
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Topic 4
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Topic 5
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Topic 6
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Topic 7
-                            </span>
-                          </span>
-                        </p>
-                        <h5
-                          class="c-mb-2 font-weight-semi-bold"
-                        >
-                          ZZ Global Random Vocabulary (Global)
-                        </h5>
-                        <p>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Global Random 1
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Global Random 2
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Global Random 3
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Global Random 4
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Global Random 5
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Global Random 6
-                            </span>
-                          </span>
-                        </p>
-                      </div>
-                    </div>
-                    <div
-                      class="c-mb-4 item-vocabularies sidebar-section c-mt-4"
-                    >
-                      <h6
-                        class="font-weight-semi-bold sidebar-section-subtitle-sm text-2 text-secondary text-uppercase"
-                      >
-                        internal-categories
-                      </h6>
-                      <div>
-                        <h5
-                          class="c-mb-2 font-weight-semi-bold"
-                        >
-                          Internal categorization (Liferay)
-                        </h5>
-                        <p>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Internal 1
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Internal 2
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Internal 3
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Internal 4
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Internal 5
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Internal 6
-                            </span>
-                          </span>
-                        </p>
-                        <h5
-                          class="c-mb-2 font-weight-semi-bold"
-                        >
-                          Private Stuff (Demo Site)
-                        </h5>
-                        <p>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Private Stuff 1
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Private Stuff 2
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Private Stuff 3
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Private Stuff 4
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Private Stuff 5
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Private Stuff 6
-                            </span>
-                          </span>
-                          <span
-                            class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                          >
-                            <span
-                              class="label-item label-item-expand"
-                            >
-                              Private Stuff 7
-                            </span>
-                          </span>
-                        </p>
-                      </div>
-                    </div>
-                    <div
-                      class="c-mb-4 sidebar-section"
-                    >
-                      <h5
-                        class="c-mb-1 font-weight-semi-bold"
-                      >
-                        tags
-                      </h5>
-                      <p>
-                        <span
-                          class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                        >
-                          <span
-                            class="label-item label-item-expand"
-                          >
-                            tag1
-                          </span>
-                        </span>
-                        <span
-                          class="label c-mb-2 c-mr-2 label-lg label-secondary"
-                        >
-                          <span
-                            class="label-item label-item-expand"
-                          >
-                            tag2
-                          </span>
-                        </span>
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div
-                class="panel panel-unstyled"
-                role="tablist"
-              >
-                <button
-                  aria-expanded="false"
-                  class="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
-                  role="tab"
-                  type="button"
-                >
-                  <span
-                    class="c-inner"
-                    tabindex="-1"
-                  >
-                    <div>
-                      <div
-                        class="autofit-row"
-                      >
-                        <div
-                          class="align-self-center panel-title autofit-col autofit-col-expand"
-                        >
-                          <span
-                            aria-label="view details"
-                          >
-                            details
-                          </span>
-                        </div>
-                      </div>
-                    </div>
-                  </span>
-                  <span
-                    class="collapse-icon-closed"
-                  >
-                    <svg
-                      class="lexicon-icon lexicon-icon-angle-right"
-                      role="presentation"
-                    >
-                      <use
-                        xlink:href="#angle-right"
-                      />
-                    </svg>
-                  </span>
-                  <span
-                    class="collapse-icon-open"
-                  >
-                    <svg
-                      class="lexicon-icon lexicon-icon-angle-down"
-                      role="presentation"
-                    >
-                      <use
-                        xlink:href="#angle-down"
-                      />
-                    </svg>
-                  </span>
-                </button>
-                <div
-                  class="panel-collapse collapse"
                   role="tabpanel"
                 >
                   <div

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/mocks/props.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/mocks/props.js
@@ -185,6 +185,8 @@ export const mockedProps = {
 	],
 	classPK: '38070',
 	createDate: '2020-07-27T10:50:55.19',
+	getItemVersionsURL:
+		'http://localhost:8080/group/guest/p_p_id=com_liferay_content_dashboard_web_portlet_ContentDashboardAdminPortlet&p_p_lifecycle=2&p_p_state=maximized&p_p_mode=view&p_p_resource_id=%2Fcontent_dashboard%2Fget_content_dashboard_item_versions',
 	languageTag: 'en',
 	latestVersions: [
 		{

--- a/portal-web/test/functional/com/liferay/portalweb/macros/ContentDashboard.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/ContentDashboard.macro
@@ -519,7 +519,7 @@ definition {
 	}
 
 	macro viewAssetsTranslatedVersion {
-		Panel.expandPanel(panel = "Details");
+		Panel.expandPanel(panel = "Properties");
 
 		ClickNoError(
 			key_language = ${language},


### PR DESCRIPTION
# **Motivation**
The motivation behind this ticket is to improve Content Dashboard info panels UI experience.
https://liferay.atlassian.net/browse/LPS-164349
https://liferay.atlassian.net/browse/LPS-164348

# **Proposed Solution**
What I did to solve this problem is to change the Details key name to Properties in one of the info panels section and make that section expanded by default when the info panel is open. Also I moved the Categorization section to a new tab by using a new ClayTab.Item and ClayTab.Content when the item has linked vocabularies or tags.

# **Steps to Verify**
2. Create some tags and vocabularies.
3. Create a Display Page Template for web contents.
4. Create a web content and add the tag and vocabularies to it and also attach it to the DPT created.
5. Go to the Content Dashboard.
6. Hover over the web content created and click on the info button in the right side
7. When the info panel is opened, check that the item contains three tabs and all work correctly
8. Also, check the same with some item that hasn't has categories