### PR TITLE
LPS-195643 Fix JournalFeedTypeUpgradeProcess: `DuplicateVocabularyExc…

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_4_4/JournalFeedTypeUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_4_4/JournalFeedTypeUpgradeProcess.java
@@ -208,9 +208,24 @@ public class JournalFeedTypeUpgradeProcess extends UpgradeProcess {
 						serviceContext.setAddGroupPermissions(true);
 						serviceContext.setAddGuestPermissions(true);
 
+						Locale defaultLocale = LocaleUtil.fromLanguageId(
+							UpgradeProcessUtil.getDefaultLanguageId(
+								company.getCompanyId()));
+
+						String assetVocabularyTitle = "type";
+
+						Map<Locale, String> assetVocabularyTitleMap =
+							_localization.getLocalizationMap(
+								_language.getAvailableLocales(
+									company.getGroupId()),
+								defaultLocale, assetVocabularyTitle);
+
+						String assetVocabularyName =
+							assetVocabularyTitleMap.get(defaultLocale);
+
 						AssetVocabulary assetVocabulary =
 							_assetVocabularyLocalService.fetchGroupVocabulary(
-								company.getGroupId(), "type");
+								company.getGroupId(), assetVocabularyName);
 
 						if (assetVocabulary == null) {
 							AssetVocabularySettingsHelper
@@ -229,15 +244,9 @@ public class JournalFeedTypeUpgradeProcess extends UpgradeProcess {
 
 							assetVocabulary =
 								_assetVocabularyLocalService.addVocabulary(
-									userId, company.getGroupId(), "type",
-									_localization.getLocalizationMap(
-										_language.getAvailableLocales(
-											company.getGroupId()),
-										LocaleUtil.fromLanguageId(
-											UpgradeProcessUtil.
-												getDefaultLanguageId(
-													company.getCompanyId())),
-										"type"),
+									userId, company.getGroupId(),
+									assetVocabularyTitle,
+									assetVocabularyTitleMap,
 									Collections.emptyMap(),
 									assetVocabularySettingsHelper.toString(),
 									serviceContext);


### PR DESCRIPTION
Sending again based on my comment: https://github.com/brianchandotcom/liferay-portal/pull/140712#issuecomment-1719731583

This makes it clear that assetVocabularyName is being retrieved from assetVocabularyTitleMap when adding vocabulary on `titleMap.get(LocaleUtil.getSiteDefault())` in https://github.com/liferay/liferay-portal/blob/1a561075882158d5f2d316d3b9581eb332cf45f9/portal-impl/src/com/liferay/portlet/asset/service/impl/AssetVocabularyLocalServiceImpl.java#L119