### PR TITLE
LPS-193726 Duplicate Asset type when trying to select a Related Asset

### DIFF
--- a/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/asset/model/DLFileEntryClassTypeReader.java
+++ b/modules/apps/document-library/document-library-api/src/main/java/com/liferay/document/library/asset/model/DLFileEntryClassTypeReader.java
@@ -31,8 +31,6 @@ public class DLFileEntryClassTypeReader implements ClassTypeReader {
 
 		List<ClassType> classTypes = new ArrayList<>();
 
-		classTypes.add(getBasicDocumentClassType(locale));
-
 		String languageId = LocaleUtil.toLanguageId(locale);
 
 		List<DLFileEntryType> dlFileEntryTypes =


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-193726)

## Proposed solution

Remove add for Basic Document Class Type because it’s already added with the dlFileEntryTypes

## Test Scenario 1

1. Navigate to Content and Data
2. Add a web content
3. Go to Related Assets
4. Try to select an Asset type

<img width="249" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/1649c51f-5016-4d69-b41e-0dcc4730dd9d">
