### PR TITLE
LPS-193605 The breadcrumb is different between document and web content

### DIFF
--- a/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/trash/BaseBookmarksTrashHandler.java
+++ b/modules/apps/bookmarks/bookmarks-web/src/main/java/com/liferay/bookmarks/web/internal/trash/BaseBookmarksTrashHandler.java
@@ -95,7 +95,7 @@ public abstract class BaseBookmarksTrashHandler extends BaseTrashHandler {
 
 	@Override
 	public String getRootContainerModelName() {
-		return "folder";
+		return "home";
 	}
 
 	@Override

--- a/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/trash/BaseDLTrashHandler.java
+++ b/modules/apps/document-library/document-library-service/src/main/java/com/liferay/document/library/internal/trash/BaseDLTrashHandler.java
@@ -114,7 +114,7 @@ public abstract class BaseDLTrashHandler extends BaseTrashHandler {
 
 	@Override
 	public String getRootContainerModelName() {
-		return "folder";
+		return "home";
 	}
 
 	@Override


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-193605)

Fix the folder label in breadcrumb and footer button for documents and media and bookmarks.

## Proposed solution

Replace “folder” label with “home” label.

## Test Scenario 1

1. Add a folder in Documents and Media
2. Add a document inside folder
3. Remove the folder to recycle bin
4. Navigate to the Recycle Bin
5. Go to the folder
6. Restore the document

<img width="588" alt="Pasted Graphic 2" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/4da15446-36bc-4dc9-b4a9-2a79ebc0655a">

## Test Scenario 2

1. Add a folder in bookmarks
2. Add a bookmark inside folder
3. Remove the folder to recycle bin
4. Navigate to the Recycle Bin
5. Go to the folder
6. Restore the bookmark

<img width="585" alt="Pasted Graphic 1" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/cbc9858f-bd46-4158-8c50-781f8c59dfeb">
