### PR TITLE
LPS-190842 Remove no needed translations in labels and titles for clay:button, clay:link, clay:label and clay:checkbox in Echo modules

### DIFF
--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/init.jsp
@@ -21,7 +21,6 @@ taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
 page import="com.liferay.asset.categories.item.selector.web.internal.display.context.SelectAssetCategoryInfoItemDisplayContext" %><%@
 page import="com.liferay.asset.categories.item.selector.web.internal.display.context.SelectAssetCategoryTreeNodeDisplayContext" %><%@
 page import="com.liferay.asset.categories.item.selector.web.internal.display.context.SelectAssetVocabularyDisplayContext" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %>
 
 <liferay-frontend:defineObjects />

--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/select_asset_category_tree_node.jsp
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/select_asset_category_tree_node.jsp
@@ -28,7 +28,7 @@ SelectAssetCategoryTreeNodeDisplayContext selectAssetCategoryTreeNodeDisplayCont
 			data-category-tree-node-type="<%= selectAssetCategoryTreeNodeDisplayContext.getAssetCategoryTreeNodeType() %>"
 			data-title="<%= selectAssetCategoryTreeNodeDisplayContext.getAssetCategoryTreeNodeName() %>"
 			displayType="primary"
-			label='<%= LanguageUtil.get(resourceBundle, "select-this-level") %>'
+			label="select-this-level"
 			small="<%= true %>"
 		/>
 	</div>

--- a/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/select_asset_vocabulary.jsp
+++ b/modules/apps/asset/asset-categories-item-selector-web/src/main/resources/META-INF/resources/select_asset_vocabulary.jsp
@@ -31,7 +31,7 @@ SelectAssetVocabularyDisplayContext selectAssetVocabularyDisplayContext = (Selec
 					cssClass="asset-category-tree-node-selector"
 					disabled="<%= true %>"
 					displayType="primary"
-					label='<%= LanguageUtil.get(resourceBundle, "select-this-level") %>'
+					label="select-this-level"
 					small="<%= true %>"
 				/>
 			</div>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry.jsp
@@ -38,7 +38,7 @@ renderResponse.setTitle(assetListDisplayContext.getAssetListEntryTitle());
 			<c:when test="<%= segmentsConfigurationURL != null %>">
 				<clay:link
 					href="<%= segmentsConfigurationURL %>"
-					label='<%= LanguageUtil.get(request, "to-enable,-go-to-instance-settings") %>'
+					label="to-enable,-go-to-instance-settings"
 				/>
 			</c:when>
 			<c:otherwise>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/view.jsp
@@ -91,7 +91,7 @@ AssetListManagementToolbarDisplayContext assetListManagementToolbarDisplayContex
 									<c:otherwise>
 										<clay:label
 											cssClass="mr-auto"
-											label='<%= LanguageUtil.get(request, "no-variations") %>'
+											label="no-variations"
 										/>
 									</c:otherwise>
 								</c:choose>

--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/input_asset_links/page.jsp
@@ -72,7 +72,7 @@
 				data-rowId="<%= assetLinkEntry.getEntryId() %>"
 				displayType="secondary"
 				icon="times-circle"
-				title='<%= LanguageUtil.get(request, "remove") %>'
+				title="remove"
 				type="button"
 			/>
 		</liferay-ui:search-container-column-text>

--- a/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/init.jsp
@@ -8,8 +8,7 @@
 <%@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %>
 
-<%@ page import="com.liferay.fragment.collection.filter.category.display.context.FragmentCollectionFilterCategoryDisplayContext" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %>
+<%@ page import="com.liferay.fragment.collection.filter.category.display.context.FragmentCollectionFilterCategoryDisplayContext" %>
 
 <%
 FragmentCollectionFilterCategoryDisplayContext fragmentCollectionFilterCategoryDisplayContext = (FragmentCollectionFilterCategoryDisplayContext)request.getAttribute(FragmentCollectionFilterCategoryDisplayContext.class.getName());

--- a/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/page.jsp
+++ b/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/page.jsp
@@ -17,7 +17,7 @@
 			cssClass="dropdown-toggle form-control form-control-select form-control-sm text-left w-100"
 			disabled="<%= true %>"
 			displayType="secondary"
-			label='<%= LanguageUtil.get(request, "select") %>'
+			label="select"
 			small="<%= true %>"
 		/>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/categorization.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/categorization.jsp
@@ -74,7 +74,7 @@ DDMStructure ddmStructure = journalEditArticleDisplayContext.getDDMStructure();
 	<clay:checkbox
 		checked="<%= assetAutoTaggerConfiguration.isUpdateAutoTags() %>"
 		id='<%= liferayPortletResponse.getNamespace() + "updateAutoTags" %>'
-		label='<%= LanguageUtil.get(request, "update-auto-tags") %>'
+		label="update-auto-tags"
 		name='<%= liferayPortletResponse.getNamespace() + "updateAutoTags" %>'
 	/>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_article.jsp
@@ -135,7 +135,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 								id='<%= liferayPortletResponse.getNamespace() + "contextualSidebarButton" %>'
 								role="tab"
 								small="<%= true %>"
-								title='<%= LanguageUtil.get(request, "close-configuration-panel") %>'
+								title="close-configuration-panel"
 								type="button"
 							/>
 						</div>

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/edit_folder.jsp
@@ -303,7 +303,7 @@ renderResponse.setTitle(title);
 										displayType="secondary"
 										icon="times-circle"
 										monospaced="<%= true %>"
-										title='<%= LanguageUtil.get(request, "remove") %>'
+										title="remove"
 									/>
 								</liferay-ui:search-container-column-text>
 							</liferay-ui:search-container-row>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/information_messages.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/dynamic_include/information_messages.jsp
@@ -19,7 +19,7 @@ LayoutInformationMessagesDisplayContext layoutInformationMessagesDisplayContext 
 		monospaced="<%= true %>"
 		small="<%= true %>"
 		symbol="information-live"
-		title='<%= LanguageUtil.get(request, "additional-information") %>'
+		title="additional-information"
 	/>
 
 	<react:component

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/design.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/screen/navigation/entries/design.jsp
@@ -59,7 +59,7 @@ LayoutRevision layoutRevision = LayoutStagingUtil.getLayoutRevision(selLayout);
 
 				<clay:link
 					href="<%= layoutsAdminDisplayContext.getPreviewCurrentDesignURL() %>"
-					label='<%= LanguageUtil.get(request, "see-current-published-configuration-here") %>'
+					label="see-current-published-configuration-here"
 				/>
 			</clay:alert>
 		</c:if>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_theme_details.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_theme_details.jsp
@@ -147,7 +147,7 @@ String styleBookWarningMessage = layoutsAdminDisplayContext.getStyleBookWarningM
 			disabled="<%= layoutsAdminDisplayContext.isReadOnly() %>"
 			displayType="secondary"
 			id='<%= liferayPortletResponse.getNamespace() + "changeTheme" %>'
-			label='<%= LanguageUtil.get(request, "change-current-theme") %>'
+			label="change-current-theme"
 		/>
 
 		<portlet:renderURL copyCurrentRenderParameters="<%= true %>" var="lookAndFeelDetailURL" windowState="<%= LiferayWindowState.EXCLUSIVE.toString() %>">

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_info.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/look_and_feel_themes_info.jsp
@@ -72,7 +72,7 @@ PluginPackage selPluginPackage = selTheme.getPluginPackage();
 		<clay:button
 			disabled="true"
 			displayType="secondary"
-			label='<%= LanguageUtil.get(request, "change-current-theme") %>'
+			label="change-current-theme"
 		/>
 	</clay:col>
 </clay:row>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/view_toolbar.jsp
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/view_toolbar.jsp
@@ -42,7 +42,7 @@ ContentPageEditorDisplayContext contentPageEditorDisplayContext = (ContentPageEd
 						icon="undo"
 						monospaced="<%= true %>"
 						small="<%= true %>"
-						title='<%= LanguageUtil.get(request, "undo") %>'
+						title="undo"
 					/>
 
 					<clay:button
@@ -51,7 +51,7 @@ ContentPageEditorDisplayContext contentPageEditorDisplayContext = (ContentPageEd
 						icon="redo"
 						monospaced="<%= true %>"
 						small="<%= true %>"
-						title='<%= LanguageUtil.get(request, "redo") %>'
+						title="redo"
 					/>
 				</div>
 
@@ -64,7 +64,7 @@ ContentPageEditorDisplayContext contentPageEditorDisplayContext = (ContentPageEd
 							icon="time"
 							monospaced="<%= true %>"
 							small="<%= true %>"
-							title='<%= LanguageUtil.get(request, "history") %>'
+							title="history"
 						/>
 					</div>
 				</span>
@@ -90,7 +90,7 @@ ContentPageEditorDisplayContext contentPageEditorDisplayContext = (ContentPageEd
 							icon="view"
 							monospaced="<%= true %>"
 							small="<%= true %>"
-							title='<%= LanguageUtil.get(request, "view") %>'
+							title="view"
 						/>
 					</li>
 				</ul>

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/merge_alert.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/merge_alert.jsp
@@ -30,7 +30,7 @@ int mergeFailCount = layoutPrototype.getMergeFailCount();
 		<clay:link
 			displayType="secondary"
 			href="<%= resetMergeFailCountURL %>"
-			label='<%= LanguageUtil.get(request, "reset") %>'
+			label="reset"
 			type="button"
 		/>
 	</clay:alert>

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -92,7 +92,7 @@ Group group = siteAdministrationPanelCategoryDisplayContext.getGroup();
 					displayType="unstyled"
 					icon="pages-tree"
 					id='<%= liferayPortletResponse.getNamespace() + "pagesTreeSidenavToggleId" %>'
-					label='<%= LanguageUtil.get(resourceBundle, "page-tree") %>'
+					label="page-tree"
 				/>
 			</c:if>
 		</clay:col>

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_icon_sites.jspf
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_icon_sites.jspf
@@ -15,7 +15,7 @@
 		id='<%= liferayPortletResponse.getNamespace() + "manageSitesLink" %>'
 		monospaced="<%= true %>"
 		small="<%= true %>"
-		title='<%= LanguageUtil.get(request, "go-to-other-site") %>'
+		title="go-to-other-site"
 	/>
 </div>
 

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_no_collapsible.jspf
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_header_no_collapsible.jspf
@@ -69,7 +69,7 @@
 				icon="times"
 				monospaced="<%= true %>"
 				small="<%= true %>"
-				title='<%= LanguageUtil.get(request, "close") %>'
+				title="close"
 			/>
 		</clay:content-col>
 	</clay:content-row>

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/init.jsp
@@ -17,7 +17,6 @@ taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 
 <%@ page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.util.HashMapBuilder" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@

--- a/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-simulation-web/src/main/resources/META-INF/resources/view.jsp
@@ -44,7 +44,7 @@ SegmentsSimulationDisplayContext segmentsSimulationDisplayContext = (SegmentsSim
 										<c:when test="<%= segmentsSimulationDisplayContext.getSegmentsCompanyConfigurationURL() != null %>">
 											<clay:link
 												href="<%= segmentsSimulationDisplayContext.getSegmentsCompanyConfigurationURL() %>"
-												label='<%= LanguageUtil.get(request, "to-enable,-go-to-instance-settings") %>'
+												label="to-enable,-go-to-instance-settings"
 											/>
 										</c:when>
 										<c:otherwise>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_configuration.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_configuration.jsp
@@ -128,7 +128,7 @@ SegmentsCompanyConfigurationDisplayContext segmentsCompanyConfigurationDisplayCo
 						checked="<%= segmentsCompanyConfigurationDisplayContext.isSegmentationChecked() %>"
 						disabled="<%= !segmentsCompanyConfigurationDisplayContext.isSegmentationEnabled() %>"
 						id='<%= liferayPortletResponse.getNamespace() + "segmentationEnabled" %>'
-						label='<%= LanguageUtil.get(request, "segmentation-enabled-name") %>'
+						label="segmentation-enabled-name"
 						name='<%= liferayPortletResponse.getNamespace() + "segmentationEnabled" %>'
 					/>
 
@@ -155,7 +155,7 @@ SegmentsCompanyConfigurationDisplayContext segmentsCompanyConfigurationDisplayCo
 						checked="<%= segmentsCompanyConfigurationDisplayContext.isRoleSegmentationChecked() %>"
 						disabled="<%= !segmentsCompanyConfigurationDisplayContext.isRoleSegmentationEnabled() %>"
 						id='<%= liferayPortletResponse.getNamespace() + "roleSegmentationEnabled" %>'
-						label='<%= LanguageUtil.get(request, "role-segmentation-enabled-name") %>'
+						label="role-segmentation-enabled-name"
 						name='<%= liferayPortletResponse.getNamespace() + "roleSegmentationEnabled" %>'
 					/>
 

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_configuration.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/segments_configuration.jsp
@@ -65,7 +65,7 @@ SegmentsCompanyConfigurationDisplayContext segmentsCompanyConfigurationDisplayCo
 					<c:when test="<%= segmentsConfigurationURL != null %>">
 						<clay:link
 							href="<%= segmentsConfigurationURL %>"
-							label='<%= LanguageUtil.get(request, "to-enable,-go-to-system-settings") %>'
+							label="to-enable,-go-to-system-settings"
 						/>
 					</c:when>
 					<c:otherwise>
@@ -91,7 +91,7 @@ SegmentsCompanyConfigurationDisplayContext segmentsCompanyConfigurationDisplayCo
 					<c:when test="<%= segmentsConfigurationURL != null %>">
 						<clay:link
 							href="<%= segmentsConfigurationURL %>"
-							label='<%= LanguageUtil.get(request, "to-enable,-go-to-system-settings") %>'
+							label="to-enable,-go-to-system-settings"
 						/>
 					</c:when>
 					<c:otherwise>
@@ -197,7 +197,7 @@ SegmentsCompanyConfigurationDisplayContext segmentsCompanyConfigurationDisplayCo
 					displayType="secondary"
 					href="<%= redirect %>"
 					id='<%= liferayPortletResponse.getNamespace() + "cancel" %>'
-					label='<%= LanguageUtil.get(request, "cancel") %>'
+					label="cancel"
 					type="button"
 				/>
 			</div>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/view.jsp
@@ -36,7 +36,7 @@ request.setAttribute("view.jsp-eventName", eventName);
 			<c:when test="<%= segmentsConfigurationURL != null %>">
 				<clay:link
 					href="<%= segmentsConfigurationURL %>"
-					label='<%= LanguageUtil.get(request, "to-enable,-go-to-instance-settings") %>'
+					label="to-enable,-go-to-instance-settings"
 				/>
 			</c:when>
 			<c:otherwise>

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/select_site_navigation_menu.jsp
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/select_site_navigation_menu.jsp
@@ -31,7 +31,7 @@ SelectSiteNavigationMenuDisplayContext selectSiteNavigationMenuDisplayContext = 
 					cssClass="site-navigation-menu-selector"
 					disabled="<%= true %>"
 					displayType="primary"
-					label='<%= LanguageUtil.get(resourceBundle, "select-this-level") %>'
+					label="select-this-level"
 					small="<%= true %>"
 				/>
 			</div>

--- a/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/select_site_navigation_menu_level.jsp
+++ b/modules/apps/site-navigation/site-navigation-item-selector-web/src/main/resources/META-INF/resources/select_site_navigation_menu_level.jsp
@@ -29,7 +29,7 @@ SelectSiteNavigationMenuDisplayContext selectSiteNavigationMenuDisplayContext = 
 			data-site-navigation-menu-id="<%= selectSiteNavigationMenuDisplayContext.getSiteNavigationMenuId() %>"
 			data-title="<%= selectSiteNavigationMenuDisplayContext.getCurrentLevelTitle() %>"
 			displayType="primary"
-			label='<%= LanguageUtil.get(resourceBundle, "select-this-level") %>'
+			label="select-this-level"
 			small="<%= true %>"
 		/>
 	</div>

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/edit_layout.jsp
@@ -77,7 +77,7 @@ if (selLayout != null) {
 	cssClass="mb-4"
 	displayType="secondary"
 	id='<%= liferayPortletResponse.getNamespace() + "chooseLayout" %>'
-	label='<%= LanguageUtil.get(resourceBundle, "choose") %>'
+	label="choose"
 	propsTransformer="js/ChooseLayoutButtonPropsTransformer"
 	small="<%= true %>"
 />

--- a/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-item-layout/src/main/resources/META-INF/resources/init.jsp
@@ -19,7 +19,6 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.item.selector.criteria.UUIDItemSelectorReturnType" %><%@
 page import="com.liferay.layout.item.selector.criterion.LayoutItemSelectorCriterion" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@
 page import="com.liferay.portal.kernel.model.ModelHintsUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil" %><%@

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/default_user_associations.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/default_user_associations.jsp
@@ -39,9 +39,9 @@ DefaultUserAssociationsDisplayContext defaultUserAssociationsDisplayContext = (D
 			cssClass="modify-link"
 			displayType="secondary"
 			id='<%= liferayPortletResponse.getNamespace() + "selectSiteRoleLink" %>'
-			label='<%= LanguageUtil.get(request, "select") %>'
+			label="select"
 			small="<%= true %>"
-			title='<%= LanguageUtil.get(request, "select") %>'
+			title="select"
 		/>
 	</clay:content-col>
 </clay:content-row>
@@ -73,7 +73,7 @@ DefaultUserAssociationsDisplayContext defaultUserAssociationsDisplayContext = (D
 				displayType="secondary"
 				icon="times-circle"
 				monospaced="<%= true %>"
-				title='<%= LanguageUtil.get(request, "remove") %>'
+				title="remove"
 				type="button"
 			/>
 		</liferay-ui:search-container-column-text>
@@ -101,9 +101,9 @@ DefaultUserAssociationsDisplayContext defaultUserAssociationsDisplayContext = (D
 			cssClass="modify-link"
 			displayType="secondary"
 			id='<%= liferayPortletResponse.getNamespace() + "selectTeamLink" %>'
-			label='<%= LanguageUtil.get(request, "select") %>'
+			label="select"
 			small="<%= true %>"
-			title='<%= LanguageUtil.get(request, "select") %>'
+			title="select"
 		/>
 	</clay:content-col>
 </clay:content-row>
@@ -135,7 +135,7 @@ DefaultUserAssociationsDisplayContext defaultUserAssociationsDisplayContext = (D
 				displayType="secondary"
 				icon="times-circle"
 				monospaced="<%= true %>"
-				title='<%= LanguageUtil.get(request, "remove") %>'
+				title="remove"
 				type="button"
 			/>
 		</liferay-ui:search-container-column-text>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/menu_access.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/menu_access.jsp
@@ -69,9 +69,9 @@ String textCssClass = menuAccessDisplayContext.isShowControlMenuByRole() ? "modi
 				disabled="<%= !menuAccessDisplayContext.isShowControlMenuByRole() %>"
 				displayType="secondary"
 				id='<%= liferayPortletResponse.getNamespace() + "selectRoleLink" %>'
-				label='<%= LanguageUtil.get(request, "select") %>'
+				label="select"
 				small="<%= true %>"
-				title='<%= LanguageUtil.get(request, "select") %>'
+				title="select"
 			/>
 		</clay:content-col>
 	</clay:content-row>
@@ -110,7 +110,7 @@ String textCssClass = menuAccessDisplayContext.isShowControlMenuByRole() ? "modi
 								displayType="secondary"
 								icon="times-circle"
 								monospaced="<%= true %>"
-								title='<%= LanguageUtil.get(request, "remove") %>'
+								title="remove"
 								type="button"
 							/>
 						</c:if>

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/menu_access.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/site_settings/menu_access.jsp
@@ -41,7 +41,7 @@ String textCssClass = menuAccessDisplayContext.isShowControlMenuByRole() ? "modi
 				aria-describedby='<%= liferayPortletResponse.getNamespace() + "showControlMenuByRoleDescription" %>'
 				checked="<%= menuAccessDisplayContext.isShowControlMenuByRole() %>"
 				id='<%= liferayPortletResponse.getNamespace() + "showControlMenuByRole" %>'
-				label='<%= LanguageUtil.get(request, "show-control-menu-by-role-name") %>'
+				label="show-control-menu-by-role-name"
 				name='<%= liferayPortletResponse.getNamespace() + "showControlMenuByRole" %>'
 			/>
 


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/PS-LPS-190842)

## Proposed solution

Remove all no needed translations for clay:button, clay:link, clay:label and clay:checkbox in Echo Modules

## Notes

This changes don't modify the behaviours 

## Test Scenario 1

1. Go to the Home Page
2. Start editing the Home Page
3. Check this buttons tittles:

<img width="171" alt="Pasted Graphic" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/df7ea55d-2c3f-403a-91db-b4f1e48db959">

## Test Scenario 2

1. Go to Instance Settings > Segments 
2. Disable Segmentation
3. Create a new Manual collection
4. Check the link in the warning

<img width="1273" alt="Pasted Graphic 1" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/d03b981e-fe9d-4ec2-9b19-f89ac7ff18f1">

## Test Scenario 3

1. Create a new Manual collection
2. Create a Widget Page and add an Asset Publisher
3. Select a collection
4. Check the label that says “no variations”

<img width="745" alt="Pasted Graphic 2" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/f0b92d06-969f-420b-aa0b-481577001f96">

## Test Scenario 4

1. Go to Instance Settings > Segments > Segments Service
2. Look at the checkbox for Enable Segmentation.

<img width="215" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/101d060b-3e9d-449e-9864-f8b51486617b">
