### PR TITLE
LPS-196028 Preview notification improvements

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/EditableActionPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/EditableActionPanel.js
@@ -3,7 +3,8 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayForm, {ClayInput, ClayToggle} from '@clayui/form';
+import ClayButton from '@clayui/button';
+import ClayForm, {ClayInput} from '@clayui/form';
 import {useId} from 'frontend-js-components-web';
 import {debounce, openToast, sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
@@ -194,7 +195,7 @@ function InteractionSelector({config, data, fragmentId, onValueSelect}) {
 		[onConfigChange]
 	);
 
-	const onPreviewToggle = (checked) => {
+	const onShowPreview = (checked) => {
 		setShowPreview(checked);
 
 		dispatch(
@@ -256,13 +257,13 @@ function InteractionSelector({config, data, fragmentId, onValueSelect}) {
 							{sub(Liferay.Language.get('x-text'), label)}
 						</label>
 
-						<ClayInput.Group small>
+						<ClayInput.Group className="c-mb-2" small>
 							<ClayInput.GroupItem>
 								<ClayInput
 									id={textInputId}
 									onChange={(event) => {
 										if (showPreview) {
-											onPreviewToggle(false);
+											onShowPreview(false);
 											hidePreview();
 										}
 
@@ -287,34 +288,31 @@ function InteractionSelector({config, data, fragmentId, onValueSelect}) {
 								<CurrentLanguageFlag />
 							</ClayInput.GroupItem>
 						</ClayInput.Group>
-					</ClayForm.Group>
 
-					<ClayToggle
-						label={sub(
-							Liferay.Language.get('preview-x-notification'),
-							label
-						)}
-						onToggle={(checked) => {
-							onPreviewToggle(checked);
-
-							if (checked) {
+						<ClayButton
+							aria-label={sub(
+								Liferay.Language.get('preview-x-notification'),
+								label
+							)}
+							displayType="secondary"
+							onClick={() => {
+								onShowPreview(true);
 								openToast({
 									message:
 										textValue[languageId] ||
 										defaultMessage[languageId],
-									onClose: () => onPreviewToggle(false),
+									onClose: () => onShowPreview(false),
 									toastProps: {
 										id: previewId,
 									},
 									type,
 								});
-							}
-							else {
-								hidePreview();
-							}
-						}}
-						toggled={showPreview}
-					/>
+							}}
+							size="sm"
+						>
+							{Liferay.Language.get('preview')}
+						</ClayButton>
+					</ClayForm.Group>
 				</>
 			)}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormGeneralPanel.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/item_configuration_panels/FormGeneralPanel.js
@@ -4,6 +4,7 @@
  */
 
 import ClayAlert from '@clayui/alert';
+import ClayButton from '@clayui/button';
 import ClayForm, {ClayInput, ClayToggle} from '@clayui/form';
 import ClayPanel from '@clayui/panel';
 import {useId} from 'frontend-js-components-web';
@@ -382,7 +383,7 @@ function SuccessInteractionOptions({item, onValueSelect}) {
 						<>
 							<ClayForm.Group small>
 								<ClayInput.Group
-									className="align-items-end"
+									className="align-items-end c-mb-2"
 									small
 								>
 									<ClayInput.GroupItem>
@@ -415,35 +416,26 @@ function SuccessInteractionOptions({item, onValueSelect}) {
 										<CurrentLanguageFlag />
 									</ClayInput.GroupItem>
 								</ClayInput.Group>
-							</ClayForm.Group>
-							<ClayForm.Group small>
-								<ClayToggle
-									label={Liferay.Language.get(
+
+								<ClayButton
+									aria-label={Liferay.Language.get(
 										'preview-success-notification'
 									)}
-									onToggle={(checked) => {
-										onPreviewNotification(checked);
-
-										if (checked) {
-											openToast({
-												message: localizedNotificationText,
-												onClose: () =>
-													onPreviewNotification(
-														false
-													),
-												toastProps: {
-													id: previewId,
-												},
-											});
-										}
-										else {
-											hidePreview();
-										}
+									displayType="secondary"
+									onClick={() => {
+										onPreviewNotification(true);
+										openToast({
+											message: localizedNotificationText,
+											onClose: () =>
+												onPreviewNotification(false),
+											toastProps: {
+												id: previewId,
+											},
+										});
 									}}
-									toggled={Boolean(
-										item.config.showNotificationPreview
-									)}
-								/>
+								>
+									{Liferay.Language.get('preview')}
+								</ClayButton>
 							</ClayForm.Group>
 						</>
 					)}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page_structure/components/item_configuration_panels/EditableActionPanel.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/browser/components/page_structure/components/item_configuration_panels/EditableActionPanel.test.js
@@ -178,7 +178,7 @@ describe('EditableActionPanel', () => {
 
 		expect(screen.getByText('success-text')).toBeInTheDocument();
 		expect(
-			screen.getByText('preview-success-notification')
+			screen.getByLabelText('preview-success-notification')
 		).toBeInTheDocument();
 	});
 


### PR DESCRIPTION
Motivation
=======
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-196028)

Steps to Verify:
----------------
1. Create and Object with one action
1. Go to the Home page and edit it
1. Add a form container and in its options select the new created Object as the content type
1. In the Options check the "Show Notification when Form Is Submitted" checkbox
1. Check that the preview success message toggle has been replaced with a replace button
2. Publish the page
3. Create an instance of the Object using the form
4. Edit the home page again and add a button
5. In the button action options select the Object instance as the item and the Object action as the action
6. In the "Success interaction" field select the "Show notification" option
7. Check that the preview success message toggle and the preview error message toggle have been replaced with a replace button

Screenshots (optional):
-----------------------
<img width="282" alt="Captura de pantalla 2023-09-13 a las 21 52 12" src="https://github.com/liferay-echo/liferay-portal/assets/3276218/4d544735-2c6a-4ff6-9b69-f726f4824fd7">
<img width="282" alt="Captura de pantalla 2023-09-13 a las 21 52 01" src="https://github.com/liferay-echo/liferay-portal/assets/3276218/73169128-6b6b-4ec5-adc3-1f3be2100499">
