### PR TITLE
LPS-195803 Breadcrumb

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/build.gradle
+++ b/modules/apps/layout/layout-page-template-admin-web/build.gradle
@@ -37,6 +37,7 @@ dependencies {
 	compileOnly project(":apps:layout:layout-set-prototype-api")
 	compileOnly project(":apps:portal-vulcan:portal-vulcan-api")
 	compileOnly project(":apps:segments:segments-api")
+	compileOnly project(":apps:site-navigation:site-navigation-taglib")
 	compileOnly project(":apps:staging:staging-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -14,6 +14,7 @@ taglib uri="http://liferay.com/tld/clay" prefix="clay" %><%@
 taglib uri="http://liferay.com/tld/frontend" prefix="liferay-frontend" %><%@
 taglib uri="http://liferay.com/tld/portlet" prefix="liferay-portlet" %><%@
 taglib uri="http://liferay.com/tld/react" prefix="react" %><%@
+taglib uri="http://liferay.com/tld/site-navigation" prefix="liferay-site-navigation" %><%@
 taglib uri="http://liferay.com/tld/theme" prefix="liferay-theme" %><%@
 taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %><%@
 taglib uri="http://liferay.com/tld/util" prefix="liferay-util" %>
@@ -60,6 +61,7 @@ page import="com.liferay.layout.page.template.service.LayoutPageTemplateEntrySer
 page import="com.liferay.portal.kernel.dao.orm.QueryUtil" %><%@
 page import="com.liferay.portal.kernel.exception.PortalException" %><%@
 page import="com.liferay.portal.kernel.exception.RequiredLayoutPrototypeException" %><%@
+page import="com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.model.LayoutPrototype" %><%@

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_display_pages.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_display_pages.jsp
@@ -36,6 +36,12 @@ DisplayPageManagementToolbarDisplayContext displayPageManagementToolbarDisplayCo
 
 	<liferay-ui:success key="displayPageTemplateDeleted" message='<%= GetterUtil.getString(MultiSessionMessages.get(renderRequest, "displayPageTemplateDeleted")) %>' />
 
+	<c:if test='<%= FeatureFlagManagerUtil.isEnabled("LPS-189856") %>'>
+		<liferay-site-navigation:breadcrumb
+			breadcrumbEntries="<%= displayPageDisplayContext.getLayoutPageTemplateBreadcrumbEntries(renderResponse) %>"
+		/>
+	</c:if>
+
 	<liferay-ui:search-container
 		id="displayPages"
 		searchContainer="<%= displayPageDisplayContext.getDisplayPagesSearchContainer() %>"

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateCollection.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateCollection.java
@@ -54,4 +54,8 @@ public interface LayoutPageTemplateCollection
 
 			};
 
+	public LayoutPageTemplateCollection getAncestor();
+
+	public java.util.List<LayoutPageTemplateCollection> getAncestors();
+
 }

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateCollectionWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/model/LayoutPageTemplateCollectionWrapper.java
@@ -173,6 +173,16 @@ public class LayoutPageTemplateCollectionWrapper
 		return wrap(model.cloneWithOriginalValues());
 	}
 
+	@Override
+	public LayoutPageTemplateCollection getAncestor() {
+		return model.getAncestor();
+	}
+
+	@Override
+	public java.util.List<LayoutPageTemplateCollection> getAncestors() {
+		return model.getAncestors();
+	}
+
 	/**
 	 * Returns the company ID of this layout page template collection.
 	 *

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/model/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/model/packageinfo
@@ -1,1 +1,1 @@
-version 7.1.0
+version 7.2.0

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateCollectionImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/model/impl/LayoutPageTemplateCollectionImpl.java
@@ -5,9 +5,49 @@
 
 package com.liferay.layout.page.template.model.impl;
 
+import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
+import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalServiceUtil;
+
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * @author Brian Wing Shun Chan
  */
 public class LayoutPageTemplateCollectionImpl
 	extends LayoutPageTemplateCollectionBaseImpl {
+
+	@Override
+	public LayoutPageTemplateCollection getAncestor() {
+		if (getParentLayoutPageTemplateCollectionId() ==
+				LayoutPageTemplateConstants.
+					PARENT_LAYOUT_PAGE_TEMPLATE_COLLECTION_ID_DEFAULT) {
+
+			return null;
+		}
+
+		return LayoutPageTemplateCollectionLocalServiceUtil.
+			fetchLayoutPageTemplateCollection(
+				getParentLayoutPageTemplateCollectionId());
+	}
+
+	@Override
+	public List<LayoutPageTemplateCollection> getAncestors() {
+		List<LayoutPageTemplateCollection>
+			ancestorsLayoutPageTemplateCollection = new ArrayList<>();
+
+		LayoutPageTemplateCollection curLayoutPageTemplateCollection = this;
+
+		while (curLayoutPageTemplateCollection != null) {
+			ancestorsLayoutPageTemplateCollection.add(
+				curLayoutPageTemplateCollection);
+
+			curLayoutPageTemplateCollection =
+				curLayoutPageTemplateCollection.getAncestor();
+		}
+
+		return ancestorsLayoutPageTemplateCollection;
+	}
+
 }


### PR DESCRIPTION
Motivation
=======
A way of  being able to move back to previous folders or home folder is needed.

Proposed Solution
========
Add breadcrumbs to Display Page Template tab when having nested folders

Steps to Verify
========
1. Go to Design > Page Templates > Display Page Templates tab
2. Create several nested folders.
3. Ensure the breadcrumb is shown and you could navigate by clicking in them