### PR TITLE
LPS-195017 Remove soy from dynamic-data-mapping modules

### DIFF
--- a/modules/sdk/project-templates/project-templates-form-field/src/main/java/com/liferay/project/templates/form/field/internal/FormFieldProjectTemplateCustomizer.java
+++ b/modules/sdk/project-templates/project-templates-form-field/src/main/java/com/liferay/project/templates/form/field/internal/FormFieldProjectTemplateCustomizer.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.maven.archetype.ArchetypeGenerationRequest;
 import org.apache.maven.archetype.ArchetypeGenerationResult;
 
 /**
@@ -149,20 +148,6 @@ public class FormFieldProjectTemplateCustomizer
 			ProjectTemplateCustomizer.deleteFileInPath(
 				fileName, projectDirPath);
 		}
-	}
-
-	@Override
-	public void onBeforeGenerateProject(
-			ProjectTemplatesArgs projectTemplatesArgs,
-			ArchetypeGenerationRequest archetypeGenerationRequest)
-		throws Exception {
-
-		setProperty(
-			archetypeGenerationRequest.getProperties(), "reactTemplate",
-			String.valueOf(
-				_isReactFramework(
-					(FormFieldProjectTemplatesArgs)
-						projectTemplatesArgs.getProjectTemplatesArgsExt())));
 	}
 
 	private boolean _isReactFramework(

--- a/modules/sdk/project-templates/project-templates-form-field/src/main/resources/META-INF/maven/archetype-metadata.xml
+++ b/modules/sdk/project-templates/project-templates-form-field/src/main/resources/META-INF/maven/archetype-metadata.xml
@@ -41,8 +41,5 @@
 		<requiredProperty key="liferayVersion">
 			<validationRegex>^[0-7]\.\d+\.\d+.*</validationRegex>
 		</requiredProperty>
-		<requiredProperty key="reactTemplate">
-			<defaultValue>false</defaultValue>
-		</requiredProperty>
 	</requiredProperties>
 </archetype-descriptor>

--- a/modules/sdk/project-templates/project-templates-form-field/src/main/resources/archetype-resources/.babelrc
+++ b/modules/sdk/project-templates/project-templates-form-field/src/main/resources/archetype-resources/.babelrc
@@ -1,6 +1,6 @@
 {
 #if (!(${liferayVersion.startsWith("7.0")} || ${liferayVersion.startsWith("7.1")}))
-	"presets": ["@babel/preset-env"#if(!(${liferayVersion.startsWith("7.0")} || ${liferayVersion.startsWith("7.1")} || ${liferayVersion.startsWith("7.2")}) && ${reactTemplate.equals("true")}), "@babel/preset-react"#end]
+	"presets": ["@babel/preset-env"#if(!(${liferayVersion.startsWith("7.0")} || ${liferayVersion.startsWith("7.1")} || ${liferayVersion.startsWith("7.2")})), "@babel/preset-react"#end]
 #else
 	"presets": ["es2015", "liferay-project"]
 #end

--- a/modules/sdk/project-templates/project-templates-form-field/src/main/resources/archetype-resources/bnd.bnd
+++ b/modules/sdk/project-templates/project-templates-form-field/src/main/resources/archetype-resources/bnd.bnd
@@ -5,7 +5,7 @@ Bundle-Version: ${version}
 #if (!(${liferayVersion.startsWith("7.2")} || ${liferayVersion.startsWith("7.3")}))
 Liferay-JS-Config: /META-INF/resources/config.js
 #end
-#if ((!${liferayVersion.startsWith("7.0")} || (!${liferayVersion.startsWith("7.1")}) && !${reactTemplate.equals("true")}))
+#if ((!${liferayVersion.startsWith("7.0")} || (!${liferayVersion.startsWith("7.1")})))
 Provide-Capability:\
 	soy;\
 		type:String="LiferayFormField"

--- a/modules/sdk/project-templates/project-templates-form-field/src/main/resources/archetype-resources/package.json
+++ b/modules/sdk/project-templates/project-templates-form-field/src/main/resources/archetype-resources/package.json
@@ -15,7 +15,7 @@
 		#elseif (${liferayVersion.startsWith("7.4")})
 		"@liferay/portal-7.4": "*"
 		#end
-		#if (!((${liferayVersion.startsWith("7.3")} || ${liferayVersion.startsWith("7.4")}) && ${reactTemplate.equals("true")})),
+		#if (!((${liferayVersion.startsWith("7.3")} || ${liferayVersion.startsWith("7.4")}))),
 		"metal-tools-soy": "4.3.2"
 		#end
 #else
@@ -36,8 +36,8 @@
 	"name": "dynamic-data-${artifactId}-form-field",
 	"scripts": {
 #if (!(${liferayVersion.startsWith("7.0")} || ${liferayVersion.startsWith("7.1")}))
-		"build": "#if (!((${liferayVersion.startsWith("7.3")} || ${liferayVersion.startsWith("7.4")}) && ${reactTemplate.equals("true")}))npm run build-soy &&#end npm run build-js && liferay-npm-bundler",
-		"build-js": "babel --source-maps -d build/resources/main/META-INF/resources src/main/resources/META-INF/resources"#if (!((${liferayVersion.startsWith("7.3")} || ${liferayVersion.startsWith("7.4")}) && ${reactTemplate.equals("true")})),
+		"build": "#if (!((${liferayVersion.startsWith("7.3")} || ${liferayVersion.startsWith("7.4")})))npm run build-soy &&#end npm run build-js && liferay-npm-bundler",
+		"build-js": "babel --source-maps -d build/resources/main/META-INF/resources src/main/resources/META-INF/resources"#if (!((${liferayVersion.startsWith("7.3")} || ${liferayVersion.startsWith("7.4")}))),
 		"build-soy": "metalsoy --externalMsgFormat \"Liferay.Language.get('\\$2')\" --soyDeps \"../../node_modules/clay-*/src/**/*.soy\" \"../../node_modules/com.liferay.dynamic.data.mapping.form.field.type/META-INF/resources/+(FieldBase|components)/**/*.soy\""
 		#end
 #else

--- a/modules/sdk/project-templates/project-templates-form-field/src/main/resources/archetype-resources/src/main/resources/META-INF/resources/__artifactId__.es.js
+++ b/modules/sdk/project-templates/project-templates-form-field/src/main/resources/archetype-resources/src/main/resources/META-INF/resources/__artifactId__.es.js
@@ -1,4 +1,4 @@
-#if (!(${liferayVersion.startsWith("7.0")} && ${liferayVersion.startsWith("7.1")} && ${liferayVersion.startsWith("7.2")}) && ${reactTemplate.equals("true")})
+#if (!(${liferayVersion.startsWith("7.0")} && ${liferayVersion.startsWith("7.1")} && ${liferayVersion.startsWith("7.2")}))
 import React from 'react';
 import {FieldBase} from 'dynamic-data-mapping-form-field-type/FieldBase/ReactFieldBase.es';
 import {useSyncValue} from 'dynamic-data-mapping-form-field-type/hooks/useSyncValue.es';
@@ -9,12 +9,12 @@ import templates from './${artifactId}.soy.js';
 import {Config} from 'metal-state';
 #end
 
-#if (${liferayVersion.startsWith("7.0")} || ${liferayVersion.startsWith("7.1")} || ${liferayVersion.startsWith("7.2")} || !${reactTemplate.equals("true")})
+#if (${liferayVersion.startsWith("7.0")} || ${liferayVersion.startsWith("7.1")} || ${liferayVersion.startsWith("7.2")})
 import Component from 'metal-component';
 import Soy from 'metal-soy';
 #end
 
-#if (!(${liferayVersion.startsWith("7.0")} && ${liferayVersion.startsWith("7.1")} && ${liferayVersion.startsWith("7.2")}) && ${reactTemplate.equals("true")})
+#if (!(${liferayVersion.startsWith("7.0")} && ${liferayVersion.startsWith("7.1")} && ${liferayVersion.startsWith("7.2")}))
 const ${className} = ({name, onChange, predefinedValue, readOnly, value}) =>
 		<input
 			className="ddm-field-${artifactId} form-control ${artifactId}"
@@ -116,6 +116,6 @@ ${className}.STATE = {
 Soy.register(${className}, templates);
 #end
 
-#if (${liferayVersion.startsWith("7.0")} || ${liferayVersion.startsWith("7.1")} || ${liferayVersion.startsWith("7.2")} || !${reactTemplate.equals("true")})
+#if (${liferayVersion.startsWith("7.0")} || ${liferayVersion.startsWith("7.1")} || ${liferayVersion.startsWith("7.2")})
 export default ${className};
 #end


### PR DESCRIPTION
Here I have removed unused soy files from dynamic-data-mapping-form-field type.

The only remaining usage lives in project-templates-form-field, and I have updated that to enforce using React for new projects. That way those templates cannot depend on Soy unless they are created for a previous portal release.