### PR TITLE
LPS-193763 Add actions to created folders

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/DisplayPageTemplateCollectionHorizontalCard.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/DisplayPageTemplateCollectionHorizontalCard.java
@@ -6,11 +6,21 @@
 package com.liferay.layout.page.template.admin.web.internal.frontend.taglib.clay.servlet.taglib;
 
 import com.liferay.frontend.taglib.clay.servlet.taglib.BaseHorizontalCard;
+import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
+import com.liferay.layout.page.template.admin.web.internal.servlet.taglib.util.LayoutPageTemplateCollectionActionDropdownItem;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.portal.kernel.dao.search.RowChecker;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.util.List;
 
 import javax.portlet.RenderRequest;
+import javax.portlet.RenderResponse;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Yurena Cabrera
@@ -20,11 +30,37 @@ public class DisplayPageTemplateCollectionHorizontalCard
 
 	public DisplayPageTemplateCollectionHorizontalCard(
 		BaseModel<?> baseModel, RenderRequest renderRequest,
-		RowChecker rowChecker) {
+		RenderResponse renderResponse, RowChecker rowChecker) {
 
 		super(baseModel, renderRequest, rowChecker);
 
+		_renderResponse = renderResponse;
+
 		_layoutPageTemplateCollection = (LayoutPageTemplateCollection)baseModel;
+	}
+
+	@Override
+	public List<DropdownItem> getActionDropdownItems() {
+		HttpServletRequest httpServletRequest =
+			PortalUtil.getHttpServletRequest(renderRequest);
+
+		LayoutPageTemplateCollectionActionDropdownItem
+			layoutPageTemplateCollectionActionDropdownItem =
+				new LayoutPageTemplateCollectionActionDropdownItem(
+					httpServletRequest, _renderResponse);
+
+		try {
+			return layoutPageTemplateCollectionActionDropdownItem.
+				getActionDropdownItems(
+					_layoutPageTemplateCollection, "display-page-templates");
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+		}
+
+		return null;
 	}
 
 	@Override
@@ -37,6 +73,10 @@ public class DisplayPageTemplateCollectionHorizontalCard
 		return _layoutPageTemplateCollection.getName();
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		DisplayPageTemplateCollectionHorizontalCard.class);
+
 	private final LayoutPageTemplateCollection _layoutPageTemplateCollection;
+	private final RenderResponse _renderResponse;
 
 }

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/EditLayoutPageTemplateCollectionMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/EditLayoutPageTemplateCollectionMVCActionCommand.java
@@ -72,19 +72,19 @@ public class EditLayoutPageTemplateCollectionMVCActionCommand
 		}
 
 		String redirect = getRedirectURL(
-			actionResponse, layoutPageTemplateCollection);
+			actionRequest, actionResponse, layoutPageTemplateCollection);
 
 		sendRedirect(actionRequest, actionResponse, redirect);
 	}
 
 	protected String getRedirectURL(
-		ActionResponse actionResponse,
+		ActionRequest actionRequest, ActionResponse actionResponse,
 		LayoutPageTemplateCollection layoutPageTemplateCollection) {
 
 		return PortletURLBuilder.createRenderURL(
 			_portal.getLiferayPortletResponse(actionResponse)
 		).setTabs1(
-			"page-templates"
+			ParamUtil.getString(actionRequest, "tabs1")
 		).setParameter(
 			"layoutPageTemplateCollectionId",
 			layoutPageTemplateCollection.getLayoutPageTemplateCollectionId()

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateCollectionActionDropdownItem.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateCollectionActionDropdownItem.java
@@ -37,7 +37,7 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 	}
 
 	public List<DropdownItem> getActionDropdownItems(
-		LayoutPageTemplateCollection layoutPageTemplateCollection) {
+		LayoutPageTemplateCollection layoutPageTemplateCollection, String tab) {
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)_httpServletRequest.getAttribute(
@@ -60,7 +60,7 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 								).setRedirect(
 									themeDisplay.getURLCurrent()
 								).setTabs1(
-									"page-templates"
+									tab
 								).setParameter(
 									"layoutPageTemplateCollectionId",
 									layoutPageTemplateCollection.
@@ -127,7 +127,7 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 									PortletURLBuilder.createRenderURL(
 										_renderResponse
 									).setTabs1(
-										"page-templates"
+										tab
 									).buildString()
 								).setParameter(
 									"layoutPageTemplateCollectionId",

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateCollectionActionDropdownItem.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateCollectionActionDropdownItem.java
@@ -37,7 +37,8 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 	}
 
 	public List<DropdownItem> getActionDropdownItems(
-		LayoutPageTemplateCollection layoutPageTemplateCollection, String tab) {
+		LayoutPageTemplateCollection layoutPageTemplateCollection,
+		String tabs1) {
 
 		ThemeDisplay themeDisplay =
 			(ThemeDisplay)_httpServletRequest.getAttribute(
@@ -60,7 +61,7 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 								).setRedirect(
 									themeDisplay.getURLCurrent()
 								).setTabs1(
-									tab
+									tabs1
 								).setParameter(
 									"layoutPageTemplateCollectionId",
 									layoutPageTemplateCollection.
@@ -127,7 +128,7 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 									PortletURLBuilder.createRenderURL(
 										_renderResponse
 									).setTabs1(
-										tab
+										tabs1
 									).buildString()
 								).setParameter(
 									"layoutPageTemplateCollectionId",

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/edit_layout_page_template_collection.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/edit_layout_page_template_collection.jsp
@@ -22,7 +22,7 @@ renderResponse.setTitle((layoutPageTemplateCollection != null) ? layoutPageTempl
 
 <portlet:actionURL name="/layout_page_template_admin/edit_layout_page_template_collection" var="editLayoutPageTemplateCollectionURL">
 	<portlet:param name="mvcRenderCommandName" value="/layout_page_template_admin/edit_layout_page_template_collection" />
-	<portlet:param name="tabs1" value='<%= ParamUtil.getString(request, "tabs1") %>' />
+	<portlet:param name="tabs1" value='<%= ParamUtil.getString(request, "tabs1", "page-templates") %>' />
 </portlet:actionURL>
 
 <liferay-frontend:edit-form

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/edit_layout_page_template_collection.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/edit_layout_page_template_collection.jsp
@@ -22,7 +22,7 @@ renderResponse.setTitle((layoutPageTemplateCollection != null) ? layoutPageTempl
 
 <portlet:actionURL name="/layout_page_template_admin/edit_layout_page_template_collection" var="editLayoutPageTemplateCollectionURL">
 	<portlet:param name="mvcRenderCommandName" value="/layout_page_template_admin/edit_layout_page_template_collection" />
-	<portlet:param name="tabs1" value="page-templates" />
+	<portlet:param name="tabs1" value='<%= ParamUtil.getString(request, "tabs1") %>' />
 </portlet:actionURL>
 
 <liferay-frontend:edit-form

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPageTemplateCollectionPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPageTemplateCollectionPropsTransformer.js
@@ -32,32 +32,37 @@ const ACTIONS = {
 	},
 };
 
+const updateItem = (item, portletNamespace) => {
+	const newItem = {
+		...item,
+		onClick(event) {
+			const action = item.data?.action;
+
+			if (action) {
+				event.preventDefault();
+
+				ACTIONS[action]?.(item.data, portletNamespace);
+			}
+		},
+	};
+
+	if (Array.isArray(item.items)) {
+		newItem.items = item.items.map(updateItem);
+	}
+
+	return newItem;
+};
+
 export default function LayoutPageTemplateEntryPropsTransformer({
+	actions,
 	items,
 	portletNamespace,
 	...otherProps
 }) {
 	return {
 		...otherProps,
-		items: items?.map((item) => {
-			return {
-				...item,
-				items: item.items?.map((child) => {
-					return {
-						...child,
-						onClick(event) {
-							const action = child.data?.action;
-
-							if (action) {
-								event.preventDefault();
-
-								ACTIONS[action](child.data, portletNamespace);
-							}
-						},
-					};
-				}),
-			};
-		}),
+		actions: actions?.map((item) => updateItem(item, portletNamespace)),
+		items: items?.map((item) => updateItem(item, portletNamespace)),
 		portletNamespace,
 	};
 }

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_display_pages.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_display_pages.jsp
@@ -71,6 +71,7 @@ DisplayPageManagementToolbarDisplayContext displayPageManagementToolbarDisplayCo
 					>
 						<clay:horizontal-card
 							horizontalCard="<%= new DisplayPageTemplateCollectionHorizontalCard (curLayoutPageTemplateCollection, renderRequest, renderResponse, searchContainer.getRowChecker()) %>"
+							propsTransformer="js/propsTransformers/LayoutPageTemplateCollectionPropsTransformer"
 						/>
 					</liferay-ui:search-container-column-text>
 				</c:when>

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_display_pages.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_display_pages.jsp
@@ -70,7 +70,7 @@ DisplayPageManagementToolbarDisplayContext displayPageManagementToolbarDisplayCo
 						colspan="<%= 2 %>"
 					>
 						<clay:horizontal-card
-							horizontalCard="<%= new DisplayPageTemplateCollectionHorizontalCard(curLayoutPageTemplateCollection, renderRequest, searchContainer.getRowChecker()) %>"
+							horizontalCard="<%= new DisplayPageTemplateCollectionHorizontalCard (curLayoutPageTemplateCollection, renderRequest, renderResponse, searchContainer.getRowChecker()) %>"
 						/>
 					</liferay-ui:search-container-column-text>
 				</c:when>

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
@@ -143,7 +143,7 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 
 								<clay:dropdown-actions
 									aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
-									dropdownItems="<%= layoutPageTemplateCollectionActionDropdownItem.getActionDropdownItems(layoutPageTemplateCollection) %>"
+									dropdownItems="<%= layoutPageTemplateCollectionActionDropdownItem.getActionDropdownItems(layoutPageTemplateCollection, "display-page") %>"
 									propsTransformer="js/propsTransformers/LayoutPageTemplateCollectionPropsTransformer"
 								/>
 							</clay:content-col>


### PR DESCRIPTION
Motivation
=======
The new feature to display and edit object entries is producing that users have several display pages for the same object. This said, it will be very useful to provide a way to our users so they can organize them.

Proposed Solution
========
Allow users to create folders to organize them

Steps to Verify
========
1. Go to Design > Page Templates > Display Page templates
2. Create a folder
3. Verify that the actions are show when displaying the dropdown menu (rename, delete, permissions) and that work as expected

COMMITS:

- LPS-193763 Add return tab as a variable when retrieving dropdown item actions
- LPS-193763 Create method to retrieve dropdown item actions for DisplayPageTemplateCollectionHorizontalCards
- LPS-193763 Show dropdown item actions for DisplayPageTemplateCollectionHorizontalCards
- LPS-193763 Redirecting to the right tab after rename collection
- LPS-193763 Adding PropsTransformer
- LPS-193763 Modifying propsTransformer to work also with actions
- LPS-193763 Refactor modifying propsTransformer to work also with actions
