### PR TITLE
[TS] LPS-198057 Fix login button with called ckeditor invalid

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryValidator.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryValidator.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.servlet.DummyHttpServletResponse;
+import com.liferay.portal.kernel.servlet.taglib.aui.ScriptData;
 import com.liferay.portal.kernel.template.StringTemplateResource;
 import com.liferay.portal.kernel.template.Template;
 import com.liferay.portal.kernel.template.TemplateConstants;
@@ -65,28 +66,33 @@ public class FreeMarkerFragmentEntryValidator
 			return;
 		}
 
+		HttpServletRequest httpServletRequest = null;
+		HttpServletResponse httpServletResponse = null;
+
+		ServiceContext serviceContext =
+			ServiceContextThreadLocal.getServiceContext();
+
+		if (serviceContext != null) {
+			httpServletRequest = serviceContext.getRequest();
+			httpServletResponse = serviceContext.getResponse();
+		}
+
+		if ((httpServletRequest == null) ||
+			(httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY) == null)) {
+
+			return;
+		}
+
+		if (httpServletResponse == null) {
+			httpServletResponse = new DummyHttpServletResponse();
+		}
+
+		ScriptData scriptData = (ScriptData)httpServletRequest.getAttribute(
+			WebKeys.AUI_SCRIPT_DATA);
+
 		try {
-			HttpServletRequest httpServletRequest = null;
-			HttpServletResponse httpServletResponse = null;
-
-			ServiceContext serviceContext =
-				ServiceContextThreadLocal.getServiceContext();
-
-			if (serviceContext != null) {
-				httpServletRequest = serviceContext.getRequest();
-				httpServletResponse = serviceContext.getResponse();
-			}
-
-			if ((httpServletRequest == null) ||
-				(httpServletRequest.getAttribute(WebKeys.THEME_DISPLAY) ==
-					null)) {
-
-				return;
-			}
-
-			if (httpServletResponse == null) {
-				httpServletResponse = new DummyHttpServletResponse();
-			}
+			httpServletRequest.setAttribute(
+				WebKeys.AUI_SCRIPT_DATA, new ScriptData());
 
 			JSONObject configurationDefaultValuesJSONObject =
 				_fragmentEntryConfigurationParser.
@@ -126,6 +132,10 @@ public class FreeMarkerFragmentEntryValidator
 		catch (TemplateException templateException) {
 			throw new FragmentEntryContentException(
 				_getMessage(templateException, locale), templateException);
+		}
+		finally {
+			httpServletRequest.setAttribute(
+				WebKeys.AUI_SCRIPT_DATA, scriptData);
 		}
 	}
 


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPS-198057
cc: @dacousalr 

<h1>Motivation</h1>
Make the login button work correctly
<h1>Proposed Solution</h1>
The proposed solution involved manipulating the WebKeys.AUI_SCRIPT_DATA attribute of the HttpServletRequest object to resolve an issue that affected the functionality of the login button. The change included creating a new empty ScriptData object before processing the FreeMarker model and then restoring the original value in the finally block, in order to avoid rendering unused Javascript code introduced by aui:script taglib in the OTB Rich Text Input fragment when this fragement is validated in the first request
<h1>Steps to Verify</h1>
Steps to reproduce:

Set the following properties in the [portal-ext.properties](http://portal-ext.properties/) file:

setup.wizard.enabled=false 
browser.launcher.url=

The setup.wizard.enabled=false setting is only required if we want to see the issue at the first startup. If this is not set, we need to go through the setup wizard and restart the portal to reproduce the issue.The browser.launcher.url= setting is required to reproduce the issue. 

Start the Liferay from Docker image

Open http://localhost:8080/ in Google Chrome

Expected result: user can log in when credentials typed in and clicked on the ‘Sign in’ button