### PR TITLE
LRAC-14606

### DIFF
--- a/modules/dxp/apps/segments/segments-asah-connector-test/src/testIntegration/java/com/liferay/segments/asah/connector/internal/portlet/action/test/AddSegmentsExperimentMVCActionCommandTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector-test/src/testIntegration/java/com/liferay/segments/asah/connector/internal/portlet/action/test/AddSegmentsExperimentMVCActionCommandTest.java
@@ -254,18 +254,22 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 							"id", "123456"
 						).toString())));
 
-			ReflectionTestUtil.invoke(
+			JSONObject jsonObject = ReflectionTestUtil.invoke(
 				_mvcActionCommand, "_addSegmentsExperiment",
 				new Class<?>[] {ActionRequest.class},
 				mockLiferayPortletActionRequest);
 
+			JSONObject segmentsExperimentJSONObject =
+				(JSONObject)jsonObject.get("segmentsExperiment");
+
 			segmentsExperiment =
 				_segmentsExperimentLocalService.fetchSegmentsExperiment(
 					_group.getGroupId(),
-					segmentsExperience.getSegmentsExperienceId(),
+					segmentsExperimentJSONObject.getLong(
+						"segmentsExperienceId"),
 					_layout.getPlid());
 
-			Assert.assertNotNull(segmentsExperience);
+			Assert.assertNotNull(segmentsExperiment);
 			Assert.assertEquals(name, segmentsExperiment.getName());
 		}
 	}

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/AddSegmentsExperimentMVCActionCommand.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/AddSegmentsExperimentMVCActionCommand.java
@@ -158,6 +158,10 @@ public class AddSegmentsExperimentMVCActionCommand
 
 				_segmentsExperimentService.deleteSegmentsExperiment(
 					segmentsExperiment, false);
+
+				segmentsExperienceId =
+					_segmentsExperienceLocalService.
+						fetchDefaultSegmentsExperienceId(plid);
 			}
 			else {
 				throw new DuplicateSegmentsExperimentException();


### PR DESCRIPTION
Hi team!

See LRAC-14606 for more details on the issue we're fixing here.

TLDR: We were mixing `experienceIds` from the terminated test with the newly created one leading to errors in some corner case.

In this PR:

- When removing a test we make sure to reset the relevant `experienceId` to the DEFAULT one (that is always existing).
- We avoid associating the variant `experienceId` of a terminated test with the newly created one.

Thanks! 