### PR TITLE
LPS-195781 Add link at the page name column

### DIFF
--- a/modules/apps/layout/layout-locked-layouts-web/src/main/java/com/liferay/layout/locked/layouts/web/internal/display/context/LockedLayoutsDisplayContext.java
+++ b/modules/apps/layout/layout-locked-layouts-web/src/main/java/com/liferay/layout/locked/layouts/web/internal/display/context/LockedLayoutsDisplayContext.java
@@ -12,14 +12,18 @@ import com.liferay.layout.model.LockedLayout;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocalizationUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -33,11 +37,13 @@ import java.util.List;
 public class LockedLayoutsDisplayContext {
 
 	public LockedLayoutsDisplayContext(
-		Language language, LayoutLockManager layoutLockManager,
+		Language language, LayoutLocalService layoutLocalService,
+		LayoutLockManager layoutLockManager,
 		LiferayPortletRequest liferayPortletRequest,
 		LiferayPortletResponse liferayPortletResponse) {
 
 		_language = language;
+		_layoutLocalService = layoutLocalService;
 		_layoutLockManager = layoutLockManager;
 		_liferayPortletRequest = liferayPortletRequest;
 		_liferayPortletResponse = liferayPortletResponse;
@@ -60,6 +66,14 @@ public class LockedLayoutsDisplayContext {
 		return _layoutLockManager.getLayoutType(
 			lockedLayout.getClassPK(), _themeDisplay.getLocale(),
 			lockedLayout.getType());
+	}
+
+	public String getLayoutURL(LockedLayout lockedLayout)
+		throws PortalException {
+
+		Layout layout = _layoutLocalService.fetchLayout(lockedLayout.getPlid());
+
+		return PortalUtil.getLayoutFullURL(layout, _themeDisplay);
 	}
 
 	public List<DropdownItem> getLockedLayoutDropdownItems(
@@ -178,6 +192,7 @@ public class LockedLayoutsDisplayContext {
 	private List<LockedLayout> _filteredLockedLayouts;
 	private String _keywords;
 	private final Language _language;
+	private final LayoutLocalService _layoutLocalService;
 	private final LayoutLockManager _layoutLockManager;
 	private final LiferayPortletRequest _liferayPortletRequest;
 	private final LiferayPortletResponse _liferayPortletResponse;

--- a/modules/apps/layout/layout-locked-layouts-web/src/main/java/com/liferay/layout/locked/layouts/web/internal/portlet/LockedLayoutsPortlet.java
+++ b/modules/apps/layout/layout-locked-layouts-web/src/main/java/com/liferay/layout/locked/layouts/web/internal/portlet/LockedLayoutsPortlet.java
@@ -10,6 +10,7 @@ import com.liferay.layout.locked.layouts.web.internal.display.context.LockedLayo
 import com.liferay.layout.manager.LayoutLockManager;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.util.Portal;
 
 import java.io.IOException;
@@ -50,7 +51,7 @@ public class LockedLayoutsPortlet extends MVCPortlet {
 		renderRequest.setAttribute(
 			LockedLayoutsDisplayContext.class.getName(),
 			new LockedLayoutsDisplayContext(
-				_language, _layoutLockManager,
+				_language, _layoutLocalService, _layoutLockManager,
 				_portal.getLiferayPortletRequest(renderRequest),
 				_portal.getLiferayPortletResponse(renderResponse)));
 
@@ -59,6 +60,9 @@ public class LockedLayoutsPortlet extends MVCPortlet {
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private LayoutLocalService _layoutLocalService;
 
 	@Reference
 	private LayoutLockManager _layoutLockManager;

--- a/modules/apps/layout/layout-locked-layouts-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-locked-layouts-web/src/main/resources/META-INF/resources/view.jsp
@@ -58,8 +58,14 @@ LockedLayoutsDisplayContext lockedLayoutsDisplayContext = (LockedLayoutsDisplayC
 					<liferay-ui:search-container-column-text
 						cssClass="table-cell-expand"
 						name="name"
-						value="<%= name %>"
-					/>
+					>
+						<clay:link
+							aria-lable="<%= name %>"
+							href="<%= lockedLayoutsDisplayContext.getLayoutURL(lockedLayout) %>"
+							label="<%= name %>"
+							target="_blank"
+						/>
+					</liferay-ui:search-container-column-text>
 
 					<liferay-ui:search-container-column-text
 						cssClass="table-cell-expand"


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-195781)

## Context
As we are blocking editors when a page is already being edited, we need to provide an alternative to manually unlock these pages in case they are urgently needed. This "unlock" feature will only be available for Site Admin and Super Admin. This story define a new functionality that allows users to see the page before unlock it.
We cant to add a link to the pages in locked pages list.

## Steps 

- Enable FF "feature.flag.LPS-180328=true"
- Go to Site Builder > Pages > Create a content page
- Edit the page and copy the edit URL
- In a new tab, paste the url and make changes in the page
- In the other tab, go to Configuration > Locked Pages > see the pages list
![ezgif com-video-to-gif (1)](https://github.com/liferay-echo/liferay-portal/assets/91208451/932b3b54-33b6-41d6-a321-67cf19e7f09f)
