### PR TITLE
LPS-196356 Add permission checker by group when site is initialized

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/SelectSiteInitializerMVCRenderCommand.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/SelectSiteInitializerMVCRenderCommand.java
@@ -5,12 +5,20 @@
 
 package com.liferay.site.admin.web.internal.portlet.action;
 
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.GroupConstants;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCRenderCommand;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.security.permission.PermissionChecker;
+import com.liferay.portal.kernel.service.GroupService;
+import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortalPermission;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.site.admin.web.internal.constants.SiteAdminPortletKeys;
 
@@ -39,17 +47,37 @@ public class SelectSiteInitializerMVCRenderCommand implements MVCRenderCommand {
 		ThemeDisplay themeDisplay = (ThemeDisplay)renderRequest.getAttribute(
 			WebKeys.THEME_DISPLAY);
 
-		if (_portalPermission.contains(
-				themeDisplay.getPermissionChecker(),
-				ActionKeys.ADD_COMMUNITY)) {
+		PermissionChecker permissionChecker =
+			themeDisplay.getPermissionChecker();
 
-			return "/select_site_initializer.jsp";
+		long parentGroupId = ParamUtil.getLong(
+			renderRequest, "parentGroupId",
+			GroupConstants.DEFAULT_PARENT_GROUP_ID);
+
+		try {
+			if (_portalPermission.contains(
+					permissionChecker, ActionKeys.ADD_COMMUNITY) ||
+				GroupPermissionUtil.contains(
+					permissionChecker, _groupService.getGroup(parentGroupId),
+					ActionKeys.ADD_COMMUNITY)) {
+
+				return "/select_site_initializer.jsp";
+			}
+
+			SessionErrors.add(renderRequest, PrincipalException.class);
 		}
-
-		SessionErrors.add(renderRequest, PrincipalException.class);
+		catch (PortalException portalException) {
+			_log.error(portalException);
+		}
 
 		return "/error.jsp";
 	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		SelectSiteInitializerMVCRenderCommand.class);
+
+	@Reference
+	private GroupService _groupService;
 
 	@Reference
 	private PortalPermission _portalPermission;


### PR DESCRIPTION
### **Motivation:**
[LPS-196356](https://liferay.atlassian.net/browse/LPS-196356) -> A user assigned to Site Administrator role cannot add child sites

### **Proposed Solution:**

I was investigating the class that renders the dropdown items for the site and it calls the method [hasAddChildSitePermission](https://github.com/liferay/liferay-portal/blob/master/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/servlet/taglib/util/SiteActionDropdownItemsProvider.java#L93) to check the permission related to adding the child page. This method is from the SiteAdminDisplayContext class. It will check[ if the permission is contained in PortalPermissionUtil or GroupPermissionUtil](https://github.com/liferay/liferay-portal/blob/master/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminDisplayContext.java#L297).

Furthermore I investigated the render class for the child page (SelectSiteInitializerMVCRenderCommand) since the permission error message appears there after we click the button. It has a similar verification, but [only checks inside the PortalPermission class](https://github.com/liferay/liferay-portal/blob/master/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/portlet/action/SelectSiteInitializerMVCRenderCommand.java#L42).

After discussing with echo product team in this [PTR](https://liferay.atlassian.net/browse/PTR-4335), it was confirmed that the user with the Site Administrator role have this permission to create child sites by default.

> The user has permission because they have the action “Manage Subgroups“. So, if you check just a bit further, you will arrive to [AdvancedPermissionChecker](https://github.com/liferay/liferay-portal/blob/33dcc7116256d2c52b3a676d48e7ed3276320ed4/portal-impl/src/com/liferay/portal/security/permission/AdvancedPermissionChecker.java#L1390), and you will see that it specifically checks for Site Admin Role, granting permission to the user to see the action. 

> In any case, for the fix. What I personally would propose based on the findings is to also add the check for GroupPermission to the site initializer resource command.

### **Steps to Verify:**

1. Start the bundle and log in as admin
2. Control Panel > Users and Organisations, create a new user
3. Add the new user as a member of Liferay DXP site on the Membership tab
4. At the Roles tab, add the new user as Site administrator of Liferay DXP site
5. Control Panel > Roles, Select User role, Define permissions tab > Control Panel > Sites > Sites
6. Add 'Access in Control Panel' and 'View' APPLICATION PERMISSIONS
7. Impersonate the user and navigate to Control Panel > Sites
8. At the kebab menu of Liferay DXP site, click on Add child site

✅ _Expected result:_ the child site has been created successfully
❌ _Actual result:_ button is there, but when clicked, error message appears showing that there is no permission