### PR TITLE
LPS-197963 Allow page to display input fragments in read-only mode

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/checkbox/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/checkbox/index.html
@@ -4,7 +4,7 @@
 	<div class="custom-checkbox custom-control [#if input.errorMessage?has_content]has-error[/#if] mb-0">
 		<input aria-describedby="${fragmentEntryLinkNamespace}-checkbox-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-checkbox-label [#if input.errorMessage?has_content]${fragmentEntryLinkNamespace}-checkbox-error-message[/#if]" class="custom-control-input" id="${fragmentEntryLinkNamespace}-checkbox" name="${input.name}" [#if readOnly]readonly onclick="return false;"[/#if] ${input.required?then('required', '')} type="checkbox" [#if input.value?? && input.value == 'true']checked[/#if] />
 
-		<label class="custom-control-label" id="${fragmentEntryLinkNamespace}-checkbox-label">
+		<label class="custom-control-label" for="${fragmentEntryLinkNamespace}-checkbox" id="${fragmentEntryLinkNamespace}-checkbox-label">
 			<span class="[#if !input.showLabel || !input.label?has_content]sr-only [/#if]custom-control-label-text">
 				${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
 			</span>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/checkbox/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/checkbox/index.html
@@ -1,9 +1,13 @@
+[#assign readOnly = input.attributes.readOnly?? && input.attributes.readOnly ]
+
 <div class="forms-checkbox">
 	<div class="custom-checkbox custom-control [#if input.errorMessage?has_content]has-error[/#if] mb-0">
-		<input aria-describedby="${fragmentEntryLinkNamespace}-checkbox-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-checkbox-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-checkbox-error-message[/#if]" class="custom-control-input" id="${fragmentEntryLinkNamespace}-checkbox" name="${input.name}" ${input.required?then('required', '')} type="checkbox" [#if input.value?? && input.value == 'true']checked[/#if] />
+		<input aria-describedby="${fragmentEntryLinkNamespace}-checkbox-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-checkbox-label [#if input.errorMessage?has_content]${fragmentEntryLinkNamespace}-checkbox-error-message[/#if]" class="custom-control-input" id="${fragmentEntryLinkNamespace}-checkbox" name="${input.name}" [#if readOnly]readonly onclick="return false;"[/#if] ${input.required?then('required', '')} type="checkbox" [#if input.value?? && input.value == 'true']checked[/#if] />
 
 		<label class="custom-control-label" id="${fragmentEntryLinkNamespace}-checkbox-label">
-			<span class="[#if !input.showLabel || !input.label?has_content]sr-only [/#if]custom-control-label-text">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</span>
+			<span class="[#if !input.showLabel || !input.label?has_content]sr-only [/#if]custom-control-label-text">
+				${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+			</span>
 		</label>
 	</div>
 

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.html
@@ -1,8 +1,12 @@
+[#assign readOnly = input.attributes.readOnly?? && input.attributes.readOnly ]
+
 <div class="date-input">
 	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-date-input-label">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-date-input-label">
+			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+		</label>
 
-		<input aria-describedby="${fragmentEntryLinkNamespace}-date-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-date-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-date-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-date-input" max="9999-12-31" name="${input.name}" ${input.required?then('required', '')} type="date" [#if input.value??]value="${input.value}"[/#if] />
+		<input aria-describedby="${fragmentEntryLinkNamespace}-date-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-date-input-label [#if input.errorMessage?has_content]${fragmentEntryLinkNamespace}-date-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-date-input" max="9999-12-31" name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="date" [#if input.value??]value="${input.value}"[/#if] />
 
 		[#if input.errorMessage?has_content]
 			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentEntryLinkNamespace}-date-input-error-message">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.html
@@ -2,7 +2,7 @@
 
 <div class="date-input">
 	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-date-input-label">
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" for="${fragmentEntryLinkNamespace}-date-input" id="${fragmentEntryLinkNamespace}-date-input-label">
 			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
 		</label>
 

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.js
@@ -1,7 +1,14 @@
-if (layoutMode === 'edit') {
-	const input = document.getElementById(`${fragmentNamespace}-date-input`);
+const inputElement = document.getElementById(`${fragmentNamespace}-date-input`);
 
-	if (input) {
-		input.setAttribute('disabled', true);
+if (inputElement) {
+	if (input.attributes?.readOnly) {
+		inputElement.addEventListener('keydown', (event) => {
+			if (event.code === 'Space') {
+				event.preventDefault();
+			}
+		});
+	}
+	else if (layoutMode === 'edit') {
+		inputElement.setAttribute('disabled', true);
 	}
 }

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.html
@@ -1,8 +1,12 @@
-<div class="date-input">
-	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" for="${fragmentEntryLinkNamespace}-date-input">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+[#assign readOnly = input.attributes.readOnly?? && input.attributes.readOnly ]
 
-		<input aria-describedby="${fragmentEntryLinkNamespace}-date-input-help-text" class="form-control" id="${fragmentEntryLinkNamespace}-date-input" max="9999-12-31" name="${input.name}" ${input.required?then('required', '')} type="datetime-local" [#if input.value??]value="${input.value}"[/#if] />
+<div class="date-input">
+	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" for="${fragmentEntryLinkNamespace}-date-input">
+			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+		</label>
+
+		<input aria-describedby="${fragmentEntryLinkNamespace}-date-input-help-text" class="form-control" id="${fragmentEntryLinkNamespace}-date-input" max="9999-12-31" name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="datetime-local" [#if input.value??]value="${input.value}"[/#if] />
 
 		[#if input.errorMessage?has_content]
 			<p class="font-weight-semi-bold mt-1 text-danger">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.html
@@ -6,10 +6,10 @@
 			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
 		</label>
 
-		<input aria-describedby="${fragmentEntryLinkNamespace}-date-input-help-text" class="form-control" id="${fragmentEntryLinkNamespace}-date-input" max="9999-12-31" name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="datetime-local" [#if input.value??]value="${input.value}"[/#if] />
+		<input aria-describedby="${fragmentEntryLinkNamespace}-date-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-date-input-label [#if input.errorMessage?has_content]${fragmentEntryLinkNamespace}-date-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-date-input" max="9999-12-31" name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="datetime-local" [#if input.value??]value="${input.value}"[/#if] />
 
 		[#if input.errorMessage?has_content]
-			<p class="font-weight-semi-bold mt-1 text-danger">
+			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentEntryLinkNamespace}-date-input-error-message">
 				<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
 					<use xlink:href="${siteSpritemap}#info-circle" />
 				</svg>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.js
@@ -1,7 +1,14 @@
-if (layoutMode === 'edit') {
-	const input = document.getElementById(`${fragmentNamespace}-date-input`);
+const inputElement = document.getElementById(`${fragmentNamespace}-date-input`);
 
-	if (input) {
-		input.setAttribute('disabled', true);
+if (inputElement) {
+	if (input.attributes?.readOnly) {
+		inputElement.addEventListener('keydown', (event) => {
+			if (event.code === 'Space') {
+				event.preventDefault();
+			}
+		});
+	}
+	else if (layoutMode === 'edit') {
+		inputElement.setAttribute('disabled', true);
 	}
 }

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.html
@@ -1,5 +1,6 @@
 [#assign
 	localFileUploaded = false
+	readOnly = input.attributes.readOnly?? && input.attributes.readOnly
 	showDocumentLibrarySelector = input.attributes.selectFromDocumentLibrary?? && input.attributes.selectFromDocumentLibrary
 ]
 
@@ -9,27 +10,31 @@
 
 <div class="file-upload">
 	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-file-upload-label">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-file-upload-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
 
-		<div class="align-items-center d-flex">
-			<div class="position-relative">
-				<button class="btn btn-secondary" id="${fragmentEntryLinkNamespace}-file-upload-button-label" type="button">[@clay["icon"] symbol="upload" /] ${htmlUtil.escape(configuration.buttonText)}</button>
+		[#if readOnly]
+			<input class="form-control" aria-labelledby="${fragmentEntryLinkNamespace}-file-upload-label" class="form-control" id="${fragmentEntryLinkNamespace}-file-upload" name="${input.name}" placeholder="${languageUtil.get(locale, "no-file-selected")}" readonly type="text" [#if input.attributes.fileName??]value="${htmlUtil.escape(input.attributes.fileName)}"[/#if] />
+		[#else]
+			<div class="align-items-center d-flex">
+				<div class="position-relative">
+					<button class="btn btn-secondary" id="${fragmentEntryLinkNamespace}-file-upload-button-label" type="button">[@clay["icon"] symbol="upload" /] ${htmlUtil.escape(configuration.buttonText)}</button>
 
-				<input id="${fragmentEntryLinkNamespace}-file-upload-hidden" [#if localFileUploaded]name="${input.name}"[/#if] type="hidden" value="${input.value}" />
+					<input id="${fragmentEntryLinkNamespace}-file-upload-hidden" [#if localFileUploaded]name="${input.name}"[/#if] type="hidden" value="${input.value}" />
 
-				<input accept="${(input.attributes.allowedFileExtensions?has_content)?then(input.attributes.allowedFileExtensions, '*')}" aria-describedby="${fragmentEntryLinkNamespace}-file-upload-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-file-upload-label ${fragmentEntryLinkNamespace}-file-upload-button-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-file-upload-error-message[/#if]" class="file-upload-input" formenctype="multipart/form-data" id="${fragmentEntryLinkNamespace}-file-upload" [#if !localFileUploaded]name="${input.name}"[/#if] ${input.required?then('required', '' )} type="${showDocumentLibrarySelector?then('text', 'file')}" [#if input.value??]value="${input.value}"[/#if] tabIndex="-1" />
+					<input accept="${(input.attributes.allowedFileExtensions?has_content)?then(input.attributes.allowedFileExtensions, '*')}" aria-describedby="${fragmentEntryLinkNamespace}-file-upload-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-file-upload-label ${fragmentEntryLinkNamespace}-file-upload-button-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-file-upload-error-message[/#if]" class="file-upload-input" formenctype="multipart/form-data" id="${fragmentEntryLinkNamespace}-file-upload" [#if !localFileUploaded]name="${input.name}"[/#if] ${input.required?then('required', '' )} type="${showDocumentLibrarySelector?then('text', 'file')}" [#if input.value??]value="${input.value}"[/#if] tabIndex="-1" />
+				</div>
+
+				<small class="inline-item inline-item-after">
+					<strong class="forms-file-upload-file-name">
+						[#if input.attributes.fileName??]${htmlUtil.escape(input.attributes.fileName)}[/#if]
+					</strong>
+				</small>
+
+				<button class="btn btn-monospaced btn-outline-borderless btn-outline-secondary d-none ml-1" id="${fragmentEntryLinkNamespace}-file-upload-remove-button" type="button">
+					[@clay["icon"] symbol="times-circle-full" /]
+				</button>
 			</div>
-
-			<small class="inline-item inline-item-after">
-				<strong class="forms-file-upload-file-name">
-					[#if input.attributes.fileName??]${htmlUtil.escape(input.attributes.fileName)}[/#if]
-				</strong>
-			</small>
-
-			<button class="btn btn-monospaced btn-outline-borderless btn-outline-secondary d-none ml-1" id="${fragmentEntryLinkNamespace}-file-upload-remove-button" type="button">
-				[@clay["icon"] symbol="times-circle-full" /]
-			</button>
-		</div>
+		[/#if]
 
 		[#if input.errorMessage?has_content]
 			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentEntryLinkNamespace}-file-upload-error-message">
@@ -43,7 +48,7 @@
 			</p>
 		[/#if]
 
-		[#if (input.showHelpText && input.helpText?has_content) || (configuration.showSupportedFileInfo && input.attributes.allowedFileExtensions?? && input.attributes.maxFileSize??)]
+		[#if !readOnly && ((input.showHelpText && input.helpText?has_content) || (configuration.showSupportedFileInfo && input.attributes.allowedFileExtensions?? && input.attributes.maxFileSize??))]
 			<p class="mb-0 mt-1 text-secondary" id="${fragmentEntryLinkNamespace}-file-upload-help-text">${configuration.showSupportedFileInfo?then(languageUtil.format(locale, "upload-a-x-no-larger-than-x-mb", [input.attributes.allowedFileExtensions!"", input.attributes.maxFileSize!""]), '' )} ${input.showHelpText?then(htmlUtil.escape(input.helpText), '' )}</p>
 		[/#if]
 	</div>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiple-select-from-list/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiple-select-from-list/index.html
@@ -1,7 +1,9 @@
+[#assign readOnly = input.attributes.readOnly?? && input.attributes.readOnly ]
+
 <div class="multiselect-list">
-	<div class="custom-checkbox custom-control [#if  input.errorMessage?has_content]has-error[/#if] mb-0">
+	<div class="custom-checkbox custom-control [#if input.errorMessage?has_content]has-error[/#if] mb-0">
 		<span class="font-weight-semi-bold mb-1 multiselect-list-label text-3 [#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-multiselect-list-label">
-			${htmlUtil.escape(input.label)} [#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
 		</span>
 
 		<div aria-describedby="${fragmentEntryLinkNamespace}-multiselect-list-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-multiselect-list-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-multiselect-list-error-message[/#if]" class="multiselect-list-fieldset" role="group">
@@ -14,7 +16,7 @@
 				[/#if]
 
 				<div class="custom-control mb-0">
-					<input class="custom-control-input" [#if values?seq_contains(option.value)]checked[/#if] id="${fragmentEntryLinkNamespace}-checkbox-${option.value}" name="${input.name}" ${input.required?then('required', '')} type="checkbox" value="${option.value}" />
+					<input class="custom-control-input" [#if values?seq_contains(option.value)]checked[/#if] id="${fragmentEntryLinkNamespace}-checkbox-${option.value}" name="${input.name}" [#if readOnly]readonly onclick="return false;"[/#if] ${input.required?then('required', '')} type="checkbox" value="${option.value}" />
 
 					<label class="custom-control-label" for="${fragmentEntryLinkNamespace}-checkbox-${option.value}">
 						<span class="custom-control-label-text">${htmlUtil.escape(option.label)}</span>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/numeric-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/numeric-input/index.html
@@ -2,7 +2,7 @@
 
 <div class="numeric-input">
 	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-numeric-input-label">
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" for="${fragmentEntryLinkNamespace}-numeric-input" id="${fragmentEntryLinkNamespace}-numeric-input-label">
 			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
 		</label>
 

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/numeric-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/numeric-input/index.html
@@ -1,8 +1,12 @@
-<div class="numeric-input">
-	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-numeric-input-label">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+[#assign readOnly = input.attributes.readOnly?? && input.attributes.readOnly]
 
-	<input aria-describedby="${fragmentEntryLinkNamespace}-numeric-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-numeric-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-numeric-input-error-message[/#if]" class="form-control" data-validation-message-text="${languageUtil.get(locale, "enter-a-valid-value.-the-value-has-too-many-decimals")}" id="${fragmentEntryLinkNamespace}-numeric-input" [#if input.attributes.max??]max="${input.attributes.max}"[/#if] [#if input.attributes.min??]min="${input.attributes.min}"[/#if] name="${input.name}" [#if input.required]required[/#if] [#if input.attributes.dataType?? && input.attributes.dataType="decimal" && input.attributes.step??]step="${input.attributes.step}"[/#if] placeholder="${configuration.placeholder}" type="number" [#if input.value??]value="${input.value}"[/#if] />
+<div class="numeric-input">
+	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-numeric-input-label">
+			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+		</label>
+
+		<input aria-describedby="${fragmentEntryLinkNamespace}-numeric-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-numeric-input-label [#if input.errorMessage?has_content]${fragmentEntryLinkNamespace}-numeric-input-error-message[/#if]" class="form-control" data-validation-message-text="${languageUtil.get(locale, "enter-a-valid-value.-the-value-has-too-many-decimals")}" id="${fragmentEntryLinkNamespace}-numeric-input" [#if input.attributes.max??]max="${input.attributes.max}"[/#if] [#if input.attributes.min??]min="${input.attributes.min}"[/#if] name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} [#if input.attributes.dataType?? && input.attributes.dataType="decimal" && input.attributes.step??]step="${input.attributes.step}"[/#if] placeholder="${configuration.placeholder}" type="number" [#if input.value??]value="${input.value}"[/#if] />
 
 		[#if input.errorMessage?has_content]
 			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentEntryLinkNamespace}-numeric-input-error-message">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.css
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.css
@@ -3,3 +3,16 @@
 	pointer-events: none;
 	position: absolute;
 }
+
+.rich-text-input .form-control[aria-readonly='true'] {
+	background-color: #fff;
+	border-color: #e7e7ed;
+	cursor: text;
+	opacity: 1;
+}
+
+.rich-text-input .form-control[aria-readonly='true']:focus,
+.rich-text-input .form-control[aria-readonly='true']:focus-visible {
+	border-color: #80acff;
+	box-shadow: none;
+}

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.html
@@ -1,18 +1,22 @@
+[#assign
+	readOnly = input.attributes.readOnly?? && input.attributes.readOnly
+	showLabel = input.showLabel && input.label?has_content && (layoutMode == "edit" || readOnly)
+]
+
 <div class="rich-text-input [#if !input.showLabel || !input.label?has_content]rich-text-input--hidden-label[/#if]">
-	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0">
-		[#if layoutMode == "edit"]
-			[@liferay_editor["resources"] editorName="ckeditor" /]
+	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
+		<label class="[#if !showLabel]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-rich-text-input-label">
+			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+		</label>
+
+		[#if readOnly]
+			<div aria-labelledby="${fragmentEntryLinkNamespace}-rich-text-input-label" aria-multiline="true" aria-readonly="true" [#if input.required]aria-required="true"[/#if] class="form-control" contenteditable="false" id="${fragmentEntryLinkNamespace}-rich-text-input" role="textbox" tabindex="0"></div>
+		[#elseif layoutMode == "edit"]
+			[@liferay_editor["resources"]editorName="ckeditor" /]
 
 			<link href="/o/frontend-editor-ckeditor-web/ckeditor/skins/moono-lexicon/editor_gecko.css" rel="stylesheet" />
 
 			<div role="presentation">
-				[#if input.showLabel && input.label?has_content]
-					<label role="presentation">
-						${htmlUtil.escape(input.label)}
-						[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
-					</label>
-				[/#if]
-
 				<div class="cke cke_chrome cke_reset cke_ltr">
 					<div class="cke_inner">
 						<div class="cke_top cke_reset_all">
@@ -20,43 +24,33 @@
 								<div class="cke_toolbar">
 									<div class="cke_toolgroup mb-0">
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__undo_icon"></div>
+										<div class="cke_button_icon cke_button__undo_icon"></div>
 										</a>
 
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__redo_icon"></div>
+										<div class="cke_button_icon cke_button__redo_icon" />
 										</a>
 									</div>
 								</div>
 
 								<div class="cke_toolbar">
 									<a class="cke_button cke_button_disabled">
-										<div class="cke_button_label cke_button__source_label text-muted">Styles</div>
+										<div class="cke_button_label cke_button__source_label text-muted">
+											Styles
+										</div>
 									</a>
 
 									<div class="cke_toolgroup mb-0">
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__bold_icon"></div>
+										<div class="cke_button_icon cke_button__bold_icon"></div>
 										</a>
 
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__italic_icon"></div>
+										<div class="cke_button_icon cke_button__italic_icon" />
 										</a>
 
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__underline_icon"></div>
-										</a>
-									</div>
-								</div>
-
-								<div class="cke_toolbar">
-									<div class="cke_toolgroup mb-0">
-										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__bulletedlist_icon"></div>
-										</a>
-
-										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__numberedlist_icon"></div>
+										<div class="cke_button_icon cke_button__underline_icon" />
 										</a>
 									</div>
 								</div>
@@ -64,27 +58,11 @@
 								<div class="cke_toolbar">
 									<div class="cke_toolgroup mb-0">
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__link_icon"></div>
+										<div class="cke_button_icon cke_button__bulletedlist_icon" />
 										</a>
 
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__unlink_icon"></div>
-										</a>
-									</div>
-								</div>
-
-								<div class="cke_toolbar">
-									<div class="cke_toolgroup mb-0">
-										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__table_icon"></div>
-										</a>
-
-										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__image_icon"></div>
-										</a>
-
-										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__videoselector_icon"></div>
+										<div class="cke_button_icon cke_button__numberedlist_icon" />
 										</a>
 									</div>
 								</div>
@@ -92,16 +70,46 @@
 								<div class="cke_toolbar">
 									<div class="cke_toolgroup mb-0">
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__source_icon"></div>
+										<div class="cke_button_icon cke_button__link_icon" />
+										</a>
 
-											<div class="cke_button_label cke_button__source_label text-muted">Source</div>
+										<a class="cke_button cke_button_disabled">
+										<div class="cke_button_icon cke_button__unlink_icon" />
+										</a>
+									</div>
+								</div>
+
+								<div class="cke_toolbar">
+									<div class="cke_toolgroup mb-0">
+										<a class="cke_button cke_button_disabled">
+										<div class="cke_button_icon cke_button__table_icon" />
+										</a>
+
+										<a class="cke_button cke_button_disabled">
+										<div class="cke_button_icon cke_button__image_icon" />
+										</a>
+
+										<a class="cke_button cke_button_disabled">
+										<div class="cke_button_icon cke_button__videoselector_icon" />
+										</a>
+									</div>
+								</div>
+
+								<div class="cke_toolbar">
+									<div class="cke_toolgroup mb-0">
+										<a class="cke_button cke_button_disabled">
+										<div class="cke_button_icon cke_button__source_icon" />
+
+											<div class="cke_button_label cke_button__source_label text-muted">
+												Source
+											</div>
 										</a>
 									</div>
 								</div>
 							</div>
 						</div>
 
-						<div class="cke_contents cke_editable" style="height: 200px"></div>
+					<div class="cke_contents cke_editable" style="height: 200px"></div>
 					</div>
 				</div>
 			</div>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.js
@@ -1,9 +1,17 @@
-if (layoutMode === 'edit') {
-	const input = document.getElementById(
-		`${fragmentNamespace}-rich-text-input`
-	);
+const inputElement = document.getElementById(
+	`${fragmentNamespace}-rich-text-input`
+);
 
-	if (input) {
-		input.setAttribute('disabled', true);
+if (input.attributes?.readOnly) {
+	if (inputElement) {
+		const parser = new DOMParser();
+		const html = parser.parseFromString(input.value, 'text/html');
+
+		inputElement.appendChild(html.documentElement);
+	}
+}
+else if (layoutMode === 'edit') {
+	if (inputElement) {
+		inputElement.setAttribute('disabled', true);
 	}
 }

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.html
@@ -1,67 +1,73 @@
+[#assign
+	readOnly = input.attributes.readOnly?? && input.attributes.readOnly
+]
+
 <div class="select-from-list">
 	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0">
-		<div class="align-items-end input-group">
-			<div class="input-group-item input-group-prepend">
-				<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-select-from-list-input-label">
-					${htmlUtil.escape(input.label)}
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-select-from-list-input-label">
+			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+		</label>
 
-					[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
-				</label>
+		[#if readOnly]
+			<input aria-describedby="${fragmentEntryLinkNamespace}-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-select-from-list-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-select-from-list-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-select-from-list-input" name="${input.name}" placeholder="${languageUtil.get(locale, "choose-an-option")}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="text" [#if input.value??]value="${input.value}"[/#if] />
+		[#else]
+			<div class="align-items-end input-group">
+				<div class="input-group-item input-group-prepend">
+					<input aria-autocomplete="list" aria-controls="${fragmentEntryLinkNamespace}-listbox" aria-expanded="false" aria-labelledby="${fragmentEntryLinkNamespace}-select-from-list-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-select-from-list-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-select-from-list-input" name="" placeholder="${languageUtil.get(locale, "choose-an-option")}" role="combobox" type="text" ${input.required?then('required', '')} [#if input.attributes.selectedOptionLabel??]value="${input.attributes.selectedOptionLabel}"[/#if] />
 
-				<input aria-autocomplete="list" aria-controls="${fragmentEntryLinkNamespace}-listbox" aria-expanded="false" aria-labelledby="${fragmentEntryLinkNamespace}-select-from-list-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-select-from-list-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-select-from-list-input" name="" placeholder="${languageUtil.get(locale, "choose-an-option")}" role="combobox" type="text" ${input.required?then('required', '')} [#if input.attributes.selectedOptionLabel??]value="${input.attributes.selectedOptionLabel}"[/#if] />
+					<input id="${fragmentEntryLinkNamespace}-value-input" name="${input.name}" type="hidden" [#if input.attributes.selectedOptionValue??]value="${input.value}"[/#if] />
+					<input id="${fragmentEntryLinkNamespace}-label-input" name="${input.name}-label" type="hidden" [#if input.attributes.selectedOptionLabel??]value="${input.attributes.selectedOptionLabel}"[/#if] />
+				</div>
 
-				<input id="${fragmentEntryLinkNamespace}-value-input" name="${input.name}" type="hidden" [#if input.attributes.selectedOptionValue??]value="${input.value}"[/#if] />
-				<input id="${fragmentEntryLinkNamespace}-label-input" name="${input.name}-label" type="hidden" [#if input.attributes.selectedOptionLabel??]value="${input.attributes.selectedOptionLabel}"[/#if] />
-			</div>
+				<span class="input-group-append input-group-item input-group-item-shrink">
+					<button aria-controls="${fragmentEntryLinkNamespace}-listbox" [#if input.showHelpText && input.helpText?has_content]aria-describedby="${fragmentEntryLinkNamespace}-help-text"[/#if] aria-expanded="false" class="btn btn-secondary" type="button">
+						[@clay["icon"] symbol="caret-double" /]
+					</button>
+				</span>
 
-			<span class="input-group-append input-group-item input-group-item-shrink">
-				<button aria-controls="${fragmentEntryLinkNamespace}-listbox" [#if input.showHelpText && input.helpText?has_content]aria-describedby="${fragmentEntryLinkNamespace}-help-text"[/#if] aria-expanded="false" class="btn btn-secondary" type="button">
-					[@clay["icon"] symbol="caret-double" /]
-				</button>
-			</span>
+				<div class="d-none dropdown-menu dropdown-menu-width-sm select-from-list__dropdown-menu" id="${fragmentEntryLinkNamespace}-dropdown">
+					<p class="mb-0 px-3 py-2 text-muted" id="${fragmentEntryLinkNamespace}-choose-option-message">
+						${languageUtil.get(locale, "choose-an-option")}
+					</p>
 
-			<div class="d-none dropdown-menu dropdown-menu-width-sm select-from-list__dropdown-menu" id="${fragmentEntryLinkNamespace}-dropdown">
-				<p class="mb-0 px-3 py-2 text-muted" id="${fragmentEntryLinkNamespace}-choose-option-message">
-					${languageUtil.get(locale, "choose-an-option")}
-				</p>
+					<p class="d-none mb-0 px-3 py-2 text-muted" id="${fragmentEntryLinkNamespace}-loading-results-message">
+						${languageUtil.get(locale, "loading")}
+					</p>
 
-				<p class="d-none mb-0 px-3 py-2 text-muted" id="${fragmentEntryLinkNamespace}-loading-results-message">
-					${languageUtil.get(locale, "loading")}
-				</p>
+					<p class="d-none mb-0 px-3 py-2 text-muted" id="${fragmentEntryLinkNamespace}-no-results-message">
+						${languageUtil.get(locale, "no-results-were-found")}
+					</p>
 
-				<p class="d-none mb-0 px-3 py-2 text-muted" id="${fragmentEntryLinkNamespace}-no-results-message">
-					${languageUtil.get(locale, "no-results-were-found")}
-				</p>
+					<ul aria-labelledby="${fragmentEntryLinkNamespace}-label" class="list-unstyled" id="${fragmentEntryLinkNamespace}-listbox" role="listbox">
+						[#assign options=(input.attributes.options)![]]
+						[#assign selectedValueFoundInOptions=false]
 
-				<ul aria-labelledby="${fragmentEntryLinkNamespace}-label" class="list-unstyled" id="${fragmentEntryLinkNamespace}-listbox" role="listbox">
-					[#assign options=(input.attributes.options)![]]
-					[#assign selectedValueFoundInOptions=false]
+						[#list options as option]
+							[#if option?index == 10]
+								[#break]
+							[/#if]
 
-					[#list options as option]
-						[#if option?index == 10]
-							[#break]
+							[#assign selectedOption=false]
+
+							[#if input.value?? && option.value == input.value]
+								[#assign selectedOption=true]
+								[#assign selectedValueFoundInOptions=true]
+							[/#if]
+
+							<li [#if selectedOption]aria-selected="true"[/#if] class="[#if selectedOption]active[/#if] dropdown-item" data-option-value="${option.value}" id="${fragmentEntryLinkNamespace}-option-${option.value}" role="option">
+								${htmlUtil.escape(option.label)}
+							</li>
+						[/#list]
+
+						[#if !selectedValueFoundInOptions && input.value?? && input.attributes.selectedOptionLabel??]
+							<li class="dropdown-item" data-option-value="${input.value}" id="${fragmentEntryLinkNamespace}-option-${input.value}" role="option">
+								${htmlUtil.escape(input.attributes.selectedOptionLabel)}
+							</li>
 						[/#if]
-
-						[#assign selectedOption=false]
-
-						[#if input.value?? && option.value == input.value]
-							[#assign selectedOption=true]
-							[#assign selectedValueFoundInOptions=true]
-						[/#if]
-
-						<li [#if selectedOption]aria-selected="true"[/#if] class="[#if selectedOption]active[/#if] dropdown-item" data-option-value="${option.value}" id="${fragmentEntryLinkNamespace}-option-${option.value}" role="option">
-							${htmlUtil.escape(option.label)}
-						</li>
-					[/#list]
-
-					[#if !selectedValueFoundInOptions && input.value?? && input.attributes.selectedOptionLabel??]
-						<li class="dropdown-item" data-option-value="${input.value}" id="${fragmentEntryLinkNamespace}-option-${input.value}" role="option">
-							${htmlUtil.escape(input.attributes.selectedOptionLabel)}
-						</li>
-					[/#if]
-				</ul>
+					</ul>
+				</div>
 			</div>
-		</div>
+		[/#if]
 
 		[#if input.errorMessage?has_content]
 			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentEntryLinkNamespace}-select-from-list-input-error-message">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/text-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/text-input/index.html
@@ -4,7 +4,7 @@
 
 <div class="text-input">
 	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0" id="${fragmentEntryLinkNamespace}-form-group">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-text-input-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" for="${fragmentEntryLinkNamespace}-text-input" id="${fragmentEntryLinkNamespace}-text-input-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
 
 		<input aria-describedby="${fragmentEntryLinkNamespace}-text-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-text-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-text-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-text-input" name="${input.name}" placeholder="${configuration.placeholder}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="text" [#if input.value??]value="${input.value}"[/#if] />
 

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/text-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/text-input/index.html
@@ -1,8 +1,12 @@
+[#assign
+	readOnly = input.attributes.readOnly?? && input.attributes.readOnly
+]
+
 <div class="text-input">
 	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0" id="${fragmentEntryLinkNamespace}-form-group">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-text-input-label">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-text-input-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
 
-		<input aria-describedby="${fragmentEntryLinkNamespace}-text-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-text-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-text-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-text-input" name="${input.name}" placeholder="${configuration.placeholder}" ${input.required?then('required', '')} type="text" [#if input.value??]value="${input.value}"[/#if] />
+		<input aria-describedby="${fragmentEntryLinkNamespace}-text-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-text-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-text-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-text-input" name="${input.name}" placeholder="${configuration.placeholder}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="text" [#if input.value??]value="${input.value}"[/#if] />
 
 		<p class="mt-1 text-secondary [#if !configuration.showCharactersCount]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-length-info">
 			<span class="sr-only" id="${fragmentEntryLinkNamespace}-length-warning">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/textarea/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/textarea/index.html
@@ -4,7 +4,7 @@
 
 <div class="textarea">
 	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0" id="${fragmentEntryLinkNamespace}-form-group">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-textarea-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" for="${fragmentEntryLinkNamespace}-textarea" id="${fragmentEntryLinkNamespace}-textarea-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
 
 		<textarea aria-describedby="${fragmentEntryLinkNamespace}-textarea-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-textarea-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-textarea-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-textarea" name="${input.name}" placeholder="${configuration.placeholder}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} [#if configuration.numberOfLines > 0]rows="${configuration.numberOfLines}"[/#if] type="text">[#if input.value??]${input.value}[/#if]</textarea>
 

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/textarea/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/textarea/index.html
@@ -1,8 +1,12 @@
+[#assign
+	readOnly = input.attributes.readOnly?? && input.attributes.readOnly
+]
+
 <div class="textarea">
 	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0" id="${fragmentEntryLinkNamespace}-form-group">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-textarea-label">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-textarea-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
 
-		<textarea aria-describedby="${fragmentEntryLinkNamespace}-textarea-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-textarea-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-textarea-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-textarea" name="${input.name}" placeholder="${configuration.placeholder}" ${input.required?then('required', '')} [#if configuration.numberOfLines > 0]rows="${configuration.numberOfLines}"[/#if] type="text">[#if input.value??]${input.value}[/#if]</textarea>
+		<textarea aria-describedby="${fragmentEntryLinkNamespace}-textarea-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-textarea-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-textarea-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-textarea" name="${input.name}" placeholder="${configuration.placeholder}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} [#if configuration.numberOfLines > 0]rows="${configuration.numberOfLines}"[/#if] type="text">[#if input.value??]${input.value}[/#if]</textarea>
 
 		<p class="mt-1 text-secondary [#if !configuration.showCharactersCount]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-length-info">
 			<span class="sr-only" id="${fragmentEntryLinkNamespace}-length-warning">


### PR DESCRIPTION
Dear developer,

to test this PR you have to do a cherry pick of this commit https://github.com/veroglez/liferay-portal/pull/128/commits/ec1f97add208adb7adcfd8c35f04e745114e82c1. This commit adds the property `readOnly` to the object of each field. 


**How to test it?**
1. Activate the FF LPS-183727
2. Create an object with several fields and 
3. In the tab Details, set Scope to Size and Panel Link to Site Administration > Site Builder
4. Go to Site Administration > Site Builder and select the object created
5. Add a new one and fill the form with values
6. Create a Display Page Template based in your object
7. Mark the Display Page Template as Default
8. Create a Content Page
9. Add a Button
10. Select the Link editable and in the right panel select Link tab
11. Select Mapped URL in the Link field
12. Select the corresponding object in the Item selector
13. Select Display Page URL in the Field field
14. Publish the page
15. Go to the view mode of the page

Also, you can test it creating a Content Page and adding a Form container with the object created (this case has no values)

**Check the following in the fields with read only:**
1. All field labels must have the text "(Read only)"
2. All fields must have the readonly attribute.
3. No field can be modified.