### PR TITLE
[TS]LPS-196445 Change site configuration for instance configuration

### DIFF
--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/terms_of_use.jsp
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/resources/META-INF/resources/terms_of_use.jsp
@@ -44,7 +44,7 @@
 						<liferay-ui:language
 							formAction="<%= updateLanguageFormAction %>"
 							languageId="<%= themeDisplay.getLanguageId() %>"
-							languageIds="<%= LocaleUtil.toLanguageIds(LanguageUtil.getAvailableLocales(themeDisplay.getSiteGroupId())) %>"
+							languageIds="<%= LocaleUtil.toLanguageIds(LanguageUtil.getAvailableLocales(themeDisplay.getCompanyGroupId())) %>"
 						/>
 					</div>
 				</div>


### PR DESCRIPTION
<h1>Motivation</h1>
When changing languages ​​in "site settings", a component of the instance was affected. However, this component, which is the "Terms of Use", must be changed in "instance settings". According to the component description itself

Ticket: https://liferay.atlassian.net/browse/LPS-196445

<h1>Proposed Solution</h1>
I made a change so that it takes data from the instance configuration instead of the site settings

<h1>Steps to Verify</h1>
1-Start Liferay

2-On Terms of Use or Password Reminder screen, check which Languages are available
→Default: We can select 12 or 13 languages (depending on the version used)

3-Go to Liferay DXP site’s [Configuration > Site Settings > Localization > Languages]

4-Select “Define a custom default language and additional available languages for this site.”

5-Move all languages except "English(United States)" from Current to Available and Save

6-Go to Control Panel > Users > Users and Organizations > "+"

7-Add New User

8-Sign-in by new user and check “Terms of Use” screen

@dacousalr
