### PR TITLE
LPS-197569 When you create a webcontent using the headless API, the display date is not correct

### DIFF
--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -37,12 +37,14 @@ import com.liferay.journal.util.JournalConverter;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.search.BooleanClauseOccur;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
@@ -71,7 +73,9 @@ import com.liferay.portal.vulcan.util.LocalDateTimeUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -79,6 +83,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MultivaluedMap;
@@ -279,6 +284,16 @@ public class StructuredContentResourceImpl
 
 		LocalDateTime localDateTime = LocalDateTimeUtil.toLocalDateTime(
 			structuredContent.getDatePublished());
+
+		User user = GuestOrUserUtil.getGuestOrUser();
+
+		Instant instant = localDateTime.toInstant(ZoneOffset.UTC);
+
+		TimeZone timeZone = user.getTimeZone();
+
+		localDateTime = instant.atZone(
+			timeZone.toZoneId()
+		).toLocalDateTime();
 
 		ServiceContext serviceContext = ServiceContextBuilder.create(
 			siteId, contextHttpServletRequest,

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -81,6 +81,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.search.filter.BooleanFilter;
 import com.liferay.portal.kernel.search.filter.Filter;
 import com.liferay.portal.kernel.search.filter.TermFilter;
+import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
 import com.liferay.portal.kernel.security.permission.resource.ModelResourcePermission;
@@ -119,7 +120,9 @@ import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -129,6 +132,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 
 import javax.ws.rs.BadRequestException;
 import javax.ws.rs.core.MultivaluedMap;
@@ -717,6 +721,16 @@ public class StructuredContentResourceImpl
 
 		LocalDateTime localDateTime = LocalDateTimeUtil.toLocalDateTime(
 			structuredContent.getDatePublished());
+
+		User user = GuestOrUserUtil.getGuestOrUser();
+
+		Instant instant = localDateTime.toInstant(ZoneOffset.UTC);
+
+		TimeZone timeZone = user.getTimeZone();
+
+		localDateTime = instant.atZone(
+			timeZone.toZoneId()
+		).toLocalDateTime();
 
 		Map<Locale, String> titleMap = LocalizedMapUtil.getLocalizedMap(
 			contextAcceptLanguage.getPreferredLocale(),


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-197569

When you create a web content using the headless API and the Liferay user is configured with a timezone different to GMT/UTC, the display date of the created web content is not correct, it will created with a date some hours before or later than current one, depending on the configured time zone.

This behavior:
- Is not reproduced if you create the web content from the user interface, the dates will match
- Is also reproduced If you specify a custom publish date in the headless API, it will be always created with some hours offset than the specified, depending on the configured timezone.

**Root cause of the issue**

- The `JournalArticleLocalServiceImpl.addArticle` method converts the received displayDate from the user time zone to GMT before saving it to the database, see: https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java#L375-L377
- The headless API uses the dates in UTC time zone when calling the JournalArticleLocalServiceImpl.addArticle method.

**Steps to reproduce**

- See [LPS-197569](https://liferay.atlassian.net/browse/LPS-197569) description

**Implemented solution**

- To solve the issue I have changed the headless code that calls `JournalArticleLocalServiceImpl.addArticle` adding a conversion from UTC to the user's time zone.

[LPS-197569]: https://liferay.atlassian.net/browse/LPS-197569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ