### PR TITLE
LPS-194762 A Master Page in draft can be mark as default

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutUtilityPageEntryActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutUtilityPageEntryActionDropdownItemsProvider.java
@@ -40,7 +40,6 @@ import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
-import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.staging.StagingGroupHelper;
 import com.liferay.staging.StagingGroupHelperUtil;
 import com.liferay.taglib.security.PermissionsURLTag;
@@ -281,8 +280,7 @@ public class LayoutUtilityPageEntryActionDropdownItemsProvider {
 			"/layout_admin/export_layout_utility_page_entries");
 
 		return dropdownItem -> {
-			dropdownItem.setDisabled(
-				_draftLayout.getStatus() == WorkflowConstants.STATUS_DRAFT);
+			dropdownItem.setDisabled(!_layout.isPublished());
 			dropdownItem.setHref(exportLayoutUtilityPageEntryURL);
 			dropdownItem.setIcon("upload");
 			dropdownItem.setLabel(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/helper/LayoutCopyHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/helper/LayoutCopyHelperImpl.java
@@ -660,10 +660,33 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 	}
 
 	private String _getTypeSettings(Layout sourceLayout, Layout targetLayout) {
-		if ((!sourceLayout.isDraftLayout() && !targetLayout.isDraftLayout()) ||
-			targetLayout.isDraftLayout()) {
-
+		if (!sourceLayout.isDraftLayout() && !targetLayout.isDraftLayout()) {
 			return sourceLayout.getTypeSettings();
+		}
+
+		if (targetLayout.isDraftLayout()) {
+			UnicodeProperties typeSettingsUnicodeProperties =
+				UnicodePropertiesBuilder.create(
+					true
+				).fastLoad(
+					sourceLayout.getTypeSettings()
+				).build();
+
+			return UnicodePropertiesBuilder.create(
+				true
+			).fastLoad(
+				sourceLayout.getTypeSettings()
+			).setProperty(
+				"query-string",
+				typeSettingsUnicodeProperties.getProperty("query-string")
+			).setProperty(
+				"target", typeSettingsUnicodeProperties.getProperty("target")
+			).setProperty(
+				"targetType",
+				typeSettingsUnicodeProperties.getProperty("targetType")
+			).setProperty(
+				"published", Boolean.FALSE.toString()
+			).buildString();
 		}
 
 		UnicodeProperties typeSettingsUnicodeProperties =

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/CopyLayoutPageTemplateEntryMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/CopyLayoutPageTemplateEntryMVCActionCommand.java
@@ -91,29 +91,23 @@ public class CopyLayoutPageTemplateEntryMVCActionCommand
 		ServiceContext serviceContext = ServiceContextFactory.getInstance(
 			actionRequest);
 
-		LayoutPageTemplateEntry sourceLayoutPageTemplateEntry =
-			_layoutPageTemplateEntryLocalService.getLayoutPageTemplateEntry(
-				layoutPageTemplateEntryId);
-
 		LayoutPageTemplateEntry layoutPageTemplateEntry =
 			_layoutPageTemplateEntryService.copyLayoutPageTemplateEntry(
 				themeDisplay.getScopeGroupId(), layoutPageTemplateCollectionId,
 				layoutPageTemplateEntryId, serviceContext);
 
+		LayoutPageTemplateEntry sourceLayoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.getLayoutPageTemplateEntry(
+				layoutPageTemplateEntryId);
+
 		Layout sourceLayout = _layoutLocalService.getLayout(
 			sourceLayoutPageTemplateEntry.getPlid());
-
-		Layout draftSourceLayout = _layoutLocalService.fetchLayout(
-			_portal.getClassNameId(Layout.class), sourceLayout.getPlid());
 
 		Layout targetLayout = _layoutLocalService.getLayout(
 			layoutPageTemplateEntry.getPlid());
 
-		Layout draftTargetLayout = _layoutLocalService.fetchLayout(
-			_portal.getClassNameId(Layout.class), targetLayout.getPlid());
-
 		_layoutCopyHelper.copyLayoutContent(
-			draftSourceLayout, draftTargetLayout);
+			sourceLayout, targetLayout.fetchDraftLayout());
 
 		_layoutCopyHelper.copyLayoutContent(sourceLayout, targetLayout);
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/MasterLayoutActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/MasterLayoutActionDropdownItemsProvider.java
@@ -327,7 +327,7 @@ public class MasterLayoutActionDropdownItemsProvider {
 		_getExportMasterLayoutActionUnsafeConsumer() {
 
 		return dropdownItem -> {
-			dropdownItem.setDisabled(_layoutPageTemplateEntry.isDraft());
+			dropdownItem.setDisabled(!_layout.isPublished());
 			dropdownItem.setHref(
 				ResourceURLBuilder.createResourceURL(
 					_renderResponse

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/MasterLayoutActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/MasterLayoutActionDropdownItemsProvider.java
@@ -67,6 +67,8 @@ public class MasterLayoutActionDropdownItemsProvider {
 
 		_draftLayout = LayoutLocalServiceUtil.fetchDraftLayout(
 			layoutPageTemplateEntry.getPlid());
+		_layout = LayoutLocalServiceUtil.fetchLayout(
+			layoutPageTemplateEntry.getPlid());
 	}
 
 	public List<DropdownItem> getActionDropdownItems() throws Exception {
@@ -123,7 +125,6 @@ public class MasterLayoutActionDropdownItemsProvider {
 					).add(
 						() ->
 							(layoutPageTemplateEntryId > 0) &&
-							_layoutPageTemplateEntry.isApproved() &&
 							!_layoutPageTemplateEntry.isDefaultTemplate() &&
 							hasUpdatePermission,
 						_getMarkAsDefaultMasterLayoutActionUnsafeConsumer()
@@ -433,6 +434,7 @@ public class MasterLayoutActionDropdownItemsProvider {
 					"layoutPageTemplateEntryId",
 					_layoutPageTemplateEntry.getLayoutPageTemplateEntryId()
 				).buildString());
+			dropdownItem.setDisabled(!_layout.isPublished());
 
 			String name = "Blank";
 
@@ -545,6 +547,7 @@ public class MasterLayoutActionDropdownItemsProvider {
 	private final Layout _draftLayout;
 	private final HttpServletRequest _httpServletRequest;
 	private final ItemSelector _itemSelector;
+	private final Layout _layout;
 	private final LayoutPageTemplateEntry _layoutPageTemplateEntry;
 	private final RenderResponse _renderResponse;
 	private final ThemeDisplay _themeDisplay;

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
@@ -279,7 +279,7 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 				sourceLayoutPageTemplateEntry.getClassTypeId(), name,
 				sourceLayoutPageTemplateEntry.getType(), 0, false,
 				sourceLayoutPageTemplateEntry.getLayoutPrototypeId(), 0,
-				masterLayoutPlid, sourceLayoutPageTemplateEntry.getStatus(),
+				masterLayoutPlid, WorkflowConstants.STATUS_DRAFT,
 				serviceContext);
 
 		FileEntry targetPreviewFileEntry = _copyPreviewFileEntry(


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-194762)

## Proposed solution

Modify the CopyHelper to set the "published" property to false when copying Master Layouts and Utility Pages.

## Test Scenario 1

1. Navigate to Design > Master Pages(MP)
2. Create a new MP and publish it
3. Make a copy from that MP
4. Check that you can’t mark the copy by default because it’s in draft and it has never been publish before.

<img width="828" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/13c6f9f8-00b5-4562-ba59-925addfa0ab9">

## Test Scenario 2

1. Navigate to Pages > Utility Pages(UP)
2. Make a copy from any UP existing
3. Check that you can’t mark the copy by default because it’s in draft and it has never been publish before.

<img width="849" alt="Pasted Graphic 3" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/7b1fee3d-434d-43cd-a339-90d8f6b4b11b">

## Notes

If we edit the Master Page/Utility Page and leave it in draft, but it has a previous version published, it will let us mark it by default.