### PR TITLE
[TS] LPS-189462

### DIFF
--- a/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/AssetCategoryInfoItemFieldValuesProvider.java
+++ b/modules/apps/asset/asset-categories-admin-web/src/main/java/com/liferay/asset/categories/admin/web/internal/info/item/provider/AssetCategoryInfoItemFieldValuesProvider.java
@@ -32,6 +32,8 @@ import com.liferay.template.info.item.provider.TemplateInfoItemFieldSetProvider;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -74,6 +76,18 @@ public class AssetCategoryInfoItemFieldValuesProvider
 		}
 	}
 
+	private Map<Locale, String> _getAssetCategoryDescriptionMap(
+		AssetCategory assetCategory) {
+
+		Map<Locale, String> descriptionMap = assetCategory.getDescriptionMap();
+
+		descriptionMap.putIfAbsent(
+			LocaleUtil.fromLanguageId(assetCategory.getDefaultLanguageId()),
+			StringPool.BLANK);
+
+		return descriptionMap;
+	}
+
 	private List<InfoFieldValue<Object>> _getAssetCategoryInfoFieldValues(
 		AssetCategory assetCategory) {
 
@@ -98,7 +112,7 @@ public class AssetCategoryInfoItemFieldValuesProvider
 					LocaleUtil.fromLanguageId(
 						assetCategory.getDefaultLanguageId())
 				).values(
-					assetCategory.getDescriptionMap()
+					_getAssetCategoryDescriptionMap(assetCategory)
 				).build()));
 
 		AssetVocabulary assetVocabulary =


### PR DESCRIPTION
Motivation
=======
This is a PR that aims to fix LPS-189462 making mapped categories behave as the rest of description fields of other assets when these fields are not filled

Proposed Solution
========
Make sure that AssetCategoryInfoItemFieldValuesProvider._getAssetCategoryDescriptionMap always return an empty string for the default language.

Steps to Verify
========
1. Create a new Vocabulary voc1
2. Create a new Category cat1 inside vocabulary voc1
3. Create a new Content Page
4. Add a paragraph fragment
5. Map that fragment to the category cat1 with the field Description

*Expected behavior:*
- The mapped fragment is in blank

*Actual behavior:*
- The mapped fragment shows the default value of the fragment