### PR TITLE
LPS-192060 Rename layoutReportsTabsURL and segmentExperienceSelectorData

### DIFF
--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/product/navigation/control/menu/LayoutReportsProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/product/navigation/control/menu/LayoutReportsProductNavigationControlMenuEntry.java
@@ -343,7 +343,7 @@ public class LayoutReportsProductNavigationControlMenuEntry
 							(ThemeDisplay)httpServletRequest.getAttribute(
 								WebKeys.THEME_DISPLAY);
 
-						if (!FeatureFlagManagerUtil.isEnabled("LPS-187284")) {
+						if (FeatureFlagManagerUtil.isEnabled("LPS-187284")) {
 							return HttpComponentsUtil.addParameters(
 								StringBundler.concat(
 									themeDisplay.getPortalURL(),
@@ -354,9 +354,10 @@ public class LayoutReportsProductNavigationControlMenuEntry
 						}
 
 						return HttpComponentsUtil.addParameters(
-							themeDisplay.getPortalURL() +
-								themeDisplay.getPathMain() +
-									"/layout_reports/get_layout_reports_tabs",
+							StringBundler.concat(
+								themeDisplay.getPortalURL(),
+								themeDisplay.getPathMain(), "/layout_reports",
+								"/get_google_page_speed_data"),
 							"p_l_id", themeDisplay.getPlid());
 					}
 				).build(),

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/product/navigation/control/menu/LayoutReportsProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/product/navigation/control/menu/LayoutReportsProductNavigationControlMenuEntry.java
@@ -331,13 +331,7 @@ public class LayoutReportsProductNavigationControlMenuEntry
 						ProductNavigationControlMenuEntryConstants.
 							SESSION_CLICKS_KEY)
 				).put(
-					() -> {
-						if (!FeatureFlagManagerUtil.isEnabled("LPS-187284")) {
-							return "layoutReportsDataURL";
-						}
-
-						return "layoutReportsTabsURL";
-					},
+					"layoutReportsDataURL",
 					() -> {
 						ThemeDisplay themeDisplay =
 							(ThemeDisplay)httpServletRequest.getAttribute(

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/product/navigation/control/menu/LayoutReportsProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/product/navigation/control/menu/LayoutReportsProductNavigationControlMenuEntry.java
@@ -338,13 +338,27 @@ public class LayoutReportsProductNavigationControlMenuEntry
 								WebKeys.THEME_DISPLAY);
 
 						if (FeatureFlagManagerUtil.isEnabled("LPS-187284")) {
-							return HttpComponentsUtil.addParameters(
-								StringBundler.concat(
-									themeDisplay.getPortalURL(),
-									themeDisplay.getPathMain(),
-									"/layout_reports",
-									"/get_layout_reports_data"),
-								"p_l_id", themeDisplay.getPlid());
+							String layoutReportsDataURL =
+								HttpComponentsUtil.addParameters(
+									StringBundler.concat(
+										themeDisplay.getPortalURL(),
+										themeDisplay.getPathMain(),
+										"/layout_reports",
+										"/get_layout_reports_data"),
+									"p_l_id", themeDisplay.getPlid());
+
+							long segmentsExperienceId = ParamUtil.getLong(
+								_portal.getOriginalServletRequest(
+									httpServletRequest),
+								"segmentsExperienceId", -1);
+
+							if (segmentsExperienceId == -1) {
+								return layoutReportsDataURL;
+							}
+
+							return HttpComponentsUtil.addParameter(
+								layoutReportsDataURL, "segmentsExperienceId",
+								segmentsExperienceId);
 						}
 
 						return HttpComponentsUtil.addParameters(

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportDataStrutsAction.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportDataStrutsAction.java
@@ -29,10 +29,10 @@ import org.osgi.service.component.annotations.Reference;
  * @author Mikel Lorza
  */
 @Component(
-	property = "path=/layout_reports/get_layout_reports_tabs",
+	property = "path=/layout_reports/get_layout_reports_data",
 	service = StrutsAction.class
 )
-public class GetLayoutReportTabsStrutsAction implements StrutsAction {
+public class GetLayoutReportDataStrutsAction implements StrutsAction {
 
 	@Override
 	public String execute(

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportDataStrutsAction.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportDataStrutsAction.java
@@ -6,10 +6,14 @@
 package com.liferay.layout.reports.web.internal.struts;
 
 import com.liferay.layout.reports.web.internal.configuration.provider.LayoutReportsGooglePageSpeedConfigurationProvider;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
 import com.liferay.portal.kernel.struts.StrutsAction;
@@ -18,6 +22,18 @@ import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.segments.constants.SegmentsEntryConstants;
+import com.liferay.segments.manager.SegmentsExperienceManager;
+import com.liferay.segments.model.SegmentsEntry;
+import com.liferay.segments.model.SegmentsExperience;
+import com.liferay.segments.model.SegmentsExperiment;
+import com.liferay.segments.model.SegmentsExperimentRel;
+import com.liferay.segments.service.SegmentsEntryLocalService;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
+import com.liferay.segments.service.SegmentsExperimentLocalService;
+import com.liferay.segments.service.SegmentsExperimentRelLocalService;
+
+import java.util.List;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -94,15 +110,256 @@ public class GetLayoutReportDataStrutsAction implements StrutsAction {
 					HttpComponentsUtil.addParameter(
 						themeDisplay.getPortalURL() +
 							themeDisplay.getPathMain() +
-								"/layout_reports/get_layout_reports_data",
+								"/layout_reports/get_google_page_speed_data",
 						"p_l_id", themeDisplay.getPlid())
 				));
 		}
 
-		ServletResponseUtil.write(httpServletResponse, jsonArray.toString());
+		ServletResponseUtil.write(
+			httpServletResponse,
+			JSONUtil.put(
+				"segmentsExperienceSelectorData",
+				JSONUtil.put(
+					"segmentsExperiences",
+					_getSegmentsExperiencesJSONArray(themeDisplay)
+				).put(
+					"selectedSegmentsExperience",
+					_getSegmentsExperienceSelectedJSONObject(
+						httpServletRequest, themeDisplay)
+				)
+			).put(
+				"tabsData", jsonArray
+			).toString());
 
 		return null;
 	}
+
+	private SegmentsExperience _fetchSegmentsExperienceFromRequest(
+		HttpServletRequest httpServletRequest) {
+
+		long segmentsExperienceId = ParamUtil.getLong(
+			httpServletRequest, "segmentsExperienceId", -1);
+
+		if (segmentsExperienceId == -1) {
+			SegmentsExperienceManager segmentsExperienceManager =
+				new SegmentsExperienceManager(_segmentsExperienceLocalService);
+
+			segmentsExperienceId =
+				segmentsExperienceManager.getSegmentsExperienceId(
+					httpServletRequest);
+		}
+
+		return _segmentsExperienceLocalService.fetchSegmentsExperience(
+			segmentsExperienceId);
+	}
+
+	private SegmentsExperience _getParentSegmentsExperience(
+		SegmentsExperience segmentsExperience) {
+
+		List<SegmentsExperimentRel> segmentsExperimentRels =
+			_segmentsExperimentRelLocalService.
+				getSegmentsExperimentRelsBySegmentsExperienceId(
+					segmentsExperience.getSegmentsExperienceId());
+
+		if (segmentsExperimentRels.isEmpty()) {
+			return null;
+		}
+
+		SegmentsExperimentRel segmentsExperimentRel =
+			segmentsExperimentRels.get(0);
+
+		try {
+			SegmentsExperiment segmentsExperiment =
+				_segmentsExperimentLocalService.getSegmentsExperiment(
+					segmentsExperimentRel.getSegmentsExperimentId());
+
+			return _segmentsExperienceLocalService.getSegmentsExperience(
+				segmentsExperiment.getSegmentsExperienceId());
+		}
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
+
+		return null;
+	}
+
+	private JSONObject _getSegmentsExperienceJSONObject(
+			long segmentsExperienceId, ThemeDisplay themeDisplay)
+		throws Exception {
+
+		JSONArray segmentsExperiencesJSONArray =
+			_getSegmentsExperiencesJSONArray(themeDisplay);
+
+		for (int i = 0; i < segmentsExperiencesJSONArray.length(); i++) {
+			JSONObject segmentsExperiencesJSONObject =
+				segmentsExperiencesJSONArray.getJSONObject(i);
+
+			if (segmentsExperienceId == segmentsExperiencesJSONObject.getLong(
+					"segmentsExperienceId")) {
+
+				return segmentsExperiencesJSONObject;
+			}
+		}
+
+		return _jsonFactory.createJSONObject();
+	}
+
+	private JSONObject _getSegmentsExperienceJSONObject(
+			SegmentsExperience segmentsExperience,
+			List<SegmentsExperience> segmentsExperiences,
+			ThemeDisplay themeDisplay)
+		throws Exception {
+
+		boolean segmentsExperienceIsActive = _isActive(
+			segmentsExperience, segmentsExperiences);
+
+		return JSONUtil.put(
+			"active", segmentsExperienceIsActive
+		).put(
+			"segmentsEntryId", segmentsExperience.getSegmentsEntryId()
+		).put(
+			"segmentsEntryName",
+			() -> {
+				SegmentsEntry segmentsEntry =
+					_segmentsEntryLocalService.fetchSegmentsEntry(
+						segmentsExperience.getSegmentsEntryId());
+
+				if (segmentsEntry != null) {
+					return segmentsEntry.getName(themeDisplay.getLocale());
+				}
+
+				return SegmentsEntryConstants.getDefaultSegmentsEntryName(
+					themeDisplay.getLocale());
+			}
+		).put(
+			"segmentsExperienceId", segmentsExperience.getSegmentsExperienceId()
+		).put(
+			"segmentsExperienceName",
+			segmentsExperience.getName(themeDisplay.getLocale())
+		).put(
+			"statusLabel",
+			() -> {
+				String statusLabelKey = "inactive";
+
+				if (segmentsExperienceIsActive) {
+					statusLabelKey = "active";
+				}
+
+				return _language.get(themeDisplay.getLocale(), statusLabelKey);
+			}
+		).put(
+			"url",
+			HttpComponentsUtil.setParameter(
+				_portal.getLayoutURL(themeDisplay), "segmentsExperienceId",
+				segmentsExperience.getSegmentsExperienceId())
+		);
+	}
+
+	private JSONObject _getSegmentsExperienceSelectedJSONObject(
+			HttpServletRequest httpServletRequest, ThemeDisplay themeDisplay)
+		throws Exception {
+
+		SegmentsExperience segmentsExperience =
+			_fetchSegmentsExperienceFromRequest(httpServletRequest);
+
+		long plid = themeDisplay.getPlid();
+
+		Layout layout = themeDisplay.getLayout();
+
+		if (layout.isDraftLayout()) {
+			plid = layout.getClassPK();
+		}
+
+		if ((segmentsExperience == null) ||
+			(segmentsExperience.getPlid() != plid)) {
+
+			long defaultSegmentsExperienceId =
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(plid);
+
+			segmentsExperience =
+				_segmentsExperienceLocalService.fetchSegmentsExperience(
+					defaultSegmentsExperienceId);
+		}
+
+		if (segmentsExperience != null) {
+			JSONObject segmentsExperienceSelectedJSONObject =
+				_getSegmentsExperienceJSONObject(
+					segmentsExperience.getSegmentsExperienceId(), themeDisplay);
+
+			segmentsExperienceSelectedJSONObject.put(
+				"segmentsExperienceName",
+				_getSelectedSegmentsExperienceName(
+					segmentsExperience, themeDisplay));
+
+			return segmentsExperienceSelectedJSONObject;
+		}
+
+		return _jsonFactory.createJSONObject();
+	}
+
+	private JSONArray _getSegmentsExperiencesJSONArray(
+			ThemeDisplay themeDisplay)
+		throws Exception {
+
+		JSONArray segmentsExperiencesJSONArray = _jsonFactory.createJSONArray();
+
+		List<SegmentsExperience> segmentsExperiences =
+			_segmentsExperienceLocalService.getSegmentsExperiences(
+				themeDisplay.getScopeGroupId(), themeDisplay.getPlid(), true);
+
+		for (SegmentsExperience segmentsExperience : segmentsExperiences) {
+			segmentsExperiencesJSONArray.put(
+				_getSegmentsExperienceJSONObject(
+					segmentsExperience, segmentsExperiences, themeDisplay));
+		}
+
+		return segmentsExperiencesJSONArray;
+	}
+
+	private String _getSelectedSegmentsExperienceName(
+		SegmentsExperience segmentsExperience, ThemeDisplay themeDisplay) {
+
+		SegmentsExperience parentSegmentsExperience =
+			_getParentSegmentsExperience(segmentsExperience);
+
+		if (parentSegmentsExperience != null) {
+			segmentsExperience = parentSegmentsExperience;
+		}
+
+		if (segmentsExperience != null) {
+			return segmentsExperience.getName(themeDisplay.getLocale());
+		}
+
+		return SegmentsEntryConstants.getDefaultSegmentsEntryName(
+			themeDisplay.getLocale());
+	}
+
+	private boolean _isActive(
+		SegmentsExperience segmentsExperience,
+		List<SegmentsExperience> segmentsExperiences) {
+
+		for (SegmentsExperience curSegmentsExperience : segmentsExperiences) {
+			if ((curSegmentsExperience.getSegmentsEntryId() ==
+					segmentsExperience.getSegmentsEntryId()) ||
+				(curSegmentsExperience.getSegmentsEntryId() ==
+					SegmentsEntryConstants.ID_DEFAULT)) {
+
+				if (curSegmentsExperience.getSegmentsExperienceId() ==
+						segmentsExperience.getSegmentsExperienceId()) {
+
+					return true;
+				}
+
+				return false;
+			}
+		}
+
+		return false;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		GetLayoutReportDataStrutsAction.class);
 
 	@Reference
 	private JSONFactory _jsonFactory;
@@ -116,5 +373,18 @@ public class GetLayoutReportDataStrutsAction implements StrutsAction {
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private SegmentsEntryLocalService _segmentsEntryLocalService;
+
+	@Reference
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
+
+	@Reference
+	private SegmentsExperimentLocalService _segmentsExperimentLocalService;
+
+	@Reference
+	private SegmentsExperimentRelLocalService
+		_segmentsExperimentRelLocalService;
 
 }

--- a/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportsGooglePageSpeedDataStrutsAction.java
+++ b/modules/apps/layout/layout-reports-web/src/main/java/com/liferay/layout/reports/web/internal/struts/GetLayoutReportsGooglePageSpeedDataStrutsAction.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -64,10 +64,11 @@ import org.osgi.service.component.annotations.Reference;
  * @author Alejandro Tardín
  */
 @Component(
-	property = "path=/layout_reports/get_layout_reports_data",
+	property = "path=/layout_reports/get_google_page_speed_data",
 	service = StrutsAction.class
 )
-public class GetLayoutReportsDataStrutsAction implements StrutsAction {
+public class GetLayoutReportsGooglePageSpeedDataStrutsAction
+	implements StrutsAction {
 
 	@Override
 	public String execute(
@@ -359,7 +360,7 @@ public class GetLayoutReportsDataStrutsAction implements StrutsAction {
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(
-		GetLayoutReportsDataStrutsAction.class);
+		GetLayoutReportsGooglePageSpeedDataStrutsAction.class);
 
 	@Reference
 	private GroupLocalService _groupLocalService;

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/PageAudit.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/PageAudit.js
@@ -18,27 +18,31 @@ import './PageAudit.scss';
 
 export default function PageAudit({panelIsOpen}) {
 	const [data, setData] = useState({});
-	const {layoutReportsTabsURL} = useContext(ConstantsContext);
+	const {layoutReportsDataURL} = useContext(ConstantsContext);
 
 	useEffect(() => {
-		if (panelIsOpen && layoutReportsTabsURL) {
-			fetch(layoutReportsTabsURL, {method: 'GET'})
+		if (panelIsOpen && layoutReportsDataURL) {
+			fetch(layoutReportsDataURL, {method: 'GET'})
 				.then((response) => response.json())
 				.then((data) => setData(data))
 				.catch((error) => console.error(error));
 		}
-	}, [layoutReportsTabsURL, panelIsOpen]);
+	}, [layoutReportsDataURL, panelIsOpen]);
 
-	if (!data.tabsData || !data.segmentExperienceSelectorData) {
+	if (!data.tabsData || !data.segmentsExperienceSelectorData) {
 		return null;
 	}
 
+	const pageSpeedData = data.tabsData.find(
+		({id}) => id === 'page-speed-insights'
+	);
+
 	return (
 		<PageAuditBody
-			segments={data.segmentExperienceSelectorData}
+			segments={data.segmentsExperienceSelectorData}
 			tabs={data.tabsData}
 		>
-			<LayoutReports />
+			<LayoutReports url={pageSpeedData.url} />
 		</PageAuditBody>
 	);
 }

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3611,6 +3611,7 @@
         /image_gallery_display/find_folder,\
         /image_gallery_display/find_image,\
         \
+        /layout_reports/get_google_page_speed_data,\
         /layout_reports/get_layout_reports_data,\
         /layout_reports/get_layout_reports_issues,\
         /layout_reports/get_render_times_data,\

--- a/portal-impl/src/portal.properties
+++ b/portal-impl/src/portal.properties
@@ -3613,7 +3613,6 @@
         \
         /layout_reports/get_layout_reports_data,\
         /layout_reports/get_layout_reports_issues,\
-        /layout_reports/get_layout_reports_tabs,\
         /layout_reports/get_render_times_data,\
         \
         /login/facebook_connect_oauth,\


### PR DESCRIPTION
Just review the last commit 2666c5a471775b104bac7cc11fb3f681068deff1. This PR is part of https://github.com/liferay-echo/liferay-portal/pull/13114

**How to test?**
- The Page Speed Insight tab in Page Audit panel has to work perfectly.