### PR TITLE
LPS-196831 Copy naming for Web Content should follow the pattern

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -1052,10 +1052,10 @@ public class JournalArticleLocalServiceImpl
 		for (Map.Entry<Locale, String> entry : newTitleMap.entrySet()) {
 			Locale locale = entry.getKey();
 
-			String urlTitle = StringBundler.concat(
-				entry.getValue(), StringPool.SPACE,
-				_language.get(locale, "duplicate"), StringPool.SPACE,
-				uniqueUrlTitleCount);
+			String urlTitle = StringUtil.appendParentheticalSuffix(
+				entry.getValue(),
+				_language.get(locale, "copy") + StringPool.SPACE +
+					uniqueUrlTitleCount);
 
 			newTitleMap.put(locale, urlTitle);
 			newUniqueURLTitleMap.put(
@@ -7789,6 +7789,9 @@ public class JournalArticleLocalServiceImpl
 	private int _getUniqueUrlTitleCount(
 		long groupId, String articleId, String urlTitle) {
 
+		String copy = _language.get(LocaleUtil.getMostRelevantLocale(), "copy");
+		String prefix = urlTitle;
+
 		for (int i = 1;; i++) {
 			JournalArticle article = fetchArticleByUrlTitle(groupId, urlTitle);
 
@@ -7798,14 +7801,8 @@ public class JournalArticleLocalServiceImpl
 				return i - 1;
 			}
 
-			String suffix = StringPool.DASH + i;
-
-			String prefix = urlTitle;
-
-			if (urlTitle.length() > suffix.length()) {
-				prefix = urlTitle.substring(
-					0, urlTitle.length() - suffix.length());
-			}
+			String suffix = StringBundler.concat(
+				StringPool.DASH, copy, StringPool.DASH, i, StringPool.DASH);
 
 			urlTitle = prefix + suffix;
 		}


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-196831)

### Changes

Copy naming for Web Content should follow the pattern of “(Copy x)”.

## Test scenario 1

1. Create a Web Content 
2. Copy the same WC a few times and check the names

## Results

https://github.com/liferay-echo/liferay-portal/assets/93203423/1f4a9554-3ad3-4a8d-b4e9-bf6a83288637

