### PR TITLE
[TS] LPS-195074 | Site templates should not indicate propagation for master pages page templates or display pages

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/product/navigation/control/menu/InformationMessagesProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/product/navigation/control/menu/InformationMessagesProductNavigationControlMenuEntry.java
@@ -5,6 +5,9 @@
 
 package com.liferay.layout.admin.web.internal.product.navigation.control.menu;
 
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -103,7 +106,26 @@ public class InformationMessagesProductNavigationControlMenuEntry
 
 		Layout layout = themeDisplay.getLayout();
 
-		if (layout.isTypeControlPanel() ||
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.
+				fetchLayoutPageTemplateEntryByPlid(layout.getPlid());
+
+		if (layoutPageTemplateEntry == null) {
+			layoutPageTemplateEntry =
+				_layoutPageTemplateEntryLocalService.
+					fetchLayoutPageTemplateEntryByPlid(layout.getClassPK());
+		}
+
+		int layoutType = -1;
+
+		if (layoutPageTemplateEntry != null) {
+			layoutType = layoutPageTemplateEntry.getType();
+		}
+
+		if (layout.isTypeControlPanel() || layout.isTypeAssetDisplay() ||
+			(layoutType ==
+				LayoutPageTemplateEntryTypeConstants.TYPE_MASTER_LAYOUT) ||
+			(layoutType == LayoutPageTemplateEntryTypeConstants.TYPE_BASIC) ||
 			(!_isLinkedLayout(themeDisplay) &&
 			 !_isModifiedLayout(themeDisplay))) {
 
@@ -161,6 +183,10 @@ public class InformationMessagesProductNavigationControlMenuEntry
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		InformationMessagesProductNavigationControlMenuEntry.class);
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
 
 	@Reference(target = "(osgi.web.symbolicname=com.liferay.layout.admin.web)")
 	private ServletContext _servletContext;

--- a/modules/apps/layout/layout-set-prototype-web/build.gradle
+++ b/modules/apps/layout/layout-set-prototype-web/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-react")
+	compileOnly project(":apps:layout:layout-page-template-api")
 	compileOnly project(":apps:layout:layout-set-prototype-api")
 	compileOnly project(":apps:portal-configuration:portal-configuration-module-configuration-api")
 	compileOnly project(":apps:product-navigation:product-navigation-control-menu-api")

--- a/modules/apps/layout/layout-set-prototype-web/src/main/java/com/liferay/layout/set/prototype/web/internal/product/navigation/control/menu/PropagationMessageProductNavigationControlMenuEntry.java
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/java/com/liferay/layout/set/prototype/web/internal/product/navigation/control/menu/PropagationMessageProductNavigationControlMenuEntry.java
@@ -5,6 +5,9 @@
 
 package com.liferay.layout.set.prototype.web.internal.product.navigation.control.menu;
 
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -67,7 +70,26 @@ public class PropagationMessageProductNavigationControlMenuEntry
 			_layoutSetPrototypeLocalService.fetchLayoutSetPrototype(
 				group.getClassPK());
 
-		if ((layoutSetPrototype == null) ||
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.
+				fetchLayoutPageTemplateEntryByPlid(layout.getPlid());
+
+		if (layoutPageTemplateEntry == null) {
+			layoutPageTemplateEntry =
+				_layoutPageTemplateEntryLocalService.
+					fetchLayoutPageTemplateEntryByPlid(layout.getClassPK());
+		}
+
+		int layoutType = -1;
+
+		if (layoutPageTemplateEntry != null) {
+			layoutType = layoutPageTemplateEntry.getType();
+		}
+
+		if ((layoutSetPrototype == null) || layout.isTypeAssetDisplay() ||
+			(layoutType ==
+				LayoutPageTemplateEntryTypeConstants.TYPE_MASTER_LAYOUT) ||
+			(layoutType == LayoutPageTemplateEntryTypeConstants.TYPE_BASIC) ||
 			!LayoutSetPrototypePermissionUtil.contains(
 				themeDisplay.getPermissionChecker(),
 				layoutSetPrototype.getLayoutSetPrototypeId(),
@@ -83,6 +105,10 @@ public class PropagationMessageProductNavigationControlMenuEntry
 	protected ServletContext getServletContext() {
 		return _servletContext;
 	}
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
 
 	@Reference
 	private LayoutSetPrototypeLocalService _layoutSetPrototypeLocalService;


### PR DESCRIPTION
Hi Team,
Could you please review this pull request?
https://liferay.atlassian.net/browse/LPS-195074
Thank you!

--------------------------------

This pull request is the result of https://liferay.atlassian.net/browse/PTR-4173. Based on the PTR I removed the propagation indication in site templates for master pages, page templates, and display pages. I also removed the information marker in the child site about resetting changes related to propagation for these page types. 