### PR TITLE
[TS] LPS-197128 Check property to display Javascript sections

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/javascript.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/javascript.jsp
@@ -39,13 +39,13 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 	/>
 </liferay-frontend:fieldset>
 
-<c:if test="<%= PropsValues.FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_LAYOUT_JAVASCRIPT %>">
+<c:if test='<%= PropsValues.FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_LAYOUT_JAVASCRIPT || Validator.isNotNull(layoutTypeSettingsUnicodeProperties.getProperty("javascript")) %>'>
 	<liferay-frontend:fieldset
 		collapsed="<%= false %>"
 		collapsible="<%= true %>"
 		label="custom-javascript"
 	>
-		<aui:input cssClass="propagatable-field" disabled="<%= layoutsAdminDisplayContext.isReadOnly() || selLayout.isLayoutPrototypeLinkActive() %>" label="javascript" name="TypeSettingsProperties--javascript--" placeholder="javascript" type="textarea" value='<%= layoutTypeSettingsUnicodeProperties.getProperty("javascript") %>' wrap="soft" wrapperCssClass="c-mb-0" />
+		<aui:input cssClass="propagatable-field" disabled="<%= layoutsAdminDisplayContext.isReadOnly() || selLayout.isLayoutPrototypeLinkActive() || !PropsValues.FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_LAYOUT_JAVASCRIPT %>" label="javascript" name="TypeSettingsProperties--javascript--" placeholder="javascript" type="textarea" value='<%= layoutTypeSettingsUnicodeProperties.getProperty("javascript") %>' wrap="soft" wrapperCssClass="c-mb-0" />
 
 		<p class="text-secondary">
 			<liferay-ui:message key="this-javascript-code-is-executed-at-the-bottom-of-the-page" />

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/javascript.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout/javascript.jsp
@@ -39,14 +39,16 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 	/>
 </liferay-frontend:fieldset>
 
-<liferay-frontend:fieldset
-	collapsed="<%= false %>"
-	collapsible="<%= true %>"
-	label="custom-javascript"
->
-	<aui:input cssClass="propagatable-field" disabled="<%= layoutsAdminDisplayContext.isReadOnly() || selLayout.isLayoutPrototypeLinkActive() %>" label="javascript" name="TypeSettingsProperties--javascript--" placeholder="javascript" type="textarea" value='<%= layoutTypeSettingsUnicodeProperties.getProperty("javascript") %>' wrap="soft" wrapperCssClass="c-mb-0" />
+<c:if test="<%= PropsValues.FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_LAYOUT_JAVASCRIPT %>">
+	<liferay-frontend:fieldset
+		collapsed="<%= false %>"
+		collapsible="<%= true %>"
+		label="custom-javascript"
+	>
+		<aui:input cssClass="propagatable-field" disabled="<%= layoutsAdminDisplayContext.isReadOnly() || selLayout.isLayoutPrototypeLinkActive() %>" label="javascript" name="TypeSettingsProperties--javascript--" placeholder="javascript" type="textarea" value='<%= layoutTypeSettingsUnicodeProperties.getProperty("javascript") %>' wrap="soft" wrapperCssClass="c-mb-0" />
 
-	<p class="text-secondary">
-		<liferay-ui:message key="this-javascript-code-is-executed-at-the-bottom-of-the-page" />
-	</p>
-</liferay-frontend:fieldset>
+		<p class="text-secondary">
+			<liferay-ui:message key="this-javascript-code-is-executed-at-the-bottom-of-the-page" />
+		</p>
+	</liferay-frontend:fieldset>
+</c:if>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/javascript.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/javascript.jsp
@@ -28,14 +28,16 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 UnicodeProperties layoutSetTypeSettingsUnicodeProperties = selLayoutSet.getSettingsProperties();
 %>
 
-<liferay-frontend:fieldset
-	collapsed="<%= false %>"
-	collapsible="<%= true %>"
-	label="custom-javascript"
->
-	<aui:input label="javascript" name="TypeSettingsProperties--javascript--" placeholder="javascript" type="textarea" value='<%= layoutSetTypeSettingsUnicodeProperties.getProperty("javascript") %>' wrap="soft" wrapperCssClass="c-mb-0 c-mt-4" />
+<c:if test="<%= PropsValues.FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_LAYOUTSET_JAVASCRIPT %>">
+	<liferay-frontend:fieldset
+		collapsed="<%= false %>"
+		collapsible="<%= true %>"
+		label="custom-javascript"
+	>
+		<aui:input label="javascript" name="TypeSettingsProperties--javascript--" placeholder="javascript" type="textarea" value='<%= layoutSetTypeSettingsUnicodeProperties.getProperty("javascript") %>' wrap="soft" wrapperCssClass="c-mb-0 c-mt-4" />
 
-	<p class="text-secondary">
-		<liferay-ui:message key="paste-javascript-code-that-is-executed-at-the-bottom-of-every-page" />
-	</p>
-</liferay-frontend:fieldset>
+		<p class="text-secondary">
+			<liferay-ui:message key="paste-javascript-code-that-is-executed-at-the-bottom-of-every-page" />
+		</p>
+	</liferay-frontend:fieldset>
+</c:if>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/javascript.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/layout_set/javascript.jsp
@@ -28,13 +28,13 @@ LayoutLookAndFeelDisplayContext layoutLookAndFeelDisplayContext = new LayoutLook
 UnicodeProperties layoutSetTypeSettingsUnicodeProperties = selLayoutSet.getSettingsProperties();
 %>
 
-<c:if test="<%= PropsValues.FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_LAYOUTSET_JAVASCRIPT %>">
+<c:if test='<%= PropsValues.FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_LAYOUTSET_JAVASCRIPT || Validator.isNotNull(layoutSetTypeSettingsUnicodeProperties.getProperty("javascript")) %>'>
 	<liferay-frontend:fieldset
 		collapsed="<%= false %>"
 		collapsible="<%= true %>"
 		label="custom-javascript"
 	>
-		<aui:input label="javascript" name="TypeSettingsProperties--javascript--" placeholder="javascript" type="textarea" value='<%= layoutSetTypeSettingsUnicodeProperties.getProperty("javascript") %>' wrap="soft" wrapperCssClass="c-mb-0 c-mt-4" />
+		<aui:input disabled="<%= !PropsValues.FIELD_ENABLE_COM_LIFERAY_PORTAL_KERNEL_MODEL_LAYOUTSET_JAVASCRIPT %>" label="javascript" name="TypeSettingsProperties--javascript--" placeholder="javascript" type="textarea" value='<%= layoutSetTypeSettingsUnicodeProperties.getProperty("javascript") %>' wrap="soft" wrapperCssClass="c-mb-0 c-mt-4" />
 
 		<p class="text-secondary">
 			<liferay-ui:message key="paste-javascript-code-that-is-executed-at-the-bottom-of-every-page" />


### PR DESCRIPTION
[LPS-197128](https://liferay.atlassian.net/browse/LPS-197128)

Motivation
=======
It is no longer possible to utilise the method described in https://liferay.atlassian.net/browse/LPSA-74321 to hide the JS input fields on Layout and LayoutSet administration pages

Proposed Solution
========
Add an extra check in the respective jsp files to not render the fieldsets if the properties are false

Steps to Verify
========
Steps to Reproduce:
In the portal-ext.properties, add the following properties
```
field.enable.com.liferay.portal.kernel.model.Layout.javascript=false
field.enable.com.liferay.portal.kernel.model.LayoutSet.javascript=false
```
1. Start the bundle
2. Navigate to the Configure Page menu by clicking Site Builder > Pages > 3-dot icon next to any page > Configure
3. Select the Design submenu
4. Scroll down to Customization
5. Select the Javascript tab

**Expected result:** The javascript text area is gone
**Actual result:** The javascript text area is visible