### PR TITLE
LPS-193455 Missing tab for Blogs and more label tab when is necessary 

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -4,6 +4,7 @@
  */
 
 import ClayAlert from '@clayui/alert';
+import ClayDropdown, {Align} from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
@@ -62,6 +63,16 @@ const SidebarPanelInfoView = ({
 		!!tags.length || !!Object.keys(vocabularies).length;
 
 	const showTabs = !!getItemVersionsURL || hasCategorization;
+
+	const allTabs = !!getItemVersionsURL && hasCategorization;
+
+	const [active, setActive] = useState(false);
+
+	function _handleItemClick() {
+		setActive(false);
+
+		setActiveTabKeyValue(TABS.version);
+	}
 
 	return (
 		<>
@@ -187,7 +198,7 @@ const SidebarPanelInfoView = ({
 							</ClayTabs.Item>
 						)}
 
-						{!!getItemVersionsURL && (
+						{!!getItemVersionsURL && !hasCategorization && (
 							<ClayTabs.Item
 								active={activeTabKeyValue === TABS.version}
 								className="flex-shrink-0"
@@ -200,6 +211,32 @@ const SidebarPanelInfoView = ({
 							>
 								{Liferay.Language.get('versions')}
 							</ClayTabs.Item>
+						)}
+
+						{allTabs && (
+							<ClayDropdown
+								active={active}
+								alignmentPosition={Align.BottomLeft}
+								hasRightSymbols
+								onActiveChange={setActive}
+								trigger={
+									<ClayTabs.Item>
+										{Liferay.Language.get('more')}
+
+										<ClayIcon symbol="caret-bottom" />
+									</ClayTabs.Item>
+								}
+							>
+								<ClayDropdown.Item
+									active={activeTabKeyValue === TABS.version}
+									aria-selected={
+										activeTabKeyValue === TABS.version
+									}
+									onClick={() => _handleItemClick()}
+								>
+									{Liferay.Language.get('versions')}
+								</ClayDropdown.Item>
+							</ClayDropdown>
 						)}
 					</ClayTabs>
 				)}

--- a/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/src/main/resources/META-INF/resources/js/components/SidebarPanelInfoView/SidebarPanelInfoView.js
@@ -50,8 +50,6 @@ const SidebarPanelInfoView = ({
 }) => {
 	const [activeTabKeyValue, setActiveTabKeyValue] = useState(TABS.details);
 
-	const showTabs = !!getItemVersionsURL;
-
 	const [error, setError] = useState(false);
 
 	const stickerColor = parseInt(user.userId, 10) % 10;
@@ -62,6 +60,8 @@ const SidebarPanelInfoView = ({
 
 	const hasCategorization =
 		!!tags.length || !!Object.keys(vocabularies).length;
+
+	const showTabs = !!getItemVersionsURL || hasCategorization;
 
 	return (
 		<>
@@ -156,9 +156,7 @@ const SidebarPanelInfoView = ({
 			<div className="c-mb-3 sidebar-section">
 				{showTabs && activeTabKeyValue !== null && (
 					<ClayTabs
-						className={classNames('d-flex flex-nowrap', {
-							'justify-content-center': hasCategorization,
-						})}
+						className="c-px-3 d-flex flex-nowrap justify-content-start"
 						modern
 					>
 						<ClayTabs.Item
@@ -189,16 +187,20 @@ const SidebarPanelInfoView = ({
 							</ClayTabs.Item>
 						)}
 
-						<ClayTabs.Item
-							active={activeTabKeyValue === TABS.version}
-							className="flex-shrink-0"
-							innerProps={{
-								'aria-controls': 'versions',
-							}}
-							onClick={() => setActiveTabKeyValue(TABS.version)}
-						>
-							{Liferay.Language.get('versions')}
-						</ClayTabs.Item>
+						{!!getItemVersionsURL && (
+							<ClayTabs.Item
+								active={activeTabKeyValue === TABS.version}
+								className="flex-shrink-0"
+								innerProps={{
+									'aria-controls': 'versions',
+								}}
+								onClick={() =>
+									setActiveTabKeyValue(TABS.version)
+								}
+							>
+								{Liferay.Language.get('versions')}
+							</ClayTabs.Item>
+						)}
 					</ClayTabs>
 				)}
 			</div>

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/SidebarPanelInfoView.test.js
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/SidebarPanelInfoView.test.js
@@ -589,7 +589,7 @@ describe('SidebarPanelInfoView', () => {
 	});
 
 	it('renders Details and Versions tabs when getItemVersionsURL prop is received', () => {
-		const {getAllByRole} = render(
+		const {getAllByRole, getByText} = render(
 			_getSidebarComponent({
 				...mockedProps,
 				...mockedContentWithVersions,
@@ -600,7 +600,10 @@ describe('SidebarPanelInfoView', () => {
 
 		expect(tabs[0].innerHTML).toContain('details');
 		expect(tabs[1].innerHTML).toContain('categorization');
-		expect(tabs[2].innerHTML).toContain('versions');
+
+		userEvent.click(getByText('more'));
+
+		expect(getByText('versions').innerHTML).toContain('versions');
 	});
 
 	it('renders Details tab active by default', () => {

--- a/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/__snapshots__/SidebarPanelInfoView.test.js.snap
+++ b/modules/apps/content-dashboard/content-dashboard-web/test/js/components/SidebarPanelInfoView/__snapshots__/SidebarPanelInfoView.test.js.snap
@@ -154,7 +154,7 @@ exports[`SidebarPanelInfoView renders 1`] = `
         class="c-mb-3 sidebar-section"
       >
         <ul
-          class="nav nav-tabs d-flex flex-nowrap justify-content-center"
+          class="nav nav-tabs c-px-3 d-flex flex-nowrap justify-content-start"
           role="tablist"
         >
           <li
@@ -187,21 +187,36 @@ exports[`SidebarPanelInfoView renders 1`] = `
               categorization
             </button>
           </li>
-          <li
-            class="nav-item flex-shrink-0"
-            role="none"
+          <div
+            class="dropdown"
+            innerprops="[object Object]"
           >
-            <button
-              aria-controls="versions"
-              aria-selected="false"
-              class="nav-link btn btn-unstyled"
-              role="tab"
-              tabindex="-1"
-              type="button"
+            <li
+              aria-controls="clay-dropdown-menu-1"
+              aria-expanded="false"
+              aria-haspopup="true"
+              class="nav-item dropdown-toggle"
+              role="none"
             >
-              versions
-            </button>
-          </li>
+              <button
+                aria-selected="false"
+                class="nav-link btn btn-unstyled"
+                role="tab"
+                tabindex="-1"
+                type="button"
+              >
+                more
+                <svg
+                  class="lexicon-icon lexicon-icon-caret-bottom"
+                  role="presentation"
+                >
+                  <use
+                    xlink:href="#caret-bottom"
+                  />
+                </svg>
+              </button>
+            </li>
+          </div>
         </ul>
       </div>
       <div


### PR DESCRIPTION
Motivation
=======
The motivation behind this PR is to solve two impedibugs in the Content Dashboard sidebar about the Blogs tabs view and the tabs styles
https://liferay.atlassian.net/browse/LPS-193618
https://liferay.atlassian.net/browse/LPS-193544

Proposed Solution
========
What I did to solve this problem is to add a tab for when Blogs contains categorization and no tabs in the other case. For the styles improvement part I used a clay-dropdown for the cases there are all three tabs (Details, Versions and Categorization) so the spacing in the tabs ir correct.

Steps to Verify
========
1. Create a various Blogs and Web content with and without Categorization
2. Go the the Content Dashboard and open the sidebar panel for the elements created.
3. Check that the Details, Versions and Categorization are displayed correctly. For the cases we have all of the three, a More tab should be displayed which contains the Verions tab.

<img width="654" alt="Screenshot 2023-08-17 at 15 24 04" src="https://github.com/liferay-echo/liferay-portal/assets/91207948/dc04cd0c-6d60-41ec-90f5-1f10934aed33">

