### PR TITLE
[TECHNICAL SUPPORT] LPS-196034 Fragment displays error message when an editable field is created trough configuration

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateConfigurationValuesMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/UpdateConfigurationValuesMVCActionCommand.java
@@ -72,10 +72,6 @@ public class UpdateConfigurationValuesMVCActionCommand
 				editableValuesJSONObject.getJSONObject(
 					fragmentEntryProcessorKey);
 
-			if (editableFragmentEntryProcessorJSONObject == null) {
-				continue;
-			}
-
 			JSONObject defaultEditableFragmentEntryProcessorJSONObject =
 				defaultEditableValuesJSONObject.getJSONObject(
 					fragmentEntryProcessorKey);
@@ -84,15 +80,18 @@ public class UpdateConfigurationValuesMVCActionCommand
 				continue;
 			}
 
-			Iterator<String> iterator =
-				defaultEditableFragmentEntryProcessorJSONObject.keys();
+			if (editableFragmentEntryProcessorJSONObject != null) {
+				Iterator<String> iterator =
+					defaultEditableFragmentEntryProcessorJSONObject.keys();
 
-			while (iterator.hasNext()) {
-				String key = iterator.next();
+				while (iterator.hasNext()) {
+					String key = iterator.next();
 
-				if (editableFragmentEntryProcessorJSONObject.has(key)) {
-					defaultEditableFragmentEntryProcessorJSONObject.put(
-						key, editableFragmentEntryProcessorJSONObject.get(key));
+					if (editableFragmentEntryProcessorJSONObject.has(key)) {
+						defaultEditableFragmentEntryProcessorJSONObject.put(
+							key,
+							editableFragmentEntryProcessorJSONObject.get(key));
+					}
 				}
 			}
 


### PR DESCRIPTION
Hey,

[LPS-196034](https://liferay.atlassian.net/browse/LPS-196034),

In case the Fragment is dynamically adding editable fields through configuration when originally there were no editable fields in the Fragment it causes an error.
My solution is to update editableValuesJSONObject with defaultEditableFragmentEntryProcessorJSONObject when we encounter this scenario. Please review my change.

Thanks,