### PR TITLE
LRAC-14467 | master

### DIFF
--- a/modules/dxp/apps/segments/segments-asah-connector-test/src/testIntegration/java/com/liferay/segments/asah/connector/internal/portlet/action/test/AddSegmentsExperimentMVCActionCommandTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector-test/src/testIntegration/java/com/liferay/segments/asah/connector/internal/portlet/action/test/AddSegmentsExperimentMVCActionCommandTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.segments.experiment.web.internal.portlet.action.test;
+package com.liferay.segments.asah.connector.internal.portlet.action.test;
 
 import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.MockHttp;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
@@ -39,6 +40,8 @@ import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.model.SegmentsExperiment;
 import com.liferay.segments.service.SegmentsExperimentLocalService;
 import com.liferay.segments.test.util.SegmentsTestUtil;
+
+import java.util.Collections;
 
 import javax.portlet.ActionRequest;
 
@@ -128,6 +131,9 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 						TestPropsValues.getCompanyId(),
 						AnalyticsConfiguration.class.getName(),
 						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsFaroBackendURL",
+							"http://localhost:8086"
+						).put(
 							"liferayAnalyticsURL", liferayAnalyticsURL
 						).build())) {
 
@@ -229,8 +235,24 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 						TestPropsValues.getCompanyId(),
 						AnalyticsConfiguration.class.getName(),
 						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsFaroBackendURL",
+							"http://localhost:8086"
+						).put(
 							"liferayAnalyticsURL", "http://localhost:8080/"
 						).build())) {
+
+			Object asahFaroBackendClient = ReflectionTestUtil.getFieldValue(
+				_mvcActionCommand, "_asahFaroBackendClient");
+
+			ReflectionTestUtil.setFieldValue(
+				asahFaroBackendClient, "_http",
+				new MockHttp(
+					Collections.singletonMap(
+						"/api/1.0/experiments/" +
+							segmentsExperiment.getSegmentsExperimentKey(),
+						() -> JSONUtil.put(
+							"id", "123456"
+						).toString())));
 
 			ReflectionTestUtil.invoke(
 				_mvcActionCommand, "_addSegmentsExperiment",

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/Experiment.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/Experiment.java
@@ -132,6 +132,10 @@ public final class Experiment {
 		return _pageURL;
 	}
 
+	public Boolean getPublishable() {
+		return _publishable;
+	}
+
 	public String getPublishedDXPVariantId() {
 		return _publishedDXPVariantId;
 	}
@@ -240,6 +244,10 @@ public final class Experiment {
 		_pageURL = pageURL;
 	}
 
+	public void setPublishable(Boolean publishable) {
+		_publishable = publishable;
+	}
+
 	public void setPublishedDXPVariantId(String publishedDXPVariantId) {
 		_publishedDXPVariantId = publishedDXPVariantId;
 	}
@@ -272,6 +280,7 @@ public final class Experiment {
 	private String _pageRelativePath;
 	private String _pageTitle;
 	private String _pageURL;
+	private Boolean _publishable;
 	private String _publishedDXPVariantId;
 	private Date _startedDate;
 

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtil.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtil.java
@@ -122,6 +122,8 @@ public class ExperimentUtil {
 				segmentsExperiment.getWinnerSegmentsExperienceKey());
 		}
 
+		experiment.setPublishable(true);
+
 		SegmentsExperience segmentsExperience =
 			segmentsExperienceLocalService.getSegmentsExperience(
 				segmentsExperiment.getSegmentsExperienceId());

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/EditSegmentsExperimentStatusMVCActionCommand.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/EditSegmentsExperimentStatusMVCActionCommand.java
@@ -3,8 +3,9 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.segments.experiment.web.internal.portlet.action;
+package com.liferay.segments.asah.connector.internal.portlet.action;
 
+import com.liferay.analytics.settings.configuration.AnalyticsConfiguration;
 import com.liferay.analytics.settings.rest.manager.AnalyticsSettingsManager;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -14,18 +15,31 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
 import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.transaction.TransactionConfig;
 import com.liferay.portal.kernel.transaction.TransactionInvokerUtil;
+import com.liferay.portal.kernel.util.Http;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.segments.asah.connector.internal.client.AsahFaroBackendClient;
+import com.liferay.segments.asah.connector.internal.client.AsahFaroBackendClientImpl;
+import com.liferay.segments.asah.connector.internal.client.model.Experiment;
+import com.liferay.segments.asah.connector.internal.client.model.util.ExperimentUtil;
+import com.liferay.segments.asah.connector.internal.util.SegmentsExperimentUtil;
+import com.liferay.segments.constants.SegmentsExperimentConstants;
 import com.liferay.segments.constants.SegmentsPortletKeys;
-import com.liferay.segments.experiment.web.internal.util.SegmentsExperimentUtil;
 import com.liferay.segments.model.SegmentsExperiment;
+import com.liferay.segments.service.SegmentsEntryLocalService;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.segments.service.SegmentsExperimentService;
 
+import java.util.Map;
 import java.util.concurrent.Callable;
 
 import javax.portlet.ActionRequest;
@@ -33,7 +47,9 @@ import javax.portlet.ActionResponse;
 
 import javax.servlet.http.HttpServletResponse;
 
+import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
 import org.osgi.service.component.annotations.Reference;
 
 /**
@@ -48,6 +64,17 @@ import org.osgi.service.component.annotations.Reference;
 )
 public class EditSegmentsExperimentStatusMVCActionCommand
 	extends BaseMVCActionCommand {
+
+	@Activate
+	protected void activate(Map<String, Object> properties) {
+		_asahFaroBackendClient = new AsahFaroBackendClientImpl(
+			_analyticsSettingsManager, _http);
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_asahFaroBackendClient = null;
+	}
 
 	@Override
 	protected void doProcessAction(
@@ -97,18 +124,53 @@ public class EditSegmentsExperimentStatusMVCActionCommand
 					(ThemeDisplay)actionRequest.getAttribute(
 						WebKeys.THEME_DISPLAY);
 
+				long winnerSegmentsExperienceId = ParamUtil.getLong(
+					actionRequest, "winnerSegmentsExperienceId", -1);
+
 				SegmentsExperiment segmentsExperiment =
 					_segmentsExperimentService.updateSegmentsExperimentStatus(
 						ParamUtil.getLong(
 							actionRequest, "segmentsExperimentId"),
-						ParamUtil.getLong(
-							actionRequest, "winnerSegmentsExperienceId", -1),
+						winnerSegmentsExperienceId,
 						ParamUtil.getInteger(actionRequest, "status"));
 
-				return SegmentsExperimentUtil.toSegmentsExperimentJSONObject(
+				AnalyticsConfiguration analyticsConfiguration =
 					_analyticsSettingsManager.getAnalyticsConfiguration(
-						themeDisplay.getCompanyId()),
-					themeDisplay.getLocale(), segmentsExperiment);
+						themeDisplay.getCompanyId());
+
+				if (((segmentsExperiment.getStatus() ==
+						SegmentsExperimentConstants.STATUS_COMPLETED) ||
+					 (segmentsExperiment.getStatus() ==
+						 SegmentsExperimentConstants.STATUS_TERMINATED)) &&
+					(winnerSegmentsExperienceId != -1) &&
+					(winnerSegmentsExperienceId ==
+						segmentsExperiment.getWinnerSegmentsExperienceId())) {
+
+					Experiment experiment = ExperimentUtil.toExperiment(
+						_companyLocalService,
+						analyticsConfiguration.liferayAnalyticsDataSourceId(),
+						_groupLocalService, _layoutLocalService,
+						LocaleUtil.getSiteDefault(), _portal,
+						_segmentsEntryLocalService,
+						_segmentsExperienceLocalService, segmentsExperiment);
+
+					experiment.setPublishable(false);
+
+					_asahFaroBackendClient.updateExperiment(
+						segmentsExperiment.getCompanyId(), experiment);
+
+					segmentsExperiment.setStatus(
+						SegmentsExperimentConstants.STATUS_DELETED_ON_DXP_ONLY);
+
+					_segmentsExperimentService.deleteSegmentsExperiment(
+						segmentsExperiment, false);
+
+					segmentsExperiment = null;
+				}
+
+				return SegmentsExperimentUtil.toSegmentsExperimentJSONObject(
+					analyticsConfiguration, themeDisplay.getLocale(),
+					segmentsExperiment);
 			});
 	}
 
@@ -122,11 +184,31 @@ public class EditSegmentsExperimentStatusMVCActionCommand
 	@Reference
 	private AnalyticsSettingsManager _analyticsSettingsManager;
 
+	private AsahFaroBackendClient _asahFaroBackendClient;
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
+
+	@Reference
+	private GroupLocalService _groupLocalService;
+
+	@Reference
+	private Http _http;
+
 	@Reference
 	private Language _language;
 
 	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
 	private Portal _portal;
+
+	@Reference
+	private SegmentsEntryLocalService _segmentsEntryLocalService;
+
+	@Reference
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 	@Reference
 	private SegmentsExperimentService _segmentsExperimentService;

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/util/SegmentsExperimentUtil.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/util/SegmentsExperimentUtil.java
@@ -141,6 +141,32 @@ public class SegmentsExperimentUtil {
 		);
 	}
 
+	public static JSONObject toSegmentsExperimentRelJSONObject(
+			Locale locale, SegmentsExperimentRel segmentsExperimentRel)
+		throws PortalException {
+
+		if (segmentsExperimentRel == null) {
+			return null;
+		}
+
+		return JSONUtil.put(
+			"control", segmentsExperimentRel.isControl()
+		).put(
+			"name", segmentsExperimentRel.getName(locale)
+		).put(
+			"segmentsExperienceId",
+			String.valueOf(segmentsExperimentRel.getSegmentsExperienceId())
+		).put(
+			"segmentsExperimentId",
+			String.valueOf(segmentsExperimentRel.getSegmentsExperimentId())
+		).put(
+			"segmentsExperimentRelId",
+			String.valueOf(segmentsExperimentRel.getSegmentsExperimentRelId())
+		).put(
+			"split", segmentsExperimentRel.getSplit()
+		);
+	}
+
 	public static JSONObject toStatusJSONObject(Locale locale, int status) {
 		SegmentsExperimentConstants.Status segmentsExperimentConstantsStatus =
 			SegmentsExperimentConstants.Status.parse(status);


### PR DESCRIPTION
Jira ticket: https://issues.liferay.com/browse/LRAC-14467

We added a new property `publishable` in Experiment on Analytics Cloud side we manage on DXP side. Basically, it will be `true` when we create a new `SegmentsExperiment` and we set that to `false` when the SegmentsExperiment is deleted only on DXP side.

Also, when publishing a `SegmentsExperience`, its `SegmentsExperiment` is deleted from DXP and kept on AC side as history (with `publishable` set to `false`)

We had to move the MVCActionCommand classes to `segments-asah-connector` module, in order to be able to use the `AsahFaroBackendClient` for sending needed requests to AC