### PR TITLE
LPS-194571 Page Templates admin becomes blank after rename page template set

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_collections.jsp
@@ -143,7 +143,7 @@ List<LayoutPageTemplateCollection> layoutPageTemplateCollections = layoutPageTem
 
 								<clay:dropdown-actions
 									aria-label='<%= LanguageUtil.get(request, "show-actions") %>'
-									dropdownItems="<%= layoutPageTemplateCollectionActionDropdownItem.getActionDropdownItems(layoutPageTemplateCollection, "display-page") %>"
+									dropdownItems="<%= layoutPageTemplateCollectionActionDropdownItem.getActionDropdownItems(layoutPageTemplateCollection, "page-templates") %>"
 									propsTransformer="js/propsTransformers/LayoutPageTemplateCollectionPropsTransformer"
 								/>
 							</clay:content-col>


### PR DESCRIPTION
Motivation
=======
Page Templates admin becomes blank after rename page template set

Proposed Solution
========
The problemas was that it was redirecting to the wrong tab after renaming, this PR fixes that.

Steps to Verify
========

1. Add a new site
2. Navigate to the Page Templates admin
3. Add a page template set
4. Edit the page template set
5. Rename it then save