### PR TITLE
LRAC-14619

### DIFF
--- a/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/model/impl/SegmentsExperimentImpl.java
+++ b/modules/apps/segments/segments-service/src/main/java/com/liferay/segments/model/impl/SegmentsExperimentImpl.java
@@ -147,6 +147,13 @@ public class SegmentsExperimentImpl extends SegmentsExperimentBaseImpl {
 		return winnerSegmentsExperience.getSegmentsExperienceKey();
 	}
 
+	@Override
+	public void setTypeSettings(String typeSettings) {
+		super.setTypeSettings(typeSettings);
+
+		_typeSettingsUnicodeProperties = null;
+	}
+
 	private static final Log _log = LogFactoryUtil.getLog(
 		SegmentsExperimentImpl.class);
 

--- a/modules/apps/segments/segments-service/src/test/java/com/liferay/segments/model/impl/SegmentsExperimentImplTest.java
+++ b/modules/apps/segments/segments-service/src/test/java/com/liferay/segments/model/impl/SegmentsExperimentImplTest.java
@@ -1,0 +1,71 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.segments.model.impl;
+
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.UnicodeProperties;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * @author Riccardo Ferrari
+ */
+public class SegmentsExperimentImplTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testSetTypeSettings() {
+		SegmentsExperimentImpl segmentsExperimentImpl =
+			new SegmentsExperimentImpl();
+
+		UnicodeProperties unicodeProperties = UnicodePropertiesBuilder.put(
+			"test-property-1", RandomTestUtil.randomString()
+		).put(
+			"test-property-2", RandomTestUtil.randomString()
+		).build();
+
+		segmentsExperimentImpl.setTypeSettings(unicodeProperties.toString());
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			segmentsExperimentImpl.getTypeSettingsProperties();
+
+		Assert.assertEquals(
+			unicodeProperties.getProperty("test-property-1"),
+			typeSettingsUnicodeProperties.getProperty("test-property-1"));
+		Assert.assertEquals(
+			unicodeProperties.getProperty("test-property-2"),
+			typeSettingsUnicodeProperties.getProperty("test-property-2"));
+
+		unicodeProperties.put("test-property-1", RandomTestUtil.randomString());
+		unicodeProperties.put("test-property-2", RandomTestUtil.randomString());
+		unicodeProperties.put("test-property-3", RandomTestUtil.randomString());
+
+		segmentsExperimentImpl.setTypeSettings(unicodeProperties.toString());
+
+		typeSettingsUnicodeProperties =
+			segmentsExperimentImpl.getTypeSettingsProperties();
+
+		Assert.assertEquals(
+			unicodeProperties.getProperty("test-property-1"),
+			typeSettingsUnicodeProperties.getProperty("test-property-1"));
+		Assert.assertEquals(
+			unicodeProperties.getProperty("test-property-2"),
+			typeSettingsUnicodeProperties.getProperty("test-property-2"));
+		Assert.assertEquals(
+			unicodeProperties.getProperty("test-property-3"),
+			typeSettingsUnicodeProperties.getProperty("test-property-3"));
+	}
+
+}

--- a/modules/dxp/apps/segments/segments-asah-connector-test/src/testIntegration/java/com/liferay/segments/asah/connector/internal/portlet/action/test/AddSegmentsExperimentMVCActionCommandTest.java
+++ b/modules/dxp/apps/segments/segments-asah-connector-test/src/testIntegration/java/com/liferay/segments/asah/connector/internal/portlet/action/test/AddSegmentsExperimentMVCActionCommandTest.java
@@ -87,7 +87,8 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			_getMockLiferayPortletActionRequest(
 				RandomTestUtil.randomString(), goal.getLabel(),
-				RandomTestUtil.randomString(), segmentsExperience);
+				RandomTestUtil.randomString(), segmentsExperience.getPlid(),
+				segmentsExperience.getSegmentsExperienceId());
 
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
@@ -123,7 +124,9 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			_getMockLiferayPortletActionRequest(
-				description, goal.getLabel(), name, segmentsExperience);
+				description, goal.getLabel(), name,
+				segmentsExperience.getPlid(),
+				segmentsExperience.getSegmentsExperienceId());
 
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
@@ -227,7 +230,8 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
 			_getMockLiferayPortletActionRequest(
 				RandomTestUtil.randomString(), goal.getLabel(), name,
-				segmentsExperience);
+				segmentsExperience.getPlid(),
+				segmentsExperience.getSegmentsExperienceId());
 
 		try (CompanyConfigurationTemporarySwapper
 				companyConfigurationTemporarySwapper =
@@ -274,6 +278,97 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 		}
 	}
 
+	@Test
+	public void testAddSegmentsExperimentWithSecondaryExperienceSelected()
+		throws Exception {
+
+		String liferayAnalyticsURL = "http://localhost:8080/";
+
+		String description = RandomTestUtil.randomString();
+
+		SegmentsExperimentConstants.Goal goal =
+			SegmentsExperimentConstants.Goal.BOUNCE_RATE;
+
+		String name = RandomTestUtil.randomString();
+
+		String segmentsEntryName = RandomTestUtil.randomString();
+
+		SegmentsExperience segmentsExperience = _addSegmentsExperience(
+			segmentsEntryName);
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest(
+				description, goal.getLabel(), name,
+				segmentsExperience.getPlid(), RandomTestUtil.nextLong());
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						AnalyticsConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsFaroBackendURL",
+							"http://localhost:8086"
+						).put(
+							"liferayAnalyticsURL", liferayAnalyticsURL
+						).build())) {
+
+			JSONObject jsonObject = ReflectionTestUtil.invoke(
+				_mvcActionCommand, "_addSegmentsExperiment",
+				new Class<?>[] {ActionRequest.class},
+				mockLiferayPortletActionRequest);
+
+			JSONObject segmentsExperimentJSONObject =
+				(JSONObject)jsonObject.get("segmentsExperiment");
+
+			Assert.assertEquals(
+				0.0, segmentsExperimentJSONObject.getDouble("confidenceLevel"),
+				0);
+			Assert.assertEquals(
+				description,
+				segmentsExperimentJSONObject.getString("description"));
+
+			SegmentsExperiment segmentsExperiment =
+				_segmentsExperimentLocalService.fetchSegmentsExperiment(
+					_group.getGroupId(),
+					segmentsExperimentJSONObject.getLong(
+						"segmentsExperienceId"),
+					_layout.getPlid());
+
+			Assert.assertEquals(
+				liferayAnalyticsURL + "/tests/overview/" +
+					segmentsExperiment.getSegmentsExperimentKey(),
+				segmentsExperimentJSONObject.getString("detailsURL"));
+
+			Assert.assertTrue(
+				segmentsExperimentJSONObject.getBoolean("editable"));
+			Assert.assertEquals(
+				String.valueOf(
+					JSONUtil.put(
+						"label", "Bounce Rate"
+					).put(
+						"value", goal.getLabel()
+					)),
+				String.valueOf(
+					segmentsExperimentJSONObject.getJSONObject("goal")));
+			Assert.assertEquals(
+				name, segmentsExperimentJSONObject.getString("name"));
+			Assert.assertEquals(
+				String.valueOf(segmentsExperiment.getSegmentsExperimentId()),
+				segmentsExperimentJSONObject.getString("segmentsExperimentId"));
+			Assert.assertEquals(
+				String.valueOf(
+					JSONUtil.put(
+						"label", "Draft"
+					).put(
+						"value",
+						SegmentsExperimentConstants.Status.DRAFT.getValue()
+					)),
+				String.valueOf(
+					segmentsExperimentJSONObject.getJSONObject("status")));
+		}
+	}
+
 	private SegmentsExperience _addSegmentsExperience(String segmentsEntryName)
 		throws Exception {
 
@@ -288,8 +383,8 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 	}
 
 	private MockLiferayPortletActionRequest _getMockLiferayPortletActionRequest(
-			String description, String goal, String name,
-			SegmentsExperience segmentsExperience)
+			String description, String goal, String name, long plid,
+			long segmentsExperienceId)
 		throws Exception {
 
 		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
@@ -299,14 +394,13 @@ public class AddSegmentsExperimentMVCActionCommandTest {
 			WebKeys.THEME_DISPLAY, _getThemeDisplay());
 
 		mockLiferayPortletActionRequest.setParameter(
-			"plid", String.valueOf(segmentsExperience.getPlid()));
+			"plid", String.valueOf(plid));
 		mockLiferayPortletActionRequest.setParameter(
 			"description", description);
 		mockLiferayPortletActionRequest.setParameter("goal", goal);
 		mockLiferayPortletActionRequest.setParameter("name", name);
 		mockLiferayPortletActionRequest.setParameter(
-			"segmentsExperienceId",
-			String.valueOf(segmentsExperience.getSegmentsExperienceId()));
+			"segmentsExperienceId", String.valueOf(segmentsExperienceId));
 
 		return mockLiferayPortletActionRequest;
 	}

--- a/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/AddSegmentsExperimentMVCActionCommand.java
+++ b/modules/dxp/apps/segments/segments-asah-connector/src/main/java/com/liferay/segments/asah/connector/internal/portlet/action/AddSegmentsExperimentMVCActionCommand.java
@@ -37,6 +37,7 @@ import com.liferay.segments.asah.connector.internal.util.SegmentsExperimentUtil;
 import com.liferay.segments.constants.SegmentsExperimentConstants;
 import com.liferay.segments.constants.SegmentsPortletKeys;
 import com.liferay.segments.exception.DuplicateSegmentsExperimentException;
+import com.liferay.segments.model.SegmentsExperience;
 import com.liferay.segments.model.SegmentsExperiment;
 import com.liferay.segments.model.SegmentsExperimentRel;
 import com.liferay.segments.service.SegmentsEntryLocalService;
@@ -44,6 +45,7 @@ import com.liferay.segments.service.SegmentsExperienceLocalService;
 import com.liferay.segments.service.SegmentsExperimentRelService;
 import com.liferay.segments.service.SegmentsExperimentService;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 
@@ -159,13 +161,17 @@ public class AddSegmentsExperimentMVCActionCommand
 				_segmentsExperimentService.deleteSegmentsExperiment(
 					segmentsExperiment, false);
 
-				segmentsExperienceId =
-					_segmentsExperienceLocalService.
-						fetchDefaultSegmentsExperienceId(plid);
+				segmentsExperienceId = _getActiveExperienceId(
+					serviceContext.getScopeGroupId(), plid,
+					segmentsExperienceId);
 			}
 			else {
 				throw new DuplicateSegmentsExperimentException();
 			}
+		}
+		else {
+			segmentsExperienceId = _getActiveExperienceId(
+				serviceContext.getScopeGroupId(), plid, segmentsExperienceId);
 		}
 
 		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
@@ -193,6 +199,27 @@ public class AddSegmentsExperimentMVCActionCommand
 			SegmentsExperimentUtil.toSegmentsExperimentRelJSONObject(
 				themeDisplay.getLocale(), segmentsExperimentRel)
 		);
+	}
+
+	private long _getActiveExperienceId(
+			long groupId, long plid, long segmentsExperienceId)
+		throws Exception {
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.fetchSegmentsExperience(
+				segmentsExperienceId);
+
+		if (segmentsExperience != null) {
+			return segmentsExperienceId;
+		}
+
+		List<SegmentsExperience> segmentsExperiences =
+			_segmentsExperienceLocalService.getSegmentsExperiences(
+				groupId, plid, true, 0, 1, null);
+
+		segmentsExperience = segmentsExperiences.get(0);
+
+		return segmentsExperience.getSegmentsExperienceId();
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es.js
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/resources/META-INF/resources/js/components/SegmentsExperimentsSidebar.es.js
@@ -451,7 +451,7 @@ function SegmentsExperimentsSidebar({
 					)
 				);
 
-				navigateToExperience(experiment.segmentsExperienceId);
+				navigateToExperience(experienceId);
 			})
 			.catch((_error) => {
 				openErrorToast();


### PR DESCRIPTION
Hi team,

Please review this bugfix PR:
- We found a bug where the `SegmentsExperimentImpl` was creating a local cache of the type settings properties and never invalidating it.
- On the FE we were not redirecting to the winner experience id when publishing a winner experience
- When fetching an experiment we are using the selected experience id, however there are are cases where the experience is removed in the process - i.e. when publishing the other variant.

Thank you!