### PR TITLE
LPS-195345 ordering categories based on hierarchy

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java
+++ b/modules/apps/asset/asset-taglib/src/main/java/com/liferay/asset/taglib/servlet/taglib/AssetCategoriesSelectorTag.java
@@ -41,6 +41,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portlet.asset.util.comparator.AssetCategoryParentIdComparator;
 import com.liferay.portlet.asset.util.comparator.AssetVocabularyGroupLocalizedTitleComparator;
 import com.liferay.taglib.aui.AUIUtil;
 import com.liferay.taglib.util.IncludeTag;
@@ -214,6 +215,8 @@ public class AssetCategoriesSelectorTag extends IncludeTag {
 					List<AssetCategory> categories =
 						AssetCategoryServiceUtil.getCategories(
 							_className, _classPK);
+
+					categories.sort(new AssetCategoryParentIdComparator());
 
 					categoryIds = ListUtil.toString(
 						categories, AssetCategory.CATEGORY_ID_ACCESSOR);

--- a/portal-impl/src/com/liferay/portlet/asset/util/comparator/AssetCategoryParentIdComparator.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/comparator/AssetCategoryParentIdComparator.java
@@ -1,0 +1,48 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portlet.asset.util.comparator;
+
+import com.liferay.asset.kernel.model.AssetCategory;
+
+import java.util.Comparator;
+
+/**
+ * @author Miklos Zakanyi
+ */
+public class AssetCategoryParentIdComparator
+	implements Comparator<AssetCategory> {
+
+	@Override
+	public int compare(
+		AssetCategory assetCategory1, AssetCategory assetCategory2) {
+
+		if (_findParent(assetCategory1, assetCategory2)) {
+			return 1;
+		}
+		else if (_findParent(assetCategory2, assetCategory1)) {
+			return -1;
+		}
+
+		return 0;
+	}
+
+	private boolean _findParent(
+		AssetCategory assetCategory1, AssetCategory assetCategory2) {
+
+		AssetCategory parent = assetCategory1.getParentCategory();
+
+		while (parent != null) {
+			if (assetCategory2.getCategoryId() == parent.getCategoryId()) {
+				return true;
+			}
+
+			parent = parent.getParentCategory();
+		}
+
+		return false;
+	}
+
+}


### PR DESCRIPTION
### Motivation
A solution to [this ticket](https://liferay.atlassian.net/browse/LPS-195345) where category display is not displayed in order 

### Proposed Solution
Adding a new comperator to sort the categories based on hierarchy 

### Steps to Verify

1. Go to Categorization > Categories > “+“
2. Add a new vocabulary
3. Add a category hiearchy  (A > B > C > D > E > F)
4. Create a new web content
5. Open CATEGORIZATION on the right menu, and select all categories 
6. Check the order in which they line up from the top. (A > B > C > D > E > F)
7. Publish it
8. Open it again and check the categories

### screenshot of the initial order
![image](https://github.com/liferay-echo/liferay-portal/assets/128690033/0277ef01-83e5-4060-8b56-ea1ccc1ecff9)

### Screenshot of the wrong order
![image](https://github.com/liferay-echo/liferay-portal/assets/128690033/20d93ec2-b8c9-4e26-bff1-d0749581a408)
