### PR TITLE
LPS-193454 Add Separators to the dropdown

### DIFF
--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/util/SegmentsEntryActionDropdownItemsProvider.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/util/SegmentsEntryActionDropdownItemsProvider.java
@@ -33,20 +33,22 @@ public class SegmentsEntryActionDropdownItemsProvider {
 
 	public List<DropdownItem> getActionDropdownItems() {
 		return DropdownItemListBuilder.addGroup(
+			dropdownGroupItem -> dropdownGroupItem.setDropdownItems(
+				DropdownItemListBuilder.add(
+					() -> _segmentsDisplayContext.isShowUpdateAction(
+						_segmentsEntry),
+					dropdownItem -> {
+						dropdownItem.setHref(
+							_segmentsDisplayContext.getEditURL(_segmentsEntry));
+						dropdownItem.setIcon("pencil");
+						dropdownItem.setLabel(
+							LanguageUtil.get(_httpServletRequest, "edit"));
+					}
+				).build())
+		).addGroup(
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
 					DropdownItemListBuilder.add(
-						() -> _segmentsDisplayContext.isShowUpdateAction(
-							_segmentsEntry),
-						dropdownItem -> {
-							dropdownItem.setHref(
-								_segmentsDisplayContext.getEditURL(
-									_segmentsEntry));
-							dropdownItem.setIcon("pencil");
-							dropdownItem.setLabel(
-								LanguageUtil.get(_httpServletRequest, "edit"));
-						}
-					).add(
 						() -> _segmentsDisplayContext.isShowViewAction(
 							_segmentsEntry),
 						dropdownItem -> {
@@ -90,7 +92,13 @@ public class SegmentsEntryActionDropdownItemsProvider {
 								LanguageUtil.get(
 									_httpServletRequest, "assign-site-roles"));
 						}
-					).add(
+					).build());
+				dropdownGroupItem.setSeparator(true);
+			}
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
 						() -> _segmentsDisplayContext.isShowPermissionAction(
 							_segmentsEntry),
 						dropdownItem -> {
@@ -105,7 +113,13 @@ public class SegmentsEntryActionDropdownItemsProvider {
 								LanguageUtil.get(
 									_httpServletRequest, "permissions"));
 						}
-					).add(
+					).build());
+				dropdownGroupItem.setSeparator(true);
+			}
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
 						() -> _segmentsDisplayContext.isShowDeleteAction(
 							_segmentsEntry),
 						dropdownItem -> {


### PR DESCRIPTION
Motivation
=======
The motivation behind this PR is to add separators between the dropdown items for segments entries.

Proposed Solution
========
What I did to solve this problem is to use groupDropdownItems and add separators using setSeparators method.

Steps to Verify
========
1. Go to People -> Segments
2. Create a Segment of any kind a save it
3. Go to the Segments view and click on the ellipsis button of the segments entry created
4. Check that the separators are rendered correctly

Screenshots (if applies)
========
<img width="494" alt="Screenshot 2023-08-16 at 12 17 14" src="https://github.com/liferay-echo/liferay-portal/assets/91207948/2486a8da-020c-4588-9291-e71fc60c8e1a">
