### PR TITLE
LPS-192606 Replace aui:button with clay:button in terms_of_use.jsp

### DIFF
--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/build.gradle
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly project(":apps:asset:asset-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
+	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:layout:layout-taglib")
 	compileOnly project(":apps:layout:layout-utility-page-api")
 	compileOnly project(":core:petra:petra-io")

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/package.json
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/package.json
@@ -1,0 +1,12 @@
+{
+	"dependencies": {
+		"frontend-js-web": "*"
+	},
+	"name": "@liferay/layout-utility-page-terms-of-use",
+	"scripts": {
+		"build": "liferay-npm-scripts build",
+		"checkFormat": "liferay-npm-scripts check",
+		"format": "liferay-npm-scripts fix"
+	},
+	"version": "1.0.12"
+}

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/init.jsp
@@ -8,6 +8,7 @@
 <%@ taglib uri="http://java.sun.com/jsp/jstl/core" prefix="c" %>
 
 <%@ taglib uri="http://liferay.com/tld/aui" prefix="aui" %><%@
+taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/layout" prefix="liferay-layout" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/init.jsp
@@ -16,7 +16,6 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.layout.utility.page.kernel.constants.LayoutUtilityPageEntryConstants" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
-page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
 page import="com.liferay.portal.kernel.security.auth.AuthTokenUtil" %><%@
 page import="com.liferay.portal.kernel.terms.of.use.TermsOfUseContentProvider" %><%@
 page import="com.liferay.portal.kernel.util.HttpComponentsUtil" %><%@

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/js/DisagreeButtonPropsTransformer.js
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/js/DisagreeButtonPropsTransformer.js
@@ -1,0 +1,19 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {openAlertModal} from 'frontend-js-web';
+
+export default function ({...props}) {
+	return {
+		...props,
+		onClick() {
+			openAlertModal({
+				message: Liferay.Language.get(
+					'you-must-agree-with-the-terms-of-use-to-continue'
+				),
+			});
+		},
+	};
+}

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/terms_of_use.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/terms_of_use.jsp
@@ -81,29 +81,21 @@
 				</c:choose>
 			</div>
 
-			<div class="sheet-footer">
-				<c:if test="<%= !user.isAgreedToTermsOfUse() %>">
-					<aui:button-row>
-						<clay:button
-							label="i-agree"
-							type="submit"
-						/>
+			<c:if test="<%= !user.isAgreedToTermsOfUse() %>">
+				<div class="sheet-footer">
+					<clay:button
+						label="i-agree"
+						type="submit"
+					/>
 
-						<%
-						String disagreeMessage = UnicodeLanguageUtil.get(request, "you-must-agree-with-the-terms-of-use-to-continue");
-
-						String taglibOnClick = String.format("Liferay.Util.openAlertModal({message: '%s'})", disagreeMessage, disagreeMessage);
-						%>
-
-						<clay:button
-							displayType="secondary"
-							label="i-disagree"
-							onClick="<%= taglibOnClick %>"
-							type="cancel"
-						/>
-					</aui:button-row>
-				</c:if>
-			</div>
+					<clay:button
+						displayType="secondary"
+						label="i-disagree"
+						propsTransformer="js/DisagreeButtonPropsTransformer"
+						type="button"
+					/>
+				</div>
+			</c:if>
 		</aui:form>
 	</div>
 </liferay-layout:render-layout-utility-page-entry>

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/terms_of_use.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/terms_of_use.jsp
@@ -84,7 +84,10 @@
 			<div class="sheet-footer">
 				<c:if test="<%= !user.isAgreedToTermsOfUse() %>">
 					<aui:button-row>
-						<aui:button type="submit" value="i-agree" />
+						<clay:button
+							label="i-agree"
+							type="submit"
+						/>
 
 						<%
 						String disagreeMessage = UnicodeLanguageUtil.get(request, "you-must-agree-with-the-terms-of-use-to-continue");
@@ -92,7 +95,12 @@
 						String taglibOnClick = String.format("Liferay.Util.openAlertModal({message: '%s'})", disagreeMessage, disagreeMessage);
 						%>
 
-						<aui:button onClick="<%= taglibOnClick %>" type="cancel" value="i-disagree" />
+						<clay:button
+							displayType="secondary"
+							label="i-disagree"
+							onClick="<%= taglibOnClick %>"
+							type="cancel"
+						/>
 					</aui:button-row>
 				</c:if>
 			</div>


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-192606)

## Proposed solution

Change aui:button with clay:button.

## Test Scenario 1

Note: Every time you want to test this buttons you will need a clean Data Base and re-run the portal.
1. Log in
2. check the “I agree” and “I disagree” buttons of Terms of Use 

<img width="753" alt="Pasted Graphic" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/d11d4be2-9284-40d7-a109-8f4c71bde4d1">
