### PR TITLE
LPS-195253 Change cached/not cached label styles

### DIFF
--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/ItemDetail.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/ItemDetail.js
@@ -81,7 +81,7 @@ function FragmentDetail({fragment}) {
 				/>
 
 				<TextSection
-					labelType="primary"
+					labelType="secondary"
 					text={
 						cached
 							? Liferay.Language.get('cached')


### PR DESCRIPTION
Motivation
=======
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-195253)

Steps to Verify:
----------------
1. Set feature.flag.LPS-187284=true in portal-ext.properties
2. Go to Home page and open the Page Audit
3. In the Performance tag click on the Heading fragment
4. Check that the cached/no cached label has secondary styles (gray)

Screenshots (optional):
-----------------------
<img width="324" alt="Captura de pantalla 2023-09-04 a las 16 43 49" src="https://github.com/liferay-echo/liferay-portal/assets/3276218/4aecc358-09f5-4735-a3f1-9ec755577d54">

