### PR TITLE
LPS-197782 Add context title to back button in Fragment

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/EditFragmentEntryDisplayContext.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/display/context/EditFragmentEntryDisplayContext.java
@@ -623,6 +623,7 @@ public class EditFragmentEntryDisplayContext {
 
 		portletDisplay.setShowBackIcon(true);
 		portletDisplay.setURLBack(getRedirect());
+		portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 		FragmentEntry fragmentEntry = getFragmentEntry();
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_collection.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/edit_fragment_collection.jsp
@@ -14,6 +14,7 @@ FragmentCollection fragmentCollection = FragmentCollectionLocalServiceUtil.fetch
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(fragmentEntriesDisplayContext.getRedirect());
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle((fragmentCollection != null) ? fragmentCollection.getName() : LanguageUtil.get(request, "add-fragment-set"));
 %>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entry_usages.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_fragment_entry_usages.jsp
@@ -14,6 +14,7 @@ FragmentEntry fragmentEntry = fragmentEntryLinkDisplayContext.getFragmentEntry()
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(fragmentEntryLinkDisplayContext.getRedirect());
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle(LanguageUtil.format(request, "usages-and-propagation-x", fragmentEntry.getName()));
 %>

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_group_fragment_entry_usages.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_group_fragment_entry_usages.jsp
@@ -14,6 +14,7 @@ FragmentEntry fragmentEntry = groupFragmentEntryLinkDisplayContext.getFragmentEn
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(groupFragmentEntryLinkDisplayContext.getRedirect());
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle(LanguageUtil.format(request, "usages-and-propagation-x", fragmentEntry.getName()));
 %>


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-197782)

## Steps 
**- Case 1**
- Go to Design > Fragments > Create a fragment set > edit the fragment set > see back button
<img width="219" alt="Screenshot 2023-10-02 at 12 28 07" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/b7efe970-e27a-4cfc-9fa7-67e1ba38aad7">

**- Case 2**
- Go to Design > Fragments > Create a fragment set 
- Create a fragment entry > Edit the fragment entry > see back button
<img width="293" alt="Screenshot 2023-10-02 at 12 27 01" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/057333c3-a10c-4fe0-9a78-1ed1f50e1f0e">

**- Case 3**
- Go to Design > Fragments > Create a fragment set 
- Create a fragment entry 
- Go to Site Builder > Pages > create a content page
- Add the fragment created to the page
- Go to Design > Fragments > select the kebab of the fragment created
- Go to view usages
<img width="212" alt="Screenshot 2023-10-02 at 12 29 52" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/8b9ee088-2d6d-4098-92ed-9e2b2efbddb5">

**- Case 4**
- Go to global site 
- Go to Design > Fragments > Create a fragment set 
- Create a fragment entry 
- Go back to the previous site
- Go to Site Builder > Pages > create a content page
- Add the fragment created in global site to the page > publish
- Go back to global site
- Go to Design > Fragments > select the kebab of the fragment created
- Go to view usages
![Screenshot 2023-10-02 at 12 31 29](https://github.com/liferay-echo/liferay-portal/assets/91208451/f2c2e482-63a5-48fc-afbc-1edd56dc6ef8)
