### PR TITLE
LRAC-14547

### DIFF
--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtil.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtil.java
@@ -115,8 +115,10 @@ public class ExperimentUtil {
 		experiment.setPageTitle(layout.getTitle(locale));
 		experiment.setPageURL(pageURL);
 
-		if (segmentsExperiment.getStatus() ==
-				SegmentsExperimentConstants.STATUS_COMPLETED) {
+		if ((segmentsExperiment.getStatus() ==
+				SegmentsExperimentConstants.STATUS_COMPLETED) ||
+			(segmentsExperiment.getStatus() ==
+				SegmentsExperimentConstants.STATUS_TERMINATED)) {
 
 			experiment.setPublishedDXPVariantId(
 				segmentsExperiment.getWinnerSegmentsExperienceKey());

--- a/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtilTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/test/java/com/liferay/segments/asah/connector/internal/client/model/util/ExperimentUtilTest.java
@@ -168,7 +168,7 @@ public class ExperimentUtilTest {
 
 		Experiment experiment = ExperimentUtil.toExperiment(
 			channelId, dataSourceId, RandomTestUtil.randomString(), layout,
-			LocaleUtil.ENGLISH, pageURL, _segmentsEntryLocalService,
+			locale, pageURL, _segmentsEntryLocalService,
 			_segmentsExperienceLocalService, segmentsExperiment);
 
 		Assert.assertEquals(channelId, experiment.getChannelId());
@@ -192,6 +192,95 @@ public class ExperimentUtilTest {
 			segmentsEntry.getName(locale), experiment.getDXPSegmentName());
 		Assert.assertEquals(
 			ExperimentStatus.COMPLETED, experiment.getExperimentStatus());
+		Assert.assertEquals(ExperimentType.AB, experiment.getExperimentType());
+
+		Goal goal = experiment.getGoal();
+
+		GoalMetric goalMetric = goal.getGoalMetric();
+
+		Assert.assertEquals(
+			SegmentsExperimentConstants.Goal.BOUNCE_RATE.name(),
+			goalMetric.name());
+
+		Assert.assertEquals(
+			segmentsExperiment.getSegmentsExperimentKey(), experiment.getId());
+		Assert.assertEquals(
+			segmentsExperiment.getModifiedDate(), experiment.getModifiedDate());
+		Assert.assertEquals(segmentsExperiment.getName(), experiment.getName());
+		Assert.assertEquals(
+			layout.getFriendlyURL(), experiment.getPageRelativePath());
+		Assert.assertEquals(layout.getTitle(locale), experiment.getPageTitle());
+		Assert.assertEquals(pageURL, experiment.getPageURL());
+		Assert.assertEquals(
+			segmentsExperiment.getWinnerSegmentsExperienceKey(),
+			experiment.getPublishedDXPVariantId());
+	}
+
+	@Test
+	public void testToExperimentWithSegmentsExperimentWithStatusTerminated()
+		throws PortalException {
+
+		Locale locale = LocaleUtil.ENGLISH;
+
+		Layout layout = _createLayout(locale);
+
+		SegmentsEntry segmentsEntry = _createSegmentsEntry(locale);
+
+		long segmentsEntryId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_segmentsEntryLocalService.fetchSegmentsEntry(segmentsEntryId)
+		).thenReturn(
+			segmentsEntry
+		);
+
+		SegmentsExperience segmentsExperience = _createSegmentsExperience(
+			locale, segmentsEntryId);
+
+		long segmentsExperienceId = RandomTestUtil.randomLong();
+
+		Mockito.when(
+			_segmentsExperienceLocalService.getSegmentsExperience(
+				segmentsExperienceId)
+		).thenReturn(
+			segmentsExperience
+		);
+
+		SegmentsExperiment segmentsExperiment = _createSegmentsExperiment(
+			segmentsExperienceId,
+			SegmentsExperimentConstants.Goal.BOUNCE_RATE.getLabel(),
+			SegmentsExperimentConstants.STATUS_TERMINATED);
+
+		String channelId = RandomTestUtil.randomString();
+		String dataSourceId = RandomTestUtil.randomString();
+		String pageURL = RandomTestUtil.randomString();
+
+		Experiment experiment = ExperimentUtil.toExperiment(
+			channelId, dataSourceId, RandomTestUtil.randomString(), layout,
+			locale, pageURL, _segmentsEntryLocalService,
+			_segmentsExperienceLocalService, segmentsExperiment);
+
+		Assert.assertEquals(channelId, experiment.getChannelId());
+		Assert.assertEquals(
+			segmentsExperiment.getCreateDate(), experiment.getCreateDate());
+		Assert.assertEquals(dataSourceId, experiment.getDataSourceId());
+		Assert.assertEquals(
+			segmentsExperiment.getDescription(), experiment.getDescription());
+		Assert.assertEquals(
+			segmentsExperience.getSegmentsExperienceKey(),
+			experiment.getDXPExperienceId());
+		Assert.assertEquals(
+			segmentsExperience.getName(locale),
+			experiment.getDXPExperienceName());
+		Assert.assertEquals(
+			(Long)layout.getGroupId(), experiment.getDXPGroupId());
+		Assert.assertEquals(layout.getUuid(), experiment.getDXPLayoutId());
+		Assert.assertEquals(
+			segmentsEntry.getSegmentsEntryKey(), experiment.getDXPSegmentId());
+		Assert.assertEquals(
+			segmentsEntry.getName(locale), experiment.getDXPSegmentName());
+		Assert.assertEquals(
+			ExperimentStatus.TERMINATED, experiment.getExperimentStatus());
 		Assert.assertEquals(ExperimentType.AB, experiment.getExperimentType());
 
 		Goal goal = experiment.getGoal();


### PR DESCRIPTION
Hi team,

In this PR:

- We include the `publishedDXPVariantId` for TERMINATED tests when sending a notification to AC.
- Update unit tests to validate the util class changes.

Thanks!