### PR TITLE
LPS-194263 Adding the Convert to Page Template option to the ellipsis menu of the page

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/MillerColumnsDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/MillerColumnsDisplayContext.java
@@ -147,12 +147,11 @@ public class MillerColumnsDisplayContext {
 			).put(
 				"createTemplateURL", _getCreateLayoutPageTemplateEntryURL()
 			).put(
+				"getCollectionsURL", _getLayoutPageTemplateCollectionsURL()
+			).put(
 				"getItemActionsURL", getLayoutActionsURL()
 			).put(
 				"getItemChildrenURL", getLayoutChildrenURL()
-			).put(
-				"getLayoutPageTemplateCollectionsURL",
-				_getLayoutPageTemplateCollectionsURL()
 			).put(
 				"isLayoutSetPrototype",
 				() -> {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/MillerColumnsDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/MillerColumnsDisplayContext.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -144,9 +145,14 @@ public class MillerColumnsDisplayContext {
 			HashMapBuilder.<String, Object>put(
 				"breadcrumbEntries", _getBreadcrumbEntriesJSONArray()
 			).put(
+				"createTemplateURL", _getCreateLayoutPageTemplateEntryURL()
+			).put(
 				"getItemActionsURL", getLayoutActionsURL()
 			).put(
 				"getItemChildrenURL", getLayoutChildrenURL()
+			).put(
+				"getLayoutPageTemplateCollectionsURL",
+				_getLayoutPageTemplateCollectionsURL()
 			).put(
 				"isLayoutSetPrototype",
 				() -> {
@@ -352,6 +358,18 @@ public class MillerColumnsDisplayContext {
 		return breadcrumbEntriesJSONArray;
 	}
 
+	private String _getCreateLayoutPageTemplateEntryURL() {
+		return PortletURLBuilder.createActionURL(
+			_liferayPortletResponse
+		).setActionName(
+			"/layout_content_page_editor/create_layout_page_template_entry"
+		).setBackURL(
+			ParamUtil.getString(
+				PortalUtil.getOriginalServletRequest(_httpServletRequest),
+				"p_l_back_url", _themeDisplay.getURLCurrent())
+		).buildString();
+	}
+
 	private List<Long> _getDuplicatedFriendlyURLPlids() throws PortalException {
 		if (_duplicatedFriendlyURLPlids != null) {
 			return _duplicatedFriendlyURLPlids;
@@ -496,6 +514,14 @@ public class MillerColumnsDisplayContext {
 		}
 
 		return jsonArray;
+	}
+
+	private String _getLayoutPageTemplateCollectionsURL() {
+		return ResourceURLBuilder.createResourceURL(
+			_liferayPortletResponse
+		).setResourceID(
+			"/layout_content_page_editor/get_layout_page_template_collections"
+		).buildString();
 	}
 
 	private JSONArray _getLayoutSetBranchesJSONArray() throws Exception {

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/servlet/taglib/util/LayoutActionDropdownItemsProvider.java
@@ -12,7 +12,9 @@ import com.liferay.frontend.taglib.clay.servlet.taglib.util.DropdownItemListBuil
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.admin.web.internal.display.context.LayoutsAdminDisplayContext;
 import com.liferay.layout.admin.web.internal.helper.LayoutActionsHelper;
+import com.liferay.layout.admin.web.internal.security.permission.resource.LayoutPageTemplatePermission;
 import com.liferay.layout.constants.LayoutTypeSettingsConstants;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateActionKeys;
 import com.liferay.petra.function.UnsafeConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
@@ -80,9 +82,7 @@ public class LayoutActionDropdownItemsProvider {
 				dropdownGroupItem.setDropdownItems(
 					DropdownItemListBuilder.add(
 						() ->
-							(_layoutsAdminDisplayContext.isConversionDraft(
-								layout) ||
-							 layout.isTypeContent()) &&
+							_isEditable(layout) &&
 							_layoutActionsHelper.isShowConfigureAction(layout),
 						_getEditLayoutActionUnsafeConsumer(layout)
 					).add(
@@ -143,7 +143,18 @@ public class LayoutActionDropdownItemsProvider {
 		).addGroup(
 			dropdownGroupItem -> {
 				dropdownGroupItem.setDropdownItems(
-					DropdownItemListBuilder.addContext(
+					DropdownItemListBuilder.add(
+						() -> _isShowConvertToPageTemplateAction(layout),
+						dropdownItem -> {
+							dropdownItem.putData(
+								"action", "convertToPageTemplate");
+							dropdownItem.setIcon("page-template");
+							dropdownItem.setLabel(
+								LanguageUtil.get(
+									_httpServletRequest,
+									"convert-to-page-template"));
+						}
+					).addContext(
 						_getCopyLayoutWithPermissionsActionUnsafeConsumer(
 							layout)
 					).add(
@@ -677,6 +688,32 @@ public class LayoutActionDropdownItemsProvider {
 		}
 
 		return draftLayout.hasScopeGroup();
+	}
+
+	private boolean _isEditable(Layout layout) {
+		if (_layoutsAdminDisplayContext.isConversionDraft(layout) ||
+			layout.isTypeContent()) {
+
+			return true;
+		}
+
+		return false;
+	}
+
+	private boolean _isShowConvertToPageTemplateAction(Layout layout) {
+		if (_isEditable(layout) &&
+			LayoutPageTemplatePermission.contains(
+				_themeDisplay.getPermissionChecker(), layout.getGroupId(),
+				LayoutPageTemplateActionKeys.
+					ADD_LAYOUT_PAGE_TEMPLATE_COLLECTION) &&
+			LayoutPageTemplatePermission.contains(
+				_themeDisplay.getPermissionChecker(), layout.getGroupId(),
+				LayoutPageTemplateActionKeys.ADD_LAYOUT_PAGE_TEMPLATE_ENTRY)) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/Layout.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/layout/Layout.js
@@ -10,6 +10,8 @@ import Breadcrumbs from '../breadcrumbs/Breadcrumbs';
 import MillerColumns from '../miller_columns/MillerColumns';
 
 const Layout = ({
+	createTemplateURL,
+	getCollectionsURL,
 	getItemActionsURL,
 	getItemChildrenURL,
 	initialBreadcrumbEntries,
@@ -165,6 +167,8 @@ const Layout = ({
 			<Breadcrumbs entries={breadcrumbEntries} />
 
 			<MillerColumns
+				createTemplateURL={createTemplateURL}
+				getCollectionsURL={getCollectionsURL}
 				getItemActionsURL={getItemActionsURL}
 				initialColumns={layoutColumns}
 				isPrivateLayoutsEnabled={isPrivateLayoutsEnabled}
@@ -184,6 +188,8 @@ export default function ({
 	context: {namespace},
 	props: {
 		breadcrumbEntries,
+		createTemplateURL,
+		getCollectionsURL,
 		getItemActionsURL,
 		getItemChildrenURL,
 		isLayoutSetPrototype = false,
@@ -196,6 +202,8 @@ export default function ({
 }) {
 	return (
 		<Layout
+			createTemplateURL={createTemplateURL}
+			getCollectionsURL={getCollectionsURL}
 			getItemActionsURL={getItemActionsURL}
 			getItemChildrenURL={getItemChildrenURL}
 			initialBreadcrumbEntries={breadcrumbEntries}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumns.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumns.js
@@ -61,6 +61,8 @@ const getItemsMap = (columns, oldItems = new Map()) => {
 const noop = () => {};
 
 const MillerColumns = ({
+	createTemplateURL,
+	getCollectionsURL,
 	getItemActionsURL,
 	initialColumns = [],
 	isLayoutSetPrototype,
@@ -277,6 +279,8 @@ const MillerColumns = ({
 					<MillerColumnsColumn
 						columnItems={column.items}
 						columnsContainer={ref}
+						createTemplateURL={createTemplateURL}
+						getCollectionsURL={getCollectionsURL}
 						getItemActionsURL={getItemActionsURL}
 						isLayoutSetPrototype={isLayoutSetPrototype}
 						isPrivateLayoutsEnabled={isPrivateLayoutsEnabled}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumnsColumn.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumnsColumn.js
@@ -47,6 +47,8 @@ const isValidTarget = (sources, parent) =>
 	);
 
 const MillerColumnsColumn = ({
+	createTemplateURL,
+	getCollectionsURL,
 	getItemActionsURL,
 	columnItems = [],
 	columnsContainer,
@@ -104,6 +106,8 @@ const MillerColumnsColumn = ({
 		>
 			{columnItems.map((item, index) => (
 				<MillerColumnsItem
+					createTemplateURL={createTemplateURL}
+					getCollectionsURL={getCollectionsURL}
 					getItemActionsURL={getItemActionsURL}
 					isLayoutSetPrototype={isLayoutSetPrototype}
 					isPrivateLayoutsEnabled={isPrivateLayoutsEnabled}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumnsItem.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumnsItem.js
@@ -160,8 +160,8 @@ const noop = () => {};
 
 const MillerColumnsItem = ({
 	createTemplateURL,
-	getItemActionsURL,
 	getCollectionsURL,
+	getItemActionsURL,
 	isLayoutSetPrototype,
 	isPrivateLayoutsEnabled,
 	item: {
@@ -566,10 +566,8 @@ const MillerColumnsItem = ({
 
 					{openModal && (
 						<PageTemplateModal
-							createLayoutPageTemplateEntryURL={createTemplateURL}
-							getLayoutPageTemplateCollectionsURL={
-								getCollectionsURL
-							}
+							createTemplateURL={createTemplateURL}
+							getCollectionsURL={getCollectionsURL}
 							layoutId={itemId}
 							namespace={namespace}
 							onClose={onClose}

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumnsItem.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumnsItem.js
@@ -11,6 +11,7 @@ import ClayLabel from '@clayui/label';
 import ClayLayout from '@clayui/layout';
 import ClayLink from '@clayui/link';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
+import {PageTemplateModal} from '@liferay/layout-js-components-web';
 import classNames from 'classnames';
 import {fetch, sub} from 'frontend-js-web';
 import React, {useEffect, useMemo, useRef, useState} from 'react';
@@ -158,7 +159,9 @@ function filterEmptyGroups(items) {
 const noop = () => {};
 
 const MillerColumnsItem = ({
+	createTemplateURL,
 	getItemActionsURL,
+	getCollectionsURL,
 	isLayoutSetPrototype,
 	isPrivateLayoutsEnabled,
 	item: {
@@ -191,6 +194,12 @@ const MillerColumnsItem = ({
 }) => {
 	const ref = useRef();
 	const timeoutRef = useRef();
+
+	const onClose = () => {
+		setOpenModal(false);
+	};
+
+	const [openModal, setOpenModal] = useState(false);
 
 	const [dropZone, setDropZone] = useState();
 
@@ -236,7 +245,10 @@ const MillerColumnsItem = ({
 							onClick(event) {
 								const action = item.data?.action;
 
-								if (action) {
+								if (action === 'convertToPageTemplate') {
+									setOpenModal(true);
+								}
+								else if (action) {
 									event.preventDefault();
 
 									ACTIONS[action]?.(item.data);
@@ -551,6 +563,18 @@ const MillerColumnsItem = ({
 					<span aria-live="polite" className="sr-only">
 						{loadMessage}
 					</span>
+
+					{openModal && (
+						<PageTemplateModal
+							createLayoutPageTemplateEntryURL={createTemplateURL}
+							getLayoutPageTemplateCollectionsURL={
+								getCollectionsURL
+							}
+							layoutId={itemId}
+							namespace={namespace}
+							onClose={onClose}
+						/>
+					)}
 				</ClayLayout.ContentCol>
 			)}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -286,7 +286,7 @@ public class ContentPageEditorDisplayContext {
 					LanguageResources.getResourceBundle(
 						themeDisplay.getLocale()))
 			).put(
-				"createLayoutPageTemplateEntryURL",
+				"createTemplateURL",
 				getFragmentEntryActionURL(
 					"/layout_content_page_editor" +
 						"/create_layout_page_template_entry")
@@ -427,6 +427,11 @@ public class ContentPageEditorDisplayContext {
 					"/layout_content_page_editor" +
 						"/get_collection_supported_filters")
 			).put(
+				"getCollectionsURL",
+				_getResourceURL(
+					"/layout_content_page_editor" +
+						"/get_layout_page_template_collections")
+			).put(
 				"getCollectionVariationsURL",
 				_getResourceURL(
 					"/layout_content_page_editor/get_collection_variations")
@@ -496,11 +501,6 @@ public class ContentPageEditorDisplayContext {
 				"getLayoutFriendlyURL",
 				_getResourceURL(
 					"/layout_content_page_editor/get_layout_friendly_url")
-			).put(
-				"getLayoutPageTemplateCollectionsURL",
-				_getResourceURL(
-					"/layout_content_page_editor" +
-						"/get_layout_page_template_collections")
 			).put(
 				"getPageContentsURL",
 				_getResourceURL("/layout_content_page_editor/get_page_content")

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/CreateLayoutPageTemplateEntryMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/CreateLayoutPageTemplateEntryMVCActionCommand.java
@@ -5,6 +5,7 @@
 
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
+import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
@@ -33,6 +34,7 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.segments.service.SegmentsExperienceLocalService;
 
 import java.util.Locale;
 
@@ -49,6 +51,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"javax.portlet.name=" + ContentPageEditorPortletKeys.CONTENT_PAGE_EDITOR_PORTLET,
+		"javax.portlet.name=" + LayoutAdminPortletKeys.GROUP_PAGES,
 		"mvc.command.name=/layout_content_page_editor/create_layout_page_template_entry"
 	},
 	service = MVCActionCommand.class
@@ -64,10 +67,20 @@ public class CreateLayoutPageTemplateEntryMVCActionCommand
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
+		long plid = ParamUtil.getLong(actionRequest, "plid");
+
 		long segmentsExperienceId = ParamUtil.getLong(
 			actionRequest, "segmentsExperienceId");
-		Layout sourceLayout = _layoutLocalService.getLayout(
-			themeDisplay.getPlid());
+		Layout sourceLayout = themeDisplay.getLayout();
+
+		if (plid > 0) {
+			segmentsExperienceId =
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(plid);
+
+			sourceLayout = _layoutLocalService.getLayout(plid);
+		}
+
 		long layoutPageTemplateCollectionId = ParamUtil.getLong(
 			actionRequest, "layoutPageTemplateCollectionId");
 
@@ -226,5 +239,8 @@ public class CreateLayoutPageTemplateEntryMVCActionCommand
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetLayoutPageTemplateCollectionsMVCResourceCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/GetLayoutPageTemplateCollectionsMVCResourceCommand.java
@@ -5,6 +5,7 @@
 
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
+import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
@@ -34,6 +35,7 @@ import org.osgi.service.component.annotations.Reference;
 @Component(
 	property = {
 		"javax.portlet.name=" + ContentPageEditorPortletKeys.CONTENT_PAGE_EDITOR_PORTLET,
+		"javax.portlet.name=" + LayoutAdminPortletKeys.GROUP_PAGES,
 		"mvc.command.name=/layout_content_page_editor/get_layout_page_template_collections"
 	},
 	service = MVCResourceCommand.class

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/convert_to_page_template_modal/components/ConvertToPageTemplateModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/convert_to_page_template_modal/components/ConvertToPageTemplateModal.js
@@ -3,7 +3,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {useModal} from '@clayui/modal';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
 import {PageTemplateModal} from '@liferay/layout-js-components-web';
 import React, {useCallback, useEffect, useState} from 'react';
@@ -45,12 +44,8 @@ export default function ConvertToPageTemplateModal() {
 
 	return (
 		<PageTemplateModal
-			createLayoutPageTemplateEntryURL={
-				config.createLayoutPageTemplateEntryURL
-			}
-			getLayoutPageTemplateCollectionsURL={
-				config.getLayoutPageTemplateCollectionsURL
-			}
+			createTemplateURL={config.createTemplateURL}
+			getCollectionsURL={config.getCollectionsURL}
 			hasMultipleSegmentsExperienceIds={hasMultipleSegmentsExperienceIds}
 			namespace={config.portletNamespace}
 			onClose={onClose}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/convert_to_page_template_modal/components/ConvertToPageTemplateModal.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/convert_to_page_template_modal/components/ConvertToPageTemplateModal.js
@@ -3,25 +3,24 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import ClayButton from '@clayui/button';
-import ClayForm, {ClayInput, ClaySelectWithOption} from '@clayui/form';
-import ClayIcon from '@clayui/icon';
-import ClayModal, {useModal} from '@clayui/modal';
+import {useModal} from '@clayui/modal';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
-import {openToast, sub} from 'frontend-js-web';
-import PropTypes from 'prop-types';
-import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
-import {flushSync} from 'react-dom';
+import {PageTemplateModal} from '@liferay/layout-js-components-web';
+import React, {useCallback, useEffect, useState} from 'react';
 
 import {config} from '../../../app/config/index';
 import {useSelector} from '../../../app/contexts/StoreContext';
 import selectSegmentsExperienceId from '../../../app/selectors/selectSegmentsExperienceId';
-import LayoutService from '../../../app/services/LayoutService';
-import getUniqueName from '../../../app/utils/getUniqueName';
-import FormField from './FormField';
 
 export default function ConvertToPageTemplateModal() {
 	const isMounted = useIsMounted();
+
+	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
+	const hasMultipleSegmentsExperienceIds = useSelector((state) =>
+		state.availableSegmentsExperiences
+			? Object.keys(state.availableSegmentsExperiences).length > 1
+			: false
+	);
 
 	const [openModal, setOpenModal] = useState(false);
 	const onClose = useCallback(() => {
@@ -29,10 +28,6 @@ export default function ConvertToPageTemplateModal() {
 			setOpenModal(false);
 		}
 	}, [isMounted]);
-
-	const {observer} = useModal({
-		onClose,
-	});
 
 	useEffect(() => {
 		const handler = Liferay.on('convertToPageTemplate', () => {
@@ -48,308 +43,18 @@ export default function ConvertToPageTemplateModal() {
 		return null;
 	}
 
-	return <PageTemplateModal observer={observer} onClose={onClose} />;
-}
-
-export function PageTemplateModal({observer, onClose}) {
-	const segmentsExperienceId = useSelector(selectSegmentsExperienceId);
-	const hasMultipleSegmentsExperienceIds = useSelector(
-		(state) => Object.keys(state.availableSegmentsExperiences).length > 1
-	);
-
-	const [availableSets, setAvailableSets] = useState([]);
-	const [formErrors, setFormErrors] = useState({});
-	const [loading, setLoading] = useState(false);
-	const [openAddTemplateSetModal, setOpenAddTemplateSetModal] = useState(
-		false
-	);
-	const [templateSetDescription, setTemplateSetDescription] = useState('');
-	const [templateSetId, setTemplateSetId] = useState('');
-	const [templateSetName, setTemplateSetName] = useState(
-		Liferay.Language.get('untitled-set')
-	);
-
-	const nameInputRef = useRef(null);
-
-	const templateSetSelectOptions = useMemo(
-		() => [
-			{label: `-- ${Liferay.Language.get('not-selected')} --`, value: ''},
-			...availableSets.map((set) => ({label: set.name, value: set.id})),
-		],
-		[availableSets]
-	);
-
-	useEffect(() => {
-		if (nameInputRef.current) {
-			nameInputRef.current.focus();
-		}
-	}, []);
-
-	useEffect(() => {
-		LayoutService.getLayoutPageTemplateCollections()
-			.then((sets) => {
-				if (Array.isArray(sets)) {
-					setAvailableSets(sets);
-					setOpenAddTemplateSetModal(!sets.length);
-					setTemplateSetName(
-						getUniqueName(
-							sets,
-							Liferay.Language.get('untitled-set')
-						)
-					);
-				}
-				else {
-					throw new Error();
-				}
-			})
-			.catch((error) => {
-				console.error(error);
-			});
-	}, []);
-
-	const validateForm = useCallback(() => {
-		const errors = {};
-
-		if (openAddTemplateSetModal) {
-			if (!templateSetName) {
-				errors.templateSetName = sub(
-					Liferay.Language.get('x-field-is-required'),
-					Liferay.Language.get('name')
-				);
-			}
-		}
-		else {
-			if (!templateSetId) {
-				errors.templateSetId = sub(
-					Liferay.Language.get('x-field-is-required'),
-					Liferay.Language.get('page-template-set')
-				);
-			}
-		}
-
-		return errors;
-	}, [templateSetId, templateSetName, openAddTemplateSetModal]);
-
-	// We are using flush here because this way we can clear errors inmediately
-	// in handleSubmit. Otherwise, React will batch setStates and will do only
-	// one update.
-
-	const resetErrors = useCallback(
-		() =>
-			flushSync(() => {
-				setFormErrors({});
-			}),
-		[]
-	);
-
-	const handleSubmit = useCallback(
-		(event) => {
-			event.preventDefault();
-
-			const errors = validateForm();
-
-			resetErrors();
-
-			if (Object.keys(errors).length) {
-				setFormErrors(errors);
-
-				return;
-			}
-
-			setLoading(true);
-
-			LayoutService.createLayoutPageTemplateEntry({
-				segmentsExperienceId,
-				templateSetDescription,
-				templateSetId: templateSetId || null,
-				templateSetName,
-			})
-				.then((response) => {
-					openToast({
-						message: sub(
-							Liferay.Language.get(
-								'the-page-template-was-created-successfully.-you-can-view-it-here-x'
-							),
-							`<a href="${response.url}">${Liferay.Language.get(
-								'see-in-page-templates'
-							)}</a>`
-						),
-						type: 'success',
-					});
-
-					onClose();
-				})
-				.catch(() => {
-					setLoading(false);
-
-					openToast({
-						message: Liferay.Language.get(
-							'an-unexpected-error-occurred'
-						),
-						type: 'danger',
-					});
-				});
-		},
-		[
-			onClose,
-			resetErrors,
-			segmentsExperienceId,
-			templateSetDescription,
-			templateSetId,
-			templateSetName,
-			validateForm,
-		]
-	);
-
 	return (
-		<ClayModal
-			containerProps={{className: 'cadmin'}}
-			observer={observer}
-			size="md"
-		>
-			<ClayModal.Header>
-				{openAddTemplateSetModal
-					? Liferay.Language.get('add-page-template-set')
-					: Liferay.Language.get('select-page-template-set')}
-			</ClayModal.Header>
-
-			<ClayModal.Body>
-				{hasMultipleSegmentsExperienceIds && (
-					<div className="form-feedback-group mb-3">
-						<div className="form-feedback-item text-info">
-							<ClayIcon className="mr-2" symbol="info-circle" />
-
-							<span>
-								{Liferay.Language.get(
-									'the-page-template-is-based-on-the-current-experience'
-								)}
-							</span>
-						</div>
-					</div>
-				)}
-
-				<ClayForm onSubmit={handleSubmit}>
-					{openAddTemplateSetModal ? (
-						<>
-							{!availableSets.length ? (
-								<div className="mb-3 text-secondary">
-									{Liferay.Language.get(
-										'a-page-template-set-must-first-be-created-before-you-can-create-your-page-template'
-									)}
-								</div>
-							) : null}
-							<FormField
-								error={formErrors.templateSetName}
-								id={`${config.portletNamespace}templateSetName`}
-								name={Liferay.Language.get('name')}
-							>
-								<ClayInput
-									id={`${config.portletNamespace}templateSetName`}
-									name={`${config.portletNamespace}name`}
-									onChange={(event) => {
-										setTemplateSetName(event.target.value);
-
-										setFormErrors({
-											...formErrors,
-											setTemplateSetName: null,
-										});
-									}}
-									ref={nameInputRef}
-									required
-									value={templateSetName}
-								/>
-							</FormField>
-							<FormField
-								id={`${config.portletNamespace}templateSetDescription`}
-								name={Liferay.Language.get('description')}
-								required={false}
-							>
-								<ClayInput
-									component="textarea"
-									id={`${config.portletNamespace}templateSetDescription`}
-									name={`${config.portletNamespace}description`}
-									onChange={(event) => {
-										setTemplateSetDescription(
-											event.target.value
-										);
-									}}
-									ref={nameInputRef}
-									value={templateSetDescription}
-								/>
-							</FormField>
-						</>
-					) : (
-						<>
-							<div className="mb-3 text-secondary">
-								{Liferay.Language.get(
-									'select-an-existing-set-or-create-a-new-one-to-save-your-page-template'
-								)}
-							</div>
-
-							<FormField
-								error={formErrors.templateSetId}
-								id={`${config.portletNamespace}templateSet`}
-								name={Liferay.Language.get('page-template-set')}
-							>
-								<ClaySelectWithOption
-									id={`${config.portletNamespace}templateSet`}
-									onChange={(event) => {
-										setTemplateSetId(event.target.value);
-										setFormErrors({
-											...formErrors,
-											templateSetId: null,
-										});
-									}}
-									options={templateSetSelectOptions}
-									required
-									value={templateSetId}
-								/>
-							</FormField>
-						</>
-					)}
-				</ClayForm>
-			</ClayModal.Body>
-
-			<ClayModal.Footer
-				first={
-					!openAddTemplateSetModal ? (
-						<ClayButton
-							displayType="secondary"
-							onClick={() => setOpenAddTemplateSetModal(true)}
-						>
-							{Liferay.Language.get('save-in-new-set')}
-						</ClayButton>
-					) : null
-				}
-				last={
-					<ClayButton.Group spaced>
-						<ClayButton displayType="secondary" onClick={onClose}>
-							{Liferay.Language.get('cancel')}
-						</ClayButton>
-
-						<ClayButton
-							displayType="primary"
-							onClick={handleSubmit}
-						>
-							{loading && (
-								<span className="inline-item inline-item-before">
-									<span
-										aria-hidden="true"
-										className="loading-animation"
-									></span>
-								</span>
-							)}
-
-							{Liferay.Language.get('save')}
-						</ClayButton>
-					</ClayButton.Group>
-				}
-			/>
-		</ClayModal>
+		<PageTemplateModal
+			createLayoutPageTemplateEntryURL={
+				config.createLayoutPageTemplateEntryURL
+			}
+			getLayoutPageTemplateCollectionsURL={
+				config.getLayoutPageTemplateCollectionsURL
+			}
+			hasMultipleSegmentsExperienceIds={hasMultipleSegmentsExperienceIds}
+			namespace={config.portletNamespace}
+			onClose={onClose}
+			segmentsExperienceId={segmentsExperienceId}
+		/>
 	);
 }
-
-PageTemplateModal.propTypes = {
-	observer: PropTypes.object.isRequired,
-	onClose: PropTypes.func.isRequired,
-};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/config.d.ts
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/types/config.d.ts
@@ -74,7 +74,7 @@ export interface Config {
 	}>;
 
 	contentPagePersonalizationLearnURL: string;
-	createLayoutPageTemplateEntryURL: string;
+	createTemplateURL: string;
 
 	defaultEditorConfigurations: Record<
 		'comment' | 'rich-text' | 'text',
@@ -119,6 +119,7 @@ export interface Config {
 	getCollectionMappingFieldsURL: string;
 	getCollectionSupportedFiltersURL: string;
 	getCollectionWarningMessageURL: string;
+	getCollectionsURL: string;
 	getExperienceDataURL: string;
 	getFormConfigURL: string;
 	getIframeContentCssURL: string;
@@ -126,7 +127,6 @@ export interface Config {
 	getInfoItemActionErrorMessageURL: string;
 	getInfoItemFieldValueURL: string;
 	getLayoutFriendlyURL: string;
-	getLayoutPageTemplateCollectionsURL: string;
 	getPageContentsURL: string;
 	getPortletsURL: string;
 	imageSelectorURL: string;

--- a/modules/apps/layout/layout-js-components-web/package.json
+++ b/modules/apps/layout/layout-js-components-web/package.json
@@ -18,7 +18,8 @@
 		"frontend-js-components-web": "*",
 		"frontend-js-web": "*",
 		"react": "16.12.0",
-		"react-dnd": "11.1.1"
+		"react-dnd": "11.1.1",
+		"react-dom": "16.12.0"
 	},
 	"main": "js/index.js",
 	"name": "@liferay/layout-js-components-web",

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/page_template_modal/FormField.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/page_template_modal/FormField.tsx
@@ -1,0 +1,43 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayForm from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import classNames from 'classnames';
+import React, {ReactNode} from 'react';
+
+interface Props {
+	children: ReactNode;
+	error?: string;
+	id: string;
+	name: string;
+	required?: boolean;
+}
+
+const FormField = ({children, error, id, name, required = false}: Props) => {
+	const hasError = Boolean(error);
+
+	return (
+		<ClayForm.Group className={classNames({'has-error': hasError})}>
+			<label htmlFor={id}>
+				{name}
+
+				{required ? (
+					<ClayIcon className="reference-mark" symbol="asterisk" />
+				) : null}
+			</label>
+
+			{children}
+
+			{hasError && (
+				<ClayForm.FeedbackGroup role="alert">
+					<ClayForm.FeedbackItem>{error}</ClayForm.FeedbackItem>
+				</ClayForm.FeedbackGroup>
+			)}
+		</ClayForm.Group>
+	);
+};
+
+export default FormField;

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/page_template_modal/PageTemplateModal.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/page_template_modal/PageTemplateModal.tsx
@@ -1,0 +1,387 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import ClayButton from '@clayui/button';
+import ClayForm, {ClayInput, ClaySelectWithOption} from '@clayui/form';
+import ClayIcon from '@clayui/icon';
+import ClayModal, {useModal} from '@clayui/modal';
+import {fetch, openToast, sub} from 'frontend-js-web';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
+import {flushSync} from 'react-dom';
+
+import FormField from './FormField';
+
+interface Props {
+	createTemplateURL: string;
+	getCollectionsURL: string;
+	hasMultipleSegmentsExperienceIds: boolean;
+	layoutId: string;
+	namespace?: string;
+	onClose: () => {};
+	segmentsExperienceId: string;
+}
+
+interface Set {
+	id: number;
+	name: string;
+}
+
+type Errors = {
+	templateSetId?: string;
+	templateSetName?: string;
+};
+
+export default function PageTemplateModal({
+	createTemplateURL,
+	getCollectionsURL,
+	hasMultipleSegmentsExperienceIds,
+	layoutId,
+	namespace,
+	onClose,
+	segmentsExperienceId,
+}: Props) {
+	const {observer} = useModal({
+		onClose,
+	});
+	const [availableSets, setAvailableSets] = useState<Set[]>([]);
+	const [formErrors, setFormErrors] = useState<Errors>({});
+	const [loading, setLoading] = useState(false);
+	const [openAddTemplateSetModal, setOpenAddTemplateSetModal] = useState(
+		false
+	);
+	const [templateSetDescription, setTemplateSetDescription] = useState('');
+	const [templateSetId, setTemplateSetId] = useState('');
+	const [templateSetName, setTemplateSetName] = useState(
+		Liferay.Language.get('untitled-set')
+	);
+
+	const nameInputRef = useRef<HTMLInputElement>(null);
+
+	const templateSetSelectOptions = useMemo(
+		() => [
+			{label: `-- ${Liferay.Language.get('not-selected')} --`, value: ''},
+			...availableSets.map((set: {id: any; name: any}) => ({
+				label: set.name,
+				value: set.id,
+			})),
+		],
+		[availableSets]
+	);
+
+	useEffect(() => {
+		if (nameInputRef.current) {
+			nameInputRef.current.focus();
+		}
+	}, []);
+
+	function getUniqueName(items: any[], languageKey: string) {
+		let name = languageKey;
+
+		const names = new Set([...items.map((item) => item.name)]);
+
+		items.forEach((_, index) => {
+			if (names.has(name)) {
+				name = `${languageKey} ${index + 2}`;
+			}
+		});
+
+		return name;
+	}
+
+	useEffect(() => {
+		fetch(getCollectionsURL)
+			.then((response) => response.json())
+			.then((sets) => {
+				if (Array.isArray(sets)) {
+					setAvailableSets(sets);
+					setOpenAddTemplateSetModal(!sets.length);
+					setTemplateSetName(
+						getUniqueName(
+							sets,
+							Liferay.Language.get('untitled-set')
+						)
+					);
+				}
+				else {
+					throw new Error();
+				}
+			})
+			.catch((error) => {
+				console.error(error);
+			});
+	}, [getCollectionsURL]);
+
+	const validateForm = useCallback(() => {
+		const errors: Errors = {};
+
+		if (openAddTemplateSetModal) {
+			if (!templateSetName) {
+				errors.templateSetName = sub(
+					Liferay.Language.get('x-field-is-required'),
+					Liferay.Language.get('name')
+				);
+			}
+		}
+		else {
+			if (!templateSetId) {
+				errors.templateSetId = sub(
+					Liferay.Language.get('x-field-is-required'),
+					Liferay.Language.get('page-template-set')
+				);
+			}
+		}
+
+		return errors;
+	}, [templateSetId, templateSetName, openAddTemplateSetModal]);
+
+	// We are using flush here because this way we can clear errors inmediately
+	// in handleSubmit. Otherwise, React will batch setStates and will do only
+	// one update.
+
+	const resetErrors = useCallback(
+		() =>
+			flushSync(() => {
+				setFormErrors({});
+			}),
+		[]
+	);
+
+	const getFormData = useCallback(
+		(body: {
+			layoutPageTemplateCollectionDescription: string;
+			layoutPageTemplateCollectionId: string;
+			layoutPageTemplateCollectionName: string;
+			plid: string;
+			segmentsExperienceId: string;
+		}): FormData => {
+			const formData = new FormData();
+
+			Object.entries(body).forEach(([key, value]) => {
+				if (!value && process.env.NODE_ENV === 'development') {
+					console.warn(
+						`${key} does not have any value, sending it this way could cause some wrong behavior`
+					);
+				}
+
+				formData.append(`${namespace}${key}`, value);
+			});
+
+			return formData;
+		},
+		[namespace]
+	);
+
+	const handleSubmit = useCallback(
+		(event) => {
+			event.preventDefault();
+
+			const errors = validateForm();
+
+			resetErrors();
+
+			if (Object.keys(errors).length) {
+				setFormErrors(errors);
+
+				return;
+			}
+
+			setLoading(true);
+
+			const body = {
+				layoutPageTemplateCollectionDescription: templateSetDescription,
+				layoutPageTemplateCollectionId: templateSetId,
+				layoutPageTemplateCollectionName: templateSetName,
+				plid: layoutId,
+				segmentsExperienceId,
+			};
+
+			fetch(createTemplateURL, {
+				body: getFormData(body),
+				method: 'POST',
+			})
+				.then((response) => response.json())
+				.then((json) => {
+					openToast({
+						message: sub(
+							Liferay.Language.get(
+								'the-page-template-was-created-successfully.-you-can-view-it-here-x'
+							),
+							`<a href="${json.url}">${Liferay.Language.get(
+								'see-in-page-templates'
+							)}</a>`
+						),
+						type: 'success',
+					});
+
+					onClose();
+				})
+				.catch(() => {
+					setLoading(false);
+
+					openToast({
+						message: Liferay.Language.get(
+							'an-unexpected-error-occurred'
+						),
+						type: 'danger',
+					});
+				});
+		},
+		[
+			createTemplateURL,
+			getFormData,
+			layoutId,
+			onClose,
+			resetErrors,
+			segmentsExperienceId,
+			templateSetDescription,
+			templateSetId,
+			templateSetName,
+			validateForm,
+		]
+	);
+
+	return (
+		<ClayModal containerProps={{className: 'cadmin'}} observer={observer}>
+			<ClayModal.Header>
+				{openAddTemplateSetModal
+					? Liferay.Language.get('add-page-template-set')
+					: Liferay.Language.get('select-page-template-set')}
+			</ClayModal.Header>
+
+			<ClayModal.Body>
+				{hasMultipleSegmentsExperienceIds && (
+					<div className="form-feedback-group mb-3">
+						<div className="form-feedback-item text-info">
+							<ClayIcon className="mr-2" symbol="info-circle" />
+
+							<span>
+								{Liferay.Language.get(
+									'the-page-template-is-based-on-the-current-experience'
+								)}
+							</span>
+						</div>
+					</div>
+				)}
+
+				<ClayForm onSubmit={handleSubmit}>
+					{openAddTemplateSetModal ? (
+						<>
+							{!availableSets.length ? (
+								<div className="mb-3 text-secondary">
+									{Liferay.Language.get(
+										'a-page-template-set-must-first-be-created-before-you-can-create-your-page-template'
+									)}
+								</div>
+							) : null}
+							<FormField
+								error={formErrors.templateSetName}
+								id={`${namespace}templateSetName`}
+								name={Liferay.Language.get('name')}
+								required
+							>
+								<ClayInput
+									id={`${namespace}templateSetName`}
+									name={`${namespace}name`}
+									onChange={(event) => {
+										setTemplateSetName(event.target.value);
+
+										setFormErrors({
+											...formErrors,
+											templateSetName: '',
+										});
+									}}
+									ref={nameInputRef}
+									required
+									value={templateSetName}
+								/>
+							</FormField>
+							<FormField
+								id={`${namespace}templateSetDescription`}
+								name={Liferay.Language.get('description')}
+							>
+								<ClayInput
+									component="textarea"
+									id={`${namespace}templateSetDescription`}
+									name={`${namespace}description`}
+									onChange={(event) => {
+										setTemplateSetDescription(
+											event.target.value
+										);
+									}}
+									ref={nameInputRef}
+									value={templateSetDescription}
+								/>
+							</FormField>
+						</>
+					) : (
+						<>
+							<div className="mb-3 text-secondary">
+								{Liferay.Language.get(
+									'select-an-existing-set-or-create-a-new-one-to-save-your-page-template'
+								)}
+							</div>
+
+							<FormField
+								error={formErrors.templateSetId}
+								id={`${namespace}templateSet`}
+								name={Liferay.Language.get('page-template-set')}
+							>
+								<ClaySelectWithOption
+									id={`${namespace}templateSet`}
+									onChange={(event) => {
+										setTemplateSetId(event.target.value);
+										setFormErrors({
+											...formErrors,
+											templateSetId: '',
+										});
+									}}
+									options={templateSetSelectOptions}
+									required
+									value={templateSetId}
+								/>
+							</FormField>
+						</>
+					)}
+				</ClayForm>
+			</ClayModal.Body>
+
+			<ClayModal.Footer
+				first={
+					!openAddTemplateSetModal ? (
+						<ClayButton
+							displayType="secondary"
+							onClick={() => setOpenAddTemplateSetModal(true)}
+						>
+							{Liferay.Language.get('save-in-new-set')}
+						</ClayButton>
+					) : undefined
+				}
+				last={
+					<ClayButton.Group spaced>
+						<ClayButton displayType="secondary" onClick={onClose}>
+							{Liferay.Language.get('cancel')}
+						</ClayButton>
+
+						<ClayButton
+							displayType="primary"
+							onClick={handleSubmit}
+						>
+							{loading && (
+								<span className="inline-item inline-item-before">
+									<span
+										aria-hidden="true"
+										className="loading-animation"
+									></span>
+								</span>
+							)}
+
+							{Liferay.Language.get('save')}
+						</ClayButton>
+					</ClayButton.Group>
+				}
+			/>
+		</ClayModal>
+	);
+}

--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+export {default as PageTemplateModal} from './components/page_template_modal/PageTemplateModal';
 export {default as DragPreview} from './components/drag_preview/DragPreview';
 export {default as ExperienceSelector} from './components/experience_selector/ExperienceSelector';
 export {default as Import} from './components/import/Import';

--- a/modules/apps/layout/layout-js-components-web/test/components/page_template_modal/PageTemplateModal.test.tsx
+++ b/modules/apps/layout/layout-js-components-web/test/components/page_template_modal/PageTemplateModal.test.tsx
@@ -5,56 +5,56 @@
 
 import {act, fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {fetch} from 'frontend-js-web';
 import React from 'react';
 
-import LayoutService from '../../../../../../src/main/resources/META-INF/resources/page_editor/app/services/LayoutService';
-import {PageTemplateModal} from '../../../../../../src/main/resources/META-INF/resources/page_editor/plugins/convert_to_page_template_modal/components/ConvertToPageTemplateModal';
-import StoreMother from '../../../../../../src/main/resources/META-INF/resources/page_editor/test_utils/StoreMother';
+import PageTemplateModal from '../../../src/main/resources/META-INF/resources/js/components/page_template_modal/PageTemplateModal';
 
 import '@testing-library/jest-dom/extend-expect';
 
-jest.mock(
-	'../../../../../../src/main/resources/META-INF/resources/page_editor/app/services/LayoutService',
-	() => ({
-		createLayoutPageTemplateEntry: jest.fn(() => Promise.resolve()),
-		getLayoutPageTemplateCollections: jest.fn(() =>
-			Promise.resolve([{name: 'test'}])
-		),
-	})
-);
-
-jest.mock(
-	'../../../../../../src/main/resources/META-INF/resources/page_editor/app/config/index',
-	() => ({
-		config: {
-			portletNamespace: 'portletNamespace_',
-		},
-	})
-);
+jest.mock('frontend-js-web');
 
 function renderConvertToPageTemplateModal() {
 	return render(
-		<StoreMother.Component>
-			<PageTemplateModal
-				observer={{
-					dispatch: () => {},
-					mutation: [true, true],
-				}}
-				onClose={jest.fn()}
-			/>
-		</StoreMother.Component>
+		<PageTemplateModal
+			createTemplateURL="http://localhost:8080/createLayoutPageTemplate"
+			getCollectionsURL="http://localhost:8080/getlayoutPageTemplateCollections"
+			hasMultipleSegmentsExperienceIds={false}
+			layoutId="0"
+			onClose={jest.fn()}
+			segmentsExperienceId="0"
+		/>
 	);
 }
 
 describe('ConvertToPageTemplateModal', () => {
 	afterEach(() => {
-		LayoutService.createLayoutPageTemplateEntry.mockClear();
+		fetch.mockClear();
+	});
+
+	beforeAll(() => {
+		jest.useFakeTimers();
 	});
 
 	describe('Select Page Template Set modal', () => {
 		it('renders the Select Page Template Set modal', async () => {
+			fetch.mockReturnValue(
+				Promise.resolve(
+					new Response(
+						JSON.stringify([
+							{id: '34286', name: 'Untitled Set'},
+							{id: '34112', name: 'Untitled Set 2'},
+						])
+					)
+				)
+			);
+
 			await act(async () => {
 				renderConvertToPageTemplateModal();
+			});
+
+			act(() => {
+				jest.runAllTimers();
 			});
 
 			expect(
@@ -63,9 +63,38 @@ describe('ConvertToPageTemplateModal', () => {
 		});
 
 		it('calls createLayoutPageTemplateEntry when a page template set is selected and the button save is pressed', async () => {
+			fetch.mockReturnValue(
+				Promise.resolve(
+					new Response(
+						JSON.stringify([
+							{id: '34286', name: 'Untitled Set'},
+							{id: '34112', name: 'Untitled Set 2'},
+						])
+					)
+				)
+			);
+
 			await act(async () => {
 				renderConvertToPageTemplateModal();
 			});
+
+			act(() => {
+				jest.runAllTimers();
+			});
+
+			fetch.mockClear();
+
+			fetch.mockReturnValue(
+				Promise.resolve(
+					new Response(
+						JSON.stringify([{url: 'www.pageTemplates.com'}])
+					)
+				)
+			);
+
+			const mockFetch = fetch.mockImplementation(async () => ({
+				json: async () => ({url: 'vamonos'}),
+			}));
 
 			const saveButton = screen.getByText('save');
 			const select = screen.getByLabelText('page-template-set');
@@ -77,10 +106,9 @@ describe('ConvertToPageTemplateModal', () => {
 				userEvent.click(saveButton);
 			});
 
-			expect(
-				LayoutService.createLayoutPageTemplateEntry
-			).toHaveBeenCalledTimes(1);
-			expect(LayoutService.createLayoutPageTemplateEntry).toBeCalledWith(
+			expect(mockFetch).toHaveBeenCalledTimes(1);
+
+			expect(mockFetch).toBeCalledWith(
 				expect.objectContaining({
 					segmentsExperienceId: '0',
 					templateSetId: 'test',
@@ -90,22 +118,50 @@ describe('ConvertToPageTemplateModal', () => {
 		});
 
 		it('does not call createLayoutPageTemplateEntry when a page template set is not selected and the Save button is pressed', async () => {
+			fetch.mockReturnValue(
+				Promise.resolve(
+					new Response(
+						JSON.stringify([
+							{id: '34286', name: 'Untitled Set'},
+							{id: '34112', name: 'Untitled Set 2'},
+						])
+					)
+				)
+			);
+
 			await act(async () => {
 				renderConvertToPageTemplateModal();
+			});
+
+			act(() => {
+				jest.runAllTimers();
 			});
 
 			const saveButton = screen.getByText('save');
 
 			userEvent.click(saveButton);
 
-			expect(
-				LayoutService.createLayoutPageTemplateEntry
-			).toHaveBeenCalledTimes(0);
+			expect(fetch).toHaveBeenCalledTimes(1);
 		});
 
 		it('changes the modal when the Save In New Set Button is pressed', async () => {
+			fetch.mockReturnValue(
+				Promise.resolve(
+					new Response(
+						JSON.stringify([
+							{id: '34286', name: 'Untitled Set'},
+							{id: '34112', name: 'Untitled Set 2'},
+						])
+					)
+				)
+			);
+
 			await act(async () => {
 				renderConvertToPageTemplateModal();
+			});
+
+			act(() => {
+				jest.runAllTimers();
 			});
 
 			const saveInNewSetButton = screen.getByText('save-in-new-set');
@@ -119,15 +175,21 @@ describe('ConvertToPageTemplateModal', () => {
 	});
 
 	describe('Add Page Template Set modal', () => {
-		beforeEach(() => {
-			LayoutService.getLayoutPageTemplateCollections.mockImplementation(
-				() => Promise.resolve([])
-			);
-		});
-
 		it('renders the Select Add Template Set modal when there are no sets', async () => {
+			fetch.mockReturnValue(
+				Promise.resolve({
+					json: () => {
+						return [];
+					},
+				})
+			);
+
 			await act(async () => {
 				renderConvertToPageTemplateModal();
+			});
+
+			act(() => {
+				jest.runAllTimers();
 			});
 
 			expect(
@@ -136,8 +198,20 @@ describe('ConvertToPageTemplateModal', () => {
 		});
 
 		it('calls createLayoutPageTemplateEntry when the Save button is pressed', async () => {
+			fetch.mockReturnValue(
+				Promise.resolve({
+					json: () => {
+						return [];
+					},
+				})
+			);
+
 			await act(async () => {
 				renderConvertToPageTemplateModal();
+			});
+
+			act(() => {
+				jest.runAllTimers();
 			});
 
 			const descriptionInput = screen.getByLabelText('description');
@@ -149,25 +223,30 @@ describe('ConvertToPageTemplateModal', () => {
 				userEvent.click(saveButton);
 			});
 
-			expect(
-				LayoutService.createLayoutPageTemplateEntry
-			).toHaveBeenCalledTimes(1);
-			expect(LayoutService.createLayoutPageTemplateEntry).toBeCalledWith(
-				expect.objectContaining({
-					segmentsExperienceId: '0',
-					templateSetDescription: 'This is a description',
-					templateSetId: null,
-					templateSetName: 'untitled-set',
-				})
-			);
+			expect(fetch).toHaveBeenCalledTimes(2);
 		});
 
 		it('does not call createLayoutPageTemplateEntry when the input name is empty and the Save button is pressed', async () => {
+			fetch.mockReturnValue(
+				Promise.resolve(
+					new Response(
+						JSON.stringify([
+							{id: '34286', name: 'Untitled Set'},
+							{id: '34112', name: 'Untitled Set 2'},
+						])
+					)
+				)
+			);
+
 			await act(async () => {
 				renderConvertToPageTemplateModal();
 			});
 
-			const nameInput = screen.getByLabelText('name');
+			act(() => {
+				jest.runAllTimers();
+			});
+
+			const nameInput = screen.getByLabelText('page-template-set');
 			const saveButton = screen.getByText('save');
 
 			fireEvent.change(nameInput, {
@@ -175,9 +254,7 @@ describe('ConvertToPageTemplateModal', () => {
 			});
 			userEvent.click(saveButton);
 
-			expect(
-				LayoutService.createLayoutPageTemplateEntry
-			).toHaveBeenCalledTimes(0);
+			expect(fetch).toHaveBeenCalledTimes(1);
 		});
 	});
 });

--- a/modules/apps/layout/layout-js-components-web/types/src/main/resources/META-INF/resources/js/components/page_template_modal/FormField.d.ts
+++ b/modules/apps/layout/layout-js-components-web/types/src/main/resources/META-INF/resources/js/components/page_template_modal/FormField.d.ts
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ReactNode} from 'react';
+interface Props {
+	children: ReactNode;
+	error?: string;
+	id: string;
+	name: string;
+	required?: boolean;
+}
+declare const FormField: ({
+	children,
+	error,
+	id,
+	name,
+	required,
+}: Props) => JSX.Element;
+export default FormField;

--- a/modules/apps/layout/layout-js-components-web/types/src/main/resources/META-INF/resources/js/components/page_template_modal/PageTemplateModal.d.ts
+++ b/modules/apps/layout/layout-js-components-web/types/src/main/resources/META-INF/resources/js/components/page_template_modal/PageTemplateModal.d.ts
@@ -6,8 +6,8 @@
 /// <reference types="react" />
 
 interface Props {
-	createLayoutPageTemplateEntryURL: string;
-	getLayoutPageTemplateCollectionsURL: string;
+	createTemplateURL: string;
+	getCollectionsURL: string;
 	hasMultipleSegmentsExperienceIds: boolean;
 	layoutId: string;
 	namespace?: string;
@@ -15,8 +15,8 @@ interface Props {
 	segmentsExperienceId: string;
 }
 export default function PageTemplateModal({
-	createLayoutPageTemplateEntryURL,
-	getLayoutPageTemplateCollectionsURL,
+	createTemplateURL,
+	getCollectionsURL,
 	hasMultipleSegmentsExperienceIds,
 	layoutId,
 	namespace,

--- a/modules/apps/layout/layout-js-components-web/types/src/main/resources/META-INF/resources/js/components/page_template_modal/PageTemplateModal.d.ts
+++ b/modules/apps/layout/layout-js-components-web/types/src/main/resources/META-INF/resources/js/components/page_template_modal/PageTemplateModal.d.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+/// <reference types="react" />
+
+interface Props {
+	createLayoutPageTemplateEntryURL: string;
+	getLayoutPageTemplateCollectionsURL: string;
+	hasMultipleSegmentsExperienceIds: boolean;
+	layoutId: string;
+	namespace?: string;
+	onClose: () => {};
+	segmentsExperienceId: string;
+}
+export default function PageTemplateModal({
+	createLayoutPageTemplateEntryURL,
+	getLayoutPageTemplateCollectionsURL,
+	hasMultipleSegmentsExperienceIds,
+	layoutId,
+	namespace,
+	onClose,
+	segmentsExperienceId,
+}: Props): JSX.Element;
+export {};

--- a/modules/apps/layout/layout-js-components-web/types/src/main/resources/META-INF/resources/js/index.d.ts
+++ b/modules/apps/layout/layout-js-components-web/types/src/main/resources/META-INF/resources/js/index.d.ts
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+export {default as PageTemplateModal} from './components/page_template_modal/PageTemplateModal';
 export {default as DragPreview} from './components/drag_preview/DragPreview';
 export {default as ExperienceSelector} from './components/experience_selector/ExperienceSelector';
 export {default as Import} from './components/import/Import';


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to add the Convert to Page Template action in the Pages portlet so it is easier to access for the user.
https://liferay.atlassian.net/browse/LPS-194263

Proposed Solution
========
What I did to solve this problem is to re-use the CreateLayoutPageTemplateEntry and GetLayoutPageTemplateCollections action commands that are used in the Page Editor for the same action and adapt them to use it from the Pages portlet. I did the same with the ConvertToPageTemplate component.

Steps to Verify
========
1. Go to Site Builder -> Pages
2. Click on the ellipsis button for a page -> Click on Convert to Page Template action
3. In the case there aren't Page Templates sets, the modal should ask to create one an will create it and add the page template to it -> Go to Page Templates and check it is created fine
4. In the case there are Page Templates sets, should let you select one of them and add a page template to it