### PR TITLE
LPS-177777 Add backURLTitles for Trash, Templates and ContentDashboard modules

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-blogs-impl/src/main/java/com/liferay/content/dashboard/blogs/internal/item/action/ViewBlogsEntryContentDashboardItemAction.java
+++ b/modules/apps/content-dashboard/content-dashboard-blogs-impl/src/main/java/com/liferay/content/dashboard/blogs/internal/item/action/ViewBlogsEntryContentDashboardItemAction.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -101,13 +102,17 @@ public class ViewBlogsEntryContentDashboardItemAction
 			String backURL = ParamUtil.getString(
 				_httpServletRequest, "backURL");
 
+			PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
 			if (Validator.isNotNull(backURL)) {
-				return HttpComponentsUtil.setParameter(
-					url, "p_l_back_url", backURL);
+				return HttpComponentsUtil.addParameters(
+					url, "p_l_back_url", backURL, "p_l_back_url_title",
+					portletDisplay.getPortletDisplayName());
 			}
 
-			return HttpComponentsUtil.setParameter(
-				url, "p_l_back_url", themeDisplay.getURLCurrent());
+			return HttpComponentsUtil.addParameters(
+				url, "p_l_back_url", themeDisplay.getURLCurrent(),
+				"p_l_back_url_title", portletDisplay.getPortletDisplayName());
 		}
 		catch (CloneNotSupportedException | PortalException exception) {
 			_log.error(exception);

--- a/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/action/ViewFileEntryContentDashboardItemAction.java
+++ b/modules/apps/content-dashboard/content-dashboard-document-library-impl/src/main/java/com/liferay/content/dashboard/document/library/internal/item/action/ViewFileEntryContentDashboardItemAction.java
@@ -15,6 +15,7 @@ import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
@@ -103,13 +104,17 @@ public class ViewFileEntryContentDashboardItemAction
 			String backURL = ParamUtil.getString(
 				_httpServletRequest, "backURL");
 
+			PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
 			if (Validator.isNotNull(backURL)) {
-				return HttpComponentsUtil.setParameter(
-					friendlyURL, "p_l_back_url", backURL);
+				return HttpComponentsUtil.addParameters(
+					friendlyURL, "p_l_back_url", backURL, "p_l_back_url_title",
+					portletDisplay.getPortletDisplayName());
 			}
 
-			return HttpComponentsUtil.setParameter(
-				friendlyURL, "p_l_back_url", themeDisplay.getURLCurrent());
+			return HttpComponentsUtil.addParameters(
+				friendlyURL, "p_l_back_url", themeDisplay.getURLCurrent(),
+				"p_l_back_url_title", portletDisplay.getPortletDisplayName());
 		}
 		catch (CloneNotSupportedException | PortalException exception) {
 			_log.error(exception);

--- a/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/action/ViewJournalArticleContentDashboardItemAction.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/action/ViewJournalArticleContentDashboardItemAction.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.ListUtil;
@@ -212,13 +213,17 @@ public class ViewJournalArticleContentDashboardItemAction
 
 		String backURL = ParamUtil.getString(_httpServletRequest, "backURL");
 
+		PortletDisplay portletDisplay = themeDisplay.getPortletDisplay();
+
 		if (Validator.isNotNull(backURL)) {
-			return HttpComponentsUtil.setParameter(
-				url, "p_l_back_url", backURL);
+			return HttpComponentsUtil.addParameters(
+				url, "p_l_back_url", backURL, "p_l_back_url_title",
+				portletDisplay.getPortletDisplayName());
 		}
 
-		return HttpComponentsUtil.setParameter(
-			url, "p_l_back_url", themeDisplay.getURLCurrent());
+		return HttpComponentsUtil.addParameters(
+			url, "p_l_back_url", themeDisplay.getURLCurrent(),
+			"p_l_back_url_title", portletDisplay.getPortletDisplayName());
 	}
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/copy_ddm_template.jsp
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/copy_ddm_template.jsp
@@ -16,6 +16,7 @@ DDMTemplate ddmTemplate = DDMTemplateLocalServiceUtil.fetchDDMTemplate(ddmTempla
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle(LanguageUtil.format(request, "copy-x", HtmlUtil.escape(ddmTemplate.getName(locale))));
 %>

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/copy_template_entry.jsp
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/copy_template_entry.jsp
@@ -18,6 +18,7 @@ DDMTemplate ddmTemplate = DDMTemplateLocalServiceUtil.fetchDDMTemplate(templateE
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle(LanguageUtil.format(request, "copy-x", HtmlUtil.escape(ddmTemplate.getName(locale))));
 %>

--- a/modules/apps/template/template-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
+++ b/modules/apps/template/template-web/src/main/resources/META-INF/resources/edit_ddm_template.jsp
@@ -24,6 +24,7 @@ EditDDMTemplateDisplayContext editDDMTemplateDisplayContext = (EditDDMTemplateDi
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 if (ddmTemplate != null) {
 	renderResponse.setTitle(LanguageUtil.format(request, "edit-x", HtmlUtil.escape(ddmTemplate.getName(locale))));

--- a/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
+++ b/modules/apps/trash/trash-web/src/main/resources/META-INF/resources/view_content.jsp
@@ -155,6 +155,7 @@ TrashHandler trashHandler = trashDisplayContext.getTrashHandler();
 		<%
 		portletDisplay.setShowBackIcon(true);
 		portletDisplay.setURLBack(trashDisplayContext.getViewContentRedirectURL());
+		portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 		TrashRenderer trashRenderer = trashDisplayContext.getTrashRenderer();
 


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is to add the backURLTItles in the cases that is possible for the Trash, Templates and Content Dashboard modules.
[LPS-197437](https://liferay.atlassian.net/browse/LPS-197437)
[LPS-197440](https://liferay.atlassian.net/browse/LPS-197440)
[LPS-197437](https://liferay.atlassian.net/browse/LPS-197437)

Proposed Solution
========
What I did to solve this problem is to use the setURLBackTitle from the PortletDisplay class to set the titles or add the parameter p_l_back_url_title in the corresponding URL.

Steps to Verify
========
For trash:
1. Add a web content and delete ir.
2. Go to Recycle Bin -> click over the recently erased item to view it -> in the view page if you hover over the back button , the title should display: Back To Recycle bin
For templates:
1. Go to templates -> Create a Information Template for web contents -> edit it -> in the edit page if you hover over the back button , the title should be: Back to Templates
2. With the same template created above in the Page Template view -> click on the dropdown button -> Make a copy -> in the Make a copy view, if you hover the back button the title should be: Go to Templates
3. Repeat the 1 and 2 steps for Widget Templates