### PR TITLE
LPS-190012 Replace aui:button with clay:button in site-memberships-web

### DIFF
--- a/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/reply_membership_request.jsp
+++ b/modules/apps/site/site-memberships-web/src/main/resources/META-INF/resources/reply_membership_request.jsp
@@ -85,8 +85,13 @@ renderResponse.setTitle(LanguageUtil.format(request, "reply-membership-request-f
 	</div>
 
 	<aui:button-row>
-		<aui:button type="submit" />
+		<clay:button label="save" type="submit"></clay:button>
 
-		<aui:button href="<%= redirect %>" type="cancel" />
+		<clay:link
+			displayType="secondary"
+			href="<%= redirect %>"
+			label="cancel"
+			type="button"
+		/>
 	</aui:button-row>
 </aui:form>


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-190012)


## Test Scenario
- Go to Contro Panel > Sites > Create a Site “test”
- Go to “test” > Configuration > Site Settings 
- Go to Site Configuration > Membership Type > Restricted
- Go to Control Panel > Users > Create a new user “user1”
- Impersonate “user1” clicking on three dots at the right
- Go to “user1” User Profile Menu > My Dashboard 
- Go to Available Sites tab
- Click on three dots at right of “test” > Request membership
- Go back to “test” with the main user 
- Go to Product Menu > People > Memberships
- Click on three dots upper right > View Membership Requests 
- Reply Membership of “user1”
- See buttons
<img width="565" alt="Screenshot 2023-08-14 at 16 29 01" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/4bdc55a8-9a70-483a-a38b-f51a531de02e">


