### PR TITLE
LPS-179670 Fix possibility to add multiple "single-use" widgets to a page

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addFragment.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addFragment.js
@@ -39,7 +39,7 @@ export default function addFragment({
 		};
 
 		if (type === FRAGMENT_ENTRY_TYPES.composition) {
-			FragmentService.addFragmentEntryLinks(params).then(
+			return FragmentService.addFragmentEntryLinks(params).then(
 				({addedItemId, fragmentEntryLinks, layoutData}) => {
 					updateState(
 						Object.values(fragmentEntryLinks),
@@ -50,7 +50,7 @@ export default function addFragment({
 			);
 		}
 		else {
-			FragmentService.addFragmentEntryLink(params).then(
+			return FragmentService.addFragmentEntryLink(params).then(
 				({addedItemId, fragmentEntryLink, layoutData}) => {
 					updateState([fragmentEntryLink], layoutData, addedItemId);
 				}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addWidget.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addWidget.js
@@ -14,7 +14,7 @@ export default function addWidget({
 	selectItem = () => {},
 }) {
 	return (dispatch, getState) => {
-		WidgetService.addPortlet({
+		return WidgetService.addPortlet({
 			onNetworkStatus: dispatch,
 			parentItemId,
 			portletId,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
@@ -38,6 +38,7 @@ const ITEM_PROPTYPES_SHAPE = PropTypes.shape({
 
 export default function TabItem({displayStyle, item, onRemoveHighlighted}) {
 	const dispatch = useDispatch();
+	const [disabled, setDisabled] = useState(item.disabled);
 
 	const onToggleHighlighted = useCallback(() => {
 		if (item.data.portletId) {
@@ -87,6 +88,8 @@ export default function TabItem({displayStyle, item, onRemoveHighlighted}) {
 				thunk = addItem;
 			}
 
+			setDisabled(true);
+
 			dispatch(
 				thunk({
 					...item.data,
@@ -94,20 +97,22 @@ export default function TabItem({displayStyle, item, onRemoveHighlighted}) {
 					parentItemId: parentId,
 					position,
 				})
-			);
+			).catch(() => {
+				setDisabled(false);
+			});
 		}
 	);
 
 	return displayStyle === FRAGMENTS_DISPLAY_STYLES.CARDS ? (
 		<CardItem
-			disabled={item.disabled || isDraggingSource}
+			disabled={item.disabled || isDraggingSource || disabled}
 			handlerRef={item.disabled ? null : sourceRef}
 			item={item}
 			onToggleHighlighted={onToggleHighlighted}
 		/>
 	) : (
 		<ListItem
-			disabled={item.disabled || isDraggingSource}
+			disabled={item.disabled || isDraggingSource || disabled}
 			handlerRef={item.disabled ? null : sourceRef}
 			item={item}
 			onToggleHighlighted={onToggleHighlighted}


### PR DESCRIPTION
Motivation
=======
Fix the Ability to add multiple "single-use" widgets to a page
[Link to bug](https://liferay.atlassian.net/browse/LPS-179670)

Proposed Solution
========
We have created a new action for updating a widgets used property and fire it before the fetch for updating the fragment entry links.

Steps to Verify:
----------------
1. Check the ticket video

