### PR TITLE
LPS-195762 XSS with `tabs2` in role assignment

### DIFF
--- a/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
+++ b/modules/apps/frontend-taglib/frontend-taglib-clay/src/main/java/com/liferay/frontend/taglib/clay/servlet/taglib/NavigationBarTag.java
@@ -8,6 +8,7 @@ package com.liferay.frontend.taglib.clay.servlet.taglib;
 import com.liferay.frontend.taglib.clay.internal.servlet.taglib.BaseContainerTag;
 import com.liferay.frontend.taglib.clay.servlet.taglib.util.NavigationItem;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
+import com.liferay.portal.kernel.util.HtmlUtil;
 import com.liferay.portal.kernel.util.Validator;
 
 import java.util.List;
@@ -133,12 +134,13 @@ public class NavigationBarTag extends BaseContainerTag {
 
 				if (Validator.isNotNull((String)navigationItem.get("href"))) {
 					jspWriter.write(" href=\"");
-					jspWriter.write((String)navigationItem.get("href"));
+					jspWriter.write((String)navigationItem.get("href")); 
 					jspWriter.write("\"");
 				}
 
 				jspWriter.write("><span class=\"navbar-text-truncate\">");
-				jspWriter.write((String)navigationItem.get("label"));
+				jspWriter.write(
+					HtmlUtil.escape((String)navigationItem.get("label")));
 				jspWriter.write("</span></a></li>");
 			}
 


### PR DESCRIPTION
Related Issue: [LPS-195762](https://liferay.atlassian.net/browse/LPS-195762)

Sending this because of a XSS vulnerability in the tabs2 using NavigationBarTag. See: [select_assignees.jsp](https://github.com/liferay-echo/liferay-portal/blob/master/modules/apps/roles/roles-admin-web/src/main/resources/META-INF/resources/select_assignees.jsp#L38)