### PR TITLE
[TS] LPS-198077 Only show description if the group's description for the given locale is not null or empty

### DIFF
--- a/modules/apps/site/site-my-sites-web/src/main/resources/META-INF/resources/post_membership_request.jsp
+++ b/modules/apps/site/site-my-sites-web/src/main/resources/META-INF/resources/post_membership_request.jsp
@@ -44,7 +44,7 @@ Group group = GroupLocalServiceUtil.fetchGroup(groupId);
 
 	<aui:model-context bean="<%= (MembershipRequest)request.getAttribute(WebKeys.MEMBERSHIP_REQUEST) %>" model="<%= MembershipRequest.class %>" />
 
-	<c:if test="<%= Validator.isNotNull(group.getDescription()) %>">
+	<c:if test="<%= Validator.isNotNull(group.getDescription()) && Validator.isNotNull(group.getDescription(locale)) %>">
 		<div class="alert alert-info">
 			<%= HtmlUtil.escape(group.getDescription(locale)) %>
 		</div>


### PR DESCRIPTION
Hi Team,
https://liferay.atlassian.net/browse/LPS-198077

Issue:
After a Site's description was deleted, the description box was still visible while requesting Membership. 
![image](https://github.com/liferay/liferay-portal/assets/97447507/683edc14-dc44-4d6f-938e-b84b9e134964)

Solution:
I put a null check to the description's locale to only show the description when it's not empty, since the full description would never be empty after the first time generating it, since its value is something like this:
`<?xml version='1.0' encoding='UTF-8'?><root available-locales="" default-locale="en_US" />`

I tested this solution in my local environment on master and it worked as expected.

Please review my PR!

Best regards,
Évi