### PR TITLE
LPS-193855 Revert click interaction on collections

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
@@ -16,7 +16,6 @@ import {fromControlsId} from '../../../app/components/layout_data_items/Collecti
 import {EDITABLE_FRAGMENT_ENTRY_PROCESSOR} from '../../../app/config/constants/editableFragmentEntryProcessor';
 import {ITEM_ACTIVATION_ORIGINS} from '../../../app/config/constants/itemActivationOrigins';
 import {ITEM_TYPES} from '../../../app/config/constants/itemTypes';
-import {LAYOUT_DATA_ITEM_TYPES} from '../../../app/config/constants/layoutDataItemTypes';
 import {
 	useHoverItem,
 	useHoveredItemId,
@@ -160,29 +159,6 @@ export default function PageContent({
 		externalReferenceCode,
 	]);
 
-	const handleOnClick = () => {
-		if (dropdownItems?.length) {
-			Object.values(layoutData.items).forEach((item) => {
-				if (item.type === LAYOUT_DATA_ITEM_TYPES.collection) {
-					const collectionConfig = item.config?.collection;
-
-					if (
-						collectionConfig.classNameId === classNameId &&
-						collectionConfig.classPK === classPK
-					) {
-						selectItem(item.itemId, {
-							itemType: ITEM_TYPES.layoutDataItem,
-							origin: ITEM_ACTIVATION_ORIGINS.sidebar,
-						});
-					}
-				}
-			});
-		}
-		else {
-			onClickEditInlineText();
-		}
-	};
-
 	const handleMouseOver = () => {
 		setIsHovered(true);
 
@@ -241,7 +217,6 @@ export default function PageContent({
 						isHovered || activeActions || isBeingEdited,
 				}
 			)}
-			onClick={handleOnClick}
 			onMouseLeave={handleMouseLeave}
 			onMouseOver={handleMouseOver}
 		>
@@ -336,9 +311,10 @@ export default function PageContent({
 								)}
 								disabled={isBeingEdited || !canUpdateEditables}
 								displayType="unstyled"
+								onClick={onClickEditInlineText}
 								size="sm"
 							>
-								{!isHovered && <ClayIcon symbol="pencil" />}
+								<ClayIcon symbol="pencil" />
 							</ClayButton>
 						)}
 					</ClayLayout.ContentCol>


### PR DESCRIPTION
Motivation
=======
The motivation behind this PR is to remove the selectItem interaction for collections in the Page Content tab from the Page Editor.
https://liferay.atlassian.net/browse/LPS-193855

Proposed Solution
========
What I did to solve this problem is to use editableId variable to discard collections since they doesn't contain it and also remove opacity for the collection item in the list.

Steps to Verify
========
1. Create a collection
2. Go to Page Content tab in the page editor
3. Check that the the Collection content is not clickable but it still contains the ellipsis button
4. Check that the inline-text elements still working fine
