### PR TITLE
LPS-192618 Replace usages of aui:button in portlet-configuration-web

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_configuration_templates.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_configuration_templates.jsp
@@ -36,7 +36,12 @@ PortletConfigurationTemplatesDisplayContext portletConfigurationTemplatesDisplay
 						<portlet:param name="portletResource" value="<%= portletResource %>" />
 					</portlet:renderURL>
 
-					<aui:button href="<%= addConfigurationTemplateURL %>" value="save-current-configuration-as-template" />
+					<clay:link
+						displayType="secondary"
+						href="<%= addConfigurationTemplateURL %>"
+						label="save-current-configuration-as-template"
+						type="button"
+					/>
 				</div>
 
 				<liferay-ui:search-container

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/resources/META-INF/resources/edit_permissions.jsp
@@ -219,9 +219,17 @@ if (Validator.isNotNull(portletConfigurationPermissionsDisplayContext.getModelRe
 	</div>
 
 	<aui:button-row>
-		<aui:button name="saveButton" type="submit" />
+		<clay:button
+			id='<%= liferayPortletResponse.getNamespace() + "saveButton" %>'
+			label="save"
+			type="submit"
+		/>
 
-		<aui:button type="cancel" />
+		<clay:button
+			cssClass="btn-cancel"
+			displayType="secondary"
+			label="cancel"
+		/>
 	</aui:button-row>
 </div>
 


### PR DESCRIPTION
Motivation
=======
The motivation behind this PR stadirize the usages of buttons in the portal by using for clay:button or clay:icon.
https://liferay.atlassian.net/browse/LPS-192618

Proposed Solution
========
The proposed solution consist in substitute the usages of aui:button for clay:button or clay:icon.

Steps to Verify
========
1. Go to the Page Editor and add an asset-publisher
2. Click on the Options dropdown button of the fragment.
3. Click on the Permissions button and check that the Save and Cancel buttons work fine.
4. From the dropdown again, now click over Configuration Templates. Check that the `Save current configuration as template` button works fine.
