### PR TITLE
LPS-196853 Fix focus lost when changing selection

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/ContentFilter.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/page_content/components/ContentFilter.js
@@ -8,13 +8,8 @@ import {Option, Picker} from '@clayui/core';
 import {SearchForm} from '@liferay/layout-js-components-web';
 import React from 'react';
 
-export default function ContentFilter({
-	contentTypes,
-	onChangeInput,
-	onChangeSelect,
-	selectedType,
-}) {
-	const Trigger = React.forwardRef(({className, ...otherProps}, ref) => (
+const Trigger = React.forwardRef(
+	({className, selectedItem, ...otherProps}, ref) => (
 		<ClayButton
 			{...otherProps}
 			aria-label={Liferay.Language.get('filter-by-content-type')}
@@ -22,10 +17,17 @@ export default function ContentFilter({
 			displayType="unstyled"
 			ref={ref}
 		>
-			<span>{selectedType}</span>
+			<span>{selectedItem}</span>
 		</ClayButton>
-	));
+	)
+);
 
+export default function ContentFilter({
+	contentTypes,
+	onChangeInput,
+	onChangeSelect,
+	selectedType,
+}) {
 	return (
 		<div className="flex-shrink-0 page-editor__page-contents__content-filter px-3">
 			<p className="mb-4 page-editor__page-contents__content-filter__help">
@@ -37,6 +39,7 @@ export default function ContentFilter({
 				as={Trigger}
 				items={contentTypes}
 				onSelectionChange={onChangeSelect}
+				selectedItem={selectedType}
 				selectedKey={selectedType}
 			>
 				{(type) => <Option key={type}>{type}</Option>}

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page_content/components/PageContents.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/plugins/page_content/components/PageContents.test.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {act, render, screen} from '@testing-library/react';
+import {act, fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
@@ -110,7 +110,7 @@ describe('PageContent', () => {
 
 		const dropdownItems = document.querySelectorAll('.dropdown-item');
 
-		userEvent.click(dropdownItems[2]);
+		fireEvent.click(dropdownItems[2]);
 
 		expect(screen.queryByText('mountain.png')).toBeInTheDocument();
 		expect(screen.queryByText('Collection1')).not.toBeInTheDocument();


### PR DESCRIPTION
Motivation
=======
The focus is lost when changing selection with the keyboard in the ContentFilter Picker. When a selection is made by pressing enter or space while an item is focused, the menu should close and the focus should move back to the trigger
[Link to ticket](https://liferay.atlassian.net/browse/LPS-196853)

Proposed Solution
========
The problem was that we were defining the custom trigger inside the component. We had to move it outside.

Steps to Verify:
----------------
1. Go to page editor
1. On the left sidebar click on "Page Content"
1. Navigate with the keyboard to the Content filter and select a type of content.
1. The focus should move back to the trigger after selecting a type of content

Screenshots (optional):
-----------------------

![Captura de pantalla 2023-09-21 a las 14 03 08](https://github.com/liferay-echo/liferay-portal/assets/3276218/c37d1135-f686-4a39-9c8a-88733424743b)
