### PR TITLE
LPS-195549 Migrate Page Editor Language Selector to Clay Picker

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Translation.scss
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/_Translation.scss
@@ -1,3 +1,3 @@
-html#{$cadmin-selector} .cadmin .page-editor__translation {
-	min-width: 35ch;
+html#{$cadmin-selector} .cadmin.translation-picker .dropdown-menu {
+	min-width: 300px;
 }

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Translation.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Translation.test.js
@@ -4,7 +4,7 @@
  */
 
 import '@testing-library/jest-dom/extend-expect';
-import {cleanup, render} from '@testing-library/react';
+import {cleanup, render, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -121,29 +121,45 @@ const renderTranslation = ({state}) => {
 	);
 };
 
+const getElementIndicatorText = (element) => {
+	return element.parentElement.parentElement.nextSibling.textContent;
+};
+
 describe('Translation', () => {
 	afterEach(cleanup);
 
 	it('renders Translation component', () => {
-		const {getByText} = renderTranslation({state: defaultState});
+		const {getByRole, getByText} = renderTranslation({state: defaultState});
+
+		const button = getByRole('combobox');
+		userEvent.click(button);
 
 		expect(getByText('language-4')).toBeInTheDocument();
 	});
 
-	it('dispatches languageId when a language is selected', () => {
-		const {getByText} = renderTranslation({state: defaultState});
-		const button = getByText('language-3').parentElement;
+	it('dispatches languageId when a language is selected', async () => {
+		const {getByRole} = renderTranslation({state: defaultState});
 
+		const button = getByRole('combobox');
 		userEvent.click(button);
 
-		expect(updateLanguageId).toHaveBeenLastCalledWith({
-			languageId: 'language_3',
+		const option = getByRole('option', {name: /language-3/});
+
+		await waitFor(() => {
+			userEvent.click(option);
+			expect(updateLanguageId).toHaveBeenLastCalledWith({
+				languageId: 'language_3',
+			});
 		});
 	});
 
 	it('sets label "translated" when there is a translated language', () => {
-		const {getByText} = renderTranslation({state: defaultState});
-		const indicator = getByText('language-1').nextSibling.textContent;
+		const {getByRole, getByText} = renderTranslation({state: defaultState});
+
+		const button = getByRole('combobox');
+		userEvent.click(button);
+
+		const indicator = getElementIndicatorText(getByText('language-1'));
 
 		expect(indicator).toBe('translated');
 	});
@@ -156,8 +172,12 @@ describe('Translation', () => {
 				[FRAGMENT_ENTRY_LINK_ID_2]: fragmentEntryLink2,
 			},
 		};
-		const {getByText} = renderTranslation({state: newState});
-		const indicator = getByText('language-1').nextSibling.textContent;
+		const {getByRole, getByText} = renderTranslation({state: newState});
+
+		const button = getByRole('combobox');
+		userEvent.click(button);
+
+		const indicator = getElementIndicatorText(getByText('language-1'));
 
 		expect(indicator).toBe('translating 1/2');
 	});
@@ -176,8 +196,12 @@ describe('Translation', () => {
 				},
 			},
 		};
-		const {getByText} = renderTranslation({state: newState});
-		const indicator = getByText('language-1').nextSibling.textContent;
+		const {getByRole, getByText} = renderTranslation({state: newState});
+
+		const button = getByRole('combobox');
+		userEvent.click(button);
+
+		const indicator = getElementIndicatorText(getByText('language-1'));
 
 		expect(indicator).toBe('translated');
 	});


### PR DESCRIPTION
Motivation
=======
Migrate Page Editor Language Selector to Clay Picker
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-195549)

Steps to Verify:
----------------
1. Open the page editor
1. Click on the language selection button

Screenshots (optional):
-----------------------

![Captura de pantalla 2023-09-07 a las 16 22 04](https://github.com/liferay-echo/liferay-portal/assets/3276218/78d0560b-f188-4ef4-a1cc-4a57cf053ed8)
