### PR TITLE
[TS] LPS-197922 NPE - Unable to process portlet com_liferay_layout_content_page_editor_web_internal_portlet_ContentPageEditorPortlet

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/ContentManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/util/ContentManager.java
@@ -735,6 +735,13 @@ public class ContentManager {
 					getLayoutDisplayPageProviderByClassName(
 						layoutClassedModelUsage.getClassName());
 
+			if (layoutDisplayPageProvider == null) {
+				_layoutClassedModelUsageLocalService.
+					deleteLayoutClassedModelUsage(layoutClassedModelUsage);
+
+				continue;
+			}
+
 			LayoutDisplayPageObjectProvider<?> layoutDisplayPageObjectProvider =
 				layoutDisplayPageProvider.getLayoutDisplayPageObjectProvider(
 					_getInfoItemIdentifier(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-197922

If you select manually a DLFolder into an asset publisher and publish it, it crashes content page editor as DLFolder doesn't have a layoutdisplaypageprovider registered.