### PR TITLE
LPS-194811 Inline content click interaction is not correct

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
@@ -233,8 +233,19 @@ export default function PageContent({
 				</div>
 			) : (
 				<ClayLayout.ContentRow
-					className={classNames({'align-items-center': !subtype})}
+					aria-label={`${Liferay.Language.get('select')} ${title}`}
+					className={classNames({
+						'align-items-center': !subtype,
+					})}
+					onClick={onClickSelectInlineText}
+					onKeyDown={(event) => {
+						if (event.key === 'Enter') {
+							onClickSelectInlineText();
+						}
+					}}
 					padded
+					role="button"
+					tabIndex="0"
 				>
 					<ClayLayout.ContentCol>
 						<ClayIcon
@@ -257,68 +268,60 @@ export default function PageContent({
 							</span>
 						)}
 					</ClayLayout.ContentCol>
-
-					<ClayLayout.ContentCol>
-						{dropdownItems?.length ? (
-							<ClayDropDownWithItems
-								active={activeActions}
-								className="align-self-center"
-								items={dropdownItems}
-								menuElementAttrs={{
-									containerProps: {
-										className: 'cadmin',
-									},
-								}}
-								onActiveChange={setActiveActions}
-								trigger={
-									<ClayButton
-										aria-label={sub(
-											Liferay.Language.get(
-												'actions-for-x'
-											),
-											title
-										)}
-										className={classNames(
-											'page-editor__page-contents__button',
-											{'mt-1': subtype}
-										)}
-										displayType="unstyled"
-										size="sm"
-										title={sub(
-											Liferay.Language.get(
-												'open-actions-menu'
-											),
-											title
-										)}
-									>
-										<ClayIcon symbol="ellipsis-v" />
-									</ClayButton>
-								}
-							/>
-						) : (
-							<ClayButton
-								aria-label={sub(
-									Liferay.Language.get('edit-inline-text-x'),
-									title
-								)}
-								className={classNames(
-									'page-editor__page-contents__button',
-									{
-										'not-allowed':
-											isBeingEdited ||
-											!canUpdateEditables,
-									}
-								)}
-								disabled={isBeingEdited || !canUpdateEditables}
-								displayType="unstyled"
-								onClick={onClickEditInlineText}
-								size="sm"
-							>
-								<ClayIcon symbol="pencil" />
-							</ClayButton>
-						)}
-					</ClayLayout.ContentCol>
 				</ClayLayout.ContentRow>
+			)}
+
+			{dropdownItems?.length ? (
+				<ClayDropDownWithItems
+					active={activeActions}
+					className="align-self-center"
+					items={dropdownItems}
+					menuElementAttrs={{
+						containerProps: {
+							className: 'cadmin',
+						},
+					}}
+					onActiveChange={setActiveActions}
+					trigger={
+						<ClayButton
+							aria-label={sub(
+								Liferay.Language.get('actions-for-x'),
+								title
+							)}
+							className={classNames(
+								'page-editor__page-contents__button',
+								{'mt-1': subtype}
+							)}
+							displayType="unstyled"
+							size="sm"
+							title={sub(
+								Liferay.Language.get('open-actions-menu'),
+								title
+							)}
+						>
+							<ClayIcon symbol="ellipsis-v" />
+						</ClayButton>
+					}
+				/>
+			) : (
+				<ClayButton
+					aria-label={sub(
+						Liferay.Language.get('edit-inline-text-x'),
+						title
+					)}
+					className={classNames(
+						'page-editor__page-contents__button',
+						{
+							'not-allowed': isBeingEdited || !canUpdateEditables,
+						}
+					)}
+					disabled={isBeingEdited || !canUpdateEditables}
+					displayType="unstyled"
+					onClick={onClickEditInlineText}
+					size="sm"
+				>
+					<ClayIcon symbol="pencil" />
+				</ClayButton>
 			)}
 
 			{imageEditorParams && (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
@@ -185,12 +185,8 @@ export default function PageContent({
 		hoverItem(null);
 	};
 
-	const onClickEditInlineText = () => {
-		if (isBeingEdited) {
-			return;
-		}
-
-		const itemId = getFirstControlsId({
+	const getInlineTextItemId = () => {
+		return getFirstControlsId({
 			item: {
 				id: editableId,
 				itemType: ITEM_TYPES.editable,
@@ -199,13 +195,29 @@ export default function PageContent({
 			},
 			layoutData,
 		});
+	};
+
+	const onClickEditInlineText = () => {
+		if (isBeingEdited || !editableId) {
+			return;
+		}
+
+		const itemId = getInlineTextItemId();
+
+		setNextEditableProcessorUniqueId(itemId);
+	};
+
+	const onClickSelectInlineText = () => {
+		if (isBeingEdited || !editableId) {
+			return;
+		}
+
+		const itemId = getInlineTextItemId();
 
 		selectItem(itemId, {
 			itemType: ITEM_TYPES.editable,
 			origin: ITEM_ACTIVATION_ORIGINS.sidebar,
 		});
-
-		setNextEditableProcessorUniqueId(itemId);
 	};
 
 	return (

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
@@ -248,6 +248,7 @@ export default function PageContent({
 					aria-label={`${Liferay.Language.get('select')} ${title}`}
 					className={classNames({
 						'align-items-center': !subtype,
+						'editable-hovered': !!editableId,
 					})}
 					onClick={onClickSelectInlineText}
 					onKeyDown={(event) => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
@@ -197,8 +197,10 @@ export default function PageContent({
 		});
 	};
 
+	const isInlineText = !!editableId;
+
 	const onClickEditInlineText = () => {
-		if (isBeingEdited || !editableId) {
+		if (isBeingEdited || !isInlineText) {
 			return;
 		}
 
@@ -208,7 +210,7 @@ export default function PageContent({
 	};
 
 	const onClickSelectInlineText = () => {
-		if (isBeingEdited || !editableId) {
+		if (isBeingEdited || !isInlineText) {
 			return;
 		}
 
@@ -219,6 +221,22 @@ export default function PageContent({
 			origin: ITEM_ACTIVATION_ORIGINS.sidebar,
 		});
 	};
+
+	const extraProps = isInlineText
+		? {
+				'aria-label': `${Liferay.Language.get('select')} ${title}`,
+				'onClick': () => onClickSelectInlineText(),
+				'onKeyDown': (event) => {
+					if (event.key === 'Enter') {
+						onClickSelectInlineText();
+					}
+				},
+				'role': 'button',
+				'tabIndex': '0',
+		  }
+		: {
+				'aria-label': title,
+		  };
 
 	return (
 		<li
@@ -245,20 +263,12 @@ export default function PageContent({
 				</div>
 			) : (
 				<ClayLayout.ContentRow
-					aria-label={`${Liferay.Language.get('select')} ${title}`}
-					className={classNames({
+					className={classNames('c-mr-1', {
 						'align-items-center': !subtype,
-						'editable-hovered': !!editableId,
+						'btn btn-unstyled editable-hovered': isInlineText,
 					})}
-					onClick={onClickSelectInlineText}
-					onKeyDown={(event) => {
-						if (event.key === 'Enter') {
-							onClickSelectInlineText();
-						}
-					}}
 					padded
-					role="button"
-					tabIndex="0"
+					{...extraProps}
 				>
 					<ClayLayout.ContentCol>
 						<ClayIcon

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/PageContent.js
@@ -223,7 +223,7 @@ export default function PageContent({
 	return (
 		<li
 			className={classNames(
-				'page-editor__page-contents__page-content mb-1 p-1',
+				'page-editor__page-contents__page-content position-relative mb-1 p-1 pr-3 d-inline-flex autofit-row',
 				{
 					'page-editor__page-contents__page-content--mapped-item-hovered':
 						isHovered || activeActions || isBeingEdited,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/_ContentsSidebar.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/_ContentsSidebar.scss
@@ -15,6 +15,10 @@ html#{$cadmin-selector} .cadmin #{$selector} {
 		font-size: 12px;
 		padding-left: 12px;
 
+		.editable-hovered {
+			cursor: pointer;
+		}
+
 		&:focus-within,
 		&--mapped-item-hovered {
 			background-color: $cadmin-gray-100;

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page_content/components/PageContent.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page_content/components/PageContent.test.js
@@ -161,11 +161,11 @@ describe('PageContent', () => {
 		expect(screen.getByLabelText('edit-inline-text-x')).toBeInTheDocument();
 	});
 
-	it('selects the corresponding element on the page when edit button is clicked', () => {
+	it('selects the corresponding element on the page when inline text item is clicked', () => {
 		const selectItem = useSelectItem();
 		renderPageContent(inlineText);
 
-		fireEvent.click(screen.getByLabelText('edit-inline-text-x'));
+		fireEvent.click(screen.getByLabelText(`select ${inlineText.title}`));
 
 		expect(selectItem).toHaveBeenCalledWith('11113-element-text', {
 			itemType: 'editable',


### PR DESCRIPTION
Motivation
=======
The motivation behind this PR is to solve some issues related to inline-text items in the Content Page from the Page Editor:
https://liferay.atlassian.net/browse/LPS-194811

Proposed Solution
========
What I did to solve the problem is differ between the whole item from the list which acts like a button and the icon-button that it has associated by taking it out in a different component.

Steps to Verify
========
1. Go to Page Editor -> Content Tab
2. Click on Inline-text and check that the element is selected.
3. Click over the pencil icon button that it has inside and check that the fragment is editable
4. Check for the documents or collections doesn't occur anything by clicking over it, the only behaviour expected is to get focus, not to be selected or in edition.
