### PR TITLE
[TS] LPS-197703

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
@@ -404,9 +404,10 @@ public class JournalArticleModelValidator
 
 		try {
 			validateReferences(
-				article.getGroupId(), article.getDDMStructureId(),
-				ddmTemplateKey, article.getLayoutUuid(), smallImage,
-				smallImageURL, smallImageBytes, article.getSmallImageId(),
+				article.getGroupId(), article.getFolderId(),
+				article.getDDMStructureId(), ddmTemplateKey,
+				article.getLayoutUuid(), smallImage, smallImageURL,
+				smallImageBytes, article.getSmallImageId(),
 				article.getSmallImageSource(), content);
 		}
 		catch (ExportImportContentValidationException
@@ -438,11 +439,13 @@ public class JournalArticleModelValidator
 	}
 
 	public void validateReferences(
-			long groupId, long ddmStructureId, String ddmTemplateKey,
-			String layoutUuid, boolean smallImage, String smallImageURL,
-			byte[] smallImageBytes, long smallImageId, int smallImageSource,
-			String content)
+			long groupId, long folderId, long ddmStructureId,
+			String ddmTemplateKey, String layoutUuid, boolean smallImage,
+			String smallImageURL, byte[] smallImageBytes, long smallImageId,
+			int smallImageSource, String content)
 		throws PortalException {
+
+		_journalFolderLocalService.getFolder(folderId);
 
 		if (ddmStructureId > 0) {
 			_ddmStructureLocalService.getDDMStructure(ddmStructureId);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
@@ -447,9 +447,7 @@ public class JournalArticleModelValidator
 
 		_journalFolderLocalService.getFolder(folderId);
 
-		if (ddmStructureId > 0) {
-			_ddmStructureLocalService.getDDMStructure(ddmStructureId);
-		}
+		_ddmStructureLocalService.getDDMStructure(ddmStructureId);
 
 		if (Validator.isNotNull(ddmTemplateKey)) {
 			DDMTemplate ddmTemplate = _ddmTemplateLocalService.fetchTemplate(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/validation/JournalArticleModelValidator.java
@@ -445,7 +445,9 @@ public class JournalArticleModelValidator
 			int smallImageSource, String content)
 		throws PortalException {
 
-		_journalFolderLocalService.getFolder(folderId);
+		if (folderId != 0) {
+			_journalFolderLocalService.getFolder(folderId);
+		}
 
 		_ddmStructureLocalService.getDDMStructure(ddmStructureId);
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -430,9 +430,9 @@ public class JournalArticleLocalServiceImpl
 
 			try {
 				validateReferences(
-					groupId, ddmStructure.getStructureId(), ddmTemplateKey,
-					layoutUuid, smallImage, smallImageURL, smallImageBytes,
-					smallImageId, smallImageSource, content);
+					groupId, folderId, ddmStructure.getStructureId(),
+					ddmTemplateKey, layoutUuid, smallImage, smallImageURL,
+					smallImageBytes, smallImageId, smallImageSource, content);
 			}
 			catch (ExportImportContentValidationException
 						exportImportContentValidationException) {
@@ -4781,9 +4781,9 @@ public class JournalArticleLocalServiceImpl
 
 			try {
 				validateReferences(
-					groupId, latestArticle.getDDMStructureId(), ddmTemplateKey,
-					layoutUuid, smallImage, smallImageURL, smallImageBytes,
-					smallImageId, smallImageSource, content);
+					groupId, folderId, latestArticle.getDDMStructureId(),
+					ddmTemplateKey, layoutUuid, smallImage, smallImageURL,
+					smallImageBytes, smallImageId, smallImageSource, content);
 			}
 			catch (ExportImportContentValidationException
 						exportImportContentValidationException) {
@@ -7269,16 +7269,16 @@ public class JournalArticleLocalServiceImpl
 	}
 
 	protected void validateReferences(
-			long groupId, long ddmStructureId, String ddmTemplateKey,
-			String layoutUuid, boolean smallImage, String smallImageURL,
-			byte[] smallImageBytes, long smallImageId, int smallImageSource,
-			String content)
+			long groupId, long folderId, long ddmStructureId,
+			String ddmTemplateKey, String layoutUuid, boolean smallImage,
+			String smallImageURL, byte[] smallImageBytes, long smallImageId,
+			int smallImageSource, String content)
 		throws PortalException {
 
 		_getModelValidator().validateReferences(
-			groupId, ddmStructureId, ddmTemplateKey, layoutUuid, smallImage,
-			smallImageURL, smallImageBytes, smallImageId, smallImageSource,
-			content);
+			groupId, folderId, ddmStructureId, ddmTemplateKey, layoutUuid,
+			smallImage, smallImageURL, smallImageBytes, smallImageId,
+			smallImageSource, content);
 	}
 
 	@Reference

--- a/modules/apps/journal/journal-test/build.gradle
+++ b/modules/apps/journal/journal-test/build.gradle
@@ -43,6 +43,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:portal-configuration:portal-configuration-test-util")
 	testIntegrationImplementation project(":apps:portal-search:portal-search-api")
 	testIntegrationImplementation project(":apps:portal-security:portal-security-permission-test-util")
+	testIntegrationImplementation project(":apps:portal-validation:portal-validation-api")
 	testIntegrationImplementation project(":apps:portal-vulcan:portal-vulcan-api")
 	testIntegrationImplementation project(":apps:portal:portal-local-service-tree-test-util")
 	testIntegrationImplementation project(":apps:portal:portal-notifications-test-util")

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/validation/test/JournalArticleModelValidatorTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/internal/validation/test/JournalArticleModelValidatorTest.java
@@ -1,0 +1,114 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.internal.validation.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.dynamic.data.mapping.exception.NoSuchStructureException;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.test.util.DDMStructureTestUtil;
+import com.liferay.dynamic.data.mapping.test.util.DDMTemplateTestUtil;
+import com.liferay.journal.exception.NoSuchFolderException;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.validation.ModelValidator;
+
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Balázs Sáfrány-Kovalik
+ */
+@RunWith(Arquillian.class)
+public class JournalArticleModelValidatorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_ddmStructure = DDMStructureTestUtil.addStructure(
+			_group.getGroupId(), JournalArticle.class.getName());
+
+		_ddmTemplate = DDMTemplateTestUtil.addTemplate(
+			_group.getGroupId(), _ddmStructure.getStructureId(),
+			_portal.getClassNameId(JournalArticle.class));
+	}
+
+	@Test
+	public void testValidateReferences() throws PortalException {
+		ReflectionTestUtil.invoke(
+			_journalArticleModelValidator, "validateReferences",
+			new Class<?>[] {
+				long.class, long.class, long.class, String.class, String.class,
+				boolean.class, String.class, byte[].class, long.class,
+				int.class, String.class
+			},
+			_group.getGroupId(), 0, _ddmStructure.getStructureId(),
+			_ddmTemplate.getTemplateKey(), null, false, null, null, 0, 0,
+			StringPool.BLANK);
+	}
+
+	@Test(expected = NoSuchStructureException.class)
+	public void testValidateReferencesInvalidDDMStructureId()
+		throws PortalException {
+
+		ReflectionTestUtil.invoke(
+			_journalArticleModelValidator, "validateReferences",
+			new Class<?>[] {
+				long.class, long.class, long.class, String.class, String.class,
+				boolean.class, String.class, byte[].class, long.class,
+				int.class, String.class
+			},
+			_group.getGroupId(), 0, -1, _ddmTemplate.getTemplateKey(), null,
+			false, null, null, 0, 0, StringPool.BLANK);
+	}
+
+	@Test(expected = NoSuchFolderException.class)
+	public void testValidateReferencesInvalidFolderId() throws PortalException {
+		ReflectionTestUtil.invoke(
+			_journalArticleModelValidator, "validateReferences",
+			new Class<?>[] {
+				long.class, long.class, long.class, String.class, String.class,
+				boolean.class, String.class, byte[].class, long.class,
+				int.class, String.class
+			},
+			_group.getGroupId(), -1, _ddmStructure.getStructureId(),
+			_ddmTemplate.getTemplateKey(), null, false, null, null, 0, 0,
+			StringPool.BLANK);
+	}
+
+	private DDMStructure _ddmStructure;
+	private DDMTemplate _ddmTemplate;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject(
+		filter = "model.class.name=com.liferay.journal.model.JournalArticle"
+	)
+	private ModelValidator<JournalArticle> _journalArticleModelValidator;
+
+	@Inject
+	private Portal _portal;
+
+}


### PR DESCRIPTION
Motivation
=======
If a JournalArticle gets created with an invalid folderId, the JournalPortlet will not be able to display any articles

Proposed Solution
========
Force a folderId validation through JournalArticleModelValidator

Steps to Verify
========
1. Go to Content & Data > Web Content
2. Add a Basic Web Content and publish
3. Edit the web content
4. Open the browser developer tools and find the element with the id=”_com_liferay_journal_web_portlet_JournalPortlet_folderId"
5. Change the value attribute from 0 to -1 and press enter
6. Press the Save as Draft button
7. An error page appears
8. Go back to Content & Data > Web Content

**Expected behaviour:** The page loads the web content
**Actual behaviour:** The Page does not load any web content