### PR TITLE
[TS] LPS-194116 Inconsistency in the column name from AssetVocabulary, when importing vocabularies replacing space with dash

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/AssetVocabularyStagedModelDataHandler.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/exportimport/data/handler/AssetVocabularyStagedModelDataHandler.java
@@ -211,7 +211,7 @@ public class AssetVocabularyStagedModelDataHandler
 
 			importedVocabulary = _assetVocabularyLocalService.addVocabulary(
 				vocabulary.getExternalReferenceCode(), userId,
-				portletDataContext.getScopeGroupId(), StringPool.BLANK,
+				portletDataContext.getScopeGroupId(), name,
 				vocabulary.getTitle(),
 				_getVocabularyTitleMap(
 					portletDataContext.getScopeGroupId(), vocabulary, name),

--- a/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/exportimport/data/handler/test/AssetVocabularyStagedModelDataHandlerTest.java
+++ b/modules/apps/asset/asset-test/src/testIntegration/java/com/liferay/asset/exportimport/data/handler/test/AssetVocabularyStagedModelDataHandlerTest.java
@@ -10,10 +10,12 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalServiceUtil;
 import com.liferay.asset.test.util.AssetTestUtil;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 
@@ -43,7 +45,10 @@ public class AssetVocabularyStagedModelDataHandlerTest
 			Map<String, List<StagedModel>> dependentStagedModelsMap)
 		throws Exception {
 
-		return AssetTestUtil.addVocabulary(group.getGroupId());
+		return AssetTestUtil.addVocabulary(
+			group.getGroupId(),
+			RandomTestUtil.randomString(3) + StringPool.SPACE +
+				RandomTestUtil.randomString(4));
 	}
 
 	@Override


### PR DESCRIPTION
Motivation
=======
There are a naming inconsistency if the user creates a Vocabulary from the UI and importing the same Vocabulary by Import/export functionality. If the vocabulary has title "Hello World", the column "name" from the AssetVocabulary table willl have the following values:
- Created by UI: "hello world"
- Created by Export/Import: "hello-world"

Proposed Solution
========
Modified the StagedModelDataHandler to pass the default name as vocabularyTitleMap.get(LocaleUtil.getSiteDefault()), like the UI.

Steps to Verify
========
Steps to reproduce with MySQL:

1. Create a site A and create a "vocabulary A" (Categorization - Categories - Vocabularies - +)
2. Export the vocabulary with the Categories Export, it will generate export.lar
3. Create a site B and import the export.lar in the Categories Import
4. Check the database, the table assetvocabulary will have two Vocabularies, one with dash ("vocabulary-a") and the other one with space ("vocabulary a").

Alternative Solutions that were discarded (if applies)
========
- I could not find any existing AssetVocabularyLocalService method that could be use in this case since it requires externalReferenceCode, but maybe is another solution to implement a new local service method.
- Moreover, there is a _generateVocabularyName method that literally replaces spaces by dash, but is not used in all the cases when adding a new vocabulary.
`private String _generateVocabularyName(long groupId, String name) {
		String vocabularyName = _getVocabularyName(name);

		vocabularyName = StringUtil.replace(
			vocabularyName, CharPool.SPACE, CharPool.DASH);
