### PR TITLE
LPS-194357 Page Editor ColorPicker does not work with manual input

### DIFF
--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/color_picker/ColorPicker.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/color_picker/ColorPicker.tsx
@@ -196,6 +196,10 @@ export default function ColorPicker({
 	};
 
 	const onBlurInput = ({target}: {target: HTMLInputElement}) => {
+		if (!value) {
+			value = defaultTokenValue;
+		}
+
 		if (value.toLowerCase() === target.value.toLowerCase()) {
 			return;
 		}


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-194357)

## Proposed solution

Check if there is a color value and use the default value if there is not

## Test Scenario 1

1. Go to the Home Page
2. Start editing the Home Page
3. Select the “Welcome to Liferay” Heading
4. On the right side menu, select the Styles tab
5. Change the background color
    * Click into the input field, don’t use the “Select a color" button on the left of the input field, nor the “Value from Stylebook" button from the right
    * Replace #00000000 with #99FF99

## Result:

https://github.com/liferay-echo/liferay-portal/assets/93203423/0565016a-e153-4f8c-8861-5383f8f93982

