### PR TITLE
LPS-192256 parentCommentId can be undefined

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/addFragmentEntryLinkComment.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/addFragmentEntryLinkComment.ts
@@ -26,7 +26,7 @@ export default function addFragmentEntryLinkComment({
 }: {
 	fragmentEntryLinkComment: FragmentEntryLinkComment;
 	fragmentEntryLinkId: string;
-	parentCommentId: string;
+	parentCommentId?: string;
 }) {
 	return {
 		fragmentEntryLinkComment,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/deleteFragmentEntryLinkComment.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/deleteFragmentEntryLinkComment.ts
@@ -12,7 +12,7 @@ export default function deleteFragmentEntryLinkComment({
 }: {
 	commentId: string;
 	fragmentEntryLinkId: string;
-	parentCommentId: string;
+	parentCommentId?: string;
 }) {
 	return {
 		commentId,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/editFragmentEntryLinkComment.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/actions/editFragmentEntryLinkComment.ts
@@ -9,11 +9,11 @@ import {EDIT_FRAGMENT_ENTRY_LINK_COMMENT} from './types';
 export default function editFragmentEntryLinkComment({
 	fragmentEntryLinkComment,
 	fragmentEntryLinkId,
-	parentCommentId = '0',
+	parentCommentId,
 }: {
 	fragmentEntryLinkComment: FragmentEntryLinkComment;
 	fragmentEntryLinkId: string;
-	parentCommentId: string;
+	parentCommentId?: string;
 }) {
 	return {
 		fragmentEntryLinkComment,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/FragmentService.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/services/FragmentService.js
@@ -31,14 +31,14 @@ export default {
 	 * @param {string} options.body Body of the comment
 	 * @param {string} options.fragmentEntryLinkId Id of the Fragment
 	 * @param {function} options.onNetworkStatus
-	 * @param {number} [options.parentCommentId=0]
+	 * @param {string} [options.parentCommentId]
 	 * @return {Promise<FragmentComment>} Created FragmentComment
 	 */
 	addComment({
 		body,
 		fragmentEntryLinkId,
 		onNetworkStatus,
-		parentCommentId = 0,
+		parentCommentId = '0',
 	}) {
 		return serviceFetch(
 			config.addFragmentEntryLinkCommentURL,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addFragmentComment.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addFragmentComment.js
@@ -6,10 +6,16 @@
 import addFragmentEntryLinkComment from '../actions/addFragmentEntryLinkComment';
 import FragmentService from '../services/FragmentService';
 
+/**
+ * @param {object} options
+ * @param {string} options.body
+ * @param {string} options.fragmentEntryLinkId
+ * @param {string} [options.parentCommentId]
+ */
 export default function addFragmentComment({
 	body,
 	fragmentEntryLinkId,
-	parentCommentId = undefined,
+	parentCommentId,
 }) {
 	return (dispatch) => {
 		return FragmentService.addComment({

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/deleteFragmentComment.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/deleteFragmentComment.js
@@ -6,6 +6,11 @@
 import deleteFragmentEntryLinkComment from '../actions/deleteFragmentEntryLinkComment';
 import FragmentService from '../services/FragmentService';
 
+/**
+ * @param {string} options.commentId
+ * @param {string} options.fragmentEntryLinkId
+ * @param {string} [options.parentCommentId]
+ */
 export default function deleteFragmentComment({
 	commentId,
 	fragmentEntryLinkId,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/editFragmentComment.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/editFragmentComment.js
@@ -6,6 +6,13 @@
 import editFragmentEntryLinkComment from '../actions/editFragmentEntryLinkComment';
 import FragmentService from '../services/FragmentService';
 
+/**
+ * @param {string} options.body
+ * @param {string} options.commentId
+ * @param {string} options.fragmentEntryLinkId
+ * @param {string} [options.parentCommentId]
+ * @param {boolean} [options.resolved]
+ */
 export default function editFragmentComment({
 	body,
 	commentId,

--- a/modules/apps/layout/layout-content-page-editor-web/types/src/main/resources/META-INF/resources/page_editor/app/actions/addFragmentEntryLinkComment.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/types/src/main/resources/META-INF/resources/page_editor/app/actions/addFragmentEntryLinkComment.d.ts
@@ -23,10 +23,10 @@ export default function addFragmentEntryLinkComment({
 }: {
 	fragmentEntryLinkComment: FragmentEntryLinkComment;
 	fragmentEntryLinkId: string;
-	parentCommentId: string;
+	parentCommentId?: string;
 }): {
 	readonly fragmentEntryLinkComment: FragmentEntryLinkComment;
 	readonly fragmentEntryLinkId: string;
-	readonly parentCommentId: string;
+	readonly parentCommentId: string | undefined;
 	readonly type: 'ADD_FRAGMENT_ENTRY_LINK_COMMENT';
 };

--- a/modules/apps/layout/layout-content-page-editor-web/types/src/main/resources/META-INF/resources/page_editor/app/actions/deleteFragmentEntryLinkComment.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/types/src/main/resources/META-INF/resources/page_editor/app/actions/deleteFragmentEntryLinkComment.d.ts
@@ -10,10 +10,10 @@ export default function deleteFragmentEntryLinkComment({
 }: {
 	commentId: string;
 	fragmentEntryLinkId: string;
-	parentCommentId: string;
+	parentCommentId?: string;
 }): {
 	readonly commentId: string;
 	readonly fragmentEntryLinkId: string;
-	readonly parentCommentId: string;
+	readonly parentCommentId: string | undefined;
 	readonly type: 'DELETE_FRAGMENT_ENTRY_LINK_COMMENT';
 };

--- a/modules/apps/layout/layout-content-page-editor-web/types/src/main/resources/META-INF/resources/page_editor/app/actions/editFragmentEntryLinkComment.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/types/src/main/resources/META-INF/resources/page_editor/app/actions/editFragmentEntryLinkComment.d.ts
@@ -11,10 +11,10 @@ export default function editFragmentEntryLinkComment({
 }: {
 	fragmentEntryLinkComment: FragmentEntryLinkComment;
 	fragmentEntryLinkId: string;
-	parentCommentId: string;
+	parentCommentId?: string;
 }): {
 	readonly fragmentEntryLinkComment: FragmentEntryLinkComment;
 	readonly fragmentEntryLinkId: string;
-	readonly parentCommentId: string;
+	readonly parentCommentId: string | undefined;
 	readonly type: 'EDIT_FRAGMENT_ENTRY_LINK_COMMENT';
 };


### PR DESCRIPTION
We need to treat parentCommentId as possibly undefined, and send '0' to backend when necessary. They do use the 0 long value as an empty value, but in JS '0' is truthy.