### PR TITLE
[TS] LPS-193722 | Fragment usage is not displayed correctly if the time difference is within the same seconds

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentEntryLinkImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentEntryLinkImpl.java
@@ -10,6 +10,7 @@ import com.liferay.fragment.model.FragmentEntry;
 import com.liferay.fragment.service.FragmentEntryLocalServiceUtil;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.GroupConstants;
+import com.liferay.portal.kernel.util.DateUtil;
 
 import java.util.Date;
 
@@ -43,7 +44,14 @@ public class FragmentEntryLinkImpl extends FragmentEntryLinkBaseImpl {
 
 		Date fragmentEntryModifiedDate = fragmentEntry.getModifiedDate();
 
-		return fragmentEntryModifiedDate.before(getLastPropagationDate());
+		int value = DateUtil.compareTo(
+			fragmentEntryModifiedDate, getLastPropagationDate());
+
+		if (value < 0) {
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://liferay.atlassian.net/browse/LPS-193722
Thank you!

-------
**Reproduction Steps**

1. Enable autopropagation
2. Deploy one of the attached fragment (you can import it on the UI)
3. Display the fragment on a page > Publish the page
4. Deploy the attached modified version of the fragment (image is changed in it)
5. Assert that the image changed on the page
6. Click on ⋮ > View Usages

**Expected Behavior**
in View Usages, it says LATEST VERSION under Using
**Actual Behavior**
in View Usages, it says A PREVIOUS VERSION under Using

The attachments are on the LPS

The root cause of the issue is that the framgentEntryLinks handles its dates as timestamps. The timestamps contain the fractions of the second in a different variable called nanos. The date.Before does not calculate with these nanos, so if the modification date is for example 10:10:10:310 and the last propagation time is 10:10:10:390 the date.Before compare will return that the propagation is not bigger than the modification time and as a result, we will display wrong information on the view usage window. My solution is to use our DateUtil.CompareTo which converts the Timestamp properly to Time as the getTime in the timeStamps also includes the nanos.

