### PR TITLE
LPS-190845 Remove no needed translation in label for clay:label

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view.jsp
@@ -91,7 +91,7 @@ AssetListManagementToolbarDisplayContext assetListManagementToolbarDisplayContex
 									<c:otherwise>
 										<clay:label
 											cssClass="mr-auto"
-											label='<%= LanguageUtil.get(request, "no-variations") %>'
+											label="no-variations"
 										/>
 									</c:otherwise>
 								</c:choose>


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-190845)

## Proposed solution

Remove all no needed translation for clay:label 

## Test Scenario 1

1. Create a new Manual collection
2. Create a Widget Page and add an Asset Publisher
3. Select a collection
4. Check the label that says “no variations”

<img width="745" alt="Pasted Graphic 2" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/f0b92d06-969f-420b-aa0b-481577001f96">

## Notes

This changes don't modify the behaviour of the clay:label.
