### PR TITLE
LPS-195618 Add warning label to fragment with errors

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/frontend/taglib/clay/servlet/taglib/BasicFragmentEntryVerticalCard.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/frontend/taglib/clay/servlet/taglib/BasicFragmentEntryVerticalCard.java
@@ -7,7 +7,10 @@ package com.liferay.fragment.web.internal.frontend.taglib.clay.servlet.taglib;
 
 import com.liferay.fragment.constants.FragmentActionKeys;
 import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
 import com.liferay.fragment.service.FragmentEntryLinkLocalServiceUtil;
+import com.liferay.fragment.validator.FragmentEntryValidator;
+import com.liferay.fragment.web.internal.constants.FragmentWebKeys;
 import com.liferay.fragment.web.internal.security.permission.resource.FragmentPermission;
 import com.liferay.fragment.web.internal.servlet.taglib.util.BasicFragmentEntryActionDropdownItemsProvider;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItem;
@@ -100,6 +103,39 @@ public class BasicFragmentEntryVerticalCard
 					WorkflowConstants.STATUS_APPROVED)
 			).add(
 				labelItem -> labelItem.setStatus(WorkflowConstants.STATUS_DRAFT)
+			).add(
+				fragmentEntry::isCacheable,
+				labelItem -> labelItem.setLabel(
+					LanguageUtil.get(_httpServletRequest, "cached"))
+			).build();
+		}
+
+		FragmentEntryValidator fragmentEntryValidator =
+			(FragmentEntryValidator)_httpServletRequest.getAttribute(
+				FragmentEntryValidator.class.getName());
+
+		FragmentEntryProcessorRegistry fragmentEntryProcessorRegistry =
+			(FragmentEntryProcessorRegistry)_httpServletRequest.getAttribute(
+				FragmentWebKeys.FRAGMENT_ENTRY_PROCESSOR_REGISTRY);
+
+		try {
+			fragmentEntryValidator.validateConfiguration(
+				fragmentEntry.getConfiguration());
+			fragmentEntryValidator.validateTypeOptions(
+				fragmentEntry.getType(), fragmentEntry.getTypeOptions());
+			fragmentEntryProcessorRegistry.validateFragmentEntryHTML(
+				fragmentEntry.getHtml(), fragmentEntry.getConfiguration());
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug(exception);
+			}
+
+			return LabelItemListBuilder.add(
+				labelItem -> labelItem.setStatus(fragmentEntry.getStatus())
+			).add(
+				labelItem -> labelItem.setStatus(
+					WorkflowConstants.STATUS_WARNING)
 			).add(
 				fragmentEntry::isCacheable,
 				labelItem -> labelItem.setLabel(

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/FragmentPortlet.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/FragmentPortlet.java
@@ -13,6 +13,7 @@ import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.processor.FragmentEntryProcessorRegistry;
 import com.liferay.fragment.renderer.FragmentRendererController;
 import com.liferay.fragment.service.FragmentCollectionService;
+import com.liferay.fragment.validator.FragmentEntryValidator;
 import com.liferay.fragment.web.internal.configuration.FragmentPortletConfiguration;
 import com.liferay.fragment.web.internal.constants.FragmentWebKeys;
 import com.liferay.item.selector.ItemSelector;
@@ -138,6 +139,9 @@ public class FragmentPortlet extends MVCPortlet {
 			_fragmentCollectionService.getFragmentCollections(
 				CompanyConstants.SYSTEM));
 
+		renderRequest.setAttribute(
+			FragmentEntryValidator.class.getName(), _fragmentEntryValidator);
+
 		super.doDispatch(renderRequest, renderResponse);
 	}
 
@@ -189,6 +193,9 @@ public class FragmentPortlet extends MVCPortlet {
 
 	@Reference
 	private FragmentEntryProcessorRegistry _fragmentEntryProcessorRegistry;
+
+	@Reference
+	private FragmentEntryValidator _fragmentEntryValidator;
 
 	@Reference
 	private FragmentRendererController _fragmentRendererController;

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowConstants.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/WorkflowConstants.java
@@ -74,6 +74,8 @@ public class WorkflowConstants {
 
 	public static final String LABEL_SCHEDULED = "scheduled";
 
+	public static final String LABEL_WARNING = "warnings";
+
 	public static final String RESOURCE_NAME = "com.liferay.portal.workflow";
 
 	public static final String SERVICE_NAME = "com.liferay.portal.workflow";
@@ -97,6 +99,8 @@ public class WorkflowConstants {
 	public static final int STATUS_PENDING = 1;
 
 	public static final int STATUS_SCHEDULED = 7;
+
+	public static final int STATUS_WARNING = 9;
 
 	public static final int TYPE_ASSIGN = 10000;
 
@@ -168,6 +172,9 @@ public class WorkflowConstants {
 		else if (status == STATUS_SCHEDULED) {
 			return LABEL_SCHEDULED;
 		}
+		else if (status == STATUS_WARNING) {
+			return LABEL_WARNING;
+		}
 
 		return LABEL_ANY;
 	}
@@ -203,6 +210,9 @@ public class WorkflowConstants {
 		else if (status == STATUS_SCHEDULED) {
 			return LABEL_SCHEDULED;
 		}
+		else if (status == STATUS_WARNING) {
+			return LABEL_WARNING;
+		}
 
 		return LABEL_ANY;
 	}
@@ -234,6 +244,9 @@ public class WorkflowConstants {
 		}
 		else if (status == WorkflowConstants.STATUS_SCHEDULED) {
 			return "info";
+		}
+		else if (status == WorkflowConstants.STATUS_WARNING) {
+			return "warning";
 		}
 
 		return "secondary";

--- a/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/workflow/packageinfo
@@ -1,1 +1,1 @@
-version 21.0.0
+version 21.1.0


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-195618)

## Motivation
When we import a Fragment, this can contain errors and now only "Draft" label shows when this happens. We want to add a "Warnings" label to know when a Fragment imported has errors.

## Steps
- Go to Design > Fragments > Create a Fragment set
- Create a Fragment
- I have added an example of a fragment that contain error but it will import it: [The file is included in the ticket](https://liferay.atlassian.net/browse/LPS-195618)
- Import that zip and see the labels 
<img width="209" alt="Screenshot 2023-09-08 at 14 07 05" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/a27d69c3-84c0-4007-b735-f71777c110f7">
