### PR TITLE
LPS-190844 Remove no needed translation in labels and titles for clay:link

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -38,7 +38,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 			<c:when test="<%= segmentsConfigurationURL != null %>">
 				<clay:link
 					href="<%= segmentsConfigurationURL %>"
-					label='<%= LanguageUtil.get(request, "to-enable,-go-to-instance-settings") %>'
+					label="to-enable,-go-to-instance-settings"
 				/>
 			</c:when>
 			<c:otherwise>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/design.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/design.jsp
@@ -59,7 +59,7 @@ LayoutRevision layoutRevision = LayoutStagingUtil.getLayoutRevision(selLayout);
 
 				<clay:link
 					href="<%= layoutsAdminDisplayContext.getPreviewCurrentDesignURL() %>"
-					label='<%= LanguageUtil.get(request, "see-current-published-configuration-here") %>'
+					label="see-current-published-configuration-here"
 				/>
 			</clay:alert>
 		</c:if>

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/merge_alert.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/merge_alert.jsp
@@ -30,7 +30,7 @@ int mergeFailCount = layoutPrototype.getMergeFailCount();
 		<clay:link
 			displayType="secondary"
 			href="<%= resetMergeFailCountURL %>"
-			label='<%= LanguageUtil.get(request, "reset") %>'
+			label="reset"
 			type="button"
 		/>
 	</clay:alert>

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,7 +17,6 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
@@ -44,7 +44,7 @@ SegmentsSimulationDisplayContext segmentsSimulationDisplayContext = (SegmentsSim
 										<c:when test="<%= segmentsSimulationDisplayContext.getSegmentsCompanyConfigurationURL() != null %>">
 											<clay:link
 												href="<%= segmentsSimulationDisplayContext.getSegmentsCompanyConfigurationURL() %>"
-												label='<%= LanguageUtil.get(request, "to-enable,-go-to-instance-settings") %>'
+												label="to-enable,-go-to-instance-settings"
 											/>
 										</c:when>
 										<c:otherwise>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_configuration.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_configuration.jsp
@@ -65,7 +65,7 @@ SegmentsCompanyConfigurationDisplayContext segmentsCompanyConfigurationDisplayCo
 					<c:when test="<%= segmentsConfigurationURL != null %>">
 						<clay:link
 							href="<%= segmentsConfigurationURL %>"
-							label='<%= LanguageUtil.get(request, "to-enable,-go-to-system-settings") %>'
+							label="to-enable,-go-to-system-settings"
 						/>
 					</c:when>
 					<c:otherwise>
@@ -91,7 +91,7 @@ SegmentsCompanyConfigurationDisplayContext segmentsCompanyConfigurationDisplayCo
 					<c:when test="<%= segmentsConfigurationURL != null %>">
 						<clay:link
 							href="<%= segmentsConfigurationURL %>"
-							label='<%= LanguageUtil.get(request, "to-enable,-go-to-system-settings") %>'
+							label="to-enable,-go-to-system-settings"
 						/>
 					</c:when>
 					<c:otherwise>
@@ -197,7 +197,7 @@ SegmentsCompanyConfigurationDisplayContext segmentsCompanyConfigurationDisplayCo
 					displayType="secondary"
 					href="<%= redirect %>"
 					id='<%= liferayPortletResponse.getNamespace() + "cancel" %>'
-					label='<%= LanguageUtil.get(request, "cancel") %>'
+					label="cancel"
 					type="button"
 				/>
 			</div>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
@@ -36,7 +36,7 @@ request.setAttribute("view.jsp-eventName", eventName);
 			<c:when test="<%= segmentsConfigurationURL != null %>">
 				<clay:link
 					href="<%= segmentsConfigurationURL %>"
-					label='<%= LanguageUtil.get(request, "to-enable,-go-to-instance-settings") %>'
+					label="to-enable,-go-to-instance-settings"
 				/>
 			</c:when>
 			<c:otherwise>


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-190844)

## Proposed solution

Remove all no needed translation for clay:link 

## Test Scenario 1

1. Go to Instance Settings > Segments 
2. Disable Segmentation
3. Create a new Manual collection
4. Check the link in the warning

<img width="1273" alt="Pasted Graphic 1" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/d03b981e-fe9d-4ec2-9b19-f89ac7ff18f1">

## Notes

This changes don't modify the behaviour of the clay:link.
