### PR TITLE
LPS 197678 Add rename option for folders

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/UpdateLayoutPageTemplateCollectionMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/UpdateLayoutPageTemplateCollectionMVCActionCommand.java
@@ -1,0 +1,115 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.admin.web.internal.portlet.action;
+
+import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
+import com.liferay.layout.page.template.exception.DuplicateLayoutPageTemplateCollectionException;
+import com.liferay.layout.page.template.exception.LayoutPageTemplateCollectionNameException;
+import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionService;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.portlet.JSONPortletResponseUtil;
+import com.liferay.portal.kernel.portlet.bridges.mvc.BaseMVCActionCommand;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+
+import javax.portlet.ActionRequest;
+import javax.portlet.ActionResponse;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Yurena Cabrera
+ */
+@Component(
+	property = {
+		"javax.portlet.name=" + LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES,
+		"mvc.command.name=/layout_page_template_admin/update_layout_page_template_collection"
+	},
+	service = MVCActionCommand.class
+)
+public class UpdateLayoutPageTemplateCollectionMVCActionCommand
+	extends BaseMVCActionCommand {
+
+	@Override
+	protected void doProcessAction(
+			ActionRequest actionRequest, ActionResponse actionResponse)
+		throws Exception {
+
+		JSONObject jsonObject = _jsonFactory.createJSONObject();
+
+		long layoutPageTemplateCollectionId = ParamUtil.getLong(
+			actionRequest, "layoutPageTemplateCollectionId");
+
+		String name = ParamUtil.getString(actionRequest, "name");
+
+		try {
+			_layoutPageTemplateCollectionService.
+				updateLayoutPageTemplateCollection(
+					layoutPageTemplateCollectionId, name);
+
+			jsonObject.put(
+				"redirectURL", ParamUtil.getString(actionRequest, "redirect"));
+		}
+		catch (PortalException portalException) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(portalException);
+			}
+
+			if (portalException instanceof
+					DuplicateLayoutPageTemplateCollectionException) {
+
+				jsonObject.put(
+					"error",
+					_language.get(
+						_portal.getHttpServletRequest(actionRequest),
+						"please-enter-a-unique-folder-name"));
+			}
+			else if (portalException instanceof
+						LayoutPageTemplateCollectionNameException) {
+
+				jsonObject.put(
+					"error",
+					_language.get(
+						_portal.getHttpServletRequest(actionRequest),
+						"please-enter-a-valid-folder-name"));
+			}
+			else {
+				jsonObject.put(
+					"error",
+					_language.get(
+						_portal.getHttpServletRequest(actionRequest),
+						"an-unexpected-error-occurred"));
+			}
+		}
+
+		JSONPortletResponseUtil.writeJSON(
+			actionRequest, actionResponse, jsonObject);
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		UpdateLayoutPageTemplateCollectionMVCActionCommand.class);
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Language _language;
+
+	@Reference
+	private LayoutPageTemplateCollectionService
+		_layoutPageTemplateCollectionService;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateCollectionActionDropdownItem.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateCollectionActionDropdownItem.java
@@ -80,6 +80,43 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 					DropdownItemListBuilder.add(
 						() -> LayoutPageTemplateCollectionPermission.contains(
 							themeDisplay.getPermissionChecker(),
+							layoutPageTemplateCollection, ActionKeys.UPDATE),
+						dropdownItem -> {
+							dropdownItem.putData(
+								"action", "updateLayoutPageTemplateCollection");
+							dropdownItem.putData(
+								"updateLayoutPageTemplateCollectionURL",
+								PortletURLBuilder.createActionURL(
+									_renderResponse
+								).setActionName(
+									"/layout_page_template_admin" +
+										"/update_layout_page_template_" +
+											"collection"
+								).setRedirect(
+									PortletURLBuilder.createRenderURL(
+										_renderResponse
+									).setTabs1(
+										tabs1
+									).buildString()
+								).setParameter(
+									"layoutPageTemplateCollectionId",
+									layoutPageTemplateCollection.
+										getLayoutPageTemplateCollectionId()
+								).buildString());
+							dropdownItem.setIcon("pencil");
+							dropdownItem.setLabel(
+								LanguageUtil.get(
+									_httpServletRequest, "rename"));
+						}
+					).build());
+				dropdownGroupItem.setSeparator(true);
+			}
+		).addGroup(
+			dropdownGroupItem -> {
+				dropdownGroupItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						() -> LayoutPageTemplateCollectionPermission.contains(
+							themeDisplay.getPermissionChecker(),
 							layoutPageTemplateCollection,
 							ActionKeys.PERMISSIONS),
 						dropdownItem -> {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateCollectionActionDropdownItem.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateCollectionActionDropdownItem.java
@@ -53,20 +53,9 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 							layoutPageTemplateCollection, ActionKeys.UPDATE),
 						dropdownItem -> {
 							dropdownItem.setHref(
-								PortletURLBuilder.createRenderURL(
-									_renderResponse
-								).setMVCRenderCommandName(
-									"/layout_page_template_admin" +
-										"/edit_layout_page_template_collection"
-								).setRedirect(
-									themeDisplay.getURLCurrent()
-								).setTabs1(
-									tabs1
-								).setParameter(
-									"layoutPageTemplateCollectionId",
-									layoutPageTemplateCollection.
-										getLayoutPageTemplateCollectionId()
-								).buildString());
+								_getEditLayoutPageTemplateCollectionURL(
+									layoutPageTemplateCollection, tabs1,
+									themeDisplay));
 							dropdownItem.setIcon("pencil");
 							dropdownItem.setLabel(
 								LanguageUtil.get(_httpServletRequest, "edit"));
@@ -85,24 +74,12 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 							dropdownItem.putData(
 								"action", "updateLayoutPageTemplateCollection");
 							dropdownItem.putData(
+								"layoutPageTemplateCollectionName",
+								layoutPageTemplateCollection.getName());
+							dropdownItem.putData(
 								"updateLayoutPageTemplateCollectionURL",
-								PortletURLBuilder.createActionURL(
-									_renderResponse
-								).setActionName(
-									"/layout_page_template_admin" +
-										"/update_layout_page_template_" +
-											"collection"
-								).setRedirect(
-									PortletURLBuilder.createRenderURL(
-										_renderResponse
-									).setTabs1(
-										tabs1
-									).buildString()
-								).setParameter(
-									"layoutPageTemplateCollectionId",
-									layoutPageTemplateCollection.
-										getLayoutPageTemplateCollectionId()
-								).buildString());
+								_getUpdateLayoutPageTemplateCollectionURL(
+									layoutPageTemplateCollection, tabs1));
 							dropdownItem.setIcon("pencil");
 							dropdownItem.setLabel(
 								LanguageUtil.get(
@@ -125,17 +102,8 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 								"permissionsLayoutPageTemplateCollection");
 							dropdownItem.putData(
 								"permissionsLayoutPageTemplateCollectionURL",
-								PermissionsURLTag.doTag(
-									StringPool.BLANK,
-									LayoutPageTemplateCollection.class.
-										getName(),
-									layoutPageTemplateCollection.getName(),
-									null,
-									String.valueOf(
-										layoutPageTemplateCollection.
-											getLayoutPageTemplateCollectionId()),
-									LiferayWindowState.POP_UP.toString(), null,
-									_httpServletRequest));
+								_getPermissionsLayoutPageTemplateCollectionURL(
+									layoutPageTemplateCollection));
 							dropdownItem.setIcon("password-policies");
 							dropdownItem.setLabel(
 								LanguageUtil.get(
@@ -156,26 +124,8 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 								"action", "deleteLayoutPageTemplateCollection");
 							dropdownItem.putData(
 								"deleteLayoutPageTemplateCollectionURL",
-								PortletURLBuilder.createActionURL(
-									_renderResponse
-								).setActionName(
-									"/layout_page_template_admin/delete_" +
-										"layout_page_template_collection"
-								).setRedirect(
-									PortletURLBuilder.createRenderURL(
-										_renderResponse
-									).setTabs1(
-										tabs1
-									).setParameter(
-										"layoutPageTemplateCollectionId",
-										layoutPageTemplateCollection.
-											getParentLayoutPageTemplateCollectionId()
-									).buildString()
-								).setParameter(
-									"layoutPageTemplateCollectionId",
-									layoutPageTemplateCollection.
-										getLayoutPageTemplateCollectionId()
-								).buildString());
+								_getDeleteLayoutPageTemplateCollectionURL(
+									layoutPageTemplateCollection, tabs1));
 							dropdownItem.setIcon("trash");
 							dropdownItem.setLabel(
 								LanguageUtil.get(
@@ -185,6 +135,81 @@ public class LayoutPageTemplateCollectionActionDropdownItem {
 				dropdownGroupItem.setSeparator(true);
 			}
 		).build();
+	}
+
+	private String _getDeleteLayoutPageTemplateCollectionURL(
+		LayoutPageTemplateCollection layoutPageTemplateCollection,
+		String tabs1) {
+
+		return PortletURLBuilder.createActionURL(
+			_renderResponse
+		).setActionName(
+			"/layout_page_template_admin/delete_layout_page_template_collection"
+		).setRedirect(
+			PortletURLBuilder.createRenderURL(
+				_renderResponse
+			).setTabs1(
+				tabs1
+			).setParameter(
+				"layoutPageTemplateCollectionId",
+				layoutPageTemplateCollection.
+					getParentLayoutPageTemplateCollectionId()
+			).buildString()
+		).setParameter(
+			"layoutPageTemplateCollectionId",
+			layoutPageTemplateCollection.getLayoutPageTemplateCollectionId()
+		).buildString();
+	}
+
+	private String _getEditLayoutPageTemplateCollectionURL(
+		LayoutPageTemplateCollection layoutPageTemplateCollection, String tabs1,
+		ThemeDisplay themeDisplay) {
+
+		return PortletURLBuilder.createRenderURL(
+			_renderResponse
+		).setMVCRenderCommandName(
+			"/layout_page_template_admin/edit_layout_page_template_collection"
+		).setRedirect(
+			themeDisplay.getURLCurrent()
+		).setTabs1(
+			tabs1
+		).setParameter(
+			"layoutPageTemplateCollectionId",
+			layoutPageTemplateCollection.getLayoutPageTemplateCollectionId()
+		).buildString();
+	}
+
+	private String _getPermissionsLayoutPageTemplateCollectionURL(
+			LayoutPageTemplateCollection layoutPageTemplateCollection)
+		throws Exception {
+
+		return PermissionsURLTag.doTag(
+			StringPool.BLANK, LayoutPageTemplateCollection.class.getName(),
+			layoutPageTemplateCollection.getName(), null,
+			String.valueOf(
+				layoutPageTemplateCollection.
+					getLayoutPageTemplateCollectionId()),
+			LiferayWindowState.POP_UP.toString(), null, _httpServletRequest);
+	}
+
+	private String _getUpdateLayoutPageTemplateCollectionURL(
+		LayoutPageTemplateCollection layoutPageTemplateCollection,
+		String tabs1) {
+
+		return PortletURLBuilder.createActionURL(
+			_renderResponse
+		).setActionName(
+			"/layout_page_template_admin/update_layout_page_template_collection"
+		).setRedirect(
+			PortletURLBuilder.createRenderURL(
+				_renderResponse
+			).setTabs1(
+				tabs1
+			).buildString()
+		).setParameter(
+			"layoutPageTemplateCollectionId",
+			layoutPageTemplateCollection.getLayoutPageTemplateCollectionId()
+		).buildString();
 	}
 
 	private final HttpServletRequest _httpServletRequest;

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPageTemplateCollectionPropsTransformer.js
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/js/propsTransformers/LayoutPageTemplateCollectionPropsTransformer.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {openModal} from 'frontend-js-web';
+import {openModal, openSimpleInputModal} from 'frontend-js-web';
 
 import openDeletePageTemplateModal from '../modal/openDeletePageTemplateModal';
 
@@ -30,6 +30,24 @@ const ACTIONS = {
 			url: permissionsLayoutPageTemplateCollectionURL,
 		});
 	},
+
+	updateLayoutPageTemplateCollection(
+		{
+			layoutPageTemplateCollectionName,
+			updateLayoutPageTemplateCollectionURL,
+		},
+		portletNamespace
+	) {
+		openSimpleInputModal({
+			dialogTitle: Liferay.Language.get('rename-display-page-template'),
+			formSubmitURL: updateLayoutPageTemplateCollectionURL,
+			mainFieldLabel: Liferay.Language.get('name'),
+			mainFieldName: 'name',
+			mainFieldPlaceholder: Liferay.Language.get('name'),
+			mainFieldValue: layoutPageTemplateCollectionName,
+			namespace: portletNamespace,
+		});
+	},
 };
 
 const updateItem = (item, portletNamespace) => {
@@ -47,7 +65,9 @@ const updateItem = (item, portletNamespace) => {
 	};
 
 	if (Array.isArray(item.items)) {
-		newItem.items = item.items.map(updateItem);
+		newItem.items = item.items.map((item) =>
+			updateItem(item, portletNamespace)
+		);
 	}
 
 	return newItem;

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalService.java
@@ -382,6 +382,10 @@ public interface LayoutPageTemplateCollectionLocalService
 		LayoutPageTemplateCollection layoutPageTemplateCollection);
 
 	public LayoutPageTemplateCollection updateLayoutPageTemplateCollection(
+			long layoutPageTemplateCollectionId, String name)
+		throws PortalException;
+
+	public LayoutPageTemplateCollection updateLayoutPageTemplateCollection(
 			long layoutPageTemplateCollectionId, String name,
 			String description)
 		throws PortalException;

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalServiceUtil.java
@@ -465,6 +465,15 @@ public class LayoutPageTemplateCollectionLocalServiceUtil {
 
 	public static LayoutPageTemplateCollection
 			updateLayoutPageTemplateCollection(
+				long layoutPageTemplateCollectionId, String name)
+		throws PortalException {
+
+		return getService().updateLayoutPageTemplateCollection(
+			layoutPageTemplateCollectionId, name);
+	}
+
+	public static LayoutPageTemplateCollection
+			updateLayoutPageTemplateCollection(
 				long layoutPageTemplateCollectionId, String name,
 				String description)
 		throws PortalException {

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionLocalServiceWrapper.java
@@ -524,6 +524,16 @@ public class LayoutPageTemplateCollectionLocalServiceWrapper
 
 	@Override
 	public LayoutPageTemplateCollection updateLayoutPageTemplateCollection(
+			long layoutPageTemplateCollectionId, String name)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutPageTemplateCollectionLocalService.
+			updateLayoutPageTemplateCollection(
+				layoutPageTemplateCollectionId, name);
+	}
+
+	@Override
+	public LayoutPageTemplateCollection updateLayoutPageTemplateCollection(
 			long layoutPageTemplateCollectionId, String name,
 			String description)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionService.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionService.java
@@ -97,6 +97,10 @@ public interface LayoutPageTemplateCollectionService extends BaseService {
 	public String getOSGiServiceIdentifier();
 
 	public LayoutPageTemplateCollection updateLayoutPageTemplateCollection(
+			long layoutPageTemplateCollectionId, String name)
+		throws PortalException;
+
+	public LayoutPageTemplateCollection updateLayoutPageTemplateCollection(
 			long layoutPageTemplateCollectionId, String name,
 			String description)
 		throws PortalException;

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionServiceUtil.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionServiceUtil.java
@@ -124,6 +124,15 @@ public class LayoutPageTemplateCollectionServiceUtil {
 
 	public static LayoutPageTemplateCollection
 			updateLayoutPageTemplateCollection(
+				long layoutPageTemplateCollectionId, String name)
+		throws PortalException {
+
+		return getService().updateLayoutPageTemplateCollection(
+			layoutPageTemplateCollectionId, name);
+	}
+
+	public static LayoutPageTemplateCollection
+			updateLayoutPageTemplateCollection(
 				long layoutPageTemplateCollectionId, String name,
 				String description)
 		throws PortalException {

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionServiceWrapper.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/service/LayoutPageTemplateCollectionServiceWrapper.java
@@ -139,6 +139,16 @@ public class LayoutPageTemplateCollectionServiceWrapper
 
 	@Override
 	public LayoutPageTemplateCollection updateLayoutPageTemplateCollection(
+			long layoutPageTemplateCollectionId, String name)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _layoutPageTemplateCollectionService.
+			updateLayoutPageTemplateCollection(
+				layoutPageTemplateCollectionId, name);
+	}
+
+	@Override
+	public LayoutPageTemplateCollection updateLayoutPageTemplateCollection(
 			long layoutPageTemplateCollectionId, String name,
 			String description)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/service/packageinfo
@@ -1,1 +1,1 @@
-version 8.0.0
+version 8.1.0

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateCollectionServiceHttp.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/http/LayoutPageTemplateCollectionServiceHttp.java
@@ -486,6 +486,51 @@ public class LayoutPageTemplateCollectionServiceHttp {
 		}
 	}
 
+	public static
+		com.liferay.layout.page.template.model.LayoutPageTemplateCollection
+				updateLayoutPageTemplateCollection(
+					HttpPrincipal httpPrincipal,
+					long layoutPageTemplateCollectionId, String name)
+			throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				LayoutPageTemplateCollectionServiceUtil.class,
+				"updateLayoutPageTemplateCollection",
+				_updateLayoutPageTemplateCollectionParameterTypes11);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, layoutPageTemplateCollectionId, name);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.layout.page.template.model.
+				LayoutPageTemplateCollection)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	private static Log _log = LogFactoryUtil.getLog(
 		LayoutPageTemplateCollectionServiceHttp.class);
 
@@ -535,6 +580,10 @@ public class LayoutPageTemplateCollectionServiceHttp {
 	private static final Class<?>[]
 		_updateLayoutPageTemplateCollectionParameterTypes10 = new Class[] {
 			long.class, String.class, String.class
+		};
+	private static final Class<?>[]
+		_updateLayoutPageTemplateCollectionParameterTypes11 = new Class[] {
+			long.class, String.class
 		};
 
 }

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionLocalServiceImpl.java
@@ -269,6 +269,32 @@ public class LayoutPageTemplateCollectionLocalServiceImpl
 
 	@Override
 	public LayoutPageTemplateCollection updateLayoutPageTemplateCollection(
+			long layoutPageTemplateCollectionId, String name)
+		throws PortalException {
+
+		LayoutPageTemplateCollection layoutPageTemplateCollection =
+			layoutPageTemplateCollectionPersistence.findByPrimaryKey(
+				layoutPageTemplateCollectionId);
+
+		if (!Objects.equals(layoutPageTemplateCollection.getName(), name)) {
+			_validate(
+				layoutPageTemplateCollection.getGroupId(), name,
+				layoutPageTemplateCollection.getType());
+		}
+
+		layoutPageTemplateCollection.setModifiedDate(new Date());
+		layoutPageTemplateCollection.setLayoutPageTemplateCollectionKey(
+			_generateLayoutPageTemplateCollectionKey(
+				layoutPageTemplateCollection.getGroupId(), name,
+				layoutPageTemplateCollection.getType()));
+		layoutPageTemplateCollection.setName(name);
+
+		return layoutPageTemplateCollectionPersistence.update(
+			layoutPageTemplateCollection);
+	}
+
+	@Override
+	public LayoutPageTemplateCollection updateLayoutPageTemplateCollection(
 			long layoutPageTemplateCollectionId, String name,
 			String description)
 		throws PortalException {

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateCollectionServiceImpl.java
@@ -155,6 +155,20 @@ public class LayoutPageTemplateCollectionServiceImpl
 
 	@Override
 	public LayoutPageTemplateCollection updateLayoutPageTemplateCollection(
+			long layoutPageTemplateCollectionId, String name)
+		throws PortalException {
+
+		_layoutPageTemplateCollectionModelResourcePermission.check(
+			getPermissionChecker(), layoutPageTemplateCollectionId,
+			ActionKeys.UPDATE);
+
+		return layoutPageTemplateCollectionLocalService.
+			updateLayoutPageTemplateCollection(
+				layoutPageTemplateCollectionId, name);
+	}
+
+	@Override
+	public LayoutPageTemplateCollection updateLayoutPageTemplateCollection(
 			long layoutPageTemplateCollectionId, String name,
 			String description)
 		throws PortalException {


### PR DESCRIPTION
Motivation
=======
Rename should be an available option for recently created folders for Diplay Page Templates

Proposed Solution
========
Implement the rename option

Steps to Verify
========
1. Go to Design > Page Templates > Display Page Templates Tab
2. Create a new Folder
3. Use the Kebab menu to display available actions for that folder
4. Select Rename, choose a different name and ensure is persisted.
 
Screenshots (if applies)
========
<img width="522" alt="RenameActionForDPTFolders" src="https://github.com/liferay-echo/liferay-portal/assets/85171101/c3bd8520-57b2-45e1-af42-3b164a964fa3">

Commits
========
- LPS-197678 Add rename option in dropdown item
- LPS-197678 Add update ActionCommand for displayPageTemplateCollections
- LPS-197678 Add renamePageTemplateCollectionModal to show a popup when rename option selected for DisplayPageTemplateSollections
