### PR TITLE
[TS] LPS-197656 Remove the template ID to avoid rendering subsequent articles with the incorrect template

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/renderer/JournalArticleDDMTemplateInfoItemTemplatedRenderer.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/info/item/renderer/JournalArticleDDMTemplateInfoItemTemplatedRenderer.java
@@ -168,6 +168,9 @@ public class JournalArticleDDMTemplateInfoItemTemplatedRenderer
 		catch (Exception exception) {
 			throw new RuntimeException(exception);
 		}
+		finally {
+			httpServletRequest.removeAttribute(WebKeys.JOURNAL_TEMPLATE_ID);
+		}
 	}
 
 	@Reference


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-197656

**Steps to Reproduce**

1. Create a new Web Content structure named "first-st" with a text field
2. Create another structure named "second-st" with a text field
3. Create a new Web Content template named "first-te" associated with the "first-st" structure adding the text field to the template
4. Create another template named "second-te" associated with the "second-st" structure adding the text field to the template
5. Create a Web Content Article using "first-st" and entering "first" in the text field
6. Create another article using "second-st" and entering "second" in the text field
7. Edit the home page
8. Add a Content Display fragment to the page
9. Select the "Second" article to display and set the template as "second-te"
10. Add an Asset Publisher widget underneath the Content Display fragment
11. Configure the Asset Publisher to show assets dynamically
12. Publish the page
13. Click on the "First" article within the Asset Publisher widget

**Expected Results**
The article displays and the content renders as "First"

**Actual Results**
The article's content does not display

**Fix**
My changes remove the template ID set in the request after the current fragment has been rendered. This is to avoid an issue here - https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/asset/model/JournalArticleAssetRenderer.java#L520-L521

If the template ID is not removed from the request then all the following fragments will also use this as the template to render articles.

Please let me know if there are any concerns with this approach.