### PR TITLE
LPS-197200 When a widget page template is created the text of the back button tooltip is Go to Page

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddLayoutPrototypeMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/AddLayoutPrototypeMVCActionCommand.java
@@ -133,7 +133,7 @@ public class AddLayoutPrototypeMVCActionCommand extends BaseMVCActionCommand {
 			if (Validator.isNotNull(backURL)) {
 				redirectURL = HttpComponentsUtil.addParameters(
 					redirectURL, "p_l_back_url", backURL, "p_l_back_url_title",
-					_language.get(themeDisplay.getLocale(), "pages"));
+					_language.get(themeDisplay.getLocale(), "page-templates"));
 			}
 
 			JSONPortletResponseUtil.writeJSON(


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-197200)

### Changes

Replace language key “pages” with “page-templates” 

## Test scenario 1 
1. Go to Design > Page Templates > Pages Templates
2. Create a page template set and a new widget page template
3. Check the back button

## Results

https://github.com/liferay-echo/liferay-portal/assets/93203423/95597ac6-c32d-4e89-a8c3-39f141dc0436

