### PR TITLE
[TS] LPS-195736 layout-impl: the mode should be search

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/content/LayoutContentProviderImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/content/LayoutContentProviderImpl.java
@@ -95,7 +95,8 @@ public class LayoutContentProviderImpl implements LayoutContentProvider {
 			httpServletRequest = DynamicServletRequest.addQueryString(
 				httpServletRequest,
 				StringBundler.concat(
-					"p_l_id=", layout.getPlid(), "&p_l_mode=", Constants.VIEW),
+					"p_l_id=", layout.getPlid(), "&p_l_mode=",
+					Constants.SEARCH),
 				false);
 
 			Layout originalRequestLayout =


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-195736

Hi team,

The layout rendering is really too complicated for me to really understand, so check how this works carefully. From my debugging I found that the [_mode initialized here](https://github.com/liferay/liferay-portal/blob/6f2ea80810c5bf5fb239d35aaaed97e1f1589df4/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/RenderLayoutStructureTag.java#L96-L98) controls whether or not [the fragment will be rendered here](https://github.com/liferay/liferay-portal/blob/beddd7cb0a41f5f9e1448d95c1a5f69e43668547/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/renderer/LayoutStructureRenderer.java#L1171-L1177), and the mode is initially [set by the LayoutContentProviderImpl here](https://github.com/liferay/liferay-portal/blob/5ea6cab6b3f7368e241195e8cdcaf36602f3b804/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/content/LayoutContentProviderImpl.java#L95-L99). If LayoutContentProvider.getLayoutContent is just used for indexing this should work fine, but if not I wouldn't know how else to change this behavior.


**Reproduction Steps**

1. Create a new fragment with the following code:`<lfr-drop-zone></lfr-drop-zone>`
2. Create a new page
3. Drag the fragment onto it
4. Drag an HTML fragment onto the fragment's drop zone
5. Set the content of the HTML field to xxxxxxxxxx
6. Click on the HTML fragment > right menu's Advanced tab > check Hide from Site Search Results
7. Publish the page
8. Search for xxxxxxxxxx

**Expected Behavior**
The page is NOT returned as a search result and "xxxxxxxxxx" is not displayed.

**Actual Behavior**
The page is returned as a search result and "xxxxxxxxxx" is displayed.