### PR TITLE
LPS-197569 When you create or update a webcontent or a blog using the headless API, the display date is not correct

### DIFF
--- a/modules/apps/blogs/blogs-api/bnd.bnd
+++ b/modules/apps/blogs/blogs-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Blogs API
 Bundle-SymbolicName: com.liferay.blogs.api
-Bundle-Version: 16.3.1
+Bundle-Version: 16.4.0
 Export-Package:\
 	com.liferay.blogs.configuration,\
 	com.liferay.blogs.configuration.definition,\

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryService.java
@@ -65,6 +65,16 @@ public interface BlogsEntryService extends BaseService {
 	public BlogsEntry addEntry(
 			String externalReferenceCode, String title, String subtitle,
 			String urlTitle, String description, String content,
+			Date displayDate, boolean allowPingbacks, boolean allowTrackbacks,
+			String[] trackbacks, String coverImageCaption,
+			ImageSelector coverImageImageSelector,
+			ImageSelector smallImageImageSelector,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public BlogsEntry addEntry(
+			String externalReferenceCode, String title, String subtitle,
+			String urlTitle, String description, String content,
 			int displayDateMonth, int displayDateDay, int displayDateYear,
 			int displayDateHour, int displayDateMinute, boolean allowPingbacks,
 			boolean allowTrackbacks, String[] trackbacks,
@@ -194,6 +204,16 @@ public interface BlogsEntryService extends BaseService {
 			long entryId, String title, String subtitle, String description,
 			String content, int displayDateMonth, int displayDateDay,
 			int displayDateYear, int displayDateHour, int displayDateMinute,
+			boolean allowPingbacks, boolean allowTrackbacks,
+			String[] trackbacks, String coverImageCaption,
+			ImageSelector coverImageImageSelector,
+			ImageSelector smallImageImageSelector,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public BlogsEntry updateEntry(
+			long entryId, String title, String subtitle, String urlTitle,
+			String description, String content, Date displayDate,
 			boolean allowPingbacks, boolean allowTrackbacks,
 			String[] trackbacks, String coverImageCaption,
 			ImageSelector coverImageImageSelector,

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceUtil.java
@@ -60,6 +60,26 @@ public class BlogsEntryServiceUtil {
 	public static BlogsEntry addEntry(
 			String externalReferenceCode, String title, String subtitle,
 			String urlTitle, String description, String content,
+			java.util.Date displayDate, boolean allowPingbacks,
+			boolean allowTrackbacks, String[] trackbacks,
+			String coverImageCaption,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				coverImageImageSelector,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				smallImageImageSelector,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addEntry(
+			externalReferenceCode, title, subtitle, urlTitle, description,
+			content, displayDate, allowPingbacks, allowTrackbacks, trackbacks,
+			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
+			serviceContext);
+	}
+
+	public static BlogsEntry addEntry(
+			String externalReferenceCode, String title, String subtitle,
+			String urlTitle, String description, String content,
 			int displayDateMonth, int displayDateDay, int displayDateYear,
 			int displayDateHour, int displayDateMinute, boolean allowPingbacks,
 			boolean allowTrackbacks, String[] trackbacks,
@@ -296,6 +316,25 @@ public class BlogsEntryServiceUtil {
 			displayDateDay, displayDateYear, displayDateHour, displayDateMinute,
 			allowPingbacks, allowTrackbacks, trackbacks, coverImageCaption,
 			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
+	public static BlogsEntry updateEntry(
+			long entryId, String title, String subtitle, String urlTitle,
+			String description, String content, java.util.Date displayDate,
+			boolean allowPingbacks, boolean allowTrackbacks,
+			String[] trackbacks, String coverImageCaption,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				coverImageImageSelector,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				smallImageImageSelector,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateEntry(
+			entryId, title, subtitle, urlTitle, description, content,
+			displayDate, allowPingbacks, allowTrackbacks, trackbacks,
+			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
+			serviceContext);
 	}
 
 	public static BlogsEntry updateEntry(

--- a/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
+++ b/modules/apps/blogs/blogs-api/src/main/java/com/liferay/blogs/service/BlogsEntryServiceWrapper.java
@@ -59,6 +59,27 @@ public class BlogsEntryServiceWrapper
 	public BlogsEntry addEntry(
 			String externalReferenceCode, String title, String subtitle,
 			String urlTitle, String description, String content,
+			java.util.Date displayDate, boolean allowPingbacks,
+			boolean allowTrackbacks, String[] trackbacks,
+			String coverImageCaption,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				coverImageImageSelector,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				smallImageImageSelector,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _blogsEntryService.addEntry(
+			externalReferenceCode, title, subtitle, urlTitle, description,
+			content, displayDate, allowPingbacks, allowTrackbacks, trackbacks,
+			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
+			serviceContext);
+	}
+
+	@Override
+	public BlogsEntry addEntry(
+			String externalReferenceCode, String title, String subtitle,
+			String urlTitle, String description, String content,
 			int displayDateMonth, int displayDateDay, int displayDateYear,
 			int displayDateHour, int displayDateMinute, boolean allowPingbacks,
 			boolean allowTrackbacks, String[] trackbacks,
@@ -337,6 +358,26 @@ public class BlogsEntryServiceWrapper
 			displayDateDay, displayDateYear, displayDateHour, displayDateMinute,
 			allowPingbacks, allowTrackbacks, trackbacks, coverImageCaption,
 			coverImageImageSelector, smallImageImageSelector, serviceContext);
+	}
+
+	@Override
+	public BlogsEntry updateEntry(
+			long entryId, String title, String subtitle, String urlTitle,
+			String description, String content, java.util.Date displayDate,
+			boolean allowPingbacks, boolean allowTrackbacks,
+			String[] trackbacks, String coverImageCaption,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				coverImageImageSelector,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				smallImageImageSelector,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _blogsEntryService.updateEntry(
+			entryId, title, subtitle, urlTitle, description, content,
+			displayDate, allowPingbacks, allowTrackbacks, trackbacks,
+			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
+			serviceContext);
 	}
 
 	@Override

--- a/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/packageinfo
+++ b/modules/apps/blogs/blogs-api/src/main/resources/com/liferay/blogs/service/packageinfo
@@ -1,1 +1,1 @@
-version 5.2.0
+version 5.3.0

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/http/BlogsEntryServiceHttp.java
@@ -138,6 +138,59 @@ public class BlogsEntryServiceHttp {
 	public static com.liferay.blogs.model.BlogsEntry addEntry(
 			HttpPrincipal httpPrincipal, String externalReferenceCode,
 			String title, String subtitle, String urlTitle, String description,
+			String content, java.util.Date displayDate, boolean allowPingbacks,
+			boolean allowTrackbacks, String[] trackbacks,
+			String coverImageCaption,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				coverImageImageSelector,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				smallImageImageSelector,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				BlogsEntryServiceUtil.class, "addEntry",
+				_addEntryParameterTypes2);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, title, subtitle, urlTitle,
+				description, content, displayDate, allowPingbacks,
+				allowTrackbacks, trackbacks, coverImageCaption,
+				coverImageImageSelector, smallImageImageSelector,
+				serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.blogs.model.BlogsEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.blogs.model.BlogsEntry addEntry(
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			String title, String subtitle, String urlTitle, String description,
 			String content, int displayDateMonth, int displayDateDay,
 			int displayDateYear, int displayDateHour, int displayDateMinute,
 			boolean allowPingbacks, boolean allowTrackbacks,
@@ -152,7 +205,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "addEntry",
-				_addEntryParameterTypes2);
+				_addEntryParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, title, subtitle, urlTitle,
@@ -196,7 +249,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "deleteEntry",
-				_deleteEntryParameterTypes3);
+				_deleteEntryParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -234,7 +287,7 @@ public class BlogsEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class,
 				"fetchBlogsEntryByExternalReferenceCode",
-				_fetchBlogsEntryByExternalReferenceCodeParameterTypes4);
+				_fetchBlogsEntryByExternalReferenceCodeParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -277,7 +330,7 @@ public class BlogsEntryServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class,
 				"getBlogsEntryByExternalReferenceCode",
-				_getBlogsEntryByExternalReferenceCodeParameterTypes5);
+				_getBlogsEntryByExternalReferenceCodeParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -319,7 +372,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getCompanyEntries",
-				_getCompanyEntriesParameterTypes6);
+				_getCompanyEntriesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, displayDate, status, max);
@@ -364,7 +417,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getCompanyEntriesRSS",
-				_getCompanyEntriesRSSParameterTypes7);
+				_getCompanyEntriesRSSParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, displayDate, status, max, type, version,
@@ -405,7 +458,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getEntriesPrevAndNext",
-				_getEntriesPrevAndNextParameterTypes8);
+				_getEntriesPrevAndNextParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -444,7 +497,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getEntry",
-				_getEntryParameterTypes9);
+				_getEntryParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -483,7 +536,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getEntry",
-				_getEntryParameterTypes10);
+				_getEntryParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, urlTitle);
@@ -524,7 +577,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes11);
+				_getGroupEntriesParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, displayDate, status, max);
@@ -559,7 +612,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes12);
+				_getGroupEntriesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, displayDate, status, start, end);
@@ -593,7 +646,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes13);
+				_getGroupEntriesParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, max);
@@ -628,7 +681,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes14);
+				_getGroupEntriesParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, start, end);
@@ -665,7 +718,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntries",
-				_getGroupEntriesParameterTypes15);
+				_getGroupEntriesParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, start, end, orderByComparator);
@@ -699,7 +752,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntriesCount",
-				_getGroupEntriesCountParameterTypes16);
+				_getGroupEntriesCountParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, displayDate, status);
@@ -731,7 +784,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntriesCount",
-				_getGroupEntriesCountParameterTypes17);
+				_getGroupEntriesCountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status);
@@ -768,7 +821,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupEntriesRSS",
-				_getGroupEntriesRSSParameterTypes18);
+				_getGroupEntriesRSSParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, displayDate, status, max, type, version,
@@ -811,7 +864,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupsEntries",
-				_getGroupsEntriesParameterTypes19);
+				_getGroupsEntriesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, groupId, displayDate, status, max);
@@ -855,7 +908,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupUserEntries",
-				_getGroupUserEntriesParameterTypes20);
+				_getGroupUserEntriesParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, status, start, end,
@@ -893,7 +946,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupUserEntries",
-				_getGroupUserEntriesParameterTypes21);
+				_getGroupUserEntriesParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, statuses, start, end,
@@ -927,7 +980,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupUserEntriesCount",
-				_getGroupUserEntriesCountParameterTypes22);
+				_getGroupUserEntriesCountParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, status);
@@ -960,7 +1013,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getGroupUserEntriesCount",
-				_getGroupUserEntriesCountParameterTypes23);
+				_getGroupUserEntriesCountParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, statuses);
@@ -995,7 +1048,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getOrganizationEntries",
-				_getOrganizationEntriesParameterTypes24);
+				_getOrganizationEntriesParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, organizationId, displayDate, status, max);
@@ -1040,7 +1093,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "getOrganizationEntriesRSS",
-				_getOrganizationEntriesRSSParameterTypes25);
+				_getOrganizationEntriesRSSParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, organizationId, displayDate, status, max, type,
@@ -1081,7 +1134,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "moveEntryToTrash",
-				_moveEntryToTrashParameterTypes26);
+				_moveEntryToTrashParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -1120,7 +1173,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "restoreEntryFromTrash",
-				_restoreEntryFromTrashParameterTypes27);
+				_restoreEntryFromTrashParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, entryId);
 
@@ -1154,7 +1207,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "subscribe",
-				_subscribeParameterTypes28);
+				_subscribeParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -1188,7 +1241,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "unsubscribe",
-				_unsubscribeParameterTypes29);
+				_unsubscribeParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -1233,7 +1286,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "updateEntry",
-				_updateEntryParameterTypes30);
+				_updateEntryParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, entryId, title, subtitle, description, content,
@@ -1242,6 +1295,58 @@ public class BlogsEntryServiceHttp {
 				allowTrackbacks, trackbacks, coverImageCaption,
 				coverImageImageSelector, smallImageImageSelector,
 				serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.blogs.model.BlogsEntry)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.blogs.model.BlogsEntry updateEntry(
+			HttpPrincipal httpPrincipal, long entryId, String title,
+			String subtitle, String urlTitle, String description,
+			String content, java.util.Date displayDate, boolean allowPingbacks,
+			boolean allowTrackbacks, String[] trackbacks,
+			String coverImageCaption,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				coverImageImageSelector,
+			com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector
+				smallImageImageSelector,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				BlogsEntryServiceUtil.class, "updateEntry",
+				_updateEntryParameterTypes32);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, entryId, title, subtitle, urlTitle, description,
+				content, displayDate, allowPingbacks, allowTrackbacks,
+				trackbacks, coverImageCaption, coverImageImageSelector,
+				smallImageImageSelector, serviceContext);
 
 			Object returnObj = null;
 
@@ -1288,7 +1393,7 @@ public class BlogsEntryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				BlogsEntryServiceUtil.class, "updateEntry",
-				_updateEntryParameterTypes31);
+				_updateEntryParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, entryId, title, subtitle, urlTitle, description,
@@ -1341,101 +1446,109 @@ public class BlogsEntryServiceHttp {
 	};
 	private static final Class<?>[] _addEntryParameterTypes2 = new Class[] {
 		String.class, String.class, String.class, String.class, String.class,
+		String.class, java.util.Date.class, boolean.class, boolean.class,
+		String[].class, String.class,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+		com.liferay.portal.kernel.service.ServiceContext.class
+	};
+	private static final Class<?>[] _addEntryParameterTypes3 = new Class[] {
+		String.class, String.class, String.class, String.class, String.class,
 		String.class, int.class, int.class, int.class, int.class, int.class,
 		boolean.class, boolean.class, String[].class, String.class,
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _deleteEntryParameterTypes3 = new Class[] {
+	private static final Class<?>[] _deleteEntryParameterTypes4 = new Class[] {
 		long.class
 	};
 	private static final Class<?>[]
-		_fetchBlogsEntryByExternalReferenceCodeParameterTypes4 = new Class[] {
+		_fetchBlogsEntryByExternalReferenceCodeParameterTypes5 = new Class[] {
 			long.class, String.class
 		};
 	private static final Class<?>[]
-		_getBlogsEntryByExternalReferenceCodeParameterTypes5 = new Class[] {
+		_getBlogsEntryByExternalReferenceCodeParameterTypes6 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _getCompanyEntriesParameterTypes6 =
+	private static final Class<?>[] _getCompanyEntriesParameterTypes7 =
 		new Class[] {long.class, java.util.Date.class, int.class, int.class};
-	private static final Class<?>[] _getCompanyEntriesRSSParameterTypes7 =
+	private static final Class<?>[] _getCompanyEntriesRSSParameterTypes8 =
 		new Class[] {
 			long.class, java.util.Date.class, int.class, int.class,
 			String.class, double.class, String.class, String.class,
 			String.class, com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getEntriesPrevAndNextParameterTypes8 =
+	private static final Class<?>[] _getEntriesPrevAndNextParameterTypes9 =
 		new Class[] {long.class};
-	private static final Class<?>[] _getEntryParameterTypes9 = new Class[] {
+	private static final Class<?>[] _getEntryParameterTypes10 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getEntryParameterTypes10 = new Class[] {
+	private static final Class<?>[] _getEntryParameterTypes11 = new Class[] {
 		long.class, String.class
 	};
-	private static final Class<?>[] _getGroupEntriesParameterTypes11 =
-		new Class[] {long.class, java.util.Date.class, int.class, int.class};
 	private static final Class<?>[] _getGroupEntriesParameterTypes12 =
+		new Class[] {long.class, java.util.Date.class, int.class, int.class};
+	private static final Class<?>[] _getGroupEntriesParameterTypes13 =
 		new Class[] {
 			long.class, java.util.Date.class, int.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupEntriesParameterTypes13 =
-		new Class[] {long.class, int.class, int.class};
 	private static final Class<?>[] _getGroupEntriesParameterTypes14 =
-		new Class[] {long.class, int.class, int.class, int.class};
+		new Class[] {long.class, int.class, int.class};
 	private static final Class<?>[] _getGroupEntriesParameterTypes15 =
+		new Class[] {long.class, int.class, int.class, int.class};
+	private static final Class<?>[] _getGroupEntriesParameterTypes16 =
 		new Class[] {
 			long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupEntriesCountParameterTypes16 =
-		new Class[] {long.class, java.util.Date.class, int.class};
 	private static final Class<?>[] _getGroupEntriesCountParameterTypes17 =
+		new Class[] {long.class, java.util.Date.class, int.class};
+	private static final Class<?>[] _getGroupEntriesCountParameterTypes18 =
 		new Class[] {long.class, int.class};
-	private static final Class<?>[] _getGroupEntriesRSSParameterTypes18 =
+	private static final Class<?>[] _getGroupEntriesRSSParameterTypes19 =
 		new Class[] {
 			long.class, java.util.Date.class, int.class, int.class,
 			String.class, double.class, String.class, String.class,
 			String.class, com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getGroupsEntriesParameterTypes19 =
+	private static final Class<?>[] _getGroupsEntriesParameterTypes20 =
 		new Class[] {
 			long.class, long.class, java.util.Date.class, int.class, int.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesParameterTypes20 =
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes21 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesParameterTypes21 =
+	private static final Class<?>[] _getGroupUserEntriesParameterTypes22 =
 		new Class[] {
 			long.class, long.class, int[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes22 =
-		new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes23 =
+		new Class[] {long.class, long.class, int.class};
+	private static final Class<?>[] _getGroupUserEntriesCountParameterTypes24 =
 		new Class[] {long.class, long.class, int[].class};
-	private static final Class<?>[] _getOrganizationEntriesParameterTypes24 =
+	private static final Class<?>[] _getOrganizationEntriesParameterTypes25 =
 		new Class[] {long.class, java.util.Date.class, int.class, int.class};
-	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes25 =
+	private static final Class<?>[] _getOrganizationEntriesRSSParameterTypes26 =
 		new Class[] {
 			long.class, java.util.Date.class, int.class, int.class,
 			String.class, double.class, String.class, String.class,
 			String.class, com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _moveEntryToTrashParameterTypes26 =
+	private static final Class<?>[] _moveEntryToTrashParameterTypes27 =
 		new Class[] {long.class};
-	private static final Class<?>[] _restoreEntryFromTrashParameterTypes27 =
+	private static final Class<?>[] _restoreEntryFromTrashParameterTypes28 =
 		new Class[] {long.class};
-	private static final Class<?>[] _subscribeParameterTypes28 = new Class[] {
+	private static final Class<?>[] _subscribeParameterTypes29 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _unsubscribeParameterTypes29 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes30 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _updateEntryParameterTypes30 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes31 = new Class[] {
 		long.class, String.class, String.class, String.class, String.class,
 		int.class, int.class, int.class, int.class, int.class, boolean.class,
 		boolean.class, String[].class, String.class,
@@ -1443,7 +1556,15 @@ public class BlogsEntryServiceHttp {
 		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _updateEntryParameterTypes31 = new Class[] {
+	private static final Class<?>[] _updateEntryParameterTypes32 = new Class[] {
+		long.class, String.class, String.class, String.class, String.class,
+		String.class, java.util.Date.class, boolean.class, boolean.class,
+		String[].class, String.class,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+		com.liferay.portal.kernel.servlet.taglib.ui.ImageSelector.class,
+		com.liferay.portal.kernel.service.ServiceContext.class
+	};
+	private static final Class<?>[] _updateEntryParameterTypes33 = new Class[] {
 		long.class, String.class, String.class, String.class, String.class,
 		String.class, int.class, int.class, int.class, int.class, int.class,
 		boolean.class, boolean.class, String[].class, String.class,

--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/service/impl/BlogsEntryServiceImpl.java
@@ -105,6 +105,28 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 	public BlogsEntry addEntry(
 			String externalReferenceCode, String title, String subtitle,
 			String urlTitle, String description, String content,
+			Date displayDate, boolean allowPingbacks, boolean allowTrackbacks,
+			String[] trackbacks, String coverImageCaption,
+			ImageSelector coverImageImageSelector,
+			ImageSelector smallImageImageSelector,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_portletResourcePermission.check(
+			getPermissionChecker(), serviceContext.getScopeGroupId(),
+			ActionKeys.ADD_ENTRY);
+
+		return blogsEntryLocalService.addEntry(
+			externalReferenceCode, getUserId(), title, subtitle, urlTitle,
+			description, content, displayDate, allowPingbacks, allowTrackbacks,
+			trackbacks, coverImageCaption, coverImageImageSelector,
+			smallImageImageSelector, serviceContext);
+	}
+
+	@Override
+	public BlogsEntry addEntry(
+			String externalReferenceCode, String title, String subtitle,
+			String urlTitle, String description, String content,
 			int displayDateMonth, int displayDateDay, int displayDateYear,
 			int displayDateHour, int displayDateMinute, boolean allowPingbacks,
 			boolean allowTrackbacks, String[] trackbacks,
@@ -585,6 +607,27 @@ public class BlogsEntryServiceImpl extends BlogsEntryServiceBaseImpl {
 			entryId, title, subtitle, StringPool.BLANK, description, content,
 			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
 			displayDateMinute, allowPingbacks, allowTrackbacks, trackbacks,
+			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
+			serviceContext);
+	}
+
+	@Override
+	public BlogsEntry updateEntry(
+			long entryId, String title, String subtitle, String urlTitle,
+			String description, String content, Date displayDate,
+			boolean allowPingbacks, boolean allowTrackbacks,
+			String[] trackbacks, String coverImageCaption,
+			ImageSelector coverImageImageSelector,
+			ImageSelector smallImageImageSelector,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_blogsEntryModelResourcePermission.check(
+			getPermissionChecker(), entryId, ActionKeys.UPDATE);
+
+		return blogsEntryLocalService.updateEntry(
+			getUserId(), entryId, title, subtitle, urlTitle, description,
+			content, displayDate, allowPingbacks, allowTrackbacks, trackbacks,
 			coverImageCaption, coverImageImageSelector, smallImageImageSelector,
 			serviceContext);
 	}

--- a/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/importer/CPFileImporterImpl.java
+++ b/modules/apps/commerce/commerce-product-service/src/main/java/com/liferay/commerce/product/internal/importer/CPFileImporterImpl.java
@@ -62,7 +62,6 @@ import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ThemeLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
@@ -79,8 +78,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 
-import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Iterator;
 import java.util.Locale;
 import java.util.Map;
@@ -343,29 +342,13 @@ public class CPFileImporterImpl implements CPFileImporter {
 		content = _getNormalizedContent(
 			content, classLoader, dependenciesFilePath, serviceContext);
 
-		Calendar displayCalendar = CalendarFactoryUtil.getCalendar(
-			serviceContext.getTimeZone());
-
-		int displayDateMonth = displayCalendar.get(Calendar.MONTH);
-		int displayDateDay = displayCalendar.get(Calendar.DAY_OF_MONTH);
-		int displayDateYear = displayCalendar.get(Calendar.YEAR);
-		int displayDateHour = displayCalendar.get(Calendar.HOUR);
-		int displayDateMinute = displayCalendar.get(Calendar.MINUTE);
-		int displayDateAmPm = displayCalendar.get(Calendar.AM_PM);
-
-		if (displayDateAmPm == Calendar.PM) {
-			displayDateHour += 12;
-		}
-
 		journalArticle = _journalArticleLocalService.addArticle(
 			null, serviceContext.getUserId(), serviceContext.getScopeGroupId(),
 			0L, JournalArticleConstants.CLASS_NAME_ID_DEFAULT, 0L, articleId,
 			false, 1, titleMap, descriptionMap, titleMap, content,
 			ddmStructure.getStructureId(), ddmTemplateKey, StringPool.BLANK,
-			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
-			displayDateMinute, 0, 0, 0, 0, 0, true, 0, 0, 0, 0, 0, true, true,
-			false, 0, 0, StringPool.BLANK, null, null, StringPool.BLANK,
-			serviceContext);
+			new Date(), null, null, true, false, 0, 0, StringPool.BLANK, null,
+			null, StringPool.BLANK, serviceContext);
 
 		JSONArray permissionsJSONArray = jsonObject.getJSONArray("permissions");
 

--- a/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-content/headless-admin-content-impl/src/main/java/com/liferay/headless/admin/content/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -67,13 +67,11 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.resource.EntityModelResource;
 import com.liferay.portal.vulcan.util.EntityExtensionUtil;
-import com.liferay.portal.vulcan.util.LocalDateTimeUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 
-import java.time.LocalDateTime;
-
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -277,8 +275,11 @@ public class StructuredContentResourceImpl
 		_validateContentFields(
 			structuredContent.getContentFields(), ddmStructure);
 
-		LocalDateTime localDateTime = LocalDateTimeUtil.toLocalDateTime(
-			structuredContent.getDatePublished());
+		Date displayDate = structuredContent.getDatePublished();
+
+		if (displayDate == null) {
+			displayDate = new Date();
+		}
 
 		ServiceContext serviceContext = ServiceContextBuilder.create(
 			siteId, contextHttpServletRequest,
@@ -317,10 +318,7 @@ public class StructuredContentResourceImpl
 					_jsonDDMFormValuesSerializer, _ddmFormValuesValidator,
 					ddmStructure, _journalConverter),
 				ddmStructure.getStructureId(), _getDDMTemplateKey(ddmStructure),
-				null, localDateTime.getMonthValue() - 1,
-				localDateTime.getDayOfMonth(), localDateTime.getYear(),
-				localDateTime.getHour(), localDateTime.getMinute(), 0, 0, 0, 0,
-				0, true, 0, 0, 0, 0, 0, true, true, false, 0, 0, null, null,
+				null, displayDate, null, null, true, false, 0, 0, null, null,
 				null, null, serviceContext));
 	}
 

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/BlogPostingResourceImpl.java
@@ -50,11 +50,10 @@ import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.portal.vulcan.util.LocalDateTimeUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 
-import java.time.LocalDateTime;
+import java.util.Date;
 
 import javax.ws.rs.core.MultivaluedMap;
 
@@ -313,8 +312,12 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 			String externalReferenceCode, long groupId, BlogPosting blogPosting)
 		throws Exception {
 
-		LocalDateTime localDateTime = LocalDateTimeUtil.toLocalDateTime(
-			blogPosting.getDatePublished());
+		Date displayDate = blogPosting.getDatePublished();
+
+		if (displayDate == null) {
+			displayDate = new Date();
+		}
+
 		Image image = blogPosting.getImage();
 
 		return _toBlogPosting(
@@ -322,9 +325,7 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 				externalReferenceCode, blogPosting.getHeadline(),
 				blogPosting.getAlternativeHeadline(),
 				blogPosting.getFriendlyUrlPath(), blogPosting.getDescription(),
-				blogPosting.getArticleBody(), localDateTime.getMonthValue() - 1,
-				localDateTime.getDayOfMonth(), localDateTime.getYear(),
-				localDateTime.getHour(), localDateTime.getMinute(), true, true,
+				blogPosting.getArticleBody(), displayDate, true, true,
 				new String[0], _getCaption(image), _getImageSelector(image),
 				null, _createServiceContext(blogPosting, groupId)));
 	}
@@ -442,8 +443,12 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 			BlogsEntry blogsEntry, BlogPosting blogPosting)
 		throws Exception {
 
-		LocalDateTime localDateTime = LocalDateTimeUtil.toLocalDateTime(
-			blogPosting.getDatePublished());
+		Date displayDate = blogPosting.getDatePublished();
+
+		if (displayDate == null) {
+			displayDate = new Date();
+		}
+
 		Image image = blogPosting.getImage();
 
 		return _toBlogPosting(
@@ -451,9 +456,7 @@ public class BlogPostingResourceImpl extends BaseBlogPostingResourceImpl {
 				blogsEntry.getEntryId(), blogPosting.getHeadline(),
 				blogPosting.getAlternativeHeadline(),
 				blogPosting.getFriendlyUrlPath(), blogPosting.getDescription(),
-				blogPosting.getArticleBody(), localDateTime.getMonthValue() - 1,
-				localDateTime.getDayOfMonth(), localDateTime.getYear(),
-				localDateTime.getHour(), localDateTime.getMinute(), true, true,
+				blogPosting.getArticleBody(), displayDate, true, true,
 				new String[0], _getCaption(image), _getImageSelector(image),
 				null,
 				_createServiceContext(blogPosting, blogsEntry.getGroupId())));

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/StructuredContentResourceImpl.java
@@ -114,15 +114,13 @@ import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.permission.ModelPermissionsUtil;
 import com.liferay.portal.vulcan.util.ContentLanguageUtil;
-import com.liferay.portal.vulcan.util.LocalDateTimeUtil;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
 import com.liferay.portal.vulcan.util.SearchUtil;
 import com.liferay.ratings.kernel.service.RatingsEntryLocalService;
 
-import java.time.LocalDateTime;
-
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -509,9 +507,11 @@ public class StructuredContentResourceImpl
 		_validateContentFields(
 			structuredContent.getContentFields(), ddmStructure);
 
-		LocalDateTime localDateTime = LocalDateTimeUtil.toLocalDateTime(
-			structuredContent.getDatePublished(),
-			journalArticle.getDisplayDate());
+		Date displayDate = structuredContent.getDatePublished();
+
+		if (displayDate == null) {
+			displayDate = journalArticle.getDisplayDate();
+		}
 
 		return _toStructuredContent(
 			_journalArticleService.updateArticle(
@@ -538,12 +538,8 @@ public class StructuredContentResourceImpl
 						structuredContent.getContentFields(), journalArticle),
 					journalArticle.getGroupId()),
 				_getDDMTemplateKey(ddmStructure),
-				journalArticle.getLayoutUuid(),
-				localDateTime.getMonthValue() - 1,
-				localDateTime.getDayOfMonth(), localDateTime.getYear(),
-				localDateTime.getHour(), localDateTime.getMinute(), 0, 0, 0, 0,
-				0, true, 0, 0, 0, 0, 0, true, true, false, 0, 0, null, null,
-				null, null,
+				journalArticle.getLayoutUuid(), displayDate, null, null, true,
+				false, 0, 0, null, null, null, null,
 				_createServiceContext(
 					_getAssetCategoryIds(journalArticle, structuredContent),
 					_getAssetLinkEntryIds(journalArticle, structuredContent),
@@ -715,8 +711,11 @@ public class StructuredContentResourceImpl
 		DDMStructure ddmStructure = _ddmStructureService.getStructure(
 			structuredContent.getContentStructureId());
 
-		LocalDateTime localDateTime = LocalDateTimeUtil.toLocalDateTime(
-			structuredContent.getDatePublished());
+		Date displayDate = structuredContent.getDatePublished();
+
+		if (displayDate == null) {
+			displayDate = new Date();
+		}
 
 		Map<Locale, String> titleMap = LocalizedMapUtil.getLocalizedMap(
 			contextAcceptLanguage.getPreferredLocale(),
@@ -767,10 +766,7 @@ public class StructuredContentResourceImpl
 					_jsonDDMFormValuesSerializer, _ddmFormValuesValidator,
 					ddmStructure, _journalConverter),
 				ddmStructure.getStructureId(), _getDDMTemplateKey(ddmStructure),
-				null, localDateTime.getMonthValue() - 1,
-				localDateTime.getDayOfMonth(), localDateTime.getYear(),
-				localDateTime.getHour(), localDateTime.getMinute(), 0, 0, 0, 0,
-				0, true, 0, 0, 0, 0, 0, true, true, false, 0, 0, null, null,
+				null, displayDate, null, null, true, false, 0, 0, null, null,
 				null, null,
 				_createServiceContext(
 					structuredContent.getTaxonomyCategoryIds(),
@@ -1304,9 +1300,11 @@ public class StructuredContentResourceImpl
 		_validateContentFields(
 			structuredContent.getContentFields(), ddmStructure);
 
-		LocalDateTime localDateTime = LocalDateTimeUtil.toLocalDateTime(
-			structuredContent.getDatePublished(),
-			journalArticle.getDisplayDate());
+		Date displayDate = structuredContent.getDatePublished();
+
+		if (displayDate == null) {
+			displayDate = journalArticle.getDisplayDate();
+		}
 
 		return _toStructuredContent(
 			_journalArticleService.updateArticle(
@@ -1320,12 +1318,8 @@ public class StructuredContentResourceImpl
 						journalArticle),
 					journalArticle.getGroupId()),
 				_getDDMTemplateKey(ddmStructure),
-				journalArticle.getLayoutUuid(),
-				localDateTime.getMonthValue() - 1,
-				localDateTime.getDayOfMonth(), localDateTime.getYear(),
-				localDateTime.getHour(), localDateTime.getMinute(), 0, 0, 0, 0,
-				0, true, 0, 0, 0, 0, 0, true, true, false, 0, 0, null, null,
-				null, null,
+				journalArticle.getLayoutUuid(), displayDate, null, null, true,
+				false, 0, 0, null, null, null, null,
 				_createServiceContext(
 					_getAssetCategoryIds(journalArticle, structuredContent),
 					_getAssetLinkEntryIds(journalArticle, structuredContent),

--- a/modules/apps/journal/journal-api/bnd.bnd
+++ b/modules/apps/journal/journal-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Journal API
 Bundle-SymbolicName: com.liferay.journal.api
-Bundle-Version: 33.2.1
+Bundle-Version: 33.3.0
 Export-Package:\
 	com.liferay.journal.configuration,\
 	com.liferay.journal.constants,\

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
@@ -127,37 +127,12 @@ public interface JournalArticleLocalService
 	 template
 	 * @param layoutUuid            the unique string identifying the web content
 	 article's display page
-	 * @param displayDateMonth      the month the web content article is set to
+	 * @param displayDate           the date the web content article is set to
 	 display
-	 * @param displayDateDay        the calendar day the web content article is set to
-	 display
-	 * @param displayDateYear       the year the web content article is set to
-	 display
-	 * @param displayDateHour       the hour the web content article is set to
-	 display
-	 * @param displayDateMinute     the minute the web content article is set to
-	 display
-	 * @param expirationDateMonth   the month the web content article is set to
+	 * @param expirationDate        the date the web content article is set to
 	 expire
-	 * @param expirationDateDay     the calendar day the web content article is set
-	 to expire
-	 * @param expirationDateYear    the year the web content article is set to
-	 expire
-	 * @param expirationDateHour    the hour the web content article is set to
-	 expire
-	 * @param expirationDateMinute  the minute the web content article is set to
-	 expire
-	 * @param neverExpire           whether the web content article is not set to auto
-	 expire
-	 * @param reviewDateMonth       the month the web content article is set for
+	 * @param reviewDate            the date the web content article is set for
 	 review
-	 * @param reviewDateDay         the calendar day the web content article is set for
-	 review
-	 * @param reviewDateYear        the year the web content article is set for review
-	 * @param reviewDateHour        the hour the web content article is set for review
-	 * @param reviewDateMinute      the minute the web content article is set for
-	 review
-	 * @param neverReview           whether the web content article is not set for review
 	 * @param indexable             whether the web content article is searchable
 	 * @param smallImage            whether the web content article has a small image
 	 * @param smallImageSource      the web content article's small image source
@@ -175,6 +150,20 @@ public interface JournalArticleLocalService
 	 * @throws PortalException if a portal exception occurred
 	 */
 	@Indexable(type = IndexableType.REINDEX)
+	public JournalArticle addArticle(
+			String externalReferenceCode, long userId, long groupId,
+			long folderId, long classNameId, long classPK, String articleId,
+			boolean autoArticleId, double version, Map<Locale, String> titleMap,
+			Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			long ddmStructureId, String ddmTemplateKey, String layoutUuid,
+			Date displayDate, Date expirationDate, Date reviewDate,
+			boolean indexable, boolean smallImage, long smallImageId,
+			int smallImageSource, String smallImageURL, File smallImageFile,
+			Map<String, byte[]> images, String articleURL,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 	public JournalArticle addArticle(
 			String externalReferenceCode, long userId, long groupId,
 			long folderId, long classNameId, long classPK, String articleId,
@@ -2245,37 +2234,12 @@ public interface JournalArticleLocalService
 	 template
 	 * @param layoutUuid the unique string identifying the web content
 	 article's display page
-	 * @param displayDateMonth the month the web content article is set to
+	 * @param displayDate the date the web content article is set to
 	 display
-	 * @param displayDateDay the calendar day the web content article is set to
-	 display
-	 * @param displayDateYear the year the web content article is set to
-	 display
-	 * @param displayDateHour the hour the web content article is set to
-	 display
-	 * @param displayDateMinute the minute the web content article is set to
-	 display
-	 * @param expirationDateMonth the month the web content article is set to
+	 * @param expirationDate the date the web content article is set to
 	 expire
-	 * @param expirationDateDay the calendar day the web content article is set
-	 to expire
-	 * @param expirationDateYear the year the web content article is set to
-	 expire
-	 * @param expirationDateHour the hour the web content article is set to
-	 expire
-	 * @param expirationDateMinute the minute the web content article is set to
-	 expire
-	 * @param neverExpire whether the web content article is not set to auto
-	 expire
-	 * @param reviewDateMonth the month the web content article is set for
+	 * @param reviewDate the date the web content article is set for
 	 review
-	 * @param reviewDateDay the calendar day the web content article is set for
-	 review
-	 * @param reviewDateYear the year the web content article is set for review
-	 * @param reviewDateHour the hour the web content article is set for review
-	 * @param reviewDateMinute the minute the web content article is set for
-	 review
-	 * @param neverReview whether the web content article is not set for review
 	 * @param indexable whether the web content is searchable
 	 * @param smallImage whether to update web content article's a small image.
 	 A file must be passed in as <code>smallImageFile</code> value,
@@ -2304,6 +2268,19 @@ public interface JournalArticleLocalService
 	 * @throws PortalException if a portal exception occurred
 	 */
 	@Indexable(type = IndexableType.REINDEX)
+	public JournalArticle updateArticle(
+			long userId, long groupId, long folderId, String articleId,
+			double version, Map<Locale, String> titleMap,
+			Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			String ddmTemplateKey, String layoutUuid, Date displayDate,
+			Date expirationDate, Date reviewDate, boolean indexable,
+			boolean smallImage, long smallImageId, int smallImageSource,
+			String smallImageURL, File smallImageFile,
+			Map<String, byte[]> images, String articleURL,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 	public JournalArticle updateArticle(
 			long userId, long groupId, long folderId, String articleId,
 			double version, Map<Locale, String> titleMap,

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
@@ -91,37 +91,12 @@ public class JournalArticleLocalServiceUtil {
 	 template
 	 * @param layoutUuid            the unique string identifying the web content
 	 article's display page
-	 * @param displayDateMonth      the month the web content article is set to
+	 * @param displayDate           the date the web content article is set to
 	 display
-	 * @param displayDateDay        the calendar day the web content article is set to
-	 display
-	 * @param displayDateYear       the year the web content article is set to
-	 display
-	 * @param displayDateHour       the hour the web content article is set to
-	 display
-	 * @param displayDateMinute     the minute the web content article is set to
-	 display
-	 * @param expirationDateMonth   the month the web content article is set to
+	 * @param expirationDate        the date the web content article is set to
 	 expire
-	 * @param expirationDateDay     the calendar day the web content article is set
-	 to expire
-	 * @param expirationDateYear    the year the web content article is set to
-	 expire
-	 * @param expirationDateHour    the hour the web content article is set to
-	 expire
-	 * @param expirationDateMinute  the minute the web content article is set to
-	 expire
-	 * @param neverExpire           whether the web content article is not set to auto
-	 expire
-	 * @param reviewDateMonth       the month the web content article is set for
+	 * @param reviewDate            the date the web content article is set for
 	 review
-	 * @param reviewDateDay         the calendar day the web content article is set for
-	 review
-	 * @param reviewDateYear        the year the web content article is set for review
-	 * @param reviewDateHour        the hour the web content article is set for review
-	 * @param reviewDateMinute      the minute the web content article is set for
-	 review
-	 * @param neverReview           whether the web content article is not set for review
 	 * @param indexable             whether the web content article is searchable
 	 * @param smallImage            whether the web content article has a small image
 	 * @param smallImageSource      the web content article's small image source
@@ -138,6 +113,31 @@ public class JournalArticleLocalServiceUtil {
 	 * @return the web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
+	public static JournalArticle addArticle(
+			String externalReferenceCode, long userId, long groupId,
+			long folderId, long classNameId, long classPK, String articleId,
+			boolean autoArticleId, double version,
+			Map<java.util.Locale, String> titleMap,
+			Map<java.util.Locale, String> descriptionMap,
+			Map<java.util.Locale, String> friendlyURLMap, String content,
+			long ddmStructureId, String ddmTemplateKey, String layoutUuid,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate, boolean indexable, boolean smallImage,
+			long smallImageId, int smallImageSource, String smallImageURL,
+			java.io.File smallImageFile, Map<String, byte[]> images,
+			String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addArticle(
+			externalReferenceCode, userId, groupId, folderId, classNameId,
+			classPK, articleId, autoArticleId, version, titleMap,
+			descriptionMap, friendlyURLMap, content, ddmStructureId,
+			ddmTemplateKey, layoutUuid, displayDate, expirationDate, reviewDate,
+			indexable, smallImage, smallImageId, smallImageSource,
+			smallImageURL, smallImageFile, images, articleURL, serviceContext);
+	}
+
 	public static JournalArticle addArticle(
 			String externalReferenceCode, long userId, long groupId,
 			long folderId, long classNameId, long classPK, String articleId,
@@ -2664,37 +2664,12 @@ public class JournalArticleLocalServiceUtil {
 	 template
 	 * @param layoutUuid the unique string identifying the web content
 	 article's display page
-	 * @param displayDateMonth the month the web content article is set to
+	 * @param displayDate the date the web content article is set to
 	 display
-	 * @param displayDateDay the calendar day the web content article is set to
-	 display
-	 * @param displayDateYear the year the web content article is set to
-	 display
-	 * @param displayDateHour the hour the web content article is set to
-	 display
-	 * @param displayDateMinute the minute the web content article is set to
-	 display
-	 * @param expirationDateMonth the month the web content article is set to
+	 * @param expirationDate the date the web content article is set to
 	 expire
-	 * @param expirationDateDay the calendar day the web content article is set
-	 to expire
-	 * @param expirationDateYear the year the web content article is set to
-	 expire
-	 * @param expirationDateHour the hour the web content article is set to
-	 expire
-	 * @param expirationDateMinute the minute the web content article is set to
-	 expire
-	 * @param neverExpire whether the web content article is not set to auto
-	 expire
-	 * @param reviewDateMonth the month the web content article is set for
+	 * @param reviewDate the date the web content article is set for
 	 review
-	 * @param reviewDateDay the calendar day the web content article is set for
-	 review
-	 * @param reviewDateYear the year the web content article is set for review
-	 * @param reviewDateHour the hour the web content article is set for review
-	 * @param reviewDateMinute the minute the web content article is set for
-	 review
-	 * @param neverReview whether the web content article is not set for review
 	 * @param indexable whether the web content is searchable
 	 * @param smallImage whether to update web content article's a small image.
 	 A file must be passed in as <code>smallImageFile</code> value,
@@ -2722,6 +2697,28 @@ public class JournalArticleLocalServiceUtil {
 	 * @return the updated web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
+	public static JournalArticle updateArticle(
+			long userId, long groupId, long folderId, String articleId,
+			double version, Map<java.util.Locale, String> titleMap,
+			Map<java.util.Locale, String> descriptionMap,
+			Map<java.util.Locale, String> friendlyURLMap, String content,
+			String ddmTemplateKey, String layoutUuid,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate, boolean indexable, boolean smallImage,
+			long smallImageId, int smallImageSource, String smallImageURL,
+			java.io.File smallImageFile, Map<String, byte[]> images,
+			String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateArticle(
+			userId, groupId, folderId, articleId, version, titleMap,
+			descriptionMap, friendlyURLMap, content, ddmTemplateKey, layoutUuid,
+			displayDate, expirationDate, reviewDate, indexable, smallImage,
+			smallImageId, smallImageSource, smallImageURL, smallImageFile,
+			images, articleURL, serviceContext);
+	}
+
 	public static JournalArticle updateArticle(
 			long userId, long groupId, long folderId, String articleId,
 			double version, Map<java.util.Locale, String> titleMap,

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
@@ -86,37 +86,12 @@ public class JournalArticleLocalServiceWrapper
 	 template
 	 * @param layoutUuid            the unique string identifying the web content
 	 article's display page
-	 * @param displayDateMonth      the month the web content article is set to
+	 * @param displayDate           the date the web content article is set to
 	 display
-	 * @param displayDateDay        the calendar day the web content article is set to
-	 display
-	 * @param displayDateYear       the year the web content article is set to
-	 display
-	 * @param displayDateHour       the hour the web content article is set to
-	 display
-	 * @param displayDateMinute     the minute the web content article is set to
-	 display
-	 * @param expirationDateMonth   the month the web content article is set to
+	 * @param expirationDate        the date the web content article is set to
 	 expire
-	 * @param expirationDateDay     the calendar day the web content article is set
-	 to expire
-	 * @param expirationDateYear    the year the web content article is set to
-	 expire
-	 * @param expirationDateHour    the hour the web content article is set to
-	 expire
-	 * @param expirationDateMinute  the minute the web content article is set to
-	 expire
-	 * @param neverExpire           whether the web content article is not set to auto
-	 expire
-	 * @param reviewDateMonth       the month the web content article is set for
+	 * @param reviewDate            the date the web content article is set for
 	 review
-	 * @param reviewDateDay         the calendar day the web content article is set for
-	 review
-	 * @param reviewDateYear        the year the web content article is set for review
-	 * @param reviewDateHour        the hour the web content article is set for review
-	 * @param reviewDateMinute      the minute the web content article is set for
-	 review
-	 * @param neverReview           whether the web content article is not set for review
 	 * @param indexable             whether the web content article is searchable
 	 * @param smallImage            whether the web content article has a small image
 	 * @param smallImageSource      the web content article's small image source
@@ -133,6 +108,33 @@ public class JournalArticleLocalServiceWrapper
 	 * @return the web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
+	@Override
+	public JournalArticle addArticle(
+			String externalReferenceCode, long userId, long groupId,
+			long folderId, long classNameId, long classPK, String articleId,
+			boolean autoArticleId, double version,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, long ddmStructureId, String ddmTemplateKey,
+			String layoutUuid, java.util.Date displayDate,
+			java.util.Date expirationDate, java.util.Date reviewDate,
+			boolean indexable, boolean smallImage, long smallImageId,
+			int smallImageSource, String smallImageURL,
+			java.io.File smallImageFile, java.util.Map<String, byte[]> images,
+			String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleLocalService.addArticle(
+			externalReferenceCode, userId, groupId, folderId, classNameId,
+			classPK, articleId, autoArticleId, version, titleMap,
+			descriptionMap, friendlyURLMap, content, ddmStructureId,
+			ddmTemplateKey, layoutUuid, displayDate, expirationDate, reviewDate,
+			indexable, smallImage, smallImageId, smallImageSource,
+			smallImageURL, smallImageFile, images, articleURL, serviceContext);
+	}
+
 	@Override
 	public JournalArticle addArticle(
 			String externalReferenceCode, long userId, long groupId,
@@ -2858,37 +2860,12 @@ public class JournalArticleLocalServiceWrapper
 	 template
 	 * @param layoutUuid the unique string identifying the web content
 	 article's display page
-	 * @param displayDateMonth the month the web content article is set to
+	 * @param displayDate the date the web content article is set to
 	 display
-	 * @param displayDateDay the calendar day the web content article is set to
-	 display
-	 * @param displayDateYear the year the web content article is set to
-	 display
-	 * @param displayDateHour the hour the web content article is set to
-	 display
-	 * @param displayDateMinute the minute the web content article is set to
-	 display
-	 * @param expirationDateMonth the month the web content article is set to
+	 * @param expirationDate the date the web content article is set to
 	 expire
-	 * @param expirationDateDay the calendar day the web content article is set
-	 to expire
-	 * @param expirationDateYear the year the web content article is set to
-	 expire
-	 * @param expirationDateHour the hour the web content article is set to
-	 expire
-	 * @param expirationDateMinute the minute the web content article is set to
-	 expire
-	 * @param neverExpire whether the web content article is not set to auto
-	 expire
-	 * @param reviewDateMonth the month the web content article is set for
+	 * @param reviewDate the date the web content article is set for
 	 review
-	 * @param reviewDateDay the calendar day the web content article is set for
-	 review
-	 * @param reviewDateYear the year the web content article is set for review
-	 * @param reviewDateHour the hour the web content article is set for review
-	 * @param reviewDateMinute the minute the web content article is set for
-	 review
-	 * @param neverReview whether the web content article is not set for review
 	 * @param indexable whether the web content is searchable
 	 * @param smallImage whether to update web content article's a small image.
 	 A file must be passed in as <code>smallImageFile</code> value,
@@ -2916,6 +2893,29 @@ public class JournalArticleLocalServiceWrapper
 	 * @return the updated web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
+	@Override
+	public JournalArticle updateArticle(
+			long userId, long groupId, long folderId, String articleId,
+			double version, java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmTemplateKey, String layoutUuid,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate, boolean indexable, boolean smallImage,
+			long smallImageId, int smallImageSource, String smallImageURL,
+			java.io.File smallImageFile, java.util.Map<String, byte[]> images,
+			String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleLocalService.updateArticle(
+			userId, groupId, folderId, articleId, version, titleMap,
+			descriptionMap, friendlyURLMap, content, ddmTemplateKey, layoutUuid,
+			displayDate, expirationDate, reviewDate, indexable, smallImage,
+			smallImageId, smallImageSource, smallImageURL, smallImageFile,
+			images, articleURL, serviceContext);
+	}
+
 	@Override
 	public JournalArticle updateArticle(
 			long userId, long groupId, long folderId, String articleId,

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleService.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 
 import java.io.File;
 
+import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -89,37 +90,12 @@ public interface JournalArticleService extends BaseService {
 	 template
 	 * @param layoutUuid            the unique string identifying the web content
 	 article's display page
-	 * @param displayDateMonth      the month the web content article is set to
+	 * @param displayDate           the date the web content article is set to
 	 display
-	 * @param displayDateDay        the calendar day the web content article is set to
-	 display
-	 * @param displayDateYear       the year the web content article is set to
-	 display
-	 * @param displayDateHour       the hour the web content article is set to
-	 display
-	 * @param displayDateMinute     the minute the web content article is set to
-	 display
-	 * @param expirationDateMonth   the month the web content article is set to
+	 * @param expirationDate        the date the web content article is set to
 	 expire
-	 * @param expirationDateDay     the calendar day the web content article is set
-	 to expire
-	 * @param expirationDateYear    the year the web content article is set to
-	 expire
-	 * @param expirationDateHour    the hour the web content article is set to
-	 expire
-	 * @param expirationDateMinute  the minute the web content article is set to
-	 expire
-	 * @param neverExpire           whether the web content article is not set to auto
-	 expire
-	 * @param reviewDateMonth       the month the web content article is set for
+	 * @param reviewDate            the date the web content article is set for
 	 review
-	 * @param reviewDateDay         the calendar day the web content article is set for
-	 review
-	 * @param reviewDateYear        the year the web content article is set for review
-	 * @param reviewDateHour        the hour the web content article is set for review
-	 * @param reviewDateMinute      the minute the web content article is set for
-	 review
-	 * @param neverReview           whether the web content article is not set for review
 	 * @param indexable             whether the web content article is searchable
 	 * @param smallImage            whether the web content article has a small image
 	 * @param smallImageSource      the web content article's small image source
@@ -136,6 +112,20 @@ public interface JournalArticleService extends BaseService {
 	 * @return the web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
+	public JournalArticle addArticle(
+			String externalReferenceCode, long groupId, long folderId,
+			long classNameId, long classPK, String articleId,
+			boolean autoArticleId, Map<Locale, String> titleMap,
+			Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			long ddmStructureId, String ddmTemplateKey, String layoutUuid,
+			Date displayDate, Date expirationDate, Date reviewDate,
+			boolean indexable, boolean smallImage, long smallImageId,
+			int smallImageSource, String smallImageURL, File smallFile,
+			Map<String, byte[]> images, String articleURL,
+			ServiceContext serviceContext)
+		throws PortalException;
+
 	public JournalArticle addArticle(
 			String externalReferenceCode, long groupId, long folderId,
 			long classNameId, long classPK, String articleId,
@@ -1377,37 +1367,12 @@ public interface JournalArticleService extends BaseService {
 	 template
 	 * @param layoutUuid           the unique string identifying the web content
 	 article's display page
-	 * @param displayDateMonth     the month the web content article is set to
+	 * @param displayDate          the date the web content article is set to
 	 display
-	 * @param displayDateDay       the calendar day the web content article is set to
-	 display
-	 * @param displayDateYear      the year the web content article is set to
-	 display
-	 * @param displayDateHour      the hour the web content article is set to
-	 display
-	 * @param displayDateMinute    the minute the web content article is set to
-	 display
-	 * @param expirationDateMonth  the month the web content article is set to
+	 * @param expirationDate       the date the web content article is set to
 	 expire
-	 * @param expirationDateDay    the calendar day the web content article is set
-	 to expire
-	 * @param expirationDateYear   the year the web content article is set to
-	 expire
-	 * @param expirationDateHour   the hour the web content article is set to
-	 expire
-	 * @param expirationDateMinute the minute the web content article is set to
-	 expire
-	 * @param neverExpire          whether the web content article is not set to auto
-	 expire
-	 * @param reviewDateMonth      the month the web content article is set for
+	 * @param reviewDate           the month the web content article is set for
 	 review
-	 * @param reviewDateDay        the calendar day the web content article is set for
-	 review
-	 * @param reviewDateYear       the year the web content article is set for review
-	 * @param reviewDateHour       the hour the web content article is set for review
-	 * @param reviewDateMinute     the minute the web content article is set for
-	 review
-	 * @param neverReview          whether the web content article is not set for review
 	 * @param indexable            whether the web content is searchable
 	 * @param smallImage           whether to update web content article's a small image.
 	 A file must be passed in as <code>smallImageFile</code> value,
@@ -1435,6 +1400,17 @@ public interface JournalArticleService extends BaseService {
 	 * @return the updated web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
+	public JournalArticle updateArticle(
+			long groupId, long folderId, String articleId, double version,
+			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			String ddmTemplateKey, String layoutUuid, Date displayDate,
+			Date expirationDate, Date reviewDate, boolean indexable,
+			boolean smallImage, long smallImageId, int smallImageSource,
+			String smallImageURL, File smallFile, Map<String, byte[]> images,
+			String articleURL, ServiceContext serviceContext)
+		throws PortalException;
+
 	public JournalArticle updateArticle(
 			long groupId, long folderId, String articleId, double version,
 			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceUtil.java
@@ -68,37 +68,12 @@ public class JournalArticleServiceUtil {
 	 template
 	 * @param layoutUuid            the unique string identifying the web content
 	 article's display page
-	 * @param displayDateMonth      the month the web content article is set to
+	 * @param displayDate           the date the web content article is set to
 	 display
-	 * @param displayDateDay        the calendar day the web content article is set to
-	 display
-	 * @param displayDateYear       the year the web content article is set to
-	 display
-	 * @param displayDateHour       the hour the web content article is set to
-	 display
-	 * @param displayDateMinute     the minute the web content article is set to
-	 display
-	 * @param expirationDateMonth   the month the web content article is set to
+	 * @param expirationDate        the date the web content article is set to
 	 expire
-	 * @param expirationDateDay     the calendar day the web content article is set
-	 to expire
-	 * @param expirationDateYear    the year the web content article is set to
-	 expire
-	 * @param expirationDateHour    the hour the web content article is set to
-	 expire
-	 * @param expirationDateMinute  the minute the web content article is set to
-	 expire
-	 * @param neverExpire           whether the web content article is not set to auto
-	 expire
-	 * @param reviewDateMonth       the month the web content article is set for
+	 * @param reviewDate            the date the web content article is set for
 	 review
-	 * @param reviewDateDay         the calendar day the web content article is set for
-	 review
-	 * @param reviewDateYear        the year the web content article is set for review
-	 * @param reviewDateHour        the hour the web content article is set for review
-	 * @param reviewDateMinute      the minute the web content article is set for
-	 review
-	 * @param neverReview           whether the web content article is not set for review
 	 * @param indexable             whether the web content article is searchable
 	 * @param smallImage            whether the web content article has a small image
 	 * @param smallImageSource      the web content article's small image source
@@ -115,6 +90,30 @@ public class JournalArticleServiceUtil {
 	 * @return the web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
+	public static JournalArticle addArticle(
+			String externalReferenceCode, long groupId, long folderId,
+			long classNameId, long classPK, String articleId,
+			boolean autoArticleId, Map<java.util.Locale, String> titleMap,
+			Map<java.util.Locale, String> descriptionMap,
+			Map<java.util.Locale, String> friendlyURLMap, String content,
+			long ddmStructureId, String ddmTemplateKey, String layoutUuid,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate, boolean indexable, boolean smallImage,
+			long smallImageId, int smallImageSource, String smallImageURL,
+			java.io.File smallFile, Map<String, byte[]> images,
+			String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addArticle(
+			externalReferenceCode, groupId, folderId, classNameId, classPK,
+			articleId, autoArticleId, titleMap, descriptionMap, friendlyURLMap,
+			content, ddmStructureId, ddmTemplateKey, layoutUuid, displayDate,
+			expirationDate, reviewDate, indexable, smallImage, smallImageId,
+			smallImageSource, smallImageURL, smallFile, images, articleURL,
+			serviceContext);
+	}
+
 	public static JournalArticle addArticle(
 			String externalReferenceCode, long groupId, long folderId,
 			long classNameId, long classPK, String articleId,
@@ -1599,37 +1598,12 @@ public class JournalArticleServiceUtil {
 	 template
 	 * @param layoutUuid           the unique string identifying the web content
 	 article's display page
-	 * @param displayDateMonth     the month the web content article is set to
+	 * @param displayDate          the date the web content article is set to
 	 display
-	 * @param displayDateDay       the calendar day the web content article is set to
-	 display
-	 * @param displayDateYear      the year the web content article is set to
-	 display
-	 * @param displayDateHour      the hour the web content article is set to
-	 display
-	 * @param displayDateMinute    the minute the web content article is set to
-	 display
-	 * @param expirationDateMonth  the month the web content article is set to
+	 * @param expirationDate       the date the web content article is set to
 	 expire
-	 * @param expirationDateDay    the calendar day the web content article is set
-	 to expire
-	 * @param expirationDateYear   the year the web content article is set to
-	 expire
-	 * @param expirationDateHour   the hour the web content article is set to
-	 expire
-	 * @param expirationDateMinute the minute the web content article is set to
-	 expire
-	 * @param neverExpire          whether the web content article is not set to auto
-	 expire
-	 * @param reviewDateMonth      the month the web content article is set for
+	 * @param reviewDate           the month the web content article is set for
 	 review
-	 * @param reviewDateDay        the calendar day the web content article is set for
-	 review
-	 * @param reviewDateYear       the year the web content article is set for review
-	 * @param reviewDateHour       the hour the web content article is set for review
-	 * @param reviewDateMinute     the minute the web content article is set for
-	 review
-	 * @param neverReview          whether the web content article is not set for review
 	 * @param indexable            whether the web content is searchable
 	 * @param smallImage           whether to update web content article's a small image.
 	 A file must be passed in as <code>smallImageFile</code> value,
@@ -1657,6 +1631,28 @@ public class JournalArticleServiceUtil {
 	 * @return the updated web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
+	public static JournalArticle updateArticle(
+			long groupId, long folderId, String articleId, double version,
+			Map<java.util.Locale, String> titleMap,
+			Map<java.util.Locale, String> descriptionMap,
+			Map<java.util.Locale, String> friendlyURLMap, String content,
+			String ddmTemplateKey, String layoutUuid,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate, boolean indexable, boolean smallImage,
+			long smallImageId, int smallImageSource, String smallImageURL,
+			java.io.File smallFile, Map<String, byte[]> images,
+			String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().updateArticle(
+			groupId, folderId, articleId, version, titleMap, descriptionMap,
+			friendlyURLMap, content, ddmTemplateKey, layoutUuid, displayDate,
+			expirationDate, reviewDate, indexable, smallImage, smallImageId,
+			smallImageSource, smallImageURL, smallFile, images, articleURL,
+			serviceContext);
+	}
+
 	public static JournalArticle updateArticle(
 			long groupId, long folderId, String articleId, double version,
 			Map<java.util.Locale, String> titleMap,

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleServiceWrapper.java
@@ -64,37 +64,12 @@ public class JournalArticleServiceWrapper
 	 template
 	 * @param layoutUuid            the unique string identifying the web content
 	 article's display page
-	 * @param displayDateMonth      the month the web content article is set to
+	 * @param displayDate           the date the web content article is set to
 	 display
-	 * @param displayDateDay        the calendar day the web content article is set to
-	 display
-	 * @param displayDateYear       the year the web content article is set to
-	 display
-	 * @param displayDateHour       the hour the web content article is set to
-	 display
-	 * @param displayDateMinute     the minute the web content article is set to
-	 display
-	 * @param expirationDateMonth   the month the web content article is set to
+	 * @param expirationDate        the date the web content article is set to
 	 expire
-	 * @param expirationDateDay     the calendar day the web content article is set
-	 to expire
-	 * @param expirationDateYear    the year the web content article is set to
-	 expire
-	 * @param expirationDateHour    the hour the web content article is set to
-	 expire
-	 * @param expirationDateMinute  the minute the web content article is set to
-	 expire
-	 * @param neverExpire           whether the web content article is not set to auto
-	 expire
-	 * @param reviewDateMonth       the month the web content article is set for
+	 * @param reviewDate            the date the web content article is set for
 	 review
-	 * @param reviewDateDay         the calendar day the web content article is set for
-	 review
-	 * @param reviewDateYear        the year the web content article is set for review
-	 * @param reviewDateHour        the hour the web content article is set for review
-	 * @param reviewDateMinute      the minute the web content article is set for
-	 review
-	 * @param neverReview           whether the web content article is not set for review
 	 * @param indexable             whether the web content article is searchable
 	 * @param smallImage            whether the web content article has a small image
 	 * @param smallImageSource      the web content article's small image source
@@ -111,6 +86,32 @@ public class JournalArticleServiceWrapper
 	 * @return the web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
+	@Override
+	public JournalArticle addArticle(
+			String externalReferenceCode, long groupId, long folderId,
+			long classNameId, long classPK, String articleId,
+			boolean autoArticleId,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, long ddmStructureId, String ddmTemplateKey,
+			String layoutUuid, java.util.Date displayDate,
+			java.util.Date expirationDate, java.util.Date reviewDate,
+			boolean indexable, boolean smallImage, long smallImageId,
+			int smallImageSource, String smallImageURL, java.io.File smallFile,
+			java.util.Map<String, byte[]> images, String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleService.addArticle(
+			externalReferenceCode, groupId, folderId, classNameId, classPK,
+			articleId, autoArticleId, titleMap, descriptionMap, friendlyURLMap,
+			content, ddmStructureId, ddmTemplateKey, layoutUuid, displayDate,
+			expirationDate, reviewDate, indexable, smallImage, smallImageId,
+			smallImageSource, smallImageURL, smallFile, images, articleURL,
+			serviceContext);
+	}
+
 	@Override
 	public JournalArticle addArticle(
 			String externalReferenceCode, long groupId, long folderId,
@@ -1687,37 +1688,12 @@ public class JournalArticleServiceWrapper
 	 template
 	 * @param layoutUuid           the unique string identifying the web content
 	 article's display page
-	 * @param displayDateMonth     the month the web content article is set to
+	 * @param displayDate          the date the web content article is set to
 	 display
-	 * @param displayDateDay       the calendar day the web content article is set to
-	 display
-	 * @param displayDateYear      the year the web content article is set to
-	 display
-	 * @param displayDateHour      the hour the web content article is set to
-	 display
-	 * @param displayDateMinute    the minute the web content article is set to
-	 display
-	 * @param expirationDateMonth  the month the web content article is set to
+	 * @param expirationDate       the date the web content article is set to
 	 expire
-	 * @param expirationDateDay    the calendar day the web content article is set
-	 to expire
-	 * @param expirationDateYear   the year the web content article is set to
-	 expire
-	 * @param expirationDateHour   the hour the web content article is set to
-	 expire
-	 * @param expirationDateMinute the minute the web content article is set to
-	 expire
-	 * @param neverExpire          whether the web content article is not set to auto
-	 expire
-	 * @param reviewDateMonth      the month the web content article is set for
+	 * @param reviewDate           the month the web content article is set for
 	 review
-	 * @param reviewDateDay        the calendar day the web content article is set for
-	 review
-	 * @param reviewDateYear       the year the web content article is set for review
-	 * @param reviewDateHour       the hour the web content article is set for review
-	 * @param reviewDateMinute     the minute the web content article is set for
-	 review
-	 * @param neverReview          whether the web content article is not set for review
 	 * @param indexable            whether the web content is searchable
 	 * @param smallImage           whether to update web content article's a small image.
 	 A file must be passed in as <code>smallImageFile</code> value,
@@ -1745,6 +1721,29 @@ public class JournalArticleServiceWrapper
 	 * @return the updated web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
+	@Override
+	public JournalArticle updateArticle(
+			long groupId, long folderId, String articleId, double version,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmTemplateKey, String layoutUuid,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate, boolean indexable, boolean smallImage,
+			long smallImageId, int smallImageSource, String smallImageURL,
+			java.io.File smallFile, java.util.Map<String, byte[]> images,
+			String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _journalArticleService.updateArticle(
+			groupId, folderId, articleId, version, titleMap, descriptionMap,
+			friendlyURLMap, content, ddmTemplateKey, layoutUuid, displayDate,
+			expirationDate, reviewDate, indexable, smallImage, smallImageId,
+			smallImageSource, smallImageURL, smallFile, images, articleURL,
+			serviceContext);
+	}
+
 	@Override
 	public JournalArticle updateArticle(
 			long groupId, long folderId, String articleId, double version,

--- a/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
+++ b/modules/apps/journal/journal-api/src/main/resources/com/liferay/journal/service/packageinfo
@@ -1,1 +1,1 @@
-version 15.0.0
+version 15.1.0

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -63,7 +63,6 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Image;
 import com.liferay.portal.kernel.model.Layout;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserNotificationEvent;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
@@ -76,7 +75,6 @@ import com.liferay.portal.kernel.service.UserNotificationEventLocalService;
 import com.liferay.portal.kernel.settings.GroupServiceSettingsLocator;
 import com.liferay.portal.kernel.trash.TrashHandler;
 import com.liferay.portal.kernel.trash.TrashHandlerRegistryUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
@@ -97,7 +95,6 @@ import com.liferay.portlet.documentlibrary.lar.FileEntryUtil;
 import java.io.File;
 import java.io.InputStream;
 
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -618,8 +615,6 @@ public class JournalArticleStagedModelDataHandler
 			userId = authorId;
 		}
 
-		User user = _userLocalService.getUser(userId);
-
 		Map<Long, Long> folderIds =
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 				JournalFolder.class);
@@ -667,87 +662,6 @@ public class JournalArticleStagedModelDataHandler
 
 		String content = portletDataContext.getZipEntryAsString(
 			ExportImportPathUtil.getModelPath(article, "journal-content-path"));
-
-		Date displayDate = article.getDisplayDate();
-
-		int displayDateMonth = 0;
-		int displayDateDay = 0;
-		int displayDateYear = 0;
-		int displayDateHour = 0;
-		int displayDateMinute = 0;
-
-		if (displayDate != null) {
-			Calendar displayCal = CalendarFactoryUtil.getCalendar(
-				user.getTimeZone());
-
-			displayCal.setTime(displayDate);
-
-			displayDateMonth = displayCal.get(Calendar.MONTH);
-			displayDateDay = displayCal.get(Calendar.DATE);
-			displayDateYear = displayCal.get(Calendar.YEAR);
-			displayDateHour = displayCal.get(Calendar.HOUR);
-			displayDateMinute = displayCal.get(Calendar.MINUTE);
-
-			if (displayCal.get(Calendar.AM_PM) == Calendar.PM) {
-				displayDateHour += 12;
-			}
-		}
-
-		Date expirationDate = article.getExpirationDate();
-
-		int expirationDateMonth = 0;
-		int expirationDateDay = 0;
-		int expirationDateYear = 0;
-		int expirationDateHour = 0;
-		int expirationDateMinute = 0;
-		boolean neverExpire = true;
-
-		if (expirationDate != null) {
-			Calendar expirationCal = CalendarFactoryUtil.getCalendar(
-				user.getTimeZone());
-
-			expirationCal.setTime(expirationDate);
-
-			expirationDateMonth = expirationCal.get(Calendar.MONTH);
-			expirationDateDay = expirationCal.get(Calendar.DATE);
-			expirationDateYear = expirationCal.get(Calendar.YEAR);
-			expirationDateHour = expirationCal.get(Calendar.HOUR);
-			expirationDateMinute = expirationCal.get(Calendar.MINUTE);
-
-			neverExpire = false;
-
-			if (expirationCal.get(Calendar.AM_PM) == Calendar.PM) {
-				expirationDateHour += 12;
-			}
-		}
-
-		Date reviewDate = article.getReviewDate();
-
-		int reviewDateMonth = 0;
-		int reviewDateDay = 0;
-		int reviewDateYear = 0;
-		int reviewDateHour = 0;
-		int reviewDateMinute = 0;
-		boolean neverReview = true;
-
-		if (reviewDate != null) {
-			Calendar reviewCal = CalendarFactoryUtil.getCalendar(
-				user.getTimeZone());
-
-			reviewCal.setTime(reviewDate);
-
-			reviewDateMonth = reviewCal.get(Calendar.MONTH);
-			reviewDateDay = reviewCal.get(Calendar.DATE);
-			reviewDateYear = reviewCal.get(Calendar.YEAR);
-			reviewDateHour = reviewCal.get(Calendar.HOUR);
-			reviewDateMinute = reviewCal.get(Calendar.MINUTE);
-
-			neverReview = false;
-
-			if (reviewCal.get(Calendar.AM_PM) == Calendar.PM) {
-				reviewDateHour += 12;
-			}
-		}
 
 		long classPK = 0;
 
@@ -895,6 +809,8 @@ public class JournalArticleStagedModelDataHandler
 			ServiceContext serviceContext =
 				portletDataContext.createServiceContext(article);
 
+			Date expirationDate = article.getExpirationDate();
+
 			if ((expirationDate != null) && expirationDate.before(new Date())) {
 				article.setStatus(WorkflowConstants.STATUS_EXPIRED);
 			}
@@ -949,13 +865,8 @@ public class JournalArticleStagedModelDataHandler
 						autoArticleId, article.getVersion(),
 						article.getTitleMap(), article.getDescriptionMap(),
 						friendlyURLMap, content, ddmStructureId, ddmTemplateKey,
-						article.getLayoutUuid(), displayDateMonth,
-						displayDateDay, displayDateYear, displayDateHour,
-						displayDateMinute, expirationDateMonth,
-						expirationDateDay, expirationDateYear,
-						expirationDateHour, expirationDateMinute, neverExpire,
-						reviewDateMonth, reviewDateDay, reviewDateYear,
-						reviewDateHour, reviewDateMinute, neverReview,
+						article.getLayoutUuid(), article.getDisplayDate(),
+						article.getExpirationDate(), article.getReviewDate(),
 						article.isIndexable(), article.isSmallImage(),
 						article.getSmallImageId(),
 						article.getSmallImageSource(),
@@ -968,13 +879,8 @@ public class JournalArticleStagedModelDataHandler
 						existingArticle.getArticleId(), article.getVersion(),
 						article.getTitleMap(), article.getDescriptionMap(),
 						friendlyURLMap, content, ddmTemplateKey,
-						article.getLayoutUuid(), displayDateMonth,
-						displayDateDay, displayDateYear, displayDateHour,
-						displayDateMinute, expirationDateMonth,
-						expirationDateDay, expirationDateYear,
-						expirationDateHour, expirationDateMinute, neverExpire,
-						reviewDateMonth, reviewDateDay, reviewDateYear,
-						reviewDateHour, reviewDateMinute, neverReview,
+						article.getLayoutUuid(), article.getDisplayDate(),
+						article.getExpirationDate(), article.getReviewDate(),
 						article.isIndexable(), article.isSmallImage(),
 						article.getSmallImageId(),
 						article.getSmallImageSource(),
@@ -1012,13 +918,8 @@ public class JournalArticleStagedModelDataHandler
 						autoArticleId, article.getVersion(),
 						article.getTitleMap(), article.getDescriptionMap(),
 						friendlyURLMap, content, ddmStructureId, ddmTemplateKey,
-						article.getLayoutUuid(), displayDateMonth,
-						displayDateDay, displayDateYear, displayDateHour,
-						displayDateMinute, expirationDateMonth,
-						expirationDateDay, expirationDateYear,
-						expirationDateHour, expirationDateMinute, neverExpire,
-						reviewDateMonth, reviewDateDay, reviewDateYear,
-						reviewDateHour, reviewDateMinute, neverReview,
+						article.getLayoutUuid(), article.getDisplayDate(),
+						article.getExpirationDate(), article.getReviewDate(),
 						article.isIndexable(), article.isSmallImage(), 0,
 						article.getSmallImageSource(),
 						article.getSmallImageURL(), smallFile, null, articleURL,
@@ -1030,14 +931,9 @@ public class JournalArticleStagedModelDataHandler
 						articleId, article.getVersion(), article.getTitleMap(),
 						article.getDescriptionMap(), friendlyURLMap, content,
 						ddmTemplateKey, article.getLayoutUuid(),
-						displayDateMonth, displayDateDay, displayDateYear,
-						displayDateHour, displayDateMinute, expirationDateMonth,
-						expirationDateDay, expirationDateYear,
-						expirationDateHour, expirationDateMinute, neverExpire,
-						reviewDateMonth, reviewDateDay, reviewDateYear,
-						reviewDateHour, reviewDateMinute, neverReview,
-						article.isIndexable(), article.isSmallImage(),
-						article.getSmallImageId(),
+						article.getDisplayDate(), article.getExpirationDate(),
+						article.getReviewDate(), article.isIndexable(),
+						article.isSmallImage(), article.getSmallImageId(),
 						article.getSmallImageSource(),
 						article.getSmallImageURL(), smallFile, null, articleURL,
 						serviceContext);
@@ -1081,12 +977,8 @@ public class JournalArticleStagedModelDataHandler
 					importedArticle.getArticleId(), article.getVersion(),
 					article.getTitleMap(), article.getDescriptionMap(),
 					friendlyURLMap, replacedContent, ddmTemplateKey,
-					article.getLayoutUuid(), displayDateMonth, displayDateDay,
-					displayDateYear, displayDateHour, displayDateMinute,
-					expirationDateMonth, expirationDateDay, expirationDateYear,
-					expirationDateHour, expirationDateMinute, neverExpire,
-					reviewDateMonth, reviewDateDay, reviewDateYear,
-					reviewDateHour, reviewDateMinute, neverReview,
+					article.getLayoutUuid(), article.getDisplayDate(),
+					article.getExpirationDate(), article.getReviewDate(),
 					article.isIndexable(), article.isSmallImage(),
 					article.getSmallImageId(), article.getSmallImageSource(),
 					article.getSmallImageURL(), smallFile, null, articleURL,

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceHttp.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/http/JournalArticleServiceHttp.java
@@ -49,6 +49,64 @@ public class JournalArticleServiceHttp {
 			java.util.Map<java.util.Locale, String> descriptionMap,
 			java.util.Map<java.util.Locale, String> friendlyURLMap,
 			String content, long ddmStructureId, String ddmTemplateKey,
+			String layoutUuid, java.util.Date displayDate,
+			java.util.Date expirationDate, java.util.Date reviewDate,
+			boolean indexable, boolean smallImage, long smallImageId,
+			int smallImageSource, String smallImageURL, java.io.File smallFile,
+			java.util.Map<String, byte[]> images, String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				JournalArticleServiceUtil.class, "addArticle",
+				_addArticleParameterTypes0);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, groupId, folderId,
+				classNameId, classPK, articleId, autoArticleId, titleMap,
+				descriptionMap, friendlyURLMap, content, ddmStructureId,
+				ddmTemplateKey, layoutUuid, displayDate, expirationDate,
+				reviewDate, indexable, smallImage, smallImageId,
+				smallImageSource, smallImageURL, smallFile, images, articleURL,
+				serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.journal.model.JournalArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.journal.model.JournalArticle addArticle(
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long groupId, long folderId, long classNameId, long classPK,
+			String articleId, boolean autoArticleId,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, long ddmStructureId, String ddmTemplateKey,
 			String layoutUuid, int displayDateMonth, int displayDateDay,
 			int displayDateYear, int displayDateHour, int displayDateMinute,
 			int expirationDateMonth, int expirationDateDay,
@@ -65,7 +123,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "addArticle",
-				_addArticleParameterTypes0);
+				_addArticleParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, folderId,
@@ -120,7 +178,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "addArticle",
-				_addArticleParameterTypes1);
+				_addArticleParameterTypes2);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, externalReferenceCode, groupId, folderId, titleMap,
@@ -177,7 +235,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "addArticleDefaultValues",
-				_addArticleDefaultValuesParameterTypes2);
+				_addArticleDefaultValuesParameterTypes3);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, classPK, titleMap,
@@ -227,7 +285,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "copyArticle",
-				_copyArticleParameterTypes3);
+				_copyArticleParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, sourceArticleId, targetArticleId,
@@ -270,7 +328,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "deleteArticle",
-				_deleteArticleParameterTypes4);
+				_deleteArticleParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, articleURL,
@@ -309,7 +367,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "deleteArticle",
-				_deleteArticleParameterTypes5);
+				_deleteArticleParameterTypes6);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, articleURL, serviceContext);
@@ -346,7 +404,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "deleteArticleDefaultValues",
-				_deleteArticleDefaultValuesParameterTypes6);
+				_deleteArticleDefaultValuesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, ddmStructureId);
@@ -384,7 +442,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "expireArticle",
-				_expireArticleParameterTypes7);
+				_expireArticleParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, articleURL,
@@ -427,7 +485,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "expireArticle",
-				_expireArticleParameterTypes8);
+				_expireArticleParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, articleURL, serviceContext);
@@ -463,7 +521,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "fetchArticle",
-				_fetchArticleParameterTypes9);
+				_fetchArticleParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -506,7 +564,7 @@ public class JournalArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class,
 				"fetchLatestArticleByExternalReferenceCode",
-				_fetchLatestArticleByExternalReferenceCodeParameterTypes10);
+				_fetchLatestArticleByExternalReferenceCodeParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -546,7 +604,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticle",
-				_getArticleParameterTypes11);
+				_getArticleParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, id);
 
@@ -585,7 +643,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticle",
-				_getArticleParameterTypes12);
+				_getArticleParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -626,7 +684,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticle",
-				_getArticleParameterTypes13);
+				_getArticleParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version);
@@ -667,7 +725,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticle",
-				_getArticleParameterTypes14);
+				_getArticleParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, className, classPK);
@@ -707,7 +765,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticleByUrlTitle",
-				_getArticleByUrlTitleParameterTypes15);
+				_getArticleByUrlTitleParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, urlTitle);
@@ -751,7 +809,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticleContent",
-				_getArticleContentParameterTypes16);
+				_getArticleContentParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, languageId,
@@ -796,7 +854,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticleContent",
-				_getArticleContentParameterTypes17);
+				_getArticleContentParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, languageId, portletRequestModel,
@@ -838,7 +896,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticles",
-				_getArticlesParameterTypes18);
+				_getArticlesParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, locale);
@@ -875,7 +933,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticles",
-				_getArticlesParameterTypes19);
+				_getArticlesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, locale, start, end,
@@ -913,7 +971,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByArticleId",
-				_getArticlesByArticleIdParameterTypes20);
+				_getArticlesByArticleIdParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, status, start, end,
@@ -951,7 +1009,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByArticleId",
-				_getArticlesByArticleIdParameterTypes21);
+				_getArticlesByArticleIdParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, start, end, orderByComparator);
@@ -985,7 +1043,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByLayoutUuid",
-				_getArticlesByLayoutUuidParameterTypes22);
+				_getArticlesByLayoutUuidParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutUuid);
@@ -1020,7 +1078,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByLayoutUuid",
-				_getArticlesByLayoutUuidParameterTypes23);
+				_getArticlesByLayoutUuidParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutUuid, start, end);
@@ -1053,7 +1111,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByLayoutUuidCount",
-				_getArticlesByLayoutUuidCountParameterTypes24);
+				_getArticlesByLayoutUuidCountParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, layoutUuid);
@@ -1089,7 +1147,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByStructureId",
-				_getArticlesByStructureIdParameterTypes25);
+				_getArticlesByStructureIdParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructureId, status, start, end,
@@ -1127,7 +1185,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByStructureId",
-				_getArticlesByStructureIdParameterTypes26);
+				_getArticlesByStructureIdParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructureId, start, end,
@@ -1165,7 +1223,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByStructureId",
-				_getArticlesByStructureIdParameterTypes27);
+				_getArticlesByStructureIdParameterTypes28);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructureId, locale, status, start, end,
@@ -1203,7 +1261,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByStructureId",
-				_getArticlesByStructureIdParameterTypes28);
+				_getArticlesByStructureIdParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, ddmStructureId, status, start,
@@ -1242,7 +1300,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByStructureId",
-				_getArticlesByStructureIdParameterTypes29);
+				_getArticlesByStructureIdParameterTypes30);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, ddmStructureId, locale, status,
@@ -1281,7 +1339,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesByStructureId",
-				_getArticlesByStructureIdParameterTypes30);
+				_getArticlesByStructureIdParameterTypes31);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, classNameId, ddmStructureId,
@@ -1315,7 +1373,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesCount",
-				_getArticlesCountParameterTypes31);
+				_getArticlesCountParameterTypes32);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId);
@@ -1347,7 +1405,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesCount",
-				_getArticlesCountParameterTypes32);
+				_getArticlesCountParameterTypes33);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, status);
@@ -1379,7 +1437,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesCountByArticleId",
-				_getArticlesCountByArticleIdParameterTypes33);
+				_getArticlesCountByArticleIdParameterTypes34);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -1412,7 +1470,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getArticlesCountByArticleId",
-				_getArticlesCountByArticleIdParameterTypes34);
+				_getArticlesCountByArticleIdParameterTypes35);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, status);
@@ -1445,7 +1503,7 @@ public class JournalArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class,
 				"getArticlesCountByStructureId",
-				_getArticlesCountByStructureIdParameterTypes35);
+				_getArticlesCountByStructureIdParameterTypes36);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructureId);
@@ -1479,7 +1537,7 @@ public class JournalArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class,
 				"getArticlesCountByStructureId",
-				_getArticlesCountByStructureIdParameterTypes36);
+				_getArticlesCountByStructureIdParameterTypes37);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, ddmStructureId, status);
@@ -1513,7 +1571,7 @@ public class JournalArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class,
 				"getArticlesCountByStructureId",
-				_getArticlesCountByStructureIdParameterTypes37);
+				_getArticlesCountByStructureIdParameterTypes38);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, classNameId, ddmStructureId, status);
@@ -1547,7 +1605,7 @@ public class JournalArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class,
 				"getArticlesCountByStructureId",
-				_getArticlesCountByStructureIdParameterTypes38);
+				_getArticlesCountByStructureIdParameterTypes39);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, classNameId, ddmStructureId,
@@ -1582,7 +1640,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getDisplayArticleByUrlTitle",
-				_getDisplayArticleByUrlTitleParameterTypes39);
+				_getDisplayArticleByUrlTitleParameterTypes40);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, urlTitle);
@@ -1622,7 +1680,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getFoldersAndArticlesCount",
-				_getFoldersAndArticlesCountParameterTypes40);
+				_getFoldersAndArticlesCountParameterTypes41);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderIds);
@@ -1661,7 +1719,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticles",
-				_getGroupArticlesParameterTypes41);
+				_getGroupArticlesParameterTypes42);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, status, includeOwner,
@@ -1709,7 +1767,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticles",
-				_getGroupArticlesParameterTypes42);
+				_getGroupArticlesParameterTypes43);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, status, includeOwner,
@@ -1756,7 +1814,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticles",
-				_getGroupArticlesParameterTypes43);
+				_getGroupArticlesParameterTypes44);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, status, start, end,
@@ -1803,7 +1861,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticles",
-				_getGroupArticlesParameterTypes44);
+				_getGroupArticlesParameterTypes45);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, start, end,
@@ -1846,7 +1904,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticlesCount",
-				_getGroupArticlesCountParameterTypes45);
+				_getGroupArticlesCountParameterTypes46);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId);
@@ -1887,7 +1945,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticlesCount",
-				_getGroupArticlesCountParameterTypes46);
+				_getGroupArticlesCountParameterTypes47);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, status);
@@ -1928,7 +1986,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getGroupArticlesCount",
-				_getGroupArticlesCountParameterTypes47);
+				_getGroupArticlesCountParameterTypes48);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, rootFolderId, status, includeOwner);
@@ -1968,7 +2026,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLatestArticle",
-				_getLatestArticleParameterTypes48);
+				_getLatestArticleParameterTypes49);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey);
@@ -2009,7 +2067,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLatestArticle",
-				_getLatestArticleParameterTypes49);
+				_getLatestArticleParameterTypes50);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, status);
@@ -2050,7 +2108,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLatestArticle",
-				_getLatestArticleParameterTypes50);
+				_getLatestArticleParameterTypes51);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, className, classPK);
@@ -2093,7 +2151,7 @@ public class JournalArticleServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class,
 				"getLatestArticleByExternalReferenceCode",
-				_getLatestArticleByExternalReferenceCodeParameterTypes51);
+				_getLatestArticleByExternalReferenceCodeParameterTypes52);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, externalReferenceCode);
@@ -2136,7 +2194,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLatestArticles",
-				_getLatestArticlesParameterTypes52);
+				_getLatestArticlesParameterTypes53);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status, start, end, orderByComparator);
@@ -2169,7 +2227,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLatestArticlesCount",
-				_getLatestArticlesCountParameterTypes53);
+				_getLatestArticlesCountParameterTypes54);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, status);
@@ -2201,7 +2259,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLayoutArticles",
-				_getLayoutArticlesParameterTypes54);
+				_getLayoutArticlesParameterTypes55);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -2234,7 +2292,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLayoutArticles",
-				_getLayoutArticlesParameterTypes55);
+				_getLayoutArticlesParameterTypes56);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, start, end);
@@ -2267,7 +2325,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "getLayoutArticlesCount",
-				_getLayoutArticlesCountParameterTypes56);
+				_getLayoutArticlesCountParameterTypes57);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -2301,7 +2359,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "moveArticle",
-				_moveArticleParameterTypes57);
+				_moveArticleParameterTypes58);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, newFolderId, serviceContext);
@@ -2339,7 +2397,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "moveArticleFromTrash",
-				_moveArticleFromTrashParameterTypes58);
+				_moveArticleFromTrashParameterTypes59);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, resourcePrimKey, newFolderId,
@@ -2382,7 +2440,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "moveArticleFromTrash",
-				_moveArticleFromTrashParameterTypes59);
+				_moveArticleFromTrashParameterTypes60);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, newFolderId, serviceContext);
@@ -2422,7 +2480,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "moveArticleToTrash",
-				_moveArticleToTrashParameterTypes60);
+				_moveArticleToTrashParameterTypes61);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -2462,7 +2520,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "removeArticleLocale",
-				_removeArticleLocaleParameterTypes61);
+				_removeArticleLocaleParameterTypes62);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, companyId, languageId);
@@ -2499,7 +2557,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "removeArticleLocale",
-				_removeArticleLocaleParameterTypes62);
+				_removeArticleLocaleParameterTypes63);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, languageId);
@@ -2539,7 +2597,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "restoreArticleFromTrash",
-				_restoreArticleFromTrashParameterTypes63);
+				_restoreArticleFromTrashParameterTypes64);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, resourcePrimKey);
@@ -2575,7 +2633,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "restoreArticleFromTrash",
-				_restoreArticleFromTrashParameterTypes64);
+				_restoreArticleFromTrashParameterTypes65);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -2611,7 +2669,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "subscribe",
-				_subscribeParameterTypes65);
+				_subscribeParameterTypes66);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -2648,7 +2706,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "subscribeStructure",
-				_subscribeStructureParameterTypes66);
+				_subscribeStructureParameterTypes67);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, ddmStructureId);
@@ -2684,7 +2742,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "unsubscribe",
-				_unsubscribeParameterTypes67);
+				_unsubscribeParameterTypes68);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId);
@@ -2721,7 +2779,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "unsubscribeStructure",
-				_unsubscribeStructureParameterTypes68);
+				_unsubscribeStructureParameterTypes69);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, userId, ddmStructureId);
@@ -2762,11 +2820,66 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticle",
-				_updateArticleParameterTypes69);
+				_updateArticleParameterTypes70);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, userId, groupId, folderId, articleId, version,
 				titleMap, descriptionMap, content, layoutUuid, serviceContext);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.journal.model.JournalArticle)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.journal.model.JournalArticle updateArticle(
+			HttpPrincipal httpPrincipal, long groupId, long folderId,
+			String articleId, double version,
+			java.util.Map<java.util.Locale, String> titleMap,
+			java.util.Map<java.util.Locale, String> descriptionMap,
+			java.util.Map<java.util.Locale, String> friendlyURLMap,
+			String content, String ddmTemplateKey, String layoutUuid,
+			java.util.Date displayDate, java.util.Date expirationDate,
+			java.util.Date reviewDate, boolean indexable, boolean smallImage,
+			long smallImageId, int smallImageSource, String smallImageURL,
+			java.io.File smallFile, java.util.Map<String, byte[]> images,
+			String articleURL,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				JournalArticleServiceUtil.class, "updateArticle",
+				_updateArticleParameterTypes71);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, groupId, folderId, articleId, version, titleMap,
+				descriptionMap, friendlyURLMap, content, ddmTemplateKey,
+				layoutUuid, displayDate, expirationDate, reviewDate, indexable,
+				smallImage, smallImageId, smallImageSource, smallImageURL,
+				smallFile, images, articleURL, serviceContext);
 
 			Object returnObj = null;
 
@@ -2819,7 +2932,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticle",
-				_updateArticleParameterTypes70);
+				_updateArticleParameterTypes72);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, articleId, version, titleMap,
@@ -2870,7 +2983,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticle",
-				_updateArticleParameterTypes71);
+				_updateArticleParameterTypes73);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderId, articleId, version, content,
@@ -2926,7 +3039,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticleDefaultValues",
-				_updateArticleDefaultValuesParameterTypes72);
+				_updateArticleDefaultValuesParameterTypes74);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, titleMap, descriptionMap,
@@ -2979,7 +3092,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateArticleTranslation",
-				_updateArticleTranslationParameterTypes73);
+				_updateArticleTranslationParameterTypes75);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, locale, title,
@@ -3022,7 +3135,7 @@ public class JournalArticleServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				JournalArticleServiceUtil.class, "updateStatus",
-				_updateStatusParameterTypes74);
+				_updateStatusParameterTypes76);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, articleId, version, status, articleURL,
@@ -3063,6 +3176,15 @@ public class JournalArticleServiceHttp {
 		String.class, long.class, long.class, long.class, long.class,
 		String.class, boolean.class, java.util.Map.class, java.util.Map.class,
 		java.util.Map.class, String.class, long.class, String.class,
+		String.class, java.util.Date.class, java.util.Date.class,
+		java.util.Date.class, boolean.class, boolean.class, long.class,
+		int.class, String.class, java.io.File.class, java.util.Map.class,
+		String.class, com.liferay.portal.kernel.service.ServiceContext.class
+	};
+	private static final Class<?>[] _addArticleParameterTypes1 = new Class[] {
+		String.class, long.class, long.class, long.class, long.class,
+		String.class, boolean.class, java.util.Map.class, java.util.Map.class,
+		java.util.Map.class, String.class, long.class, String.class,
 		String.class, int.class, int.class, int.class, int.class, int.class,
 		int.class, int.class, int.class, int.class, int.class, boolean.class,
 		int.class, int.class, int.class, int.class, int.class, boolean.class,
@@ -3070,12 +3192,12 @@ public class JournalArticleServiceHttp {
 		java.io.File.class, java.util.Map.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _addArticleParameterTypes1 = new Class[] {
+	private static final Class<?>[] _addArticleParameterTypes2 = new Class[] {
 		String.class, long.class, long.class, java.util.Map.class,
 		java.util.Map.class, String.class, long.class, String.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _addArticleDefaultValuesParameterTypes2 =
+	private static final Class<?>[] _addArticleDefaultValuesParameterTypes3 =
 		new Class[] {
 			long.class, long.class, long.class, java.util.Map.class,
 			java.util.Map.class, String.class, long.class, String.class,
@@ -3086,251 +3208,260 @@ public class JournalArticleServiceHttp {
 			int.class, String.class, java.io.File.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _copyArticleParameterTypes3 = new Class[] {
+	private static final Class<?>[] _copyArticleParameterTypes4 = new Class[] {
 		long.class, String.class, String.class, boolean.class, double.class
 	};
-	private static final Class<?>[] _deleteArticleParameterTypes4 =
-		new Class[] {
-			long.class, String.class, double.class, String.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
-		};
 	private static final Class<?>[] _deleteArticleParameterTypes5 =
 		new Class[] {
-			long.class, String.class, String.class,
-			com.liferay.portal.kernel.service.ServiceContext.class
-		};
-	private static final Class<?>[] _deleteArticleDefaultValuesParameterTypes6 =
-		new Class[] {long.class, String.class, long.class};
-	private static final Class<?>[] _expireArticleParameterTypes7 =
-		new Class[] {
 			long.class, String.class, double.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
+	private static final Class<?>[] _deleteArticleParameterTypes6 =
+		new Class[] {
+			long.class, String.class, String.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _deleteArticleDefaultValuesParameterTypes7 =
+		new Class[] {long.class, String.class, long.class};
 	private static final Class<?>[] _expireArticleParameterTypes8 =
 		new Class[] {
+			long.class, String.class, double.class, String.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _expireArticleParameterTypes9 =
+		new Class[] {
 			long.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _fetchArticleParameterTypes9 = new Class[] {
-		long.class, String.class
-	};
+	private static final Class<?>[] _fetchArticleParameterTypes10 =
+		new Class[] {long.class, String.class};
 	private static final Class<?>[]
-		_fetchLatestArticleByExternalReferenceCodeParameterTypes10 =
+		_fetchLatestArticleByExternalReferenceCodeParameterTypes11 =
 			new Class[] {long.class, String.class};
-	private static final Class<?>[] _getArticleParameterTypes11 = new Class[] {
+	private static final Class<?>[] _getArticleParameterTypes12 = new Class[] {
 		long.class
 	};
-	private static final Class<?>[] _getArticleParameterTypes12 = new Class[] {
+	private static final Class<?>[] _getArticleParameterTypes13 = new Class[] {
 		long.class, String.class
 	};
-	private static final Class<?>[] _getArticleParameterTypes13 = new Class[] {
+	private static final Class<?>[] _getArticleParameterTypes14 = new Class[] {
 		long.class, String.class, double.class
 	};
-	private static final Class<?>[] _getArticleParameterTypes14 = new Class[] {
+	private static final Class<?>[] _getArticleParameterTypes15 = new Class[] {
 		long.class, String.class, long.class
 	};
-	private static final Class<?>[] _getArticleByUrlTitleParameterTypes15 =
+	private static final Class<?>[] _getArticleByUrlTitleParameterTypes16 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _getArticleContentParameterTypes16 =
+	private static final Class<?>[] _getArticleContentParameterTypes17 =
 		new Class[] {
 			long.class, String.class, double.class, String.class,
 			com.liferay.portal.kernel.portlet.PortletRequestModel.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getArticleContentParameterTypes17 =
+	private static final Class<?>[] _getArticleContentParameterTypes18 =
 		new Class[] {
 			long.class, String.class, String.class,
 			com.liferay.portal.kernel.portlet.PortletRequestModel.class,
 			com.liferay.portal.kernel.theme.ThemeDisplay.class
 		};
-	private static final Class<?>[] _getArticlesParameterTypes18 = new Class[] {
+	private static final Class<?>[] _getArticlesParameterTypes19 = new Class[] {
 		long.class, long.class, java.util.Locale.class
 	};
-	private static final Class<?>[] _getArticlesParameterTypes19 = new Class[] {
+	private static final Class<?>[] _getArticlesParameterTypes20 = new Class[] {
 		long.class, long.class, java.util.Locale.class, int.class, int.class,
 		com.liferay.portal.kernel.util.OrderByComparator.class
 	};
-	private static final Class<?>[] _getArticlesByArticleIdParameterTypes20 =
+	private static final Class<?>[] _getArticlesByArticleIdParameterTypes21 =
 		new Class[] {
 			long.class, String.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByArticleIdParameterTypes21 =
+	private static final Class<?>[] _getArticlesByArticleIdParameterTypes22 =
 		new Class[] {
 			long.class, String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByLayoutUuidParameterTypes22 =
-		new Class[] {long.class, String.class};
 	private static final Class<?>[] _getArticlesByLayoutUuidParameterTypes23 =
+		new Class[] {long.class, String.class};
+	private static final Class<?>[] _getArticlesByLayoutUuidParameterTypes24 =
 		new Class[] {long.class, String.class, int.class, int.class};
 	private static final Class<?>[]
-		_getArticlesByLayoutUuidCountParameterTypes24 = new Class[] {
+		_getArticlesByLayoutUuidCountParameterTypes25 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes25 =
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes26 =
 		new Class[] {
 			long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes26 =
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes27 =
 		new Class[] {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes27 =
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes28 =
 		new Class[] {
 			long.class, long.class, java.util.Locale.class, int.class,
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes28 =
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes29 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes29 =
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes30 =
 		new Class[] {
 			long.class, long.class, long.class, java.util.Locale.class,
 			int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesByStructureIdParameterTypes30 =
+	private static final Class<?>[] _getArticlesByStructureIdParameterTypes31 =
 		new Class[] {
 			long.class, long.class, long.class, long.class, int.class,
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getArticlesCountParameterTypes31 =
-		new Class[] {long.class, long.class};
 	private static final Class<?>[] _getArticlesCountParameterTypes32 =
+		new Class[] {long.class, long.class};
+	private static final Class<?>[] _getArticlesCountParameterTypes33 =
 		new Class[] {long.class, long.class, int.class};
 	private static final Class<?>[]
-		_getArticlesCountByArticleIdParameterTypes33 = new Class[] {
+		_getArticlesCountByArticleIdParameterTypes34 = new Class[] {
 			long.class, String.class
 		};
 	private static final Class<?>[]
-		_getArticlesCountByArticleIdParameterTypes34 = new Class[] {
+		_getArticlesCountByArticleIdParameterTypes35 = new Class[] {
 			long.class, String.class, int.class
 		};
 	private static final Class<?>[]
-		_getArticlesCountByStructureIdParameterTypes35 = new Class[] {
+		_getArticlesCountByStructureIdParameterTypes36 = new Class[] {
 			long.class, long.class
 		};
 	private static final Class<?>[]
-		_getArticlesCountByStructureIdParameterTypes36 = new Class[] {
+		_getArticlesCountByStructureIdParameterTypes37 = new Class[] {
 			long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getArticlesCountByStructureIdParameterTypes37 = new Class[] {
+		_getArticlesCountByStructureIdParameterTypes38 = new Class[] {
 			long.class, long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getArticlesCountByStructureIdParameterTypes38 = new Class[] {
+		_getArticlesCountByStructureIdParameterTypes39 = new Class[] {
 			long.class, long.class, long.class, long.class, int.class
 		};
 	private static final Class<?>[]
-		_getDisplayArticleByUrlTitleParameterTypes39 = new Class[] {
+		_getDisplayArticleByUrlTitleParameterTypes40 = new Class[] {
 			long.class, String.class
 		};
 	private static final Class<?>[]
-		_getFoldersAndArticlesCountParameterTypes40 = new Class[] {
+		_getFoldersAndArticlesCountParameterTypes41 = new Class[] {
 			long.class, java.util.List.class
 		};
-	private static final Class<?>[] _getGroupArticlesParameterTypes41 =
+	private static final Class<?>[] _getGroupArticlesParameterTypes42 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, boolean.class,
 			int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupArticlesParameterTypes42 =
+	private static final Class<?>[] _getGroupArticlesParameterTypes43 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, boolean.class,
 			java.util.Locale.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupArticlesParameterTypes43 =
+	private static final Class<?>[] _getGroupArticlesParameterTypes44 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupArticlesParameterTypes44 =
+	private static final Class<?>[] _getGroupArticlesParameterTypes45 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupArticlesCountParameterTypes45 =
-		new Class[] {long.class, long.class, long.class};
 	private static final Class<?>[] _getGroupArticlesCountParameterTypes46 =
-		new Class[] {long.class, long.class, long.class, int.class};
+		new Class[] {long.class, long.class, long.class};
 	private static final Class<?>[] _getGroupArticlesCountParameterTypes47 =
+		new Class[] {long.class, long.class, long.class, int.class};
+	private static final Class<?>[] _getGroupArticlesCountParameterTypes48 =
 		new Class[] {
 			long.class, long.class, long.class, int.class, boolean.class
 		};
-	private static final Class<?>[] _getLatestArticleParameterTypes48 =
-		new Class[] {long.class};
 	private static final Class<?>[] _getLatestArticleParameterTypes49 =
-		new Class[] {long.class, String.class, int.class};
+		new Class[] {long.class};
 	private static final Class<?>[] _getLatestArticleParameterTypes50 =
+		new Class[] {long.class, String.class, int.class};
+	private static final Class<?>[] _getLatestArticleParameterTypes51 =
 		new Class[] {long.class, String.class, long.class};
 	private static final Class<?>[]
-		_getLatestArticleByExternalReferenceCodeParameterTypes51 = new Class[] {
+		_getLatestArticleByExternalReferenceCodeParameterTypes52 = new Class[] {
 			long.class, String.class
 		};
-	private static final Class<?>[] _getLatestArticlesParameterTypes52 =
+	private static final Class<?>[] _getLatestArticlesParameterTypes53 =
 		new Class[] {
 			long.class, int.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getLatestArticlesCountParameterTypes53 =
+	private static final Class<?>[] _getLatestArticlesCountParameterTypes54 =
 		new Class[] {long.class, int.class};
-	private static final Class<?>[] _getLayoutArticlesParameterTypes54 =
-		new Class[] {long.class};
 	private static final Class<?>[] _getLayoutArticlesParameterTypes55 =
-		new Class[] {long.class, int.class, int.class};
-	private static final Class<?>[] _getLayoutArticlesCountParameterTypes56 =
 		new Class[] {long.class};
-	private static final Class<?>[] _moveArticleParameterTypes57 = new Class[] {
+	private static final Class<?>[] _getLayoutArticlesParameterTypes56 =
+		new Class[] {long.class, int.class, int.class};
+	private static final Class<?>[] _getLayoutArticlesCountParameterTypes57 =
+		new Class[] {long.class};
+	private static final Class<?>[] _moveArticleParameterTypes58 = new Class[] {
 		long.class, String.class, long.class,
 		com.liferay.portal.kernel.service.ServiceContext.class
 	};
-	private static final Class<?>[] _moveArticleFromTrashParameterTypes58 =
+	private static final Class<?>[] _moveArticleFromTrashParameterTypes59 =
 		new Class[] {
 			long.class, long.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveArticleFromTrashParameterTypes59 =
+	private static final Class<?>[] _moveArticleFromTrashParameterTypes60 =
 		new Class[] {
 			long.class, String.class, long.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _moveArticleToTrashParameterTypes60 =
-		new Class[] {long.class, String.class};
-	private static final Class<?>[] _removeArticleLocaleParameterTypes61 =
+	private static final Class<?>[] _moveArticleToTrashParameterTypes61 =
 		new Class[] {long.class, String.class};
 	private static final Class<?>[] _removeArticleLocaleParameterTypes62 =
-		new Class[] {long.class, String.class, double.class, String.class};
-	private static final Class<?>[] _restoreArticleFromTrashParameterTypes63 =
-		new Class[] {long.class};
-	private static final Class<?>[] _restoreArticleFromTrashParameterTypes64 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _subscribeParameterTypes65 = new Class[] {
+	private static final Class<?>[] _removeArticleLocaleParameterTypes63 =
+		new Class[] {long.class, String.class, double.class, String.class};
+	private static final Class<?>[] _restoreArticleFromTrashParameterTypes64 =
+		new Class[] {long.class};
+	private static final Class<?>[] _restoreArticleFromTrashParameterTypes65 =
+		new Class[] {long.class, String.class};
+	private static final Class<?>[] _subscribeParameterTypes66 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _subscribeStructureParameterTypes66 =
+	private static final Class<?>[] _subscribeStructureParameterTypes67 =
 		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _unsubscribeParameterTypes67 = new Class[] {
+	private static final Class<?>[] _unsubscribeParameterTypes68 = new Class[] {
 		long.class, long.class
 	};
-	private static final Class<?>[] _unsubscribeStructureParameterTypes68 =
+	private static final Class<?>[] _unsubscribeStructureParameterTypes69 =
 		new Class[] {long.class, long.class, long.class};
-	private static final Class<?>[] _updateArticleParameterTypes69 =
+	private static final Class<?>[] _updateArticleParameterTypes70 =
 		new Class[] {
 			long.class, long.class, long.class, String.class, double.class,
 			java.util.Map.class, java.util.Map.class, String.class,
 			String.class, com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleParameterTypes70 =
+	private static final Class<?>[] _updateArticleParameterTypes71 =
+		new Class[] {
+			long.class, long.class, String.class, double.class,
+			java.util.Map.class, java.util.Map.class, java.util.Map.class,
+			String.class, String.class, String.class, java.util.Date.class,
+			java.util.Date.class, java.util.Date.class, boolean.class,
+			boolean.class, long.class, int.class, String.class,
+			java.io.File.class, java.util.Map.class, String.class,
+			com.liferay.portal.kernel.service.ServiceContext.class
+		};
+	private static final Class<?>[] _updateArticleParameterTypes72 =
 		new Class[] {
 			long.class, long.class, String.class, double.class,
 			java.util.Map.class, java.util.Map.class, java.util.Map.class,
@@ -3342,13 +3473,13 @@ public class JournalArticleServiceHttp {
 			java.io.File.class, java.util.Map.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleParameterTypes71 =
+	private static final Class<?>[] _updateArticleParameterTypes73 =
 		new Class[] {
 			long.class, long.class, String.class, double.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[]
-		_updateArticleDefaultValuesParameterTypes72 = new Class[] {
+		_updateArticleDefaultValuesParameterTypes74 = new Class[] {
 			long.class, String.class, java.util.Map.class, java.util.Map.class,
 			String.class, String.class, String.class, int.class, int.class,
 			int.class, int.class, int.class, int.class, int.class, int.class,
@@ -3358,13 +3489,13 @@ public class JournalArticleServiceHttp {
 			java.io.File.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateArticleTranslationParameterTypes73 =
+	private static final Class<?>[] _updateArticleTranslationParameterTypes75 =
 		new Class[] {
 			long.class, String.class, double.class, java.util.Locale.class,
 			String.class, String.class, String.class, java.util.Map.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateStatusParameterTypes74 =
+	private static final Class<?>[] _updateStatusParameterTypes76 =
 		new Class[] {
 			long.class, String.class, double.class, int.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -298,37 +298,12 @@ public class JournalArticleLocalServiceImpl
 	 *                              template
 	 * @param layoutUuid            the unique string identifying the web content
 	 *                              article's display page
-	 * @param displayDateMonth      the month the web content article is set to
+	 * @param displayDate           the date the web content article is set to
 	 *                              display
-	 * @param displayDateDay        the calendar day the web content article is set to
-	 *                              display
-	 * @param displayDateYear       the year the web content article is set to
-	 *                              display
-	 * @param displayDateHour       the hour the web content article is set to
-	 *                              display
-	 * @param displayDateMinute     the minute the web content article is set to
-	 *                              display
-	 * @param expirationDateMonth   the month the web content article is set to
+	 * @param expirationDate        the date the web content article is set to
 	 *                              expire
-	 * @param expirationDateDay     the calendar day the web content article is set
-	 *                              to expire
-	 * @param expirationDateYear    the year the web content article is set to
-	 *                              expire
-	 * @param expirationDateHour    the hour the web content article is set to
-	 *                              expire
-	 * @param expirationDateMinute  the minute the web content article is set to
-	 *                              expire
-	 * @param neverExpire           whether the web content article is not set to auto
-	 *                              expire
-	 * @param reviewDateMonth       the month the web content article is set for
+	 * @param reviewDate            the date the web content article is set for
 	 *                              review
-	 * @param reviewDateDay         the calendar day the web content article is set for
-	 *                              review
-	 * @param reviewDateYear        the year the web content article is set for review
-	 * @param reviewDateHour        the hour the web content article is set for review
-	 * @param reviewDateMinute      the minute the web content article is set for
-	 *                              review
-	 * @param neverReview           whether the web content article is not set for review
 	 * @param indexable             whether the web content article is searchable
 	 * @param smallImage            whether the web content article has a small image
 	 * @param smallImageSource      the web content article's small image source
@@ -354,15 +329,10 @@ public class JournalArticleLocalServiceImpl
 			Map<Locale, String> descriptionMap,
 			Map<Locale, String> friendlyURLMap, String content,
 			long ddmStructureId, String ddmTemplateKey, String layoutUuid,
-			int displayDateMonth, int displayDateDay, int displayDateYear,
-			int displayDateHour, int displayDateMinute, int expirationDateMonth,
-			int expirationDateDay, int expirationDateYear,
-			int expirationDateHour, int expirationDateMinute,
-			boolean neverExpire, int reviewDateMonth, int reviewDateDay,
-			int reviewDateYear, int reviewDateHour, int reviewDateMinute,
-			boolean neverReview, boolean indexable, boolean smallImage,
-			long smallImageId, int smallImageSource, String smallImageURL,
-			File smallImageFile, Map<String, byte[]> images, String articleURL,
+			Date displayDate, Date expirationDate, Date reviewDate,
+			boolean indexable, boolean smallImage, long smallImageId,
+			int smallImageSource, String smallImageURL, File smallImageFile,
+			Map<String, byte[]> images, String articleURL,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -371,27 +341,6 @@ public class JournalArticleLocalServiceImpl
 		User user = _userLocalService.getUser(userId);
 
 		articleId = StringUtil.toUpperCase(StringUtil.trim(articleId));
-
-		Date displayDate = _portal.getDate(
-			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
-			displayDateMinute, user.getTimeZone(), null);
-
-		Date expirationDate = null;
-		Date reviewDate = null;
-
-		if (!neverExpire) {
-			expirationDate = _portal.getDate(
-				expirationDateMonth, expirationDateDay, expirationDateYear,
-				expirationDateHour, expirationDateMinute, user.getTimeZone(),
-				ArticleExpirationDateException.class);
-		}
-
-		if (!neverReview) {
-			reviewDate = _portal.getDate(
-				reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
-				reviewDateMinute, user.getTimeZone(),
-				ArticleReviewDateException.class);
-		}
 
 		byte[] smallImageBytes = null;
 
@@ -590,6 +539,58 @@ public class JournalArticleLocalServiceImpl
 		startWorkflowInstance(userId, article, serviceContext);
 
 		return article;
+	}
+
+	@Override
+	public JournalArticle addArticle(
+			String externalReferenceCode, long userId, long groupId,
+			long folderId, long classNameId, long classPK, String articleId,
+			boolean autoArticleId, double version, Map<Locale, String> titleMap,
+			Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			long ddmStructureId, String ddmTemplateKey, String layoutUuid,
+			int displayDateMonth, int displayDateDay, int displayDateYear,
+			int displayDateHour, int displayDateMinute, int expirationDateMonth,
+			int expirationDateDay, int expirationDateYear,
+			int expirationDateHour, int expirationDateMinute,
+			boolean neverExpire, int reviewDateMonth, int reviewDateDay,
+			int reviewDateYear, int reviewDateHour, int reviewDateMinute,
+			boolean neverReview, boolean indexable, boolean smallImage,
+			long smallImageId, int smallImageSource, String smallImageURL,
+			File smallImageFile, Map<String, byte[]> images, String articleURL,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		User user = _userLocalService.getUser(userId);
+
+		Date displayDate = _portal.getDate(
+			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
+			displayDateMinute, user.getTimeZone(), null);
+
+		Date expirationDate = null;
+		Date reviewDate = null;
+
+		if (!neverExpire) {
+			expirationDate = _portal.getDate(
+				expirationDateMonth, expirationDateDay, expirationDateYear,
+				expirationDateHour, expirationDateMinute, user.getTimeZone(),
+				ArticleExpirationDateException.class);
+		}
+
+		if (!neverReview) {
+			reviewDate = _portal.getDate(
+				reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
+				reviewDateMinute, user.getTimeZone(),
+				ArticleReviewDateException.class);
+		}
+
+		return journalArticleLocalService.addArticle(
+			externalReferenceCode, userId, groupId, folderId, classNameId,
+			classPK, articleId, autoArticleId, version, titleMap,
+			descriptionMap, friendlyURLMap, content, ddmStructureId,
+			ddmTemplateKey, layoutUuid, displayDate, expirationDate, reviewDate,
+			indexable, smallImage, smallImageId, smallImageSource,
+			smallImageURL, smallImageFile, images, articleURL, serviceContext);
 	}
 
 	/**
@@ -4591,37 +4592,12 @@ public class JournalArticleLocalServiceImpl
 	 *         template
 	 * @param  layoutUuid the unique string identifying the web content
 	 *         article's display page
-	 * @param  displayDateMonth the month the web content article is set to
+	 * @param  displayDate the date the web content article is set to
 	 *         display
-	 * @param  displayDateDay the calendar day the web content article is set to
-	 *         display
-	 * @param  displayDateYear the year the web content article is set to
-	 *         display
-	 * @param  displayDateHour the hour the web content article is set to
-	 *         display
-	 * @param  displayDateMinute the minute the web content article is set to
-	 *         display
-	 * @param  expirationDateMonth the month the web content article is set to
+	 * @param  expirationDate the date the web content article is set to
 	 *         expire
-	 * @param  expirationDateDay the calendar day the web content article is set
-	 *         to expire
-	 * @param  expirationDateYear the year the web content article is set to
-	 *         expire
-	 * @param  expirationDateHour the hour the web content article is set to
-	 *         expire
-	 * @param  expirationDateMinute the minute the web content article is set to
-	 *         expire
-	 * @param  neverExpire whether the web content article is not set to auto
-	 *         expire
-	 * @param  reviewDateMonth the month the web content article is set for
+	 * @param  reviewDate the date the web content article is set for
 	 *         review
-	 * @param  reviewDateDay the calendar day the web content article is set for
-	 *         review
-	 * @param  reviewDateYear the year the web content article is set for review
-	 * @param  reviewDateHour the hour the web content article is set for review
-	 * @param  reviewDateMinute the minute the web content article is set for
-	 *         review
-	 * @param  neverReview whether the web content article is not set for review
 	 * @param  indexable whether the web content is searchable
 	 * @param  smallImage whether to update web content article's a small image.
 	 *         A file must be passed in as <code>smallImageFile</code> value,
@@ -4656,16 +4632,11 @@ public class JournalArticleLocalServiceImpl
 			double version, Map<Locale, String> titleMap,
 			Map<Locale, String> descriptionMap,
 			Map<Locale, String> friendlyURLMap, String content,
-			String ddmTemplateKey, String layoutUuid, int displayDateMonth,
-			int displayDateDay, int displayDateYear, int displayDateHour,
-			int displayDateMinute, int expirationDateMonth,
-			int expirationDateDay, int expirationDateYear,
-			int expirationDateHour, int expirationDateMinute,
-			boolean neverExpire, int reviewDateMonth, int reviewDateDay,
-			int reviewDateYear, int reviewDateHour, int reviewDateMinute,
-			boolean neverReview, boolean indexable, boolean smallImage,
-			long smallImageId, int smallImageSource, String smallImageURL,
-			File smallImageFile, Map<String, byte[]> images, String articleURL,
+			String ddmTemplateKey, String layoutUuid, Date displayDate,
+			Date expirationDate, Date reviewDate, boolean indexable,
+			boolean smallImage, long smallImageId, int smallImageSource,
+			String smallImageURL, File smallImageFile,
+			Map<String, byte[]> images, String articleURL,
 			ServiceContext serviceContext)
 		throws PortalException {
 
@@ -4740,29 +4711,6 @@ public class JournalArticleLocalServiceImpl
 			}
 		}
 
-		User user = _userLocalService.getUser(userId);
-
-		Date displayDate = _portal.getDate(
-			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
-			displayDateMinute, user.getTimeZone(), null);
-
-		Date expirationDate = null;
-		Date reviewDate = null;
-
-		if (!neverExpire) {
-			expirationDate = _portal.getDate(
-				expirationDateMonth, expirationDateDay, expirationDateYear,
-				expirationDateHour, expirationDateMinute, user.getTimeZone(),
-				ArticleExpirationDateException.class);
-		}
-
-		if (!neverReview) {
-			reviewDate = _portal.getDate(
-				reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
-				reviewDateMinute, user.getTimeZone(),
-				ArticleReviewDateException.class);
-		}
-
 		Date date = new Date();
 
 		boolean expired = false;
@@ -4770,6 +4718,8 @@ public class JournalArticleLocalServiceImpl
 		if ((expirationDate != null) && expirationDate.before(date)) {
 			expired = true;
 		}
+
+		User user = _userLocalService.getUser(userId);
 
 		sanitize(
 			user.getCompanyId(), groupId, userId, article.getClassPK(),
@@ -4976,6 +4926,56 @@ public class JournalArticleLocalServiceImpl
 		}
 
 		return article;
+	}
+
+	@Override
+	public JournalArticle updateArticle(
+			long userId, long groupId, long folderId, String articleId,
+			double version, Map<Locale, String> titleMap,
+			Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			String ddmTemplateKey, String layoutUuid, int displayDateMonth,
+			int displayDateDay, int displayDateYear, int displayDateHour,
+			int displayDateMinute, int expirationDateMonth,
+			int expirationDateDay, int expirationDateYear,
+			int expirationDateHour, int expirationDateMinute,
+			boolean neverExpire, int reviewDateMonth, int reviewDateDay,
+			int reviewDateYear, int reviewDateHour, int reviewDateMinute,
+			boolean neverReview, boolean indexable, boolean smallImage,
+			long smallImageId, int smallImageSource, String smallImageURL,
+			File smallImageFile, Map<String, byte[]> images, String articleURL,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		User user = _userLocalService.getUser(userId);
+
+		Date displayDate = _portal.getDate(
+			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
+			displayDateMinute, user.getTimeZone(), null);
+
+		Date expirationDate = null;
+		Date reviewDate = null;
+
+		if (!neverExpire) {
+			expirationDate = _portal.getDate(
+				expirationDateMonth, expirationDateDay, expirationDateYear,
+				expirationDateHour, expirationDateMinute, user.getTimeZone(),
+				ArticleExpirationDateException.class);
+		}
+
+		if (!neverReview) {
+			reviewDate = _portal.getDate(
+				reviewDateMonth, reviewDateDay, reviewDateYear, reviewDateHour,
+				reviewDateMinute, user.getTimeZone(),
+				ArticleReviewDateException.class);
+		}
+
+		return journalArticleLocalService.updateArticle(
+			userId, groupId, folderId, articleId, version, titleMap,
+			descriptionMap, friendlyURLMap, content, ddmTemplateKey, layoutUuid,
+			displayDate, expirationDate, reviewDate, indexable, smallImage,
+			smallImageId, smallImageSource, smallImageURL, smallImageFile,
+			images, articleURL, serviceContext);
 	}
 
 	/**

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -162,7 +162,6 @@ import com.liferay.portal.kernel.templateparser.TransformerListener;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.transaction.TransactionCommitCallbackUtil;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.Constants;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.FileUtil;
@@ -209,7 +208,6 @@ import java.io.IOException;
 import java.io.Serializable;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
@@ -634,24 +632,12 @@ public class JournalArticleLocalServiceImpl
 			ServiceContext serviceContext)
 		throws PortalException {
 
-		User user = _userLocalService.getUser(userId);
-
-		Calendar calendar = CalendarFactoryUtil.getCalendar(user.getTimeZone());
-
-		int displayDateMonth = calendar.get(Calendar.MONTH);
-		int displayDateDay = calendar.get(Calendar.DAY_OF_MONTH);
-		int displayDateYear = calendar.get(Calendar.YEAR);
-		int displayDateHour = calendar.get(Calendar.HOUR_OF_DAY);
-		int displayDateMinute = calendar.get(Calendar.MINUTE);
-
 		return journalArticleLocalService.addArticle(
 			externalReferenceCode, userId, groupId, folderId,
 			JournalArticleConstants.CLASS_NAME_ID_DEFAULT, 0, StringPool.BLANK,
 			true, 1, titleMap, descriptionMap, titleMap, content,
-			ddmStructureId, ddmTemplateKey, null, displayDateMonth,
-			displayDateDay, displayDateYear, displayDateHour, displayDateMinute,
-			0, 0, 0, 0, 0, true, 0, 0, 0, 0, 0, true, true, false, 0, 0, null,
-			null, null, null, serviceContext);
+			ddmStructureId, ddmTemplateKey, null, new Date(), null, null, true,
+			false, 0, 0, null, null, null, null, serviceContext);
 	}
 
 	@Override
@@ -5020,103 +5006,17 @@ public class JournalArticleLocalServiceImpl
 			String layoutUuid, ServiceContext serviceContext)
 		throws PortalException {
 
-		User user = _userLocalService.getUser(userId);
-
 		JournalArticle article = journalArticlePersistence.findByG_A_V(
 			groupId, articleId, version);
-
-		Date displayDate = article.getDisplayDate();
-
-		int displayDateMonth = 0;
-		int displayDateDay = 0;
-		int displayDateYear = 0;
-		int displayDateHour = 0;
-		int displayDateMinute = 0;
-
-		if (displayDate != null) {
-			Calendar displayCal = CalendarFactoryUtil.getCalendar(
-				user.getTimeZone());
-
-			displayCal.setTime(displayDate);
-
-			displayDateMonth = displayCal.get(Calendar.MONTH);
-			displayDateDay = displayCal.get(Calendar.DATE);
-			displayDateYear = displayCal.get(Calendar.YEAR);
-			displayDateHour = displayCal.get(Calendar.HOUR);
-			displayDateMinute = displayCal.get(Calendar.MINUTE);
-
-			if (displayCal.get(Calendar.AM_PM) == Calendar.PM) {
-				displayDateHour += 12;
-			}
-		}
-
-		Date expirationDate = article.getExpirationDate();
-
-		int expirationDateMonth = 0;
-		int expirationDateDay = 0;
-		int expirationDateYear = 0;
-		int expirationDateHour = 0;
-		int expirationDateMinute = 0;
-		boolean neverExpire = true;
-
-		if (expirationDate != null) {
-			Calendar expirationCal = CalendarFactoryUtil.getCalendar(
-				user.getTimeZone());
-
-			expirationCal.setTime(expirationDate);
-
-			expirationDateMonth = expirationCal.get(Calendar.MONTH);
-			expirationDateDay = expirationCal.get(Calendar.DATE);
-			expirationDateYear = expirationCal.get(Calendar.YEAR);
-			expirationDateHour = expirationCal.get(Calendar.HOUR);
-			expirationDateMinute = expirationCal.get(Calendar.MINUTE);
-
-			neverExpire = false;
-
-			if (expirationCal.get(Calendar.AM_PM) == Calendar.PM) {
-				expirationDateHour += 12;
-			}
-		}
-
-		Date reviewDate = article.getReviewDate();
-
-		int reviewDateMonth = 0;
-		int reviewDateDay = 0;
-		int reviewDateYear = 0;
-		int reviewDateHour = 0;
-		int reviewDateMinute = 0;
-		boolean neverReview = true;
-
-		if (reviewDate != null) {
-			Calendar reviewCal = CalendarFactoryUtil.getCalendar(
-				user.getTimeZone());
-
-			reviewCal.setTime(reviewDate);
-
-			reviewDateMonth = reviewCal.get(Calendar.MONTH);
-			reviewDateDay = reviewCal.get(Calendar.DATE);
-			reviewDateYear = reviewCal.get(Calendar.YEAR);
-			reviewDateHour = reviewCal.get(Calendar.HOUR);
-			reviewDateMinute = reviewCal.get(Calendar.MINUTE);
-
-			neverReview = false;
-
-			if (reviewCal.get(Calendar.AM_PM) == Calendar.PM) {
-				reviewDateHour += 12;
-			}
-		}
 
 		return journalArticleLocalService.updateArticle(
 			userId, groupId, folderId, articleId, version, titleMap,
 			descriptionMap, null, content, article.getDDMTemplateKey(),
-			layoutUuid, displayDateMonth, displayDateDay, displayDateYear,
-			displayDateHour, displayDateMinute, expirationDateMonth,
-			expirationDateDay, expirationDateYear, expirationDateHour,
-			expirationDateMinute, neverExpire, reviewDateMonth, reviewDateDay,
-			reviewDateYear, reviewDateHour, reviewDateMinute, neverReview,
-			article.isIndexable(), article.isSmallImage(),
-			article.getSmallImageId(), article.getSmallImageSource(),
-			article.getSmallImageURL(), null, null, null, serviceContext);
+			layoutUuid, article.getDisplayDate(), article.getExpirationDate(),
+			article.getReviewDate(), article.isIndexable(),
+			article.isSmallImage(), article.getSmallImageId(),
+			article.getSmallImageSource(), article.getSmallImageURL(), null,
+			null, null, serviceContext);
 	}
 
 	/**

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleServiceImpl.java
@@ -37,6 +37,7 @@ import java.io.Serializable;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -99,37 +100,12 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 *                              template
 	 * @param layoutUuid            the unique string identifying the web content
 	 *                              article's display page
-	 * @param displayDateMonth      the month the web content article is set to
+	 * @param displayDate           the date the web content article is set to
 	 *                              display
-	 * @param displayDateDay        the calendar day the web content article is set to
-	 *                              display
-	 * @param displayDateYear       the year the web content article is set to
-	 *                              display
-	 * @param displayDateHour       the hour the web content article is set to
-	 *                              display
-	 * @param displayDateMinute     the minute the web content article is set to
-	 *                              display
-	 * @param expirationDateMonth   the month the web content article is set to
+	 * @param expirationDate        the date the web content article is set to
 	 *                              expire
-	 * @param expirationDateDay     the calendar day the web content article is set
-	 *                              to expire
-	 * @param expirationDateYear    the year the web content article is set to
-	 *                              expire
-	 * @param expirationDateHour    the hour the web content article is set to
-	 *                              expire
-	 * @param expirationDateMinute  the minute the web content article is set to
-	 *                              expire
-	 * @param neverExpire           whether the web content article is not set to auto
-	 *                              expire
-	 * @param reviewDateMonth       the month the web content article is set for
+	 * @param reviewDate            the date the web content article is set for
 	 *                              review
-	 * @param reviewDateDay         the calendar day the web content article is set for
-	 *                              review
-	 * @param reviewDateYear        the year the web content article is set for review
-	 * @param reviewDateHour        the hour the web content article is set for review
-	 * @param reviewDateMinute      the minute the web content article is set for
-	 *                              review
-	 * @param neverReview           whether the web content article is not set for review
 	 * @param indexable             whether the web content article is searchable
 	 * @param smallImage            whether the web content article has a small image
 	 * @param smallImageSource      the web content article's small image source
@@ -146,6 +122,35 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * @return the web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
+	@Override
+	public JournalArticle addArticle(
+			String externalReferenceCode, long groupId, long folderId,
+			long classNameId, long classPK, String articleId,
+			boolean autoArticleId, Map<Locale, String> titleMap,
+			Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			long ddmStructureId, String ddmTemplateKey, String layoutUuid,
+			Date displayDate, Date expirationDate, Date reviewDate,
+			boolean indexable, boolean smallImage, long smallImageId,
+			int smallImageSource, String smallImageURL, File smallFile,
+			Map<String, byte[]> images, String articleURL,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		ModelResourcePermissionUtil.check(
+			_journalFolderModelResourcePermission, getPermissionChecker(),
+			groupId, folderId, ActionKeys.ADD_ARTICLE);
+
+		return journalArticleLocalService.addArticle(
+			externalReferenceCode, getUserId(), groupId, folderId, classNameId,
+			classPK, articleId, autoArticleId,
+			JournalArticleConstants.VERSION_DEFAULT, titleMap, descriptionMap,
+			friendlyURLMap, content, ddmStructureId, ddmTemplateKey, layoutUuid,
+			displayDate, expirationDate, reviewDate, indexable, smallImage,
+			smallImageId, smallImageSource, smallImageURL, smallFile, images,
+			articleURL, serviceContext);
+	}
+
 	@Override
 	public JournalArticle addArticle(
 			String externalReferenceCode, long groupId, long folderId,
@@ -1980,37 +1985,12 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 *                             template
 	 * @param layoutUuid           the unique string identifying the web content
 	 *                             article's display page
-	 * @param displayDateMonth     the month the web content article is set to
+	 * @param displayDate          the date the web content article is set to
 	 *                             display
-	 * @param displayDateDay       the calendar day the web content article is set to
-	 *                             display
-	 * @param displayDateYear      the year the web content article is set to
-	 *                             display
-	 * @param displayDateHour      the hour the web content article is set to
-	 *                             display
-	 * @param displayDateMinute    the minute the web content article is set to
-	 *                             display
-	 * @param expirationDateMonth  the month the web content article is set to
+	 * @param expirationDate       the date the web content article is set to
 	 *                             expire
-	 * @param expirationDateDay    the calendar day the web content article is set
-	 *                             to expire
-	 * @param expirationDateYear   the year the web content article is set to
-	 *                             expire
-	 * @param expirationDateHour   the hour the web content article is set to
-	 *                             expire
-	 * @param expirationDateMinute the minute the web content article is set to
-	 *                             expire
-	 * @param neverExpire          whether the web content article is not set to auto
-	 *                             expire
-	 * @param reviewDateMonth      the month the web content article is set for
+	 * @param reviewDate           the month the web content article is set for
 	 *                             review
-	 * @param reviewDateDay        the calendar day the web content article is set for
-	 *                             review
-	 * @param reviewDateYear       the year the web content article is set for review
-	 * @param reviewDateHour       the hour the web content article is set for review
-	 * @param reviewDateMinute     the minute the web content article is set for
-	 *                             review
-	 * @param neverReview          whether the web content article is not set for review
 	 * @param indexable            whether the web content is searchable
 	 * @param smallImage           whether to update web content article's a small image.
 	 *                             A file must be passed in as <code>smallImageFile</code> value,
@@ -2038,6 +2018,32 @@ public class JournalArticleServiceImpl extends JournalArticleServiceBaseImpl {
 	 * @return the updated web content article
 	 * @throws PortalException if a portal exception occurred
 	 */
+	@Override
+	public JournalArticle updateArticle(
+			long groupId, long folderId, String articleId, double version,
+			Map<Locale, String> titleMap, Map<Locale, String> descriptionMap,
+			Map<Locale, String> friendlyURLMap, String content,
+			String ddmTemplateKey, String layoutUuid, Date displayDate,
+			Date expirationDate, Date reviewDate, boolean indexable,
+			boolean smallImage, long smallImageId, int smallImageSource,
+			String smallImageURL, File smallFile, Map<String, byte[]> images,
+			String articleURL, ServiceContext serviceContext)
+		throws PortalException {
+
+		JournalArticle article = journalArticlePersistence.findByG_A_V(
+			groupId, articleId, version);
+
+		_journalArticleModelResourcePermission.check(
+			getPermissionChecker(), article, ActionKeys.UPDATE);
+
+		return journalArticleLocalService.updateArticle(
+			getUserId(), groupId, folderId, articleId, version, titleMap,
+			descriptionMap, friendlyURLMap, content, ddmTemplateKey, layoutUuid,
+			displayDate, expirationDate, reviewDate, indexable, smallImage,
+			smallImageId, smallImageSource, smallImageURL, smallFile, images,
+			articleURL, serviceContext);
+	}
+
 	@Override
 	public JournalArticle updateArticle(
 			long groupId, long folderId, String articleId, double version,

--- a/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
+++ b/modules/apps/journal/journal-test-util/src/main/java/com/liferay/journal/test/util/JournalTestUtil.java
@@ -1003,27 +1003,6 @@ public class JournalTestUtil {
 			displayDate = article.getDisplayDate();
 		}
 
-		int displayDateMonth = 0;
-		int displayDateDay = 0;
-		int displayDateYear = 0;
-		int displayDateHour = 0;
-		int displayDateMinute = 0;
-
-		if (displayDate != null) {
-			User user = TestPropsValues.getUser();
-
-			Calendar displayCal = CalendarFactoryUtil.getCalendar(
-				user.getTimeZone());
-
-			displayCal.setTime(displayDate);
-
-			displayDateMonth = displayCal.get(Calendar.MONTH);
-			displayDateDay = displayCal.get(Calendar.DATE);
-			displayDateYear = displayCal.get(Calendar.YEAR);
-			displayDateHour = displayCal.get(Calendar.HOUR_OF_DAY);
-			displayDateMinute = displayCal.get(Calendar.MINUTE);
-		}
-
 		serviceContext.setCommand(Constants.UPDATE);
 		serviceContext.setLayoutFullURL("http://localhost");
 
@@ -1031,10 +1010,8 @@ public class JournalTestUtil {
 			userId, article.getGroupId(), article.getFolderId(),
 			article.getArticleId(), article.getVersion(), titleMap,
 			article.getDescriptionMap(), null, content,
-			article.getDDMTemplateKey(), article.getLayoutUuid(),
-			displayDateMonth, displayDateDay, displayDateYear, displayDateHour,
-			displayDateMinute, 0, 0, 0, 0, 0, true, 0, 0, 0, 0, 0, true,
-			article.isIndexable(), article.isSmallImage(), 0,
+			article.getDDMTemplateKey(), article.getLayoutUuid(), displayDate,
+			null, null, article.isIndexable(), article.isSmallImage(), 0,
 			article.getSmallImageSource(), article.getSmallImageURL(), null,
 			null, null, serviceContext);
 	}

--- a/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Portal Vulcan API
 Bundle-SymbolicName: com.liferay.portal.vulcan.api
-Bundle-Version: 40.0.1
+Bundle-Version: 41.0.0
 Export-Package:\
 	com.liferay.portal.vulcan.accept.language,\
 	com.liferay.portal.vulcan.aggregation,\

--- a/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo
+++ b/modules/apps/portal-vulcan/portal-vulcan-api/src/main/resources/com/liferay/portal/vulcan/util/packageinfo
@@ -1,1 +1,1 @@
-version 11.3.0
+version 12.0.0

--- a/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
+++ b/modules/apps/site-initializer/site-initializer-extender/site-initializer-extender/src/main/java/com/liferay/site/initializer/extender/internal/BundleSiteInitializer.java
@@ -151,7 +151,6 @@ import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.settings.ArchivedSettingsFactory;
 import com.liferay.portal.kernel.template.TemplateConstants;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.DateUtil;
 import com.liferay.portal.kernel.util.FileUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -208,8 +207,8 @@ import java.net.URLConnection;
 import java.text.DateFormat;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
+import java.util.Date;
 import java.util.Dictionary;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -2080,9 +2079,6 @@ public class BundleSiteInitializer implements SiteInitializer {
 				serviceContext.getScopeGroupId(),
 				_portal.getClassNameId(DDMStructure.class), ddmTemplateKey);
 
-			Calendar calendar = CalendarFactoryUtil.getCalendar(
-				serviceContext.getTimeZone());
-
 			serviceContext.setAssetCategoryIds(
 				_getAssetCategoryIds(
 					serviceContext.getScopeGroupId(),
@@ -2110,13 +2106,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 							_servletContext),
 						stringUtilReplaceValues),
 					ddmStructure.getStructureId(), ddmTemplateKey, null,
-					calendar.get(Calendar.MONTH),
-					calendar.get(Calendar.DAY_OF_MONTH),
-					calendar.get(Calendar.YEAR),
-					calendar.get(Calendar.HOUR_OF_DAY),
-					calendar.get(Calendar.MINUTE), 0, 0, 0, 0, 0, true, 0, 0, 0,
-					0, 0, true, true, false, 0, 0, null, null, null, null,
-					serviceContext);
+					new Date(), null, null, true, false, 0, 0, null, null, null,
+					null, serviceContext);
 			}
 			else {
 				journalArticle = _journalArticleLocalService.updateArticle(
@@ -2129,13 +2120,8 @@ public class BundleSiteInitializer implements SiteInitializer {
 							_replace(resourcePath, ".json", ".xml"),
 							_servletContext),
 						stringUtilReplaceValues),
-					ddmTemplateKey, null, calendar.get(Calendar.MONTH),
-					calendar.get(Calendar.DAY_OF_MONTH),
-					calendar.get(Calendar.YEAR),
-					calendar.get(Calendar.HOUR_OF_DAY),
-					calendar.get(Calendar.MINUTE), 0, 0, 0, 0, 0, true, 0, 0, 0,
-					0, 0, true, true, false, 0, 0, null, null, null, null,
-					serviceContext);
+					ddmTemplateKey, null, new Date(), null, null, true, false,
+					0, 0, null, null, null, null, serviceContext);
 			}
 
 			JournalArticle finalJournalArticle = journalArticle;

--- a/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdater.java
+++ b/modules/apps/translation/translation-service/src/main/java/com/liferay/translation/internal/info/item/updater/JournalArticleInfoItemFieldValuesUpdater.java
@@ -28,11 +28,9 @@ import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CalendarFactoryUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -41,9 +39,7 @@ import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import java.io.Serializable;
 
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.Collections;
-import java.util.Date;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -159,15 +155,6 @@ public class JournalArticleInfoItemFieldValuesUpdater
 				fields, ddmStructure, importedLocaleContentMap, targetLocale);
 		}
 
-		User user = _userLocalService.getUser(latestArticle.getUserId());
-
-		int[] displayDateArray = _getDateArray(
-			user, latestArticle.getDisplayDate());
-		int[] expirationDateArray = _getDateArray(
-			user, latestArticle.getExpirationDate());
-		int[] reviewDateArray = _getDateArray(
-			user, latestArticle.getReviewDate());
-
 		ServiceContext serviceContext = _getServiceContext(latestArticle);
 
 		return _journalArticleLocalService.updateArticle(
@@ -178,15 +165,9 @@ public class JournalArticleInfoItemFieldValuesUpdater
 			_journalConverter.getContent(
 				ddmStructure, fields, ddmStructure.getGroupId()),
 			latestArticle.getDDMTemplateKey(), latestArticle.getLayoutUuid(),
-			displayDateArray[0], displayDateArray[1], displayDateArray[2],
-			displayDateArray[3], displayDateArray[4], expirationDateArray[0],
-			expirationDateArray[1], expirationDateArray[2],
-			expirationDateArray[3], expirationDateArray[4],
-			_isNeverExpire(latestArticle), reviewDateArray[0],
-			reviewDateArray[1], reviewDateArray[2], reviewDateArray[3],
-			reviewDateArray[4], _isNeverReview(latestArticle),
-			latestArticle.isIndexable(), latestArticle.isSmallImage(),
-			latestArticle.getSmallImageId(),
+			latestArticle.getDisplayDate(), latestArticle.getExpirationDate(),
+			latestArticle.getReviewDate(), latestArticle.isIndexable(),
+			latestArticle.isSmallImage(), latestArticle.getSmallImageId(),
 			latestArticle.getSmallImageSource(),
 			latestArticle.getSmallImageURL(), null, null, null, serviceContext);
 	}
@@ -233,30 +214,6 @@ public class JournalArticleInfoItemFieldValuesUpdater
 		AssetEntry assetEntry = _getAssetLinkEntry(assetEntryId, assetLink);
 
 		return assetEntry.getEntryId();
-	}
-
-	private int[] _getDateArray(User user, Date date) {
-		if (date == null) {
-			return new int[] {0, 0, 0, 0, 0};
-		}
-
-		int[] dateArray = new int[5];
-
-		Calendar calendar = CalendarFactoryUtil.getCalendar(user.getTimeZone());
-
-		calendar.setTime(date);
-
-		dateArray[0] = calendar.get(Calendar.MONTH);
-		dateArray[1] = calendar.get(Calendar.DATE);
-		dateArray[2] = calendar.get(Calendar.YEAR);
-		dateArray[3] = calendar.get(Calendar.HOUR);
-		dateArray[4] = calendar.get(Calendar.MINUTE);
-
-		if (calendar.get(Calendar.AM_PM) == Calendar.PM) {
-			dateArray[3] += 12;
-		}
-
-		return dateArray;
 	}
 
 	private InfoLocalizedValue<Object> _getInfoLocalizedValue(
@@ -371,22 +328,6 @@ public class JournalArticleInfoItemFieldValuesUpdater
 		}
 
 		return defaultString;
-	}
-
-	private boolean _isNeverExpire(JournalArticle journalArticle) {
-		if (journalArticle.getExpirationDate() == null) {
-			return true;
-		}
-
-		return false;
-	}
-
-	private boolean _isNeverReview(JournalArticle journalArticle) {
-		if (journalArticle.getReviewDate() == null) {
-			return true;
-		}
-
-		return false;
 	}
 
 	private void _updateFieldsDisplay(Fields ddmFields, String fieldName) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-197569

When you create or update a web content or a blog using the headless API and the Liferay user is configured with a timezone different to GMT/UTC, the display date of the created web content is not correct, it will created with a date some hours before or later than current one, depending on the configured time zone.

This behavior is not reproduced if you create/update the web content or blog from the user interface, the dates will match
This behavior is reproduced If you specify a custom publish date in the headless API, it will be always created with some hours offset than the specified, depending on the configured timezone.

**Root cause of the issue**

The JournalArticleLocalServiceImpl.addArticle method converts the received displayDate from the user time zone to GMT before saving it to the database, [see code here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java#L375-L377) and the BlogEntryLocalServiceImpl.addEntry method converts the received displayDate from the user time zone to GMT before saving it to the database, [see code here](https://github.com/liferay/liferay-portal/blob/master/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java#L375-L377) 

But the headless API uses the dates in UTC time zone when calling the JournalArticleLocalServiceImpl.addArticle or BlogEntryLocalServiceImpl.addEntry methods, the received Date object from the HTTP request is handled in the headless code using the [LocalDateTimeUtil](https://github.com/jorgediaz-lr/liferay-portal/blob/master/modules/apps/portal-vulcan/portal-vulcan-api/src/main/java/com/liferay/portal/vulcan/util/LocalDateTimeUtil.java) class and broken into its parts.

**Solution**

To solve this issue, as it was suggested in the previous PR https://github.com/liferay-echo/liferay-portal/pull/13852 I have:

1. Created new addArticle/updateArticle methods with Date parameters in JournalArticleLocalService and JournalArticleService (see 991efd313ce272fe51cc76ca10999874be5f09bc)
2. Exposed in BlogEntryService the existing addEntry/updateEntry methods with Date parameters from BlogEntryLocalService (see 790b614a2b52d2adf370b310ae53ff5679239ea1)
3. Removed all the headless code related to LocalDateTimeUtil class used by web content and blogs headless APIs, and just call the new methods with the Date parameters (see 08b1da1660c6822386eeb38f2dc1b57bfe40483f , d5e6fc8d1456bebd0f58da2dbe15cfb53d2cc578 and 8359243ad1ef414f25e21950a2c9f56b37802335)
4. I have also applied the new addArticle/updateArticle methods of JournalArticleLocalService to everywhere (see 0e4d975c62a5cbd2494ed309a076e48987fa2440) this removes lots of duplicated code that is just converting Date format to int values.

This PR affects to Echo team (_modules/apps/journal_, _modules/apps/headless_), Lima team (_modules/apps/blogs_, _modules/apps/headless_) and Headless team (_modules/apps/portal-vulcan_) code. I am sending the PR to Echo because the customer reported the bug creating a web content and because most of the changed code is from Echo.

/cc @liferay-lima @liferay-headless