### PR TITLE
LRAC-14405

### DIFF
--- a/modules/apps/segments/segments-api/bnd.bnd
+++ b/modules/apps/segments/segments-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Segments API
 Bundle-SymbolicName: com.liferay.segments.api
-Bundle-Version: 17.0.1
+Bundle-Version: 17.1.0
 Export-Package:\
 	com.liferay.segments,\
 	com.liferay.segments.configuration,\

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceService.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceService.java
@@ -90,6 +90,11 @@ public interface SegmentsExperienceService extends BaseService {
 		throws PortalException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public SegmentsExperience getSegmentsExperience(
+			long groupId, String segmentsExperienceKey, long plid)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<SegmentsExperience> getSegmentsExperiences(
 			long groupId, long plid, boolean active)
 		throws PortalException;

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceServiceUtil.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceServiceUtil.java
@@ -98,6 +98,14 @@ public class SegmentsExperienceServiceUtil {
 		return getService().getSegmentsExperience(segmentsExperienceId);
 	}
 
+	public static SegmentsExperience getSegmentsExperience(
+			long groupId, String segmentsExperienceKey, long plid)
+		throws PortalException {
+
+		return getService().getSegmentsExperience(
+			groupId, segmentsExperienceKey, plid);
+	}
+
 	public static List<SegmentsExperience> getSegmentsExperiences(
 			long groupId, long plid, boolean active)
 		throws PortalException {

--- a/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceServiceWrapper.java
+++ b/modules/apps/segments/segments-api/src/main/java/com/liferay/segments/service/SegmentsExperienceServiceWrapper.java
@@ -105,6 +105,15 @@ public class SegmentsExperienceServiceWrapper
 	}
 
 	@Override
+	public SegmentsExperience getSegmentsExperience(
+			long groupId, String segmentsExperienceKey, long plid)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _segmentsExperienceService.getSegmentsExperience(
+			groupId, segmentsExperienceKey, plid);
+	}
+
+	@Override
 	public java.util.List<SegmentsExperience> getSegmentsExperiences(
 			long groupId, long plid, boolean active)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/service/packageinfo
+++ b/modules/apps/segments/segments-api/src/main/resources/com/liferay/segments/service/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/http/SegmentsExperienceServiceHttp.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/http/SegmentsExperienceServiceHttp.java
@@ -304,6 +304,48 @@ public class SegmentsExperienceServiceHttp {
 		}
 	}
 
+	public static com.liferay.segments.model.SegmentsExperience
+			getSegmentsExperience(
+				HttpPrincipal httpPrincipal, long groupId,
+				String segmentsExperienceKey, long plid)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				SegmentsExperienceServiceUtil.class, "getSegmentsExperience",
+				_getSegmentsExperienceParameterTypes6);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, segmentsExperienceKey, plid);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.segments.model.SegmentsExperience)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static java.util.List<com.liferay.segments.model.SegmentsExperience>
 			getSegmentsExperiences(
 				HttpPrincipal httpPrincipal, long groupId, long plid,
@@ -313,7 +355,7 @@ public class SegmentsExperienceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class, "getSegmentsExperiences",
-				_getSegmentsExperiencesParameterTypes6);
+				_getSegmentsExperiencesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, plid, active);
@@ -359,7 +401,7 @@ public class SegmentsExperienceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class, "getSegmentsExperiences",
-				_getSegmentsExperiencesParameterTypes7);
+				_getSegmentsExperiencesParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, plid, active, start, end,
@@ -403,7 +445,7 @@ public class SegmentsExperienceServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class,
 				"getSegmentsExperiencesCount",
-				_getSegmentsExperiencesCountParameterTypes8);
+				_getSegmentsExperiencesCountParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, plid, active);
@@ -446,7 +488,7 @@ public class SegmentsExperienceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class, "updateSegmentsExperience",
-				_updateSegmentsExperienceParameterTypes9);
+				_updateSegmentsExperienceParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsExperienceId, segmentsEntryId, nameMap,
@@ -492,7 +534,7 @@ public class SegmentsExperienceServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class, "updateSegmentsExperience",
-				_updateSegmentsExperienceParameterTypes10);
+				_updateSegmentsExperienceParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsExperienceId, segmentsEntryId, nameMap,
@@ -535,7 +577,7 @@ public class SegmentsExperienceServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				SegmentsExperienceServiceUtil.class,
 				"updateSegmentsExperiencePriority",
-				_updateSegmentsExperiencePriorityParameterTypes11);
+				_updateSegmentsExperiencePriorityParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, segmentsExperienceId, newPriority);
@@ -593,28 +635,30 @@ public class SegmentsExperienceServiceHttp {
 		new Class[] {long.class, String.class, long.class};
 	private static final Class<?>[] _getSegmentsExperienceParameterTypes5 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getSegmentsExperiencesParameterTypes6 =
-		new Class[] {long.class, long.class, boolean.class};
+	private static final Class<?>[] _getSegmentsExperienceParameterTypes6 =
+		new Class[] {long.class, String.class, long.class};
 	private static final Class<?>[] _getSegmentsExperiencesParameterTypes7 =
+		new Class[] {long.class, long.class, boolean.class};
+	private static final Class<?>[] _getSegmentsExperiencesParameterTypes8 =
 		new Class[] {
 			long.class, long.class, boolean.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getSegmentsExperiencesCountParameterTypes8 = new Class[] {
+		_getSegmentsExperiencesCountParameterTypes9 = new Class[] {
 			long.class, long.class, boolean.class
 		};
-	private static final Class<?>[] _updateSegmentsExperienceParameterTypes9 =
+	private static final Class<?>[] _updateSegmentsExperienceParameterTypes10 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class, boolean.class
 		};
-	private static final Class<?>[] _updateSegmentsExperienceParameterTypes10 =
+	private static final Class<?>[] _updateSegmentsExperienceParameterTypes11 =
 		new Class[] {
 			long.class, long.class, java.util.Map.class, boolean.class,
 			com.liferay.portal.kernel.util.UnicodeProperties.class
 		};
 	private static final Class<?>[]
-		_updateSegmentsExperiencePriorityParameterTypes11 = new Class[] {
+		_updateSegmentsExperiencePriorityParameterTypes12 = new Class[] {
 			long.class, int.class
 		};
 

--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceServiceImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/service/impl/SegmentsExperienceServiceImpl.java
@@ -136,6 +136,21 @@ public class SegmentsExperienceServiceImpl
 	}
 
 	@Override
+	public SegmentsExperience getSegmentsExperience(
+			long groupId, String segmentsExperienceKey, long plid)
+		throws PortalException {
+
+		SegmentsExperience segmentsExperience =
+			segmentsExperienceLocalService.getSegmentsExperience(
+				groupId, segmentsExperienceKey, _getPublishedLayoutPlid(plid));
+
+		_segmentsExperienceResourcePermission.check(
+			getPermissionChecker(), segmentsExperience, ActionKeys.VIEW);
+
+		return segmentsExperience;
+	}
+
+	@Override
 	public List<SegmentsExperience> getSegmentsExperiences(
 			long groupId, long plid, boolean active)
 		throws PortalException {

--- a/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceServiceTest.java
+++ b/modules/apps/segments/segments-test/src/testIntegration/java/com/liferay/segments/service/test/SegmentsExperienceServiceTest.java
@@ -613,6 +613,11 @@ public class SegmentsExperienceServiceTest {
 
 			_segmentsExperienceService.getSegmentsExperience(
 				segmentsExperience.getSegmentsExperienceId());
+
+			_segmentsExperienceService.getSegmentsExperience(
+				segmentsExperience.getGroupId(),
+				segmentsExperience.getSegmentsExperienceKey(),
+				segmentsExperience.getPlid());
 		}
 	}
 

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/Experiment.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/client/model/Experiment.java
@@ -152,6 +152,11 @@ public final class Experiment {
 		return new Date(_startedDate.getTime());
 	}
 
+	@JsonProperty("winnerDXPVariantId")
+	public String getWinnerDXPVariantId() {
+		return _winnerDXPVariantId;
+	}
+
 	public void setChannelId(String channelId) {
 		_channelId = channelId;
 	}
@@ -258,6 +263,10 @@ public final class Experiment {
 		}
 	}
 
+	public void setWinnerDXPVariantId(String winnerDXPVariantId) {
+		_winnerDXPVariantId = winnerDXPVariantId;
+	}
+
 	private String _channelId;
 	private Double _confidenceLevel;
 	private Date _createDate;
@@ -283,5 +292,6 @@ public final class Experiment {
 	private Boolean _publishable;
 	private String _publishedDXPVariantId;
 	private Date _startedDate;
+	private String _winnerDXPVariantId;
 
 }

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/GetDataMVCResourceCommand.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/GetDataMVCResourceCommand.java
@@ -41,6 +41,7 @@ import com.liferay.segments.asah.connector.internal.configuration.SegmentsExperi
 import com.liferay.segments.asah.connector.internal.util.SegmentsExperimentUtil;
 import com.liferay.segments.constants.SegmentsExperimentConstants;
 import com.liferay.segments.constants.SegmentsPortletKeys;
+import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.model.SegmentsExperiment;
 import com.liferay.segments.service.SegmentsExperienceService;
 import com.liferay.segments.service.SegmentsExperimentRelService;
@@ -166,9 +167,23 @@ public class GetDataMVCResourceCommand extends BaseMVCResourceCommand {
 		if (!Objects.equals(
 				segmentsExperiment.getStatus(), status.getValue())) {
 
-			_segmentsExperimentService.updateSegmentsExperimentStatus(
-				segmentsExperiment.getSegmentsExperimentId(),
-				status.getValue());
+			if (experiment.getWinnerDXPVariantId() != null) {
+				SegmentsExperience segmentsExperience =
+					_segmentsExperienceService.getSegmentsExperience(
+						segmentsExperiment.getGroupId(),
+						experiment.getWinnerDXPVariantId(),
+						segmentsExperiment.getPlid());
+
+				_segmentsExperimentService.updateSegmentsExperimentStatus(
+					segmentsExperiment.getSegmentsExperimentId(),
+					segmentsExperience.getSegmentsExperienceId(),
+					status.getValue());
+			}
+			else {
+				_segmentsExperimentService.updateSegmentsExperimentStatus(
+					segmentsExperiment.getSegmentsExperimentId(),
+					status.getValue());
+			}
 		}
 
 		return experiment;

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es.js
@@ -44,6 +44,8 @@ import {
 } from '../util/navigation.es';
 import {
 	STATUS_DRAFT,
+	STATUS_FINISHED_NO_WINNER,
+	STATUS_FINISHED_WINNER,
 	STATUS_RUNNING,
 	STATUS_TERMINATED,
 } from '../util/statuses.es';
@@ -112,7 +114,15 @@ function SegmentsExperimentsSidebar({
 			return;
 		}
 
-		if (experiment.status.value === STATUS_DRAFT) {
+		if (
+			experiment.status.value === STATUS_FINISHED_NO_WINNER ||
+			experiment.status.value === STATUS_FINISHED_WINNER
+		) {
+			if (segmentsExperimentAction === 'delete') {
+				dispatch(openDeletionModal());
+			}
+		}
+		else if (experiment.status.value === STATUS_DRAFT) {
 			if (segmentsExperimentAction === 'reviewAndRun') {
 				dispatch(reviewAndRunExperiment());
 			}


### PR DESCRIPTION
Hi Team!

In this PR:

- We expose an already existing local service method to enforce permission checking. This enables us to fetch the `SegemntsExperience` by its key.
- This enable us to update the AC<->DXP synchronisation step to update the declared winner variant if relevant
- We also had to update the `Experiment` model we fetch from AC to include the `winnerDXPVariantId` if included.

On the frontend side:
- I've updated the JS to perform the relevant `segmentsExperimentAction` - i.e. open the delete modal - when invoked from the link we generate on the AC side.

Thanks!