### PR TITLE
LPS-195942 When you update the friendly url of a web content and you publish it to Live, new FriendlyUrlEntry and FriendlyUrlEntryLocalization table entries are created but older ones aren't deleted

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/model/listener/FriendlyURLEntryModelListener.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/model/listener/FriendlyURLEntryModelListener.java
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.journal.internal.model.listener;
+
+import com.liferay.friendly.url.model.FriendlyURLEntry;
+import com.liferay.friendly.url.service.FriendlyURLEntryLocalService;
+import com.liferay.journal.model.JournalArticle;
+import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.ModelListener;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.util.List;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Jorge Díaz
+ */
+@Component(service = ModelListener.class)
+public class FriendlyURLEntryModelListener
+	extends BaseModelListener<FriendlyURLEntry> {
+
+	@Override
+	public void onBeforeCreate(FriendlyURLEntry newFriendlyURLEntry) {
+		if (newFriendlyURLEntry.getClassNameId() != _portal.getClassNameId(
+				JournalArticle.class)) {
+
+			return;
+		}
+
+		List<FriendlyURLEntry> friendlyURLEntries =
+			_friendlyURLEntryLocalService.getFriendlyURLEntries(
+				newFriendlyURLEntry.getGroupId(),
+				_portal.getClassNameId(JournalArticle.class),
+				newFriendlyURLEntry.getClassPK());
+
+		for (FriendlyURLEntry friendlyURLEntry : friendlyURLEntries) {
+			if (newFriendlyURLEntry.getFriendlyURLEntryId() ==
+					friendlyURLEntry.getFriendlyURLEntryId()) {
+
+				continue;
+			}
+
+			_friendlyURLEntryLocalService.deleteFriendlyURLEntry(
+				friendlyURLEntry);
+		}
+	}
+
+	@Reference
+	private FriendlyURLEntryLocalService _friendlyURLEntryLocalService;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7128,11 +7128,10 @@ public class JournalArticleLocalServiceImpl
 				_classNameLocalService.getClassNameId(JournalArticle.class),
 				article.getResourcePrimKey());
 
-		FriendlyURLEntry newFriendlyURLEntry =
-			friendlyURLEntryLocalService.addFriendlyURLEntry(
-				article.getGroupId(),
-				_classNameLocalService.getClassNameId(JournalArticle.class),
-				article.getResourcePrimKey(), urlTitleMap, serviceContext);
+		friendlyURLEntryLocalService.addFriendlyURLEntry(
+			article.getGroupId(),
+			_classNameLocalService.getClassNameId(JournalArticle.class),
+			article.getResourcePrimKey(), urlTitleMap, serviceContext);
 
 		for (Map.Entry<String, String> entry : urlTitleMap.entrySet()) {
 			if (Validator.isNull(entry.getValue())) {
@@ -7153,17 +7152,6 @@ public class JournalArticleLocalServiceImpl
 					}
 				}
 			}
-		}
-
-		for (FriendlyURLEntry friendlyURLEntry : friendlyURLEntries) {
-			if (newFriendlyURLEntry.getFriendlyURLEntryId() ==
-					friendlyURLEntry.getFriendlyURLEntryId()) {
-
-				continue;
-			}
-
-			friendlyURLEntryLocalService.deleteFriendlyURLEntry(
-				friendlyURLEntry);
 		}
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-195942

**Problem:**
In the web content functionality, when you update a friendly url and you publish it to Live, new FriendlyUrlEntry and FriendlyUrlEntryLocalization table entries are created but older ones aren't deleted.

**Current behavior in the Staging environment (or without Staging enabled)**
If you change the friendly url title in the staging enviroment, the older FriendlyUrlEntry and FriendlyUrlEntryLocalization records are deleted because web content functionality doesn’t implements friendly url history and this point of the JournalArticleLocalServiceImpl is deleting the old records:
https://github.com/liferay-echo/liferay-portal/blob/d7210e871573904fcf486a55af02f57f5a2d2c74/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java#L7156-L7165

**Current behavior in the Live environment**
When you publish from Staging to Live, the creation of FriendlyUrlEntry and FriendlyUrlEntryLocalization records are handled by the FriendlyURLEntryStagedModelDataHandler and the deletion code of JournalArticleLocalServiceImpl is ignored due to this check:
https://github.com/liferay-echo/liferay-portal/blob/d7210e871573904fcf486a55af02f57f5a2d2c74/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java#L7117-L7121

This check was added by https://liferay.atlassian.net/browse/LPS-95020

**Reproduction steps**
See https://liferay.atlassian.net/browse/LPS-195942 description

**Solution**
To solve the issue, I am moving the code that deletes the old FriendlyUrlEntry records to a model listener.

The echo SME @dacousalr has already review this approach in https://liferay.atlassian.net/browse/PTR-4313