### PR TITLE
LPS-193149: Add endpoints to Sites API

### DIFF
--- a/modules/apps/headless/headless-site/headless-site-api/bnd.bnd
+++ b/modules/apps/headless/headless-site/headless-site-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Site API
 Bundle-SymbolicName: com.liferay.headless.site.api
-Bundle-Version: 2.2.1
+Bundle-Version: 2.3.0
 Export-Package:\
 	com.liferay.headless.site.dto.v1_0,\
 	com.liferay.headless.site.resource.v1_0

--- a/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/dto/v1_0/Creator.java
+++ b/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/dto/v1_0/Creator.java
@@ -1,0 +1,509 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.site.dto.v1_0;
+
+import com.fasterxml.jackson.annotation.JsonFilter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import com.liferay.petra.function.UnsafeSupplier;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLField;
+import com.liferay.portal.vulcan.graphql.annotation.GraphQLName;
+import com.liferay.portal.vulcan.util.ObjectMapperUtil;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.io.Serializable;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.annotation.Generated;
+
+import javax.xml.bind.annotation.XmlRootElement;
+
+/**
+ * @author Rubén Pulido
+ * @generated
+ */
+@Generated("")
+@GraphQLName(
+	description = "Represents the user who created/authored the content. Properties follow the [creator](https://schema.org/creator) specification.",
+	value = "Creator"
+)
+@JsonFilter("Liferay.Vulcan")
+@XmlRootElement(name = "Creator")
+public class Creator implements Serializable {
+
+	public static Creator toDTO(String json) {
+		return ObjectMapperUtil.readValue(Creator.class, json);
+	}
+
+	public static Creator unsafeToDTO(String json) {
+		return ObjectMapperUtil.unsafeReadValue(Creator.class, json);
+	}
+
+	@Schema(
+		description = "The user's additional name, which can be used as a middle name."
+	)
+	public String getAdditionalName() {
+		return additionalName;
+	}
+
+	public void setAdditionalName(String additionalName) {
+		this.additionalName = additionalName;
+	}
+
+	@JsonIgnore
+	public void setAdditionalName(
+		UnsafeSupplier<String, Exception> additionalNameUnsafeSupplier) {
+
+		try {
+			additionalName = additionalNameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(
+		description = "The user's additional name, which can be used as a middle name."
+	)
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String additionalName;
+
+	@Schema(description = "The type of the content.")
+	public String getContentType() {
+		return contentType;
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+	}
+
+	@JsonIgnore
+	public void setContentType(
+		UnsafeSupplier<String, Exception> contentTypeUnsafeSupplier) {
+
+		try {
+			contentType = contentTypeUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The type of the content.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String contentType;
+
+	@Schema(description = "The user's surname (last name).")
+	public String getFamilyName() {
+		return familyName;
+	}
+
+	public void setFamilyName(String familyName) {
+		this.familyName = familyName;
+	}
+
+	@JsonIgnore
+	public void setFamilyName(
+		UnsafeSupplier<String, Exception> familyNameUnsafeSupplier) {
+
+		try {
+			familyName = familyNameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The user's surname (last name).")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String familyName;
+
+	@Schema(description = "The user's first name.")
+	public String getGivenName() {
+		return givenName;
+	}
+
+	public void setGivenName(String givenName) {
+		this.givenName = givenName;
+	}
+
+	@JsonIgnore
+	public void setGivenName(
+		UnsafeSupplier<String, Exception> givenNameUnsafeSupplier) {
+
+		try {
+			givenName = givenNameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The user's first name.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String givenName;
+
+	@Schema(description = "The user's ID.")
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	@JsonIgnore
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The user's ID.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected Long id;
+
+	@Schema(description = "A relative URL to the user's profile image.")
+	public String getImage() {
+		return image;
+	}
+
+	public void setImage(String image) {
+		this.image = image;
+	}
+
+	@JsonIgnore
+	public void setImage(
+		UnsafeSupplier<String, Exception> imageUnsafeSupplier) {
+
+		try {
+			image = imageUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "A relative URL to the user's profile image.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String image;
+
+	@Schema(description = "The user's full name.")
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	@JsonIgnore
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "The user's full name.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String name;
+
+	@Schema(description = "A relative URL to the user's profile.")
+	public String getProfileURL() {
+		return profileURL;
+	}
+
+	public void setProfileURL(String profileURL) {
+		this.profileURL = profileURL;
+	}
+
+	@JsonIgnore
+	public void setProfileURL(
+		UnsafeSupplier<String, Exception> profileURLUnsafeSupplier) {
+
+		try {
+			profileURL = profileURLUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField(description = "A relative URL to the user's profile.")
+	@JsonProperty(access = JsonProperty.Access.READ_ONLY)
+	protected String profileURL;
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Creator)) {
+			return false;
+		}
+
+		Creator creator = (Creator)object;
+
+		return Objects.equals(toString(), creator.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		StringBundler sb = new StringBundler();
+
+		sb.append("{");
+
+		if (additionalName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"additionalName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(additionalName));
+
+			sb.append("\"");
+		}
+
+		if (contentType != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"contentType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(contentType));
+
+			sb.append("\"");
+		}
+
+		if (familyName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"familyName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(familyName));
+
+			sb.append("\"");
+		}
+
+		if (givenName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"givenName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(givenName));
+
+			sb.append("\"");
+		}
+
+		if (id != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(id);
+		}
+
+		if (image != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"image\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(image));
+
+			sb.append("\"");
+		}
+
+		if (name != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(name));
+
+			sb.append("\"");
+		}
+
+		if (profileURL != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"profileURL\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(profileURL));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	@Schema(
+		accessMode = Schema.AccessMode.READ_ONLY,
+		defaultValue = "com.liferay.headless.site.dto.v1_0.Creator",
+		name = "x-class-name"
+	)
+	public String xClassName;
+
+	private static String _escape(Object object) {
+		return StringUtil.replace(
+			String.valueOf(object), _JSON_ESCAPE_STRINGS[0],
+			_JSON_ESCAPE_STRINGS[1]);
+	}
+
+	private static boolean _isArray(Object value) {
+		if (value == null) {
+			return false;
+		}
+
+		Class<?> clazz = value.getClass();
+
+		return clazz.isArray();
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(_escape(entry.getKey()));
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			if (_isArray(value)) {
+				sb.append("[");
+
+				Object[] valueArray = (Object[])value;
+
+				for (int i = 0; i < valueArray.length; i++) {
+					if (valueArray[i] instanceof String) {
+						sb.append("\"");
+						sb.append(valueArray[i]);
+						sb.append("\"");
+					}
+					else {
+						sb.append(valueArray[i]);
+					}
+
+					if ((i + 1) < valueArray.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof Map) {
+				sb.append(_toJSON((Map<String, ?>)value));
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(value));
+				sb.append("\"");
+			}
+			else {
+				sb.append(value);
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	private static final String[][] _JSON_ESCAPE_STRINGS = {
+		{"\\", "\"", "\b", "\f", "\n", "\r", "\t"},
+		{"\\\\", "\\\"", "\\b", "\\f", "\\n", "\\r", "\\t"}
+	};
+
+	private Map<String, Serializable> _extendedProperties;
+
+}

--- a/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/dto/v1_0/Site.java
+++ b/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/dto/v1_0/Site.java
@@ -39,12 +39,9 @@ import javax.xml.bind.annotation.XmlRootElement;
  * @generated
  */
 @Generated("")
-@GraphQLName(description = "Represents the site being created.", value = "Site")
+@GraphQLName(description = "Represents the site.", value = "Site")
 @JsonFilter("Liferay.Vulcan")
-@Schema(
-	description = "Represents the site being created.",
-	requiredProperties = {"name"}
-)
+@Schema(description = "Represents the site.", requiredProperties = {"name"})
 @XmlRootElement(name = "Site")
 public class Site implements Serializable {
 
@@ -55,6 +52,181 @@ public class Site implements Serializable {
 	public static Site unsafeToDTO(String json) {
 		return ObjectMapperUtil.unsafeReadValue(Site.class, json);
 	}
+
+	@Schema
+	public String[] getAvailableLanguages() {
+		return availableLanguages;
+	}
+
+	public void setAvailableLanguages(String[] availableLanguages) {
+		this.availableLanguages = availableLanguages;
+	}
+
+	@JsonIgnore
+	public void setAvailableLanguages(
+		UnsafeSupplier<String[], Exception> availableLanguagesUnsafeSupplier) {
+
+		try {
+			availableLanguages = availableLanguagesUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String[] availableLanguages;
+
+	@Schema
+	@Valid
+	public Creator getCreator() {
+		return creator;
+	}
+
+	public void setCreator(Creator creator) {
+		this.creator = creator;
+	}
+
+	@JsonIgnore
+	public void setCreator(
+		UnsafeSupplier<Creator, Exception> creatorUnsafeSupplier) {
+
+		try {
+			creator = creatorUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Creator creator;
+
+	@Schema
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	@JsonIgnore
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String description;
+
+	@Schema
+	@Valid
+	public Map<String, String> getDescription_i18n() {
+		return description_i18n;
+	}
+
+	public void setDescription_i18n(Map<String, String> description_i18n) {
+		this.description_i18n = description_i18n;
+	}
+
+	@JsonIgnore
+	public void setDescription_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			description_i18nUnsafeSupplier) {
+
+		try {
+			description_i18n = description_i18nUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Map<String, String> description_i18n;
+
+	@Schema
+	public String getDescriptiveName() {
+		return descriptiveName;
+	}
+
+	public void setDescriptiveName(String descriptiveName) {
+		this.descriptiveName = descriptiveName;
+	}
+
+	@JsonIgnore
+	public void setDescriptiveName(
+		UnsafeSupplier<String, Exception> descriptiveNameUnsafeSupplier) {
+
+		try {
+			descriptiveName = descriptiveNameUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected String descriptiveName;
+
+	@Schema
+	@Valid
+	public Map<String, String> getDescriptiveName_i18n() {
+		return descriptiveName_i18n;
+	}
+
+	public void setDescriptiveName_i18n(
+		Map<String, String> descriptiveName_i18n) {
+
+		this.descriptiveName_i18n = descriptiveName_i18n;
+	}
+
+	@JsonIgnore
+	public void setDescriptiveName_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			descriptiveName_i18nUnsafeSupplier) {
+
+		try {
+			descriptiveName_i18n = descriptiveName_i18nUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Map<String, String> descriptiveName_i18n;
 
 	@Schema(description = "The site's external reference code.")
 	public String getExternalReferenceCode() {
@@ -231,6 +403,64 @@ public class Site implements Serializable {
 	protected String name;
 
 	@Schema
+	@Valid
+	public Map<String, String> getName_i18n() {
+		return name_i18n;
+	}
+
+	public void setName_i18n(Map<String, String> name_i18n) {
+		this.name_i18n = name_i18n;
+	}
+
+	@JsonIgnore
+	public void setName_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			name_i18nUnsafeSupplier) {
+
+		try {
+			name_i18n = name_i18nUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Map<String, String> name_i18n;
+
+	@Schema
+	public Long getParentSiteId() {
+		return parentSiteId;
+	}
+
+	public void setParentSiteId(Long parentSiteId) {
+		this.parentSiteId = parentSiteId;
+	}
+
+	@JsonIgnore
+	public void setParentSiteId(
+		UnsafeSupplier<Long, Exception> parentSiteIdUnsafeSupplier) {
+
+		try {
+			parentSiteId = parentSiteIdUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Long parentSiteId;
+
+	@Schema
 	public String getParentSiteKey() {
 		return parentSiteKey;
 	}
@@ -257,6 +487,35 @@ public class Site implements Serializable {
 	@GraphQLField
 	@JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
 	protected String parentSiteKey;
+
+	@Schema
+	@Valid
+	public Site[] getSites() {
+		return sites;
+	}
+
+	public void setSites(Site[] sites) {
+		this.sites = sites;
+	}
+
+	@JsonIgnore
+	public void setSites(
+		UnsafeSupplier<Site[], Exception> sitesUnsafeSupplier) {
+
+		try {
+			sites = sitesUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Site[] sites;
 
 	@Schema
 	public String getTemplateKey() {
@@ -351,6 +610,88 @@ public class Site implements Serializable {
 
 		sb.append("{");
 
+		if (availableLanguages != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"availableLanguages\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < availableLanguages.length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(availableLanguages[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < availableLanguages.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (creator != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"creator\": ");
+
+			sb.append(String.valueOf(creator));
+		}
+
+		if (description != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(description));
+
+			sb.append("\"");
+		}
+
+		if (description_i18n != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description_i18n\": ");
+
+			sb.append(_toJSON(description_i18n));
+		}
+
+		if (descriptiveName != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"descriptiveName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(descriptiveName));
+
+			sb.append("\"");
+		}
+
+		if (descriptiveName_i18n != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"descriptiveName_i18n\": ");
+
+			sb.append(_toJSON(descriptiveName_i18n));
+		}
+
 		if (externalReferenceCode != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -431,6 +772,26 @@ public class Site implements Serializable {
 			sb.append("\"");
 		}
 
+		if (name_i18n != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name_i18n\": ");
+
+			sb.append(_toJSON(name_i18n));
+		}
+
+		if (parentSiteId != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"parentSiteId\": ");
+
+			sb.append(parentSiteId);
+		}
+
 		if (parentSiteKey != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -443,6 +804,26 @@ public class Site implements Serializable {
 			sb.append(_escape(parentSiteKey));
 
 			sb.append("\"");
+		}
+
+		if (sites != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"sites\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < sites.length; i++) {
+				sb.append(String.valueOf(sites[i]));
+
+				if ((i + 1) < sites.length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		if (templateKey != null) {

--- a/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/resource/v1_0/SiteResource.java
+++ b/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/resource/v1_0/SiteResource.java
@@ -17,6 +17,8 @@ import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 
 import java.util.Collections;
 import java.util.List;
@@ -44,11 +46,21 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface SiteResource {
 
+	public Page<Site> getSitesPage(Pagination pagination) throws Exception;
+
 	public Site postSite(Site site) throws Exception;
+
+	public Site getSiteByExternalReferenceCode(String externalReferenceCode)
+		throws Exception;
 
 	public Site putSiteByExternalReferenceCode(
 			String externalReferenceCode, MultipartBody multipartBody)
 		throws Exception;
+
+	public Site getSiteByFriendlyUrlPath(String friendlyUrlPath)
+		throws Exception;
+
+	public Site getSite(Long siteId) throws Exception;
 
 	public default void setContextAcceptLanguage(
 		AcceptLanguage contextAcceptLanguage) {

--- a/modules/apps/headless/headless-site/headless-site-api/src/main/resources/com/liferay/headless/site/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-site/headless-site-api/src/main/resources/com/liferay/headless/site/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 1.1.0
+version 1.2.0

--- a/modules/apps/headless/headless-site/headless-site-api/src/main/resources/com/liferay/headless/site/resource/v1_0/packageinfo
+++ b/modules/apps/headless/headless-site/headless-site-api/src/main/resources/com/liferay/headless/site/resource/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 2.2.0
+version 2.3.0

--- a/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/dto/v1_0/Creator.java
+++ b/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/dto/v1_0/Creator.java
@@ -1,0 +1,223 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.site.client.dto.v1_0;
+
+import com.liferay.headless.site.client.function.UnsafeSupplier;
+import com.liferay.headless.site.client.serdes.v1_0.CreatorSerDes;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Rubén Pulido
+ * @generated
+ */
+@Generated("")
+public class Creator implements Cloneable, Serializable {
+
+	public static Creator toDTO(String json) {
+		return CreatorSerDes.toDTO(json);
+	}
+
+	public String getAdditionalName() {
+		return additionalName;
+	}
+
+	public void setAdditionalName(String additionalName) {
+		this.additionalName = additionalName;
+	}
+
+	public void setAdditionalName(
+		UnsafeSupplier<String, Exception> additionalNameUnsafeSupplier) {
+
+		try {
+			additionalName = additionalNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String additionalName;
+
+	public String getContentType() {
+		return contentType;
+	}
+
+	public void setContentType(String contentType) {
+		this.contentType = contentType;
+	}
+
+	public void setContentType(
+		UnsafeSupplier<String, Exception> contentTypeUnsafeSupplier) {
+
+		try {
+			contentType = contentTypeUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String contentType;
+
+	public String getFamilyName() {
+		return familyName;
+	}
+
+	public void setFamilyName(String familyName) {
+		this.familyName = familyName;
+	}
+
+	public void setFamilyName(
+		UnsafeSupplier<String, Exception> familyNameUnsafeSupplier) {
+
+		try {
+			familyName = familyNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String familyName;
+
+	public String getGivenName() {
+		return givenName;
+	}
+
+	public void setGivenName(String givenName) {
+		this.givenName = givenName;
+	}
+
+	public void setGivenName(
+		UnsafeSupplier<String, Exception> givenNameUnsafeSupplier) {
+
+		try {
+			givenName = givenNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String givenName;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public void setId(UnsafeSupplier<Long, Exception> idUnsafeSupplier) {
+		try {
+			id = idUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long id;
+
+	public String getImage() {
+		return image;
+	}
+
+	public void setImage(String image) {
+		this.image = image;
+	}
+
+	public void setImage(
+		UnsafeSupplier<String, Exception> imageUnsafeSupplier) {
+
+		try {
+			image = imageUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String image;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setName(UnsafeSupplier<String, Exception> nameUnsafeSupplier) {
+		try {
+			name = nameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String name;
+
+	public String getProfileURL() {
+		return profileURL;
+	}
+
+	public void setProfileURL(String profileURL) {
+		this.profileURL = profileURL;
+	}
+
+	public void setProfileURL(
+		UnsafeSupplier<String, Exception> profileURLUnsafeSupplier) {
+
+		try {
+			profileURL = profileURLUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String profileURL;
+
+	@Override
+	public Creator clone() throws CloneNotSupportedException {
+		return (Creator)super.clone();
+	}
+
+	@Override
+	public boolean equals(Object object) {
+		if (this == object) {
+			return true;
+		}
+
+		if (!(object instanceof Creator)) {
+			return false;
+		}
+
+		Creator creator = (Creator)object;
+
+		return Objects.equals(toString(), creator.toString());
+	}
+
+	@Override
+	public int hashCode() {
+		String string = toString();
+
+		return string.hashCode();
+	}
+
+	public String toString() {
+		return CreatorSerDes.toJSON(this);
+	}
+
+}

--- a/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/dto/v1_0/Site.java
+++ b/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/dto/v1_0/Site.java
@@ -10,6 +10,7 @@ import com.liferay.headless.site.client.serdes.v1_0.SiteSerDes;
 
 import java.io.Serializable;
 
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -24,6 +25,136 @@ public class Site implements Cloneable, Serializable {
 	public static Site toDTO(String json) {
 		return SiteSerDes.toDTO(json);
 	}
+
+	public String[] getAvailableLanguages() {
+		return availableLanguages;
+	}
+
+	public void setAvailableLanguages(String[] availableLanguages) {
+		this.availableLanguages = availableLanguages;
+	}
+
+	public void setAvailableLanguages(
+		UnsafeSupplier<String[], Exception> availableLanguagesUnsafeSupplier) {
+
+		try {
+			availableLanguages = availableLanguagesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String[] availableLanguages;
+
+	public Creator getCreator() {
+		return creator;
+	}
+
+	public void setCreator(Creator creator) {
+		this.creator = creator;
+	}
+
+	public void setCreator(
+		UnsafeSupplier<Creator, Exception> creatorUnsafeSupplier) {
+
+		try {
+			creator = creatorUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Creator creator;
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public void setDescription(
+		UnsafeSupplier<String, Exception> descriptionUnsafeSupplier) {
+
+		try {
+			description = descriptionUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String description;
+
+	public Map<String, String> getDescription_i18n() {
+		return description_i18n;
+	}
+
+	public void setDescription_i18n(Map<String, String> description_i18n) {
+		this.description_i18n = description_i18n;
+	}
+
+	public void setDescription_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			description_i18nUnsafeSupplier) {
+
+		try {
+			description_i18n = description_i18nUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, String> description_i18n;
+
+	public String getDescriptiveName() {
+		return descriptiveName;
+	}
+
+	public void setDescriptiveName(String descriptiveName) {
+		this.descriptiveName = descriptiveName;
+	}
+
+	public void setDescriptiveName(
+		UnsafeSupplier<String, Exception> descriptiveNameUnsafeSupplier) {
+
+		try {
+			descriptiveName = descriptiveNameUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected String descriptiveName;
+
+	public Map<String, String> getDescriptiveName_i18n() {
+		return descriptiveName_i18n;
+	}
+
+	public void setDescriptiveName_i18n(
+		Map<String, String> descriptiveName_i18n) {
+
+		this.descriptiveName_i18n = descriptiveName_i18n;
+	}
+
+	public void setDescriptiveName_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			descriptiveName_i18nUnsafeSupplier) {
+
+		try {
+			descriptiveName_i18n = descriptiveName_i18nUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, String> descriptiveName_i18n;
 
 	public String getExternalReferenceCode() {
 		return externalReferenceCode;
@@ -154,6 +285,49 @@ public class Site implements Cloneable, Serializable {
 
 	protected String name;
 
+	public Map<String, String> getName_i18n() {
+		return name_i18n;
+	}
+
+	public void setName_i18n(Map<String, String> name_i18n) {
+		this.name_i18n = name_i18n;
+	}
+
+	public void setName_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			name_i18nUnsafeSupplier) {
+
+		try {
+			name_i18n = name_i18nUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, String> name_i18n;
+
+	public Long getParentSiteId() {
+		return parentSiteId;
+	}
+
+	public void setParentSiteId(Long parentSiteId) {
+		this.parentSiteId = parentSiteId;
+	}
+
+	public void setParentSiteId(
+		UnsafeSupplier<Long, Exception> parentSiteIdUnsafeSupplier) {
+
+		try {
+			parentSiteId = parentSiteIdUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Long parentSiteId;
+
 	public String getParentSiteKey() {
 		return parentSiteKey;
 	}
@@ -174,6 +348,27 @@ public class Site implements Cloneable, Serializable {
 	}
 
 	protected String parentSiteKey;
+
+	public Site[] getSites() {
+		return sites;
+	}
+
+	public void setSites(Site[] sites) {
+		this.sites = sites;
+	}
+
+	public void setSites(
+		UnsafeSupplier<Site[], Exception> sitesUnsafeSupplier) {
+
+		try {
+			sites = sitesUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Site[] sites;
 
 	public String getTemplateKey() {
 		return templateKey;

--- a/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/resource/v1_0/SiteResource.java
+++ b/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/resource/v1_0/SiteResource.java
@@ -7,6 +7,8 @@ package com.liferay.headless.site.client.resource.v1_0;
 
 import com.liferay.headless.site.client.dto.v1_0.Site;
 import com.liferay.headless.site.client.http.HttpInvoker;
+import com.liferay.headless.site.client.pagination.Page;
+import com.liferay.headless.site.client.pagination.Pagination;
 import com.liferay.headless.site.client.problem.Problem;
 import com.liferay.headless.site.client.serdes.v1_0.SiteSerDes;
 
@@ -32,9 +34,22 @@ public interface SiteResource {
 		return new Builder();
 	}
 
+	public Page<Site> getSitesPage(Pagination pagination) throws Exception;
+
+	public HttpInvoker.HttpResponse getSitesPageHttpResponse(
+			Pagination pagination)
+		throws Exception;
+
 	public Site postSite(Site site) throws Exception;
 
 	public HttpInvoker.HttpResponse postSiteHttpResponse(Site site)
+		throws Exception;
+
+	public Site getSiteByExternalReferenceCode(String externalReferenceCode)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getSiteByExternalReferenceCodeHttpResponse(
+			String externalReferenceCode)
 		throws Exception;
 
 	public Site putSiteByExternalReferenceCode(
@@ -45,6 +60,18 @@ public interface SiteResource {
 	public HttpInvoker.HttpResponse putSiteByExternalReferenceCodeHttpResponse(
 			String externalReferenceCode, Site site,
 			Map<String, File> multipartFiles)
+		throws Exception;
+
+	public Site getSiteByFriendlyUrlPath(String friendlyUrlPath)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse getSiteByFriendlyUrlPathHttpResponse(
+			String friendlyUrlPath)
+		throws Exception;
+
+	public Site getSite(Long siteId) throws Exception;
+
+	public HttpInvoker.HttpResponse getSiteHttpResponse(Long siteId)
 		throws Exception;
 
 	public static class Builder {
@@ -151,6 +178,112 @@ public interface SiteResource {
 
 	public static class SiteResourceImpl implements SiteResource {
 
+		public Page<Site> getSitesPage(Pagination pagination) throws Exception {
+			HttpInvoker.HttpResponse httpResponse = getSitesPageHttpResponse(
+				pagination);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return Page.of(content, SiteSerDes::toDTO);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getSitesPageHttpResponse(
+				Pagination pagination)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			if (pagination != null) {
+				httpInvoker.parameter(
+					"page", String.valueOf(pagination.getPage()));
+				httpInvoker.parameter(
+					"pageSize", String.valueOf(pagination.getPageSize()));
+			}
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-site/v1.0/sites");
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
 		public Site postSite(Site site) throws Exception {
 			HttpInvoker.HttpResponse httpResponse = postSiteHttpResponse(site);
 
@@ -243,6 +376,111 @@ public interface SiteResource {
 				_builder._scheme + "://" + _builder._host + ":" +
 					_builder._port + _builder._contextPath +
 						"/o/headless-site/v1.0/sites");
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public Site getSiteByExternalReferenceCode(String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSiteByExternalReferenceCodeHttpResponse(
+					externalReferenceCode);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return SiteSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse
+				getSiteByExternalReferenceCodeHttpResponse(
+					String externalReferenceCode)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-site/v1.0/sites/by-external-reference-code/{externalReferenceCode}");
+
+			httpInvoker.path("externalReferenceCode", externalReferenceCode);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);
@@ -359,6 +597,208 @@ public interface SiteResource {
 						"/o/headless-site/v1.0/sites/by-external-reference-code/{externalReferenceCode}");
 
 			httpInvoker.path("externalReferenceCode", externalReferenceCode);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public Site getSiteByFriendlyUrlPath(String friendlyUrlPath)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				getSiteByFriendlyUrlPathHttpResponse(friendlyUrlPath);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return SiteSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getSiteByFriendlyUrlPathHttpResponse(
+				String friendlyUrlPath)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-site/v1.0/sites/by-friendly-url-path/{friendlyUrlPath}");
+
+			httpInvoker.path("friendlyUrlPath", friendlyUrlPath);
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public Site getSite(Long siteId) throws Exception {
+			HttpInvoker.HttpResponse httpResponse = getSiteHttpResponse(siteId);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return SiteSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse getSiteHttpResponse(Long siteId)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.GET);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-site/v1.0/sites/{siteId}");
+
+			httpInvoker.path("siteId", siteId);
 
 			httpInvoker.userNameAndPassword(
 				_builder._login + ":" + _builder._password);

--- a/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/serdes/v1_0/CreatorSerDes.java
+++ b/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/serdes/v1_0/CreatorSerDes.java
@@ -1,0 +1,363 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.site.client.serdes.v1_0;
+
+import com.liferay.headless.site.client.dto.v1_0.Creator;
+import com.liferay.headless.site.client.json.BaseJSONParser;
+
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+import javax.annotation.Generated;
+
+/**
+ * @author Rubén Pulido
+ * @generated
+ */
+@Generated("")
+public class CreatorSerDes {
+
+	public static Creator toDTO(String json) {
+		CreatorJSONParser creatorJSONParser = new CreatorJSONParser();
+
+		return creatorJSONParser.parseToDTO(json);
+	}
+
+	public static Creator[] toDTOs(String json) {
+		CreatorJSONParser creatorJSONParser = new CreatorJSONParser();
+
+		return creatorJSONParser.parseToDTOs(json);
+	}
+
+	public static String toJSON(Creator creator) {
+		if (creator == null) {
+			return "null";
+		}
+
+		StringBuilder sb = new StringBuilder();
+
+		sb.append("{");
+
+		if (creator.getAdditionalName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"additionalName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(creator.getAdditionalName()));
+
+			sb.append("\"");
+		}
+
+		if (creator.getContentType() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"contentType\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(creator.getContentType()));
+
+			sb.append("\"");
+		}
+
+		if (creator.getFamilyName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"familyName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(creator.getFamilyName()));
+
+			sb.append("\"");
+		}
+
+		if (creator.getGivenName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"givenName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(creator.getGivenName()));
+
+			sb.append("\"");
+		}
+
+		if (creator.getId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"id\": ");
+
+			sb.append(creator.getId());
+		}
+
+		if (creator.getImage() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"image\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(creator.getImage()));
+
+			sb.append("\"");
+		}
+
+		if (creator.getName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(creator.getName()));
+
+			sb.append("\"");
+		}
+
+		if (creator.getProfileURL() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"profileURL\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(creator.getProfileURL()));
+
+			sb.append("\"");
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+	public static Map<String, Object> toMap(String json) {
+		CreatorJSONParser creatorJSONParser = new CreatorJSONParser();
+
+		return creatorJSONParser.parseToMap(json);
+	}
+
+	public static Map<String, String> toMap(Creator creator) {
+		if (creator == null) {
+			return null;
+		}
+
+		Map<String, String> map = new TreeMap<>();
+
+		if (creator.getAdditionalName() == null) {
+			map.put("additionalName", null);
+		}
+		else {
+			map.put(
+				"additionalName", String.valueOf(creator.getAdditionalName()));
+		}
+
+		if (creator.getContentType() == null) {
+			map.put("contentType", null);
+		}
+		else {
+			map.put("contentType", String.valueOf(creator.getContentType()));
+		}
+
+		if (creator.getFamilyName() == null) {
+			map.put("familyName", null);
+		}
+		else {
+			map.put("familyName", String.valueOf(creator.getFamilyName()));
+		}
+
+		if (creator.getGivenName() == null) {
+			map.put("givenName", null);
+		}
+		else {
+			map.put("givenName", String.valueOf(creator.getGivenName()));
+		}
+
+		if (creator.getId() == null) {
+			map.put("id", null);
+		}
+		else {
+			map.put("id", String.valueOf(creator.getId()));
+		}
+
+		if (creator.getImage() == null) {
+			map.put("image", null);
+		}
+		else {
+			map.put("image", String.valueOf(creator.getImage()));
+		}
+
+		if (creator.getName() == null) {
+			map.put("name", null);
+		}
+		else {
+			map.put("name", String.valueOf(creator.getName()));
+		}
+
+		if (creator.getProfileURL() == null) {
+			map.put("profileURL", null);
+		}
+		else {
+			map.put("profileURL", String.valueOf(creator.getProfileURL()));
+		}
+
+		return map;
+	}
+
+	public static class CreatorJSONParser extends BaseJSONParser<Creator> {
+
+		@Override
+		protected Creator createDTO() {
+			return new Creator();
+		}
+
+		@Override
+		protected Creator[] createDTOArray(int size) {
+			return new Creator[size];
+		}
+
+		@Override
+		protected void setField(
+			Creator creator, String jsonParserFieldName,
+			Object jsonParserFieldValue) {
+
+			if (Objects.equals(jsonParserFieldName, "additionalName")) {
+				if (jsonParserFieldValue != null) {
+					creator.setAdditionalName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "contentType")) {
+				if (jsonParserFieldValue != null) {
+					creator.setContentType((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "familyName")) {
+				if (jsonParserFieldValue != null) {
+					creator.setFamilyName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "givenName")) {
+				if (jsonParserFieldValue != null) {
+					creator.setGivenName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "id")) {
+				if (jsonParserFieldValue != null) {
+					creator.setId(Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "image")) {
+				if (jsonParserFieldValue != null) {
+					creator.setImage((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name")) {
+				if (jsonParserFieldValue != null) {
+					creator.setName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "profileURL")) {
+				if (jsonParserFieldValue != null) {
+					creator.setProfileURL((String)jsonParserFieldValue);
+				}
+			}
+		}
+
+	}
+
+	private static String _escape(Object object) {
+		String string = String.valueOf(object);
+
+		for (String[] strings : BaseJSONParser.JSON_ESCAPE_STRINGS) {
+			string = string.replace(strings[0], strings[1]);
+		}
+
+		return string;
+	}
+
+	private static String _toJSON(Map<String, ?> map) {
+		StringBuilder sb = new StringBuilder("{");
+
+		@SuppressWarnings("unchecked")
+		Set set = map.entrySet();
+
+		@SuppressWarnings("unchecked")
+		Iterator<Map.Entry<String, ?>> iterator = set.iterator();
+
+		while (iterator.hasNext()) {
+			Map.Entry<String, ?> entry = iterator.next();
+
+			sb.append("\"");
+			sb.append(entry.getKey());
+			sb.append("\": ");
+
+			Object value = entry.getValue();
+
+			Class<?> valueClass = value.getClass();
+
+			if (value instanceof Map) {
+				sb.append(_toJSON((Map)value));
+			}
+			else if (valueClass.isArray()) {
+				Object[] values = (Object[])value;
+
+				sb.append("[");
+
+				for (int i = 0; i < values.length; i++) {
+					sb.append("\"");
+					sb.append(_escape(values[i]));
+					sb.append("\"");
+
+					if ((i + 1) < values.length) {
+						sb.append(", ");
+					}
+				}
+
+				sb.append("]");
+			}
+			else if (value instanceof String) {
+				sb.append("\"");
+				sb.append(_escape(entry.getValue()));
+				sb.append("\"");
+			}
+			else {
+				sb.append(String.valueOf(entry.getValue()));
+			}
+
+			if (iterator.hasNext()) {
+				sb.append(", ");
+			}
+		}
+
+		sb.append("}");
+
+		return sb.toString();
+	}
+
+}

--- a/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/serdes/v1_0/SiteSerDes.java
+++ b/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/serdes/v1_0/SiteSerDes.java
@@ -44,6 +44,88 @@ public class SiteSerDes {
 
 		sb.append("{");
 
+		if (site.getAvailableLanguages() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"availableLanguages\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < site.getAvailableLanguages().length; i++) {
+				sb.append("\"");
+
+				sb.append(_escape(site.getAvailableLanguages()[i]));
+
+				sb.append("\"");
+
+				if ((i + 1) < site.getAvailableLanguages().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
+		}
+
+		if (site.getCreator() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"creator\": ");
+
+			sb.append(String.valueOf(site.getCreator()));
+		}
+
+		if (site.getDescription() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(site.getDescription()));
+
+			sb.append("\"");
+		}
+
+		if (site.getDescription_i18n() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"description_i18n\": ");
+
+			sb.append(_toJSON(site.getDescription_i18n()));
+		}
+
+		if (site.getDescriptiveName() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"descriptiveName\": ");
+
+			sb.append("\"");
+
+			sb.append(_escape(site.getDescriptiveName()));
+
+			sb.append("\"");
+		}
+
+		if (site.getDescriptiveName_i18n() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"descriptiveName_i18n\": ");
+
+			sb.append(_toJSON(site.getDescriptiveName_i18n()));
+		}
+
 		if (site.getExternalReferenceCode() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -124,6 +206,26 @@ public class SiteSerDes {
 			sb.append("\"");
 		}
 
+		if (site.getName_i18n() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name_i18n\": ");
+
+			sb.append(_toJSON(site.getName_i18n()));
+		}
+
+		if (site.getParentSiteId() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"parentSiteId\": ");
+
+			sb.append(site.getParentSiteId());
+		}
+
 		if (site.getParentSiteKey() != null) {
 			if (sb.length() > 1) {
 				sb.append(", ");
@@ -136,6 +238,26 @@ public class SiteSerDes {
 			sb.append(_escape(site.getParentSiteKey()));
 
 			sb.append("\"");
+		}
+
+		if (site.getSites() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"sites\": ");
+
+			sb.append("[");
+
+			for (int i = 0; i < site.getSites().length; i++) {
+				sb.append(String.valueOf(site.getSites()[i]));
+
+				if ((i + 1) < site.getSites().length) {
+					sb.append(", ");
+				}
+			}
+
+			sb.append("]");
 		}
 
 		if (site.getTemplateKey() != null) {
@@ -184,6 +306,54 @@ public class SiteSerDes {
 
 		Map<String, String> map = new TreeMap<>();
 
+		if (site.getAvailableLanguages() == null) {
+			map.put("availableLanguages", null);
+		}
+		else {
+			map.put(
+				"availableLanguages",
+				String.valueOf(site.getAvailableLanguages()));
+		}
+
+		if (site.getCreator() == null) {
+			map.put("creator", null);
+		}
+		else {
+			map.put("creator", String.valueOf(site.getCreator()));
+		}
+
+		if (site.getDescription() == null) {
+			map.put("description", null);
+		}
+		else {
+			map.put("description", String.valueOf(site.getDescription()));
+		}
+
+		if (site.getDescription_i18n() == null) {
+			map.put("description_i18n", null);
+		}
+		else {
+			map.put(
+				"description_i18n", String.valueOf(site.getDescription_i18n()));
+		}
+
+		if (site.getDescriptiveName() == null) {
+			map.put("descriptiveName", null);
+		}
+		else {
+			map.put(
+				"descriptiveName", String.valueOf(site.getDescriptiveName()));
+		}
+
+		if (site.getDescriptiveName_i18n() == null) {
+			map.put("descriptiveName_i18n", null);
+		}
+		else {
+			map.put(
+				"descriptiveName_i18n",
+				String.valueOf(site.getDescriptiveName_i18n()));
+		}
+
 		if (site.getExternalReferenceCode() == null) {
 			map.put("externalReferenceCode", null);
 		}
@@ -229,11 +399,32 @@ public class SiteSerDes {
 			map.put("name", String.valueOf(site.getName()));
 		}
 
+		if (site.getName_i18n() == null) {
+			map.put("name_i18n", null);
+		}
+		else {
+			map.put("name_i18n", String.valueOf(site.getName_i18n()));
+		}
+
+		if (site.getParentSiteId() == null) {
+			map.put("parentSiteId", null);
+		}
+		else {
+			map.put("parentSiteId", String.valueOf(site.getParentSiteId()));
+		}
+
 		if (site.getParentSiteKey() == null) {
 			map.put("parentSiteKey", null);
 		}
 		else {
 			map.put("parentSiteKey", String.valueOf(site.getParentSiteKey()));
+		}
+
+		if (site.getSites() == null) {
+			map.put("sites", null);
+		}
+		else {
+			map.put("sites", String.valueOf(site.getSites()));
 		}
 
 		if (site.getTemplateKey() == null) {
@@ -270,7 +461,45 @@ public class SiteSerDes {
 			Site site, String jsonParserFieldName,
 			Object jsonParserFieldValue) {
 
-			if (Objects.equals(jsonParserFieldName, "externalReferenceCode")) {
+			if (Objects.equals(jsonParserFieldName, "availableLanguages")) {
+				if (jsonParserFieldValue != null) {
+					site.setAvailableLanguages(
+						toStrings((Object[])jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "creator")) {
+				if (jsonParserFieldValue != null) {
+					site.setCreator(
+						CreatorSerDes.toDTO((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "description")) {
+				if (jsonParserFieldValue != null) {
+					site.setDescription((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "description_i18n")) {
+				if (jsonParserFieldValue != null) {
+					site.setDescription_i18n(
+						(Map)SiteSerDes.toMap((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "descriptiveName")) {
+				if (jsonParserFieldValue != null) {
+					site.setDescriptiveName((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "descriptiveName_i18n")) {
+
+				if (jsonParserFieldValue != null) {
+					site.setDescriptiveName_i18n(
+						(Map)SiteSerDes.toMap((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(
+						jsonParserFieldName, "externalReferenceCode")) {
+
 				if (jsonParserFieldValue != null) {
 					site.setExternalReferenceCode((String)jsonParserFieldValue);
 				}
@@ -302,9 +531,36 @@ public class SiteSerDes {
 					site.setName((String)jsonParserFieldValue);
 				}
 			}
+			else if (Objects.equals(jsonParserFieldName, "name_i18n")) {
+				if (jsonParserFieldValue != null) {
+					site.setName_i18n(
+						(Map)SiteSerDes.toMap((String)jsonParserFieldValue));
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "parentSiteId")) {
+				if (jsonParserFieldValue != null) {
+					site.setParentSiteId(
+						Long.valueOf((String)jsonParserFieldValue));
+				}
+			}
 			else if (Objects.equals(jsonParserFieldName, "parentSiteKey")) {
 				if (jsonParserFieldValue != null) {
 					site.setParentSiteKey((String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "sites")) {
+				if (jsonParserFieldValue != null) {
+					Object[] jsonParserFieldValues =
+						(Object[])jsonParserFieldValue;
+
+					Site[] sitesArray = new Site[jsonParserFieldValues.length];
+
+					for (int i = 0; i < sitesArray.length; i++) {
+						sitesArray[i] = SiteSerDes.toDTO(
+							(String)jsonParserFieldValues[i]);
+					}
+
+					site.setSites(sitesArray);
 				}
 			}
 			else if (Objects.equals(jsonParserFieldName, "templateKey")) {

--- a/modules/apps/headless/headless-site/headless-site-impl/build.gradle
+++ b/modules/apps/headless/headless-site/headless-site-impl/build.gradle
@@ -15,4 +15,5 @@ dependencies {
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:site:site-api")
 	compileOnly project(":core:petra:petra-function")
+	compileOnly project(":core:petra:petra-string")
 }

--- a/modules/apps/headless/headless-site/headless-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-site/headless-site-impl/rest-openapi.yaml
@@ -1,10 +1,78 @@
 components:
     schemas:
+        Creator:
+            description:
+                Represents the user who created/authored the content. Properties follow the
+                [creator](https://schema.org/creator) specification.
+            properties:
+                additionalName:
+                    description:
+                        The user's additional name, which can be used as a middle name.
+                    readOnly: true
+                    type: string
+                contentType:
+                    # @review
+                    description:
+                        The type of the content.
+                    readOnly: true
+                    type: string
+                familyName:
+                    description:
+                        The user's surname (last name).
+                    readOnly: true
+                    type: string
+                givenName:
+                    description:
+                        The user's first name.
+                    readOnly: true
+                    type: string
+                id:
+                    description:
+                        The user's ID.
+                    format: int64
+                    readOnly: true
+                    type: integer
+                image:
+                    description:
+                        A relative URL to the user's profile image.
+                    format: uri
+                    readOnly: true
+                    type: string
+                name:
+                    description:
+                        The user's full name.
+                    readOnly: true
+                    type: string
+                profileURL:
+                    description:
+                        A relative URL to the user's profile.
+                    format: uri
+                    readOnly: true
+                    type: string
+            type: object
         Site:
             # @review
             description:
-                Represents the site being created.
+                Represents the site.
             properties:
+                availableLanguages:
+                    items:
+                        type: string
+                    type: array
+                creator:
+                    $ref: "#/components/schemas/Creator"
+                description:
+                    type: string
+                description_i18n:
+                    additionalProperties:
+                        type: string
+                    type: object
+                descriptiveName:
+                    type: string
+                descriptiveName_i18n:
+                    additionalProperties:
+                        type: string
+                    type: object
                 externalReferenceCode:
                     description:
                         The site's external reference code.
@@ -30,9 +98,20 @@ components:
                     writeOnly: true
                 name:
                     type: string
+                name_i18n:
+                    additionalProperties:
+                        type: string
+                    type: object
+                parentSiteId:
+                    format: int64
+                    type: integer
                 parentSiteKey:
                     type: string
                     writeOnly: true
+                sites:
+                    items:
+                        $ref: "#/components/schemas/Site"
+                    type: array
                 templateKey:
                     type: string
                     writeOnly: true
@@ -57,6 +136,31 @@ info:
 openapi: 3.0.1
 paths:
     /sites:
+        get:
+            operationId: getSitesPage
+            parameters:
+                - in: query
+                  name: page
+                  schema:
+                      type: integer
+                - in: query
+                  name: pageSize
+                  schema:
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Site"
+                                type: array
+                        application/xml:
+                            schema:
+                                items:
+                                    $ref: "#/components/schemas/Site"
+                                type: array
+            tags: ["Site"]
         post:
             description:
                 Adds a new site
@@ -83,6 +187,24 @@ paths:
             # @review
             tags: ["Site"]
     /sites/by-external-reference-code/{externalReferenceCode}:
+        get:
+            operationId: getSiteByExternalReferenceCode
+            parameters:
+                - in: path
+                  name: externalReferenceCode
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Site"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Site"
+            tags: ["Site"]
         put:
             description:
                 Adds or update a new site
@@ -113,4 +235,43 @@ paths:
                                 $ref: "#/components/schemas/Site"
                     description:
                         default response
+            tags: ["Site"]
+    /sites/by-friendly-url-path/{friendlyUrlPath}:
+        get:
+            operationId: getSiteByFriendlyUrlPath
+            parameters:
+                - in: path
+                  name: friendlyUrlPath
+                  required: true
+                  schema:
+                      type: string
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Site"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Site"
+            tags: ["Site"]
+    /sites/{siteId}:
+        get:
+            operationId: getSite
+            parameters:
+                - in: path
+                  name: siteId
+                  required: true
+                  schema:
+                      format: int64
+                      type: integer
+            responses:
+                200:
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "#/components/schemas/Site"
+                        application/xml:
+                            schema:
+                                $ref: "#/components/schemas/Site"
             tags: ["Site"]

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/dto/v1_0/util/CreatorUtil.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/dto/v1_0/util/CreatorUtil.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -11,6 +11,7 @@ import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Portal;
+
 /**
  * @author Javier Gamarra
  */
@@ -20,7 +21,7 @@ public class CreatorUtil {
 		if ((user == null) || user.isGuestUser()) {
 			return null;
 		}
-		
+
 		return new Creator() {
 			{
 				additionalName = user.getMiddleName();

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/dto/v1_0/util/CreatorUtil.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/dto/v1_0/util/CreatorUtil.java
@@ -1,0 +1,64 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.headless.site.internal.dto.v1_0.util;
+
+import com.liferay.headless.site.dto.v1_0.Creator;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.Portal;
+/**
+ * @author Javier Gamarra
+ */
+public class CreatorUtil {
+
+	public static Creator toCreator(Portal portal, User user) {
+		if ((user == null) || user.isGuestUser()) {
+			return null;
+		}
+		
+		return new Creator() {
+			{
+				additionalName = user.getMiddleName();
+				contentType = "UserAccount";
+				familyName = user.getLastName();
+				givenName = user.getFirstName();
+				id = user.getUserId();
+				name = user.getFullName();
+
+				setImage(
+					() -> {
+						if (user.getPortraitId() == 0) {
+							return null;
+						}
+
+						ThemeDisplay themeDisplay = new ThemeDisplay() {
+							{
+								setPathImage(portal.getPathImage());
+							}
+						};
+
+						return user.getPortraitURL(themeDisplay);
+					});
+				setProfileURL(
+					() -> {
+						Group group = user.getGroup();
+
+						ThemeDisplay themeDisplay = new ThemeDisplay() {
+							{
+								setPortalURL(StringPool.BLANK);
+								setSiteGroupId(group.getGroupId());
+							}
+						};
+
+						return group.getDisplayURL(themeDisplay);
+					});
+			}
+		};
+	}
+
+}

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -22,9 +22,12 @@ import com.liferay.portal.odata.filter.FilterParserProvider;
 import com.liferay.portal.odata.sort.SortParserProvider;
 import com.liferay.portal.vulcan.accept.language.AcceptLanguage;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.ActionUtil;
 
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -46,7 +49,38 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
-	 * curl -X 'POST' 'http://localhost:8080/o/headless-site/v1.0/sites' -d $'{"externalReferenceCode": ___, "membershipType": ___, "name": ___, "parentSiteKey": ___, "templateKey": ___, "templateType": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-site/v1.0/sites'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "page"
+			),
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.QUERY,
+				name = "pageSize"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Site")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/sites")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Page<Site> getSitesPage(
+			@javax.ws.rs.core.Context Pagination pagination)
+		throws Exception {
+
+		return Page.of(Collections.emptyList());
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-site/v1.0/sites' -d $'{"availableLanguages": ___, "creator": ___, "description": ___, "description_i18n": ___, "descriptiveName": ___, "descriptiveName_i18n": ___, "externalReferenceCode": ___, "membershipType": ___, "name": ___, "name_i18n": ___, "parentSiteId": ___, "parentSiteKey": ___, "sites": ___, "templateKey": ___, "templateType": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(description = "Adds a new site")
 	@io.swagger.v3.oas.annotations.tags.Tags(
@@ -58,6 +92,38 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 	@javax.ws.rs.Produces({"application/json", "application/xml"})
 	@Override
 	public Site postSite(Site site) throws Exception {
+		return new Site();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-site/v1.0/sites/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "externalReferenceCode"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Site")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path(
+		"/sites/by-external-reference-code/{externalReferenceCode}"
+	)
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Site getSiteByExternalReferenceCode(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("externalReferenceCode")
+			String externalReferenceCode)
+		throws Exception {
+
 		return new Site();
 	}
 
@@ -93,6 +159,66 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 			@javax.ws.rs.PathParam("externalReferenceCode")
 			String externalReferenceCode,
 			MultipartBody multipartBody)
+		throws Exception {
+
+		return new Site();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-site/v1.0/sites/by-friendly-url-path/{friendlyUrlPath}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "friendlyUrlPath"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Site")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/sites/by-friendly-url-path/{friendlyUrlPath: .+}")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Site getSiteByFriendlyUrlPath(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("friendlyUrlPath")
+			String friendlyUrlPath)
+		throws Exception {
+
+		return new Site();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
+	 * curl -X 'GET' 'http://localhost:8080/o/headless-site/v1.0/sites/{siteId}'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Parameters(
+		value = {
+			@io.swagger.v3.oas.annotations.Parameter(
+				in = io.swagger.v3.oas.annotations.enums.ParameterIn.PATH,
+				name = "siteId"
+			)
+		}
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Site")}
+	)
+	@javax.ws.rs.GET
+	@javax.ws.rs.Path("/sites/{siteId}")
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Site getSite(
+			@io.swagger.v3.oas.annotations.Parameter(hidden = true)
+			@javax.validation.constraints.NotNull
+			@javax.ws.rs.PathParam("siteId")
+			Long siteId)
 		throws Exception {
 
 		return new Site();

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -6,10 +6,13 @@
 package com.liferay.headless.site.internal.resource.v1_0;
 
 import com.liferay.headless.site.dto.v1_0.Site;
+import com.liferay.headless.site.internal.dto.v1_0.util.CreatorUtil;
 import com.liferay.headless.site.resource.v1_0.SiteResource;
 import com.liferay.portal.events.ServicePreAction;
 import com.liferay.portal.events.ThemeServicePreAction;
 import com.liferay.portal.kernel.change.tracking.CTAware;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
@@ -21,16 +24,21 @@ import com.liferay.portal.kernel.service.LayoutSetPrototypeLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextFactory;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.GroupPermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.liveusers.LiveUsers;
 import com.liferay.portal.security.permission.PermissionCacheUtil;
 import com.liferay.portal.vulcan.multipart.MultipartBody;
+import com.liferay.portal.vulcan.pagination.Page;
+import com.liferay.portal.vulcan.pagination.Pagination;
+import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.site.initializer.SiteInitializer;
 import com.liferay.site.initializer.SiteInitializerFactory;
 import com.liferay.site.initializer.SiteInitializerRegistry;
@@ -39,9 +47,13 @@ import com.liferay.sites.kernel.util.Sites;
 import java.io.File;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+
+import javax.validation.ValidationException;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -49,6 +61,7 @@ import org.osgi.service.component.annotations.ServiceScope;
 
 /**
  * @author Rubén Pulido
+ * @author Petteri Karttunen
  */
 @Component(
 	properties = "OSGI-INF/liferay/rest/v1_0/site.properties",
@@ -56,6 +69,63 @@ import org.osgi.service.component.annotations.ServiceScope;
 )
 @CTAware
 public class SiteResourceImpl extends BaseSiteResourceImpl {
+
+	@Override
+	public Site getSite(Long siteId) throws Exception {
+		return _toSite(_groupService.getGroup(siteId));
+	}
+
+	@Override
+	public Site getSiteByExternalReferenceCode(String externalReferenceCode)
+		throws Exception {
+
+		Group group = _groupLocalService.fetchGroupByExternalReferenceCode(
+			externalReferenceCode, contextCompany.getCompanyId());
+
+		if (group == null) {
+			throw new ValidationException(
+				"No site exists with externalReferenceCode " +
+					externalReferenceCode);
+		}
+
+		return _toSiteWithPermissionCheck(group);
+	}
+
+	@Override
+	public Site getSiteByFriendlyUrlPath(String url) throws Exception {
+		Group group = _groupLocalService.fetchFriendlyURLGroup(
+			contextCompany.getCompanyId(), "/" + url);
+
+		if (group == null) {
+			throw new ValidationException(
+				"No site exists with friendly URL " + url);
+		}
+
+		return _toSiteWithPermissionCheck(group);
+	}
+
+	@Override
+	public Page<Site> getSitesPage(Pagination pagination) throws Exception {
+		List<Group> groups = _groupService.getUserSitesGroups(
+			contextUser.getUserId(), new String[] {Group.class.getName()},
+			QueryUtil.ALL_POS);
+
+		int start = pagination.getStartPosition();
+
+		if (start >= groups.size()) {
+			start = groups.size() - 1;
+		}
+
+		int end = pagination.getEndPosition();
+
+		if (end > groups.size()) {
+			end = groups.size();
+		}
+
+		return Page.of(
+			transform(groups.subList(start, end), this::_toSite), pagination,
+			groups.size());
+	}
 
 	@Override
 	public Site postSite(Site site) throws Exception {
@@ -300,6 +370,54 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 			contextHttpServletRequest, contextHttpServletResponse);
 	}
 
+	private Site _toSite(Group group) throws Exception {
+		return new Site() {
+			{
+				Set<Locale> availableLocales = _language.getAvailableLocales(
+					group.getGroupId());
+
+				availableLanguages = LocaleUtil.toW3cLanguageIds(
+					availableLocales.toArray(new Locale[0]));
+
+				creator = CreatorUtil.toCreator(
+					_portal,
+					_userLocalService.fetchUser(group.getCreatorUserId()));
+				description = group.getDescription(
+					contextAcceptLanguage.getPreferredLocale());
+				description_i18n = LocalizedMapUtil.getI18nMap(
+					contextAcceptLanguage.isAcceptAllLanguages(),
+					group.getDescriptionMap());
+				descriptiveName = group.getDescriptiveName(
+					contextAcceptLanguage.getPreferredLocale());
+				descriptiveName_i18n = LocalizedMapUtil.getI18nMap(
+					contextAcceptLanguage.isAcceptAllLanguages(),
+					group.getDescriptiveNameMap());
+				externalReferenceCode = group.getExternalReferenceCode();
+				friendlyUrlPath = group.getFriendlyURL();
+				id = group.getGroupId();
+				key = group.getGroupKey();
+				name = group.getName(
+					contextAcceptLanguage.getPreferredLocale());
+				name_i18n = LocalizedMapUtil.getI18nMap(
+					contextAcceptLanguage.isAcceptAllLanguages(),
+					group.getNameMap());
+				parentSiteId = group.getParentGroupId();
+				sites = transformToArray(
+					_groupService.getGroups(
+						group.getCompanyId(), group.getGroupId(), true),
+					SiteResourceImpl.this::_toSite, Site.class);
+			}
+		};
+	}
+
+	private Site _toSiteWithPermissionCheck(Group group) throws Exception {
+		_groupPermission.check(
+			PermissionThreadLocal.getPermissionChecker(), group,
+			ActionKeys.VIEW);
+
+		return _toSite(group);
+	}
+
 	@Reference
 	private GroupLocalService _groupLocalService;
 
@@ -310,7 +428,13 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 	private GroupService _groupService;
 
 	@Reference
+	private Language _language;
+
+	@Reference
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private SiteInitializerFactory _siteInitializerFactory;
@@ -320,5 +444,8 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 
 	@Reference
 	private Sites _sites;
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.databind.util.ISO8601DateFormat;
 import com.liferay.headless.site.client.dto.v1_0.Site;
 import com.liferay.headless.site.client.http.HttpInvoker;
 import com.liferay.headless.site.client.pagination.Page;
+import com.liferay.headless.site.client.pagination.Pagination;
 import com.liferay.headless.site.client.resource.v1_0.SiteResource;
 import com.liferay.headless.site.client.serdes.v1_0.SiteSerDes;
 import com.liferay.petra.function.transform.TransformUtil;
@@ -32,6 +33,7 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.DateFormatFactoryUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
@@ -171,6 +173,8 @@ public abstract class BaseSiteResourceTestCase {
 
 		Site site = randomSite();
 
+		site.setDescription(regex);
+		site.setDescriptiveName(regex);
 		site.setExternalReferenceCode(regex);
 		site.setFriendlyUrlPath(regex);
 		site.setKey(regex);
@@ -184,12 +188,83 @@ public abstract class BaseSiteResourceTestCase {
 
 		site = SiteSerDes.toDTO(json);
 
+		Assert.assertEquals(regex, site.getDescription());
+		Assert.assertEquals(regex, site.getDescriptiveName());
 		Assert.assertEquals(regex, site.getExternalReferenceCode());
 		Assert.assertEquals(regex, site.getFriendlyUrlPath());
 		Assert.assertEquals(regex, site.getKey());
 		Assert.assertEquals(regex, site.getName());
 		Assert.assertEquals(regex, site.getParentSiteKey());
 		Assert.assertEquals(regex, site.getTemplateKey());
+	}
+
+	@Test
+	public void testGetSitesPage() throws Exception {
+		Page<Site> page = siteResource.getSitesPage(Pagination.of(1, 10));
+
+		long totalCount = page.getTotalCount();
+
+		Site site1 = testGetSitesPage_addSite(randomSite());
+
+		Site site2 = testGetSitesPage_addSite(randomSite());
+
+		page = siteResource.getSitesPage(Pagination.of(1, 10));
+
+		Assert.assertEquals(totalCount + 2, page.getTotalCount());
+
+		assertContains(site1, (List<Site>)page.getItems());
+		assertContains(site2, (List<Site>)page.getItems());
+		assertValid(page, testGetSitesPage_getExpectedActions());
+	}
+
+	protected Map<String, Map<String, String>>
+			testGetSitesPage_getExpectedActions()
+		throws Exception {
+
+		Map<String, Map<String, String>> expectedActions = new HashMap<>();
+
+		return expectedActions;
+	}
+
+	@Test
+	public void testGetSitesPageWithPagination() throws Exception {
+		Page<Site> totalPage = siteResource.getSitesPage(null);
+
+		int totalCount = GetterUtil.getInteger(totalPage.getTotalCount());
+
+		Site site1 = testGetSitesPage_addSite(randomSite());
+
+		Site site2 = testGetSitesPage_addSite(randomSite());
+
+		Site site3 = testGetSitesPage_addSite(randomSite());
+
+		Page<Site> page1 = siteResource.getSitesPage(
+			Pagination.of(1, totalCount + 2));
+
+		List<Site> sites1 = (List<Site>)page1.getItems();
+
+		Assert.assertEquals(sites1.toString(), totalCount + 2, sites1.size());
+
+		Page<Site> page2 = siteResource.getSitesPage(
+			Pagination.of(2, totalCount + 2));
+
+		Assert.assertEquals(totalCount + 3, page2.getTotalCount());
+
+		List<Site> sites2 = (List<Site>)page2.getItems();
+
+		Assert.assertEquals(sites2.toString(), 1, sites2.size());
+
+		Page<Site> page3 = siteResource.getSitesPage(
+			Pagination.of(1, totalCount + 3));
+
+		assertContains(site1, (List<Site>)page3.getItems());
+		assertContains(site2, (List<Site>)page3.getItems());
+		assertContains(site3, (List<Site>)page3.getItems());
+	}
+
+	protected Site testGetSitesPage_addSite(Site site) throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
 	}
 
 	@Test
@@ -208,6 +283,24 @@ public abstract class BaseSiteResourceTestCase {
 	}
 
 	@Test
+	public void testGetSiteByExternalReferenceCode() throws Exception {
+		Site postSite = testGetSiteByExternalReferenceCode_addSite();
+
+		Site getSite = siteResource.getSiteByExternalReferenceCode(
+			postSite.getExternalReferenceCode());
+
+		assertEquals(postSite, getSite);
+		assertValid(getSite);
+	}
+
+	protected Site testGetSiteByExternalReferenceCode_addSite()
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
 	public void testPutSiteByExternalReferenceCode() throws Exception {
 		Site postSite = testPutSiteByExternalReferenceCode_addSite();
 
@@ -221,7 +314,7 @@ public abstract class BaseSiteResourceTestCase {
 		assertEquals(randomSite, putSite);
 		assertValid(putSite);
 
-		Site getSite = testPutSiteByExternalReferenceCode_getSite(
+		Site getSite = siteResource.getSiteByExternalReferenceCode(
 			putSite.getExternalReferenceCode());
 
 		assertEquals(randomSite, getSite);
@@ -237,7 +330,7 @@ public abstract class BaseSiteResourceTestCase {
 		assertEquals(newSite, putSite);
 		assertValid(putSite);
 
-		getSite = testPutSiteByExternalReferenceCode_getSite(
+		getSite = siteResource.getSiteByExternalReferenceCode(
 			putSite.getExternalReferenceCode());
 
 		assertEquals(newSite, getSite);
@@ -245,13 +338,6 @@ public abstract class BaseSiteResourceTestCase {
 		Assert.assertEquals(
 			newSite.getExternalReferenceCode(),
 			putSite.getExternalReferenceCode());
-	}
-
-	protected Site testPutSiteByExternalReferenceCode_getSite(
-		String externalReferenceCode) {
-
-		throw new UnsupportedOperationException(
-			"This method needs to be implemented");
 	}
 
 	protected Site testPutSiteByExternalReferenceCode_createSite()
@@ -263,6 +349,37 @@ public abstract class BaseSiteResourceTestCase {
 	protected Site testPutSiteByExternalReferenceCode_addSite()
 		throws Exception {
 
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGetSiteByFriendlyUrlPath() throws Exception {
+		Site postSite = testGetSiteByFriendlyUrlPath_addSite();
+
+		Site getSite = siteResource.getSiteByFriendlyUrlPath(
+			postSite.getFriendlyUrlPath());
+
+		assertEquals(postSite, getSite);
+		assertValid(getSite);
+	}
+
+	protected Site testGetSiteByFriendlyUrlPath_addSite() throws Exception {
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testGetSite() throws Exception {
+		Site postSite = testGetSite_addSite();
+
+		Site getSite = siteResource.getSite(postSite.getId());
+
+		assertEquals(postSite, getSite);
+		assertValid(getSite);
+	}
+
+	protected Site testGetSite_addSite() throws Exception {
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
 	}
@@ -341,6 +458,58 @@ public abstract class BaseSiteResourceTestCase {
 				getAdditionalAssertFieldNames()) {
 
 			if (Objects.equals(
+					"availableLanguages", additionalAssertFieldName)) {
+
+				if (site.getAvailableLanguages() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("creator", additionalAssertFieldName)) {
+				if (site.getCreator() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("description", additionalAssertFieldName)) {
+				if (site.getDescription() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("description_i18n", additionalAssertFieldName)) {
+				if (site.getDescription_i18n() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("descriptiveName", additionalAssertFieldName)) {
+				if (site.getDescriptiveName() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"descriptiveName_i18n", additionalAssertFieldName)) {
+
+				if (site.getDescriptiveName_i18n() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
 					"externalReferenceCode", additionalAssertFieldName)) {
 
 				if (site.getExternalReferenceCode() == null) {
@@ -382,8 +551,32 @@ public abstract class BaseSiteResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("name_i18n", additionalAssertFieldName)) {
+				if (site.getName_i18n() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("parentSiteId", additionalAssertFieldName)) {
+				if (site.getParentSiteId() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("parentSiteKey", additionalAssertFieldName)) {
 				if (site.getParentSiteKey() == null) {
+					valid = false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("sites", additionalAssertFieldName)) {
+				if (site.getSites() == null) {
 					valid = false;
 				}
 
@@ -529,6 +722,74 @@ public abstract class BaseSiteResourceTestCase {
 				getAdditionalAssertFieldNames()) {
 
 			if (Objects.equals(
+					"availableLanguages", additionalAssertFieldName)) {
+
+				if (!Objects.deepEquals(
+						site1.getAvailableLanguages(),
+						site2.getAvailableLanguages())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("creator", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						site1.getCreator(), site2.getCreator())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("description", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						site1.getDescription(), site2.getDescription())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("description_i18n", additionalAssertFieldName)) {
+				if (!equals(
+						(Map)site1.getDescription_i18n(),
+						(Map)site2.getDescription_i18n())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("descriptiveName", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						site1.getDescriptiveName(),
+						site2.getDescriptiveName())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
+					"descriptiveName_i18n", additionalAssertFieldName)) {
+
+				if (!equals(
+						(Map)site1.getDescriptiveName_i18n(),
+						(Map)site2.getDescriptiveName_i18n())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals(
 					"externalReferenceCode", additionalAssertFieldName)) {
 
 				if (!Objects.deepEquals(
@@ -586,10 +847,38 @@ public abstract class BaseSiteResourceTestCase {
 				continue;
 			}
 
+			if (Objects.equals("name_i18n", additionalAssertFieldName)) {
+				if (!equals(
+						(Map)site1.getName_i18n(), (Map)site2.getName_i18n())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("parentSiteId", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(
+						site1.getParentSiteId(), site2.getParentSiteId())) {
+
+					return false;
+				}
+
+				continue;
+			}
+
 			if (Objects.equals("parentSiteKey", additionalAssertFieldName)) {
 				if (!Objects.deepEquals(
 						site1.getParentSiteKey(), site2.getParentSiteKey())) {
 
+					return false;
+				}
+
+				continue;
+			}
+
+			if (Objects.equals("sites", additionalAssertFieldName)) {
+				if (!Objects.deepEquals(site1.getSites(), site2.getSites())) {
 					return false;
 				}
 
@@ -718,6 +1007,118 @@ public abstract class BaseSiteResourceTestCase {
 		sb.append(" ");
 		sb.append(operator);
 		sb.append(" ");
+
+		if (entityFieldName.equals("availableLanguages")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("creator")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("description")) {
+			Object object = site.getDescription();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("description_i18n")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("descriptiveName")) {
+			Object object = site.getDescriptiveName();
+
+			String value = String.valueOf(object);
+
+			if (operator.equals("contains")) {
+				sb = new StringBundler();
+
+				sb.append("contains(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 2)) {
+					sb.append(value.substring(1, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else if (operator.equals("startswith")) {
+				sb = new StringBundler();
+
+				sb.append("startswith(");
+				sb.append(entityFieldName);
+				sb.append(",'");
+
+				if ((object != null) && (value.length() > 1)) {
+					sb.append(value.substring(0, value.length() - 1));
+				}
+				else {
+					sb.append(value);
+				}
+
+				sb.append("')");
+			}
+			else {
+				sb.append("'");
+				sb.append(value);
+				sb.append("'");
+			}
+
+			return sb.toString();
+		}
+
+		if (entityFieldName.equals("descriptiveName_i18n")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
 
 		if (entityFieldName.equals("externalReferenceCode")) {
 			Object object = site.getExternalReferenceCode();
@@ -913,6 +1314,16 @@ public abstract class BaseSiteResourceTestCase {
 			return sb.toString();
 		}
 
+		if (entityFieldName.equals("name_i18n")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
+		if (entityFieldName.equals("parentSiteId")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
+		}
+
 		if (entityFieldName.equals("parentSiteKey")) {
 			Object object = site.getParentSiteKey();
 
@@ -957,6 +1368,11 @@ public abstract class BaseSiteResourceTestCase {
 			}
 
 			return sb.toString();
+		}
+
+		if (entityFieldName.equals("sites")) {
+			throw new IllegalArgumentException(
+				"Invalid entity field " + entityFieldName);
 		}
 
 		if (entityFieldName.equals("templateKey")) {
@@ -1059,6 +1475,10 @@ public abstract class BaseSiteResourceTestCase {
 	protected Site randomSite() throws Exception {
 		return new Site() {
 			{
+				description = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
+				descriptiveName = StringUtil.toLowerCase(
+					RandomTestUtil.randomString());
 				externalReferenceCode = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				friendlyUrlPath = StringUtil.toLowerCase(
@@ -1066,6 +1486,7 @@ public abstract class BaseSiteResourceTestCase {
 				id = RandomTestUtil.randomLong();
 				key = StringUtil.toLowerCase(RandomTestUtil.randomString());
 				name = StringUtil.toLowerCase(RandomTestUtil.randomString());
+				parentSiteId = RandomTestUtil.randomLong();
 				parentSiteKey = StringUtil.toLowerCase(
 					RandomTestUtil.randomString());
 				templateKey = StringUtil.toLowerCase(

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -124,6 +124,28 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 	}
 
 	@Override
+	protected Site testGetSite_addSite() throws Exception {
+		return _addRandomTestSite();
+	}
+
+	@Override
+	protected Site testGetSiteByExternalReferenceCode_addSite()
+		throws Exception {
+
+		return _addRandomTestSite();
+	}
+
+	@Override
+	protected Site testGetSiteByFriendlyUrlPath_addSite() throws Exception {
+		return _addRandomTestSite();
+	}
+
+	@Override
+	protected Site testGetSitesPage_addSite(Site site) throws Exception {
+		return _addTestSite(site);
+	}
+
+	@Override
 	protected Site testPostSite_addSite(Site site) throws Exception {
 		Site postSite = siteResource.postSite(site);
 
@@ -140,22 +162,16 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			RandomTestUtil.randomString(), randomSite(), getMultipartFiles());
 	}
 
-	@Override
-	protected Site testPutSiteByExternalReferenceCode_getSite(
-		String externalReferenceCode) {
+	private Site _addRandomTestSite() throws Exception {
+		return _addTestSite(randomSite());
+	}
 
-		Group group = _groupLocalService.fetchGroupByExternalReferenceCode(
-			externalReferenceCode, testCompany.getCompanyId());
+	private Site _addTestSite(Site site) throws Exception {
+		Site postSite = siteResource.postSite(site);
 
-		return new Site() {
-			{
-				externalReferenceCode = group.getExternalReferenceCode();
-				friendlyUrlPath = group.getFriendlyURL();
-				id = group.getGroupId();
-				key = group.getGroupKey();
-				name = group.getName(LocaleUtil.getDefault());
-			}
-		};
+		_sites.add(postSite);
+
+		return postSite;
 	}
 
 	private void _testPostSiteFailureDuplicateName() throws Exception {


### PR DESCRIPTION
- Story: https://liferay.atlassian.net/browse/LPS-193149
- Related: https://liferay.slack.com/archives/CL9RTSZ52/p1692691856324109 

This PR adds to Sites API endpoints required by https://liferay.atlassian.net/browse/LPS-126745.

Changes in a nutshell:

- Site schema aligned with the headless-admin-user-impl Site schema
- Endpoints for:
   - List sites user has access to (excluding global and personal sites)
   - Get site by ERC
   - Get site by ID
   - Get site by friendlyURLPath

The logic and utils were for the most parts copied from headless-admin-user-impl 

The existing logic and endpoints of Sites API were not harmed.