### PR TITLE
[TS] LPS-194654 Scheduled web content version gets the wrong author after getting Approved

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -6111,7 +6111,7 @@ public class JournalArticleLocalServiceImpl
 				}
 
 				long userId = _portal.getValidUserId(
-					article.getCompanyId(), article.getUserId());
+					article.getCompanyId(), article.getStatusByUserId());
 
 				ServiceContext serviceContext = new ServiceContext();
 


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
When a Web Content Article's publication is scheduled, the displayed author will be the user who made the editing, while the Article is in the SCHEDULED status. After the scheduled publication, however, the displayed author will be that of the creator of the Article.
This behavior seems incorrect because if the Article is published right away without scheduling, the author will be the user who made the publishing. 

Proposed Solution
========
When an Acticle's scheduled publication is being performed, it will be updated with the statusByUserId of the article's creator. This should be the user who scheduled the Article instead.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://liferay.atlassian.net/browse/LPS-194654

Thank you and best regards,
István