### PR TITLE
LPS-188471 Structure Default Values are not taken into account when mapped fields are not populated

### DIFF
--- a/modules/apps/journal/journal-api/bnd.bnd
+++ b/modules/apps/journal/journal-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal API
 Bundle-SymbolicName: com.liferay.journal.api
-Bundle-Version: 33.0.1
+Bundle-Version: 33.1.0
 Export-Package:\
 	com.liferay.journal.configuration,\
 	com.liferay.journal.constants,\

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticle.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticle.java
@@ -96,6 +96,9 @@ public interface JournalArticle
 	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
 		getDDMFormValues();
 
+	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
+		getDDMFormValues(boolean addMissingDDMFormFieldValues);
+
 	public com.liferay.dynamic.data.mapping.model.DDMStructure
 		getDDMStructure();
 

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/model/JournalArticleWrapper.java
@@ -434,6 +434,13 @@ public class JournalArticleWrapper
 	}
 
 	@Override
+	public com.liferay.dynamic.data.mapping.storage.DDMFormValues
+		getDDMFormValues(boolean addMissingDDMFormFieldValues) {
+
+		return model.getDDMFormValues(addMissingDDMFormFieldValues);
+	}
+
+	@Override
 	public com.liferay.dynamic.data.mapping.model.DDMStructure
 		getDDMStructure() {
 

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/model/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/model/packageinfo
@@ -1,1 +1,1 @@
-version 14.3.0
+version 14.4.0

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -280,6 +280,13 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 
 	@Override
 	public DDMFormValues getDDMFormValues() {
+		return getDDMFormValues(true);
+	}
+
+	@Override
+	public DDMFormValues getDDMFormValues(
+		boolean addMissingDDMFormFieldValues) {
+
 		DDMStructure ddmStructure = getDDMStructure();
 
 		if (ddmStructure == null) {
@@ -291,7 +298,7 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 		DDMFormValues ddmFormValues = DDMFieldLocalServiceUtil.getDDMFormValues(
 			ddmForm, getId());
 
-		if (ddmFormValues != null) {
+		if ((ddmFormValues != null) && addMissingDDMFormFieldValues) {
 			ddmFormValues.setDDMFormFieldValues(
 				DDMFormValuesConverterUtil.addMissingDDMFormFieldValues(
 					ddmForm.getDDMFormFields(),


### PR DESCRIPTION
Motivation
=======
This is a PR that aims to fix [LPS-188471](https://liferay.atlassian.net/browse/LPS-188471) as per the [decision](https://liferay.atlassian.net/browse/PTR-3950?focusedCommentId=1801140) made in [PTR-3950](https://liferay.atlassian.net/browse/PTR-3950).

Proposed Solution
========
The followed approach is to add the Web Content Structure's default values to the end of the list of values provided by JournalArticleInfoItemFieldValuesProvider.

Steps to Verify
========
1. Create a Web Content Structure with a text field Text1
2. Create a Web Content based off of that Web Content Structure
3. Add a new field Text2 to the Web Content Structure
4. Edit the default values of the Web Content Structure and set Text2 field to “My Default Value”
5. Create a new Content Page with a Heading Fragment
6. Map it to Text2 field of the Web Content created in step 2

*Expected result:*
- The Heading fragment displays the value “My Default Value”

*Actual result:*
- The Heading fragment displays the value “Heading Example”

@dacousalr 