### PR TITLE
LPS-196178 Site name error when saving Site Settings in Guest site if the default translation for the site's name is missing

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -3754,6 +3754,7 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 			}
 
 			nameMap.put(LocaleUtil.getDefault(), groupDefaultName);
+			names.add(groupDefaultName);
 		}
 
 		String className = group.getClassName();

--- a/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/GroupLocalServiceImpl.java
@@ -3743,11 +3743,18 @@ public class GroupLocalServiceImpl extends GroupLocalServiceBaseImpl {
 
 		List<String> names = new ArrayList<>(nameMap.values());
 
-		if (ListUtil.isNull(names)) {
-			throw new GroupKeyException();
-		}
-
 		Group group = groupPersistence.findByPrimaryKey(groupId);
+
+		if (ListUtil.isNull(names)) {
+			String groupDefaultName = group.getName(
+				group.getDefaultLanguageId(), true);
+
+			if (!group.isGuest() || Validator.isNull(groupDefaultName)) {
+				throw new GroupKeyException();
+			}
+
+			nameMap.put(LocaleUtil.getDefault(), groupDefaultName);
+		}
 
 		String className = group.getClassName();
 		long classNameId = group.getClassNameId();


### PR DESCRIPTION
Motivation
=======
See [LPS-196178](https://liferay.atlassian.net/browse/LPS-196178).

Hi @liferay-echo! It is uncertain how an environment can end up in the following situation: the `group_.name` field  does not contain a translation in database for an available locale. Maybe due to a bug in prior versions. 

When this happens, trying to save site settings throws an error in the UI:

> The Site Name cannot be blank, numeric or a reserved word such as null.
The Site Name cannot contain the following invalid characters: *."

However, you cannot edit the name for the Guest site, so you get stuck.

It can be easily solved with a script, but I think we should make the code more robust and avoid this error.

After a quick search, at least 3 customers have already faced this issue so far:

- https://liferay-support.zendesk.com/agent/tickets/37943
- https://liferay.atlassian.net/browse/LPP-36787
- https://liferay-support.zendesk.com/agent/tickets/90720

Proposed Solution
========
Before throwing the `GroupKeyException` in `GroupLocalServiceImpl.updateGroup()`, try to retrieve and use the name for the default language id.

Steps to Verify
========
As it is uncertain how an environment can end up in this situation, to reproduce the issue you have to change manually your database data.
See [LPS-196178](https://liferay.atlassian.net/browse/LPS-196178).

References to existing code (if applies)
========
Something _similar_ can be found in `CompanyLocalServiceImpl`: https://github.com/liferay/liferay-portal/blob/1667c0138a5399e7200cf3a0e5fc833a831ae721/portal-impl/src/com/liferay/portal/service/impl/CompanyLocalServiceImpl.java#L911-L941