### PR TITLE
LPS-193727 Allow order showed items by different fields

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageDisplayContext.java
@@ -20,6 +20,7 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalServiceUtil;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryServiceUtil;
 import com.liferay.layout.page.template.util.comparator.LayoutPageTemplateCollectionLayoutPageTemplateEntryCreateDateComparator;
+import com.liferay.layout.page.template.util.comparator.LayoutPageTemplateCollectionLayoutPageTemplateEntryModifiedDateComparator;
 import com.liferay.layout.page.template.util.comparator.LayoutPageTemplateCollectionLayoutPageTemplateEntryNameComparator;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.dao.search.EmptyOnClickRowChecker;
@@ -457,6 +458,10 @@ public class DisplayPageDisplayContext {
 
 		if (Objects.equals(getOrderByCol(), "create-date")) {
 			return new LayoutPageTemplateCollectionLayoutPageTemplateEntryCreateDateComparator(
+				orderByAsc);
+		}
+		else if (Objects.equals(getOrderByCol(), "modified-date")) {
+			return new LayoutPageTemplateCollectionLayoutPageTemplateEntryModifiedDateComparator(
 				orderByAsc);
 		}
 		else if (Objects.equals(getOrderByCol(), "name")) {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/display/context/DisplayPageManagementToolbarDisplayContext.java
@@ -225,7 +225,7 @@ public class DisplayPageManagementToolbarDisplayContext
 
 	@Override
 	protected String[] getOrderByKeys() {
-		return new String[] {"create-date", "name"};
+		return new String[] {"create-date", "modified-date", "name"};
 	}
 
 	private String _getDeleteSelectedEntriesURL() {

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/util/comparator/LayoutPageTemplateCollectionLayoutPageTemplateEntryModifiedDateComparator.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/util/comparator/LayoutPageTemplateCollectionLayoutPageTemplateEntryModifiedDateComparator.java
@@ -1,0 +1,98 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.util.comparator;
+
+import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.portal.kernel.util.OrderByComparator;
+
+/**
+ * @author Yurena Cabrera
+ */
+public class
+	LayoutPageTemplateCollectionLayoutPageTemplateEntryModifiedDateComparator
+		extends OrderByComparator<Object> {
+
+	public static final String ORDER_BY_ASC = "modifiedDate ASC";
+
+	public static final String ORDER_BY_DESC = "modifiedDate DESC";
+
+	public static final String[] ORDER_BY_FIELDS = {"modifiedDate"};
+
+	public LayoutPageTemplateCollectionLayoutPageTemplateEntryModifiedDateComparator() {
+		this(false);
+	}
+
+	public LayoutPageTemplateCollectionLayoutPageTemplateEntryModifiedDateComparator(
+		boolean ascending) {
+
+		_ascending = ascending;
+	}
+
+	@Override
+	public int compare(Object object1, Object object2) {
+		if ((object1 instanceof LayoutPageTemplateCollection) &&
+			(object2 instanceof LayoutPageTemplateCollection)) {
+
+			LayoutPageTemplateCollectionModifiedDateComparator
+				layoutPageTemplateCollectionModifiedDateComparator =
+					new LayoutPageTemplateCollectionModifiedDateComparator();
+
+			return layoutPageTemplateCollectionModifiedDateComparator.compare(
+				(LayoutPageTemplateCollection)object1,
+				(LayoutPageTemplateCollection)object2);
+		}
+
+		if ((object1 instanceof LayoutPageTemplateEntry) &&
+			(object2 instanceof LayoutPageTemplateEntry)) {
+
+			LayoutPageTemplateEntryModifiedDateComparator
+				layoutPageTemplateEntryModifiedDateComparator =
+					new LayoutPageTemplateEntryModifiedDateComparator();
+
+			return layoutPageTemplateEntryModifiedDateComparator.compare(
+				(LayoutPageTemplateEntry)object1,
+				(LayoutPageTemplateEntry)object2);
+		}
+
+		int value = 0;
+
+		if (object1 instanceof LayoutPageTemplateEntry) {
+			value = -1;
+		}
+		else if (object2 instanceof LayoutPageTemplateEntry) {
+			value = 1;
+		}
+
+		if (_ascending) {
+			return value;
+		}
+
+		return -value;
+	}
+
+	@Override
+	public String getOrderBy() {
+		if (_ascending) {
+			return ORDER_BY_ASC;
+		}
+
+		return ORDER_BY_DESC;
+	}
+
+	@Override
+	public String[] getOrderByFields() {
+		return ORDER_BY_FIELDS;
+	}
+
+	@Override
+	public boolean isAscending() {
+		return _ascending;
+	}
+
+	private final boolean _ascending;
+
+}

--- a/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/util/comparator/LayoutPageTemplateCollectionModifiedDateComparator.java
+++ b/modules/apps/layout/layout-page-template-api/src/main/java/com/liferay/layout/page/template/util/comparator/LayoutPageTemplateCollectionModifiedDateComparator.java
@@ -1,0 +1,75 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.util.comparator;
+
+import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
+import com.liferay.portal.kernel.util.DateUtil;
+import com.liferay.portal.kernel.util.OrderByComparator;
+
+/**
+ * @author Yurena Cabrera
+ */
+public class LayoutPageTemplateCollectionModifiedDateComparator
+	extends OrderByComparator<LayoutPageTemplateCollection> {
+
+	public static final String ORDER_BY_ASC =
+		"LayoutPageTemplateCollection.type DESC, " +
+			"LayoutPageTemplateCollection.modifiedDate ASC";
+
+	public static final String ORDER_BY_DESC =
+		"LayoutPageTemplateCollection.type DESC, " +
+			"LayoutPageTemplateCollection.modified DESC";
+
+	public static final String[] ORDER_BY_FIELDS = {"modifiedDate"};
+
+	public LayoutPageTemplateCollectionModifiedDateComparator() {
+		this(true);
+	}
+
+	public LayoutPageTemplateCollectionModifiedDateComparator(
+		boolean ascending) {
+
+		_ascending = ascending;
+	}
+
+	@Override
+	public int compare(
+		LayoutPageTemplateCollection layoutPageTemplateCollection1,
+		LayoutPageTemplateCollection layoutPageTemplateCollection2) {
+
+		int value = DateUtil.compareTo(
+			layoutPageTemplateCollection1.getModifiedDate(),
+			layoutPageTemplateCollection2.getModifiedDate());
+
+		if (_ascending) {
+			return value;
+		}
+
+		return -value;
+	}
+
+	@Override
+	public String getOrderBy() {
+		if (_ascending) {
+			return ORDER_BY_ASC;
+		}
+
+		return ORDER_BY_DESC;
+	}
+
+	@Override
+	public String[] getOrderByFields() {
+		return ORDER_BY_FIELDS;
+	}
+
+	@Override
+	public boolean isAscending() {
+		return _ascending;
+	}
+
+	private final boolean _ascending;
+
+}

--- a/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/util/comparator/packageinfo
+++ b/modules/apps/layout/layout-page-template-api/src/main/resources/com/liferay/layout/page/template/util/comparator/packageinfo
@@ -1,1 +1,1 @@
-version 1.2.0
+version 1.3.0

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
@@ -868,7 +868,11 @@ public class LayoutPageTemplateEntryServiceImpl
 				0L
 			).as(
 				"layoutPageTemplateCollectionId"
-			)
+			),
+			LayoutPageTemplateEntryTable.INSTANCE.name.as("name"),
+			LayoutPageTemplateEntryTable.INSTANCE.createDate.as("createDate"),
+			LayoutPageTemplateEntryTable.INSTANCE.modifiedDate.as(
+				"modifiedDate")
 		).from(
 			LayoutPageTemplateEntryTable.INSTANCE
 		).where(
@@ -895,7 +899,12 @@ public class LayoutPageTemplateEntryServiceImpl
 					"layoutPageTemplateEntryId"
 				),
 				LayoutPageTemplateCollectionTable.INSTANCE.
-					layoutPageTemplateCollectionId
+					layoutPageTemplateCollectionId,
+				LayoutPageTemplateCollectionTable.INSTANCE.name.as("name"),
+				LayoutPageTemplateCollectionTable.INSTANCE.createDate.as(
+					"createDate"),
+				LayoutPageTemplateCollectionTable.INSTANCE.modifiedDate.as(
+					"modifiedDate")
 			).from(
 				LayoutPageTemplateCollectionTable.INSTANCE
 			).where(

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
@@ -884,7 +884,7 @@ public class LayoutPageTemplateEntryServiceImpl
 				groupId
 			).and(
 				() -> {
-					if (layoutPageTemplateCollectionId != -1) {
+					if (layoutPageTemplateCollectionId >= 0) {
 						return LayoutPageTemplateEntryTable.INSTANCE.
 							layoutPageTemplateCollectionId.eq(
 								layoutPageTemplateCollectionId);
@@ -914,7 +914,7 @@ public class LayoutPageTemplateEntryServiceImpl
 					groupId
 				).and(
 					() -> {
-						if (layoutPageTemplateCollectionId != -1) {
+						if (layoutPageTemplateCollectionId >= 0) {
 							return LayoutPageTemplateCollectionTable.INSTANCE.
 								parentLayoutPageTemplateCollectionId.eq(
 									layoutPageTemplateCollectionId);

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
@@ -874,10 +874,9 @@ public class LayoutPageTemplateEntryServiceImpl
 			).as(
 				"layoutPageTemplateCollectionId"
 			),
-			LayoutPageTemplateEntryTable.INSTANCE.name.as("name"),
-			LayoutPageTemplateEntryTable.INSTANCE.createDate.as("createDate"),
-			LayoutPageTemplateEntryTable.INSTANCE.modifiedDate.as(
-				"modifiedDate")
+			LayoutPageTemplateEntryTable.INSTANCE.name,
+			LayoutPageTemplateEntryTable.INSTANCE.createDate,
+			LayoutPageTemplateEntryTable.INSTANCE.modifiedDate
 		).from(
 			LayoutPageTemplateEntryTable.INSTANCE
 		).where(
@@ -905,11 +904,9 @@ public class LayoutPageTemplateEntryServiceImpl
 				),
 				LayoutPageTemplateCollectionTable.INSTANCE.
 					layoutPageTemplateCollectionId,
-				LayoutPageTemplateCollectionTable.INSTANCE.name.as("name"),
-				LayoutPageTemplateCollectionTable.INSTANCE.createDate.as(
-					"createDate"),
-				LayoutPageTemplateCollectionTable.INSTANCE.modifiedDate.as(
-					"modifiedDate")
+				LayoutPageTemplateCollectionTable.INSTANCE.name,
+				LayoutPageTemplateCollectionTable.INSTANCE.createDate,
+				LayoutPageTemplateCollectionTable.INSTANCE.modifiedDate
 			).from(
 				LayoutPageTemplateCollectionTable.INSTANCE
 			).where(

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryServiceImpl.java
@@ -16,8 +16,10 @@ import com.liferay.layout.page.template.model.LayoutPageTemplateEntryTable;
 import com.liferay.layout.page.template.service.LayoutPageTemplateCollectionLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.page.template.service.base.LayoutPageTemplateEntryServiceBaseImpl;
+import com.liferay.petra.sql.dsl.Column;
 import com.liferay.petra.sql.dsl.DSLQueryFactoryUtil;
 import com.liferay.petra.sql.dsl.Table;
+import com.liferay.petra.sql.dsl.base.BaseTable;
 import com.liferay.petra.sql.dsl.query.DSLQuery;
 import com.liferay.petra.sql.dsl.spi.expression.Scalar;
 import com.liferay.portal.aop.AopService;
@@ -35,7 +37,10 @@ import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 
+import java.sql.Types;
+
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import org.osgi.service.component.annotations.Component;
@@ -925,7 +930,9 @@ public class LayoutPageTemplateEntryServiceImpl
 				)
 			)
 		).as(
-			"tempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable"
+			"tempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable",
+			TempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable.
+				INSTANCE
 		);
 	}
 
@@ -956,5 +963,39 @@ public class LayoutPageTemplateEntryServiceImpl
 		target = "(component.name=com.liferay.layout.page.template.internal.security.permission.resource.LayoutPageTemplatePortletResourcePermission)"
 	)
 	private PortletResourcePermission _portletResourcePermission;
+
+	private static class
+		TempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable
+			extends BaseTable
+				<TempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable> {
+
+		public static final
+			TempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable
+				INSTANCE =
+					new TempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable();
+
+		public final Column
+			<TempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable,
+			 Date> createDateColumn = createColumn(
+				"createDate", Date.class, Types.TIMESTAMP, Column.FLAG_DEFAULT);
+		public final Column
+			<TempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable,
+			 Date> modifiedDateColumn = createColumn(
+				"modifiedDate", Date.class, Types.TIMESTAMP,
+				Column.FLAG_DEFAULT);
+		public final Column
+			<TempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable,
+			 String> nameColumn = createColumn(
+				"name", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+
+		private TempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable() {
+			super(
+				"TempLayoutPageTemplateCollection" +
+					"AndLayoutPageTemplateEntryTable",
+				TempLayoutPageTemplateCollectionAndLayoutPageTemplateEntryTable::
+					new);
+		}
+
+	}
 
 }


### PR DESCRIPTION
Motivation
=======
Currently we allow users to create folders to organice their DPTs so looks natural allow then to order them by different fields as well the DPTs.

Proposed Solution
========
Different comparators are implemented an the order options are shown in the management toolbar. 

Steps to Verify
========
1. Go to Design > Page Templates > Display Page Templates Tab.
2. Create several new Folders
3. Create several new Display Page Template.
4. Order by (asc/desc) the three different fields available: name, creation date and modified date.

Commits
========
- LPS-193727 Create LayoutPageTemplateCollectionModifiedDateComparator
- LPS-193763 Create LayoutPageTemplateCollectionLayoutPageTemplateEntryModifiedDateComparator
- LPS-193763 Add LayoutPageTemplateCollectionLayoutPageTemplateEntryModifiedDateComparator to vailable orderBy options
- LPS-193763 Add new fields in response to be able to orderby
- LPS-193727 Add modified date option to orderBy
- LPS-193727 Add workaround to make orderBy dates work
