### PR TITLE
LPS-198204 Add context title to back button in Stylebooks

### DIFF
--- a/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
+++ b/modules/apps/style-book/style-book-web/src/main/java/com/liferay/style/book/web/internal/display/context/EditStyleBookEntryDisplayContext.java
@@ -569,6 +569,7 @@ public class EditStyleBookEntryDisplayContext {
 
 		portletDisplay.setShowBackIcon(true);
 		portletDisplay.setURLBack(_getRedirect());
+		portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 		_renderResponse.setTitle(_getStyleBookEntryTitle());
 	}


### PR DESCRIPTION
## Motivation

[Link to ticket\](https://liferay.atlassian.net/browse/LPS-198204)

### Changes

Add the back URL title for back buttons in Stylebooks.

## Test scenario 1

1. Create a Stylebook.
2. Check the back button title. Should follow the pattern "Go to Stylebooks".
3. Publish and click on the name of the stylebook created.
4. Check again the back button title.
5. Go back and click on edit in the kebab menu.
6. Check it again.

## Results

https://github.com/liferay-echo/liferay-portal/assets/93203423/881615cf-05b9-4925-a453-38a8149222eb

