### PR TITLE
LPS-193795 Fix NullPointerException regression caused by LPS-193338

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/workflow/JournalArticleWorkflowHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/workflow/JournalArticleWorkflowHandler.java
@@ -83,12 +83,24 @@ public class JournalArticleWorkflowHandler
 		LiferayPortletResponse liferayPortletResponse,
 		String noSuchEntryRedirect) {
 
+		JournalArticle article = _journalArticleLocalService.fetchArticle(
+			classPK);
+
+		if (article == null) {
+			article = _journalArticleLocalService.fetchLatestArticle(classPK);
+		}
+
+		if (article == null) {
+			if (_log.isWarnEnabled()) {
+				_log.warn("Unable to find article " + classPK);
+			}
+
+			return null;
+		}
+
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)liferayPortletRequest.getAttribute(
 				WebKeys.THEME_DISPLAY);
-
-		JournalArticle article = _journalArticleLocalService.fetchArticle(
-			classPK);
 
 		try {
 			if (!_isShowDisplayPage(


### PR DESCRIPTION
Ticket: [LPS-193795](https://liferay.atlassian.net/browse/LPS-193795)
Regression caused by [LPS-193338](https://liferay.atlassian.net/browse/LPS-193338)

The passed-in classPK is based on what [this API](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java#L81-L89) returns, which for some confusing reason can return `id_` in some cases but `resourcePrimKey` in other cases. So we need to handle both these possibilities.