### PR TITLE
LPS-192065 Ensure only needed values are stored in data_ column of LayoutPageTemplateStructureRel

### DIFF
--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/CollectionStyledLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/CollectionStyledLayoutStructureItem.java
@@ -202,9 +202,20 @@ public class CollectionStyledLayoutStructureItem
 				"numberOfColumns",
 				viewportConfigurationJSONObject.get("numberOfColumns"));
 
+			JSONObject finalCurrentViewportConfigurationJSONObject =
+				currentViewportConfigurationJSONObject;
+
 			jsonObject.put(
 				viewportSize.getViewportSizeId(),
-				currentViewportConfigurationJSONObject);
+				() -> {
+					if (finalCurrentViewportConfigurationJSONObject.length() ==
+							0) {
+
+						return null;
+					}
+
+					return finalCurrentViewportConfigurationJSONObject;
+				});
 		}
 
 		return jsonObject;

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/ColumnLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/ColumnLayoutStructureItem.java
@@ -56,16 +56,24 @@ public class ColumnLayoutStructureItem extends LayoutStructureItem {
 
 			jsonObject.put(
 				viewportSize.getViewportSizeId(),
-				JSONUtil.put(
-					"size",
-					() -> {
-						JSONObject viewportConfigurationJSONObject =
-							_viewportConfigurationJSONObjects.getOrDefault(
-								viewportSize.getViewportSizeId(),
-								JSONFactoryUtil.createJSONObject());
+				() -> {
+					JSONObject viewportSizeJSONObject = JSONUtil.put(
+						"size",
+						() -> {
+							JSONObject viewportConfigurationJSONObject =
+								_viewportConfigurationJSONObjects.getOrDefault(
+									viewportSize.getViewportSizeId(),
+									JSONFactoryUtil.createJSONObject());
 
-						return viewportConfigurationJSONObject.get("size");
-					}));
+							return viewportConfigurationJSONObject.get("size");
+						});
+
+					if (viewportSizeJSONObject.length() == 0) {
+						return null;
+					}
+
+					return viewportSizeJSONObject;
+				});
 		}
 
 		return jsonObject;

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/ContainerStyledLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/ContainerStyledLayoutStructureItem.java
@@ -232,6 +232,10 @@ public class ContainerStyledLayoutStructureItem
 
 	@Override
 	public void updateItemConfig(JSONObject itemConfigJSONObject) {
+		if (itemConfigJSONObject == null) {
+			itemConfigJSONObject = JSONFactoryUtil.createJSONObject();
+		}
+
 		_convertStyleProperties(itemConfigJSONObject);
 
 		super.updateItemConfig(itemConfigJSONObject);
@@ -286,6 +290,10 @@ public class ContainerStyledLayoutStructureItem
 	}
 
 	private void _convertStyleProperties(JSONObject itemConfigJSONObject) {
+		if (itemConfigJSONObject == null) {
+			itemConfigJSONObject = JSONFactoryUtil.createJSONObject();
+		}
+
 		String backgroundColorCssClass = itemConfigJSONObject.getString(
 			"backgroundColorCssClass");
 

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/FragmentStyledLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/FragmentStyledLayoutStructureItem.java
@@ -76,6 +76,8 @@ public class FragmentStyledLayoutStructureItem
 			stylesJSONObject = JSONFactoryUtil.createJSONObject();
 		}
 
+		JSONObject finalStylesJSONObject = stylesJSONObject;
+
 		return jsonObject.put(
 			"fragmentEntryLinkId", String.valueOf(_fragmentEntryLinkId)
 		).put(
@@ -88,7 +90,14 @@ public class FragmentStyledLayoutStructureItem
 				return false;
 			}
 		).put(
-			"styles", stylesJSONObject
+			"styles",
+			() -> {
+				if (finalStylesJSONObject.length() == 0) {
+					return null;
+				}
+
+				return finalStylesJSONObject;
+			}
 		);
 	}
 

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/LayoutStructure.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/LayoutStructure.java
@@ -525,14 +525,37 @@ public class LayoutStructure {
 				deletedLayoutStructureItem.toJSONObject());
 		}
 
+		String finalDropZoneItemId = dropZoneItemId;
+
 		return JSONUtil.put(
-			"deletedItems", deletedLayoutStructureItemsJSONArray
+			"deletedItems",
+			() -> {
+				if (deletedLayoutStructureItemsJSONArray.length() == 0) {
+					return null;
+				}
+
+				return deletedLayoutStructureItemsJSONArray;
+			}
 		).put(
-			"items", layoutStructureItemsJSONObject
+			"items",
+			() -> {
+				if (layoutStructureItemsJSONObject.length() == 0) {
+					return null;
+				}
+
+				return layoutStructureItemsJSONObject;
+			}
 		).put(
 			"rootItems",
 			JSONUtil.put(
-				"dropZone", dropZoneItemId
+				"dropZone",
+				() -> {
+					if (Validator.isBlank(finalDropZoneItemId)) {
+						return null;
+					}
+
+					return finalDropZoneItemId;
+				}
 			).put(
 				"main", _mainItemId
 			)

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/LayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/LayoutStructureItem.java
@@ -9,6 +9,7 @@ import com.liferay.petra.lang.HashUtil;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 
 import java.util.ArrayList;
@@ -134,7 +135,14 @@ public abstract class LayoutStructureItem {
 		).put(
 			"itemId", getItemId()
 		).put(
-			"parentId", getParentItemId()
+			"parentId",
+			() -> {
+				if (Validator.isNull(getParentItemId())) {
+					return null;
+				}
+
+				return getParentItemId();
+			}
 		).put(
 			"type", getItemType()
 		);

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/RowStyledLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/RowStyledLayoutStructureItem.java
@@ -117,9 +117,20 @@ public class RowStyledLayoutStructureItem extends StyledLayoutStructureItem {
 				viewportConfigurationJSONObject.get("verticalAlignment")
 			);
 
+			JSONObject finalCurrentViewportConfigurationJSONObject =
+				currentViewportConfigurationJSONObject;
+
 			jsonObject.put(
 				viewportSize.getViewportSizeId(),
-				currentViewportConfigurationJSONObject);
+				() -> {
+					if (finalCurrentViewportConfigurationJSONObject.length() ==
+							0) {
+
+						return null;
+					}
+
+					return finalCurrentViewportConfigurationJSONObject;
+				});
 		}
 
 		return jsonObject;

--- a/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/StyledLayoutStructureItem.java
+++ b/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/util/structure/StyledLayoutStructureItem.java
@@ -16,6 +16,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.Validator;
 
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -91,13 +92,34 @@ public abstract class StyledLayoutStructureItem extends LayoutStructureItem {
 	@Override
 	public JSONObject getItemConfigJSONObject() {
 		JSONObject jsonObject = JSONUtil.put(
-			"cssClasses", JSONFactoryUtil.createJSONArray(_cssClasses)
+			"cssClasses",
+			() -> {
+				if ((_cssClasses == null) || _cssClasses.isEmpty()) {
+					return null;
+				}
+
+				return JSONFactoryUtil.createJSONArray(_cssClasses);
+			}
 		).put(
-			"customCSS", _customCSS
+			"customCSS",
+			() -> {
+				if (Validator.isNull(_customCSS)) {
+					return null;
+				}
+
+				return JSONFactoryUtil.createJSONArray(_customCSS);
+			}
 		).put(
 			"name", _name
 		).put(
-			"styles", stylesJSONObject
+			"styles",
+			() -> {
+				if (stylesJSONObject.length() == 0) {
+					return null;
+				}
+
+				return stylesJSONObject;
+			}
 		);
 
 		for (ViewportSize viewportSize : _viewportSizes) {
@@ -107,15 +129,30 @@ public abstract class StyledLayoutStructureItem extends LayoutStructureItem {
 
 			jsonObject.put(
 				viewportSize.getViewportSizeId(),
-				JSONUtil.put(
-					"customCSS",
-					_customCSSViewports.get(viewportSize.getViewportSizeId())
-				).put(
-					"styles",
-					viewportStyleJSONObjects.getOrDefault(
-						viewportSize.getViewportSizeId(),
-						JSONFactoryUtil.createJSONObject())
-				));
+				() -> {
+					JSONObject viewportStylesJSONObject = JSONUtil.put(
+						"customCSS",
+						_customCSSViewports.get(
+							viewportSize.getViewportSizeId())
+					).put(
+						"styles",
+						() -> {
+							if (viewportStyleJSONObjects.isEmpty()) {
+								return null;
+							}
+
+							return viewportStyleJSONObjects.getOrDefault(
+								viewportSize.getViewportSizeId(),
+								JSONFactoryUtil.createJSONObject());
+						}
+					);
+
+					if (viewportStylesJSONObject.length() == 0) {
+						return null;
+					}
+
+					return viewportStylesJSONObject;
+				});
 		}
 
 		return jsonObject;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/HideFragmentField.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/fragment_configuration_fields/HideFragmentField.js
@@ -34,7 +34,7 @@ function getHiddenAncestorId(layoutData, item, selectedViewportSize) {
 		selectedViewportSize
 	);
 
-	return responsiveConfig.styles.display === 'none'
+	return responsiveConfig.styles?.display === 'none'
 		? parent.itemId
 		: getHiddenAncestorId(layoutData, parent);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/updateItemConfig.js
@@ -9,7 +9,7 @@ import LayoutService from '../services/LayoutService';
 export default function updateItemConfig({
 	itemConfig,
 	itemId,
-	overridePreviousConfig = false,
+	overridePreviousConfig = true,
 }) {
 	return (dispatch, getState) => {
 		const {segmentsExperienceId} = getState();

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/hasRequiredInputChild.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/hasRequiredInputChild.js
@@ -21,7 +21,7 @@ function isItemHidden(layoutData, itemId, selectedViewportSize) {
 	);
 
 	return (
-		responsiveConfig.styles.display === 'none' ||
+		responsiveConfig.styles?.display === 'none' ||
 		isItemHidden(layoutData, item.parentId, selectedViewportSize)
 	);
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/isItemEmpty.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/isItemEmpty.js
@@ -31,5 +31,5 @@ function isItemHidden(layoutData, itemId, selectedViewportSize) {
 		selectedViewportSize
 	);
 
-	return responsiveConfig.styles.display === 'none';
+	return responsiveConfig.styles?.display === 'none';
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
@@ -561,7 +561,7 @@ function isItemHidden(item, selectedViewportSize) {
 		selectedViewportSize
 	);
 
-	return responsiveConfig.styles.display === 'none';
+	return responsiveConfig.styles?.display === 'none';
 }
 
 function isHidable(item, fragmentEntryLinks, layoutData) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTreeNodeActions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTreeNodeActions.js
@@ -135,7 +135,7 @@ const ActionList = ({item, setActive, setEditingNodeId, setOpenSaveModal}) => {
 		fragmentEntryLinks[item.config.fragmentEntryLinkId]
 			.fragmentEntryType === FRAGMENT_ENTRY_TYPES.input;
 
-	const isHidden = item.config.styles.display === 'none';
+	const isHidden = item.config.styles?.display === 'none';
 
 	const dropdownItems = useMemo(() => {
 		const items = [];


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-192065)

Motivation
=======
When creating pages, there are some empty props that are stored in the database. The goal of this task is to avoid those props to be added to the database.

## Steps
- Go to Design > Page Templates > Page Templates > Create a Content Page Template > Publish
- Go to the database > In LayoutPageTemplateStructure Schema you can find the Page Template stored
**- To test this, we will have to compare the values stores before the changes and after the changes**

**## NOTE: As we can see in the screenshots after, "config" and "children" fields cannot be removed because it breaks a lot of archives.**

**Case 1: Container styled**
  - Add a Container to a content page template
<img width="317" alt="container" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/0432ef52-3ea3-4cd9-88f9-8107efe4b55a">
<img width="400" alt="containerBefore" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/883dd39c-c668-466e-8623-2fca283bdb67">

**Case 2: Collection styled**
  - Click the Collection Display and see configurations at right side 
  - Select a Collection, for example a collection provider
<img width="418" alt="collectionBefore" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/aadf6d9d-d1ff-404c-a74b-bbc14d3093fa">
<img width="316" alt="collectionAfter" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/4f5eb1e4-cd0f-43bb-bbbe-c16e95955085">

**Case 3: Fragment styled**
  - Add a  Button to a content page template
<img width="402" alt="fragmentBefore" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/c6798f96-6d66-43d2-872f-42ed8e6ce083">
<img width="378" alt="fragmentAfter" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/712321f3-9190-4073-ad49-5d08a4f5aeb5">

**Case 4: Row styled and Column styled**
  - Add a  Grid to a content page template
  - Column and row will be stored in the database
<img width="276" alt="rowBefore" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/a541cd32-867f-463d-b11a-bcd31bc36600">
<img width="380" alt="rowAfter" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/5e37079b-d5d7-4364-aae2-eb1d06066b7c">
<img width="382" alt="columnBefore" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/7932f39a-5e7f-46ad-a187-635396b9b4c0">
<img width="390" alt="columnAter" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/a0a33a7f-578c-4bcb-b2a7-47d310140fdd">
