### PR TITLE
 LPS-198338 Adds readonly attribut to infoField

### DIFF
--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 39.0.2
+Bundle-Version: 40.0.0
 Export-Package:\
 	com.liferay.fragment.configuration,\
 	com.liferay.fragment.constants,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/FragmentEntryInputTemplateNodeContextHelper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/FragmentEntryInputTemplateNodeContextHelper.java
@@ -40,6 +40,7 @@ import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.language.LanguageUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -424,8 +425,9 @@ public class FragmentEntryInputTemplateNodeContextHelper {
 				infoField, inputTemplateNode);
 		}
 
-		inputTemplateNode.addAttribute(
-			"readOnly", String.valueOf(infoField.isReadOnly()));
+		if (FeatureFlagManagerUtil.isEnabled("LPS-183727")) {
+			inputTemplateNode.addAttribute("readOnly", infoField.isReadOnly());
+		}
 	}
 
 	private void _addLongTextInfoFieldTypeInputTemplateNodeAttributes(

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/FragmentEntryInputTemplateNodeContextHelper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/FragmentEntryInputTemplateNodeContextHelper.java
@@ -423,6 +423,9 @@ public class FragmentEntryInputTemplateNodeContextHelper {
 			_addTextInfoFieldTypeInputTemplateNodeAttributes(
 				infoField, inputTemplateNode);
 		}
+
+		inputTemplateNode.addAttribute(
+			"readOnly", String.valueOf(infoField.isReadOnly()));
 	}
 
 	private void _addLongTextInfoFieldTypeInputTemplateNodeAttributes(

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/FragmentEntryInputTemplateNodeContextHelper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/FragmentEntryInputTemplateNodeContextHelper.java
@@ -164,9 +164,11 @@ public class FragmentEntryInputTemplateNodeContextHelper {
 			locale);
 
 		String name = "name";
+		boolean readOnly = false;
 
 		if (infoField != null) {
 			name = infoField.getName();
+			readOnly = infoField.isReadOnly();
 		}
 
 		boolean required = false;
@@ -198,8 +200,9 @@ public class FragmentEntryInputTemplateNodeContextHelper {
 
 		if (infoField == null) {
 			return new InputTemplateNode(
-				errorMessage, inputHelpText, inputLabel, name, required,
-				inputShowHelpText, inputShowLabel, "type", StringPool.BLANK);
+				errorMessage, inputHelpText, inputLabel, name, readOnly,
+				required, inputShowHelpText, inputShowLabel, "type",
+				StringPool.BLANK);
 		}
 
 		InfoFieldType infoFieldType = infoField.getInfoFieldType();
@@ -263,7 +266,7 @@ public class FragmentEntryInputTemplateNodeContextHelper {
 		}
 
 		InputTemplateNode inputTemplateNode = new InputTemplateNode(
-			errorMessage, inputHelpText, inputLabel, name, required,
+			errorMessage, inputHelpText, inputLabel, name, readOnly, required,
 			inputShowHelpText, inputShowLabel, infoFieldType.getName(), value);
 
 		_addInputTemplateNodeAttributes(

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/InputTemplateNode.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/input/template/parser/InputTemplateNode.java
@@ -21,13 +21,14 @@ public class InputTemplateNode extends LinkedHashMap<String, Object> {
 
 	public InputTemplateNode(
 		String errorMessage, String helpText, String label, String name,
-		boolean required, boolean showHelpText, boolean showLabel, String type,
-		String value) {
+		boolean readOnly, boolean required, boolean showHelpText,
+		boolean showLabel, String type, String value) {
 
 		_errorMessage = errorMessage;
 		_helpText = helpText;
 		_label = label;
 		_name = name;
+		_readOnly = readOnly;
 		_required = required;
 		_showHelpText = showHelpText;
 		_showLabel = showLabel;
@@ -38,6 +39,7 @@ public class InputTemplateNode extends LinkedHashMap<String, Object> {
 		put("helpText", helpText);
 		put("label", label);
 		put("name", name);
+		put("readOnly", readOnly);
 		put("required", required);
 		put("showHelpText", showHelpText);
 		put("showLabel", showLabel);
@@ -77,6 +79,10 @@ public class InputTemplateNode extends LinkedHashMap<String, Object> {
 		return _type;
 	}
 
+	public boolean isReadOnly() {
+		return _readOnly;
+	}
+
 	public boolean isRequired() {
 		return _required;
 	}
@@ -110,6 +116,8 @@ public class InputTemplateNode extends LinkedHashMap<String, Object> {
 			"label", HtmlUtil.escapeJS(_label)
 		).put(
 			"name", _name
+		).put(
+			"readOnly", _readOnly
 		).put(
 			"required", _required
 		).put(
@@ -157,6 +165,7 @@ public class InputTemplateNode extends LinkedHashMap<String, Object> {
 	private final String _helpText;
 	private final String _label;
 	private final String _name;
+	private final boolean _readOnly;
 	private final boolean _required;
 	private final boolean _showHelpText;
 	private final boolean _showLabel;

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/input/template/parser/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/input/template/parser/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 6.0.0

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/checkbox/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/checkbox/index.html
@@ -1,9 +1,13 @@
+[#assign readOnly = input.attributes.readOnly?? && input.attributes.readOnly ]
+
 <div class="forms-checkbox">
 	<div class="custom-checkbox custom-control [#if input.errorMessage?has_content]has-error[/#if] mb-0">
-		<input aria-describedby="${fragmentEntryLinkNamespace}-checkbox-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-checkbox-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-checkbox-error-message[/#if]" class="custom-control-input" id="${fragmentEntryLinkNamespace}-checkbox" name="${input.name}" ${input.required?then('required', '')} type="checkbox" [#if input.value?? && input.value == 'true']checked[/#if] />
+		<input aria-describedby="${fragmentEntryLinkNamespace}-checkbox-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-checkbox-label [#if input.errorMessage?has_content]${fragmentEntryLinkNamespace}-checkbox-error-message[/#if]" class="custom-control-input" id="${fragmentEntryLinkNamespace}-checkbox" name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="checkbox" [#if input.value?? && input.value == 'true']checked[/#if] />
 
 		<label class="custom-control-label" id="${fragmentEntryLinkNamespace}-checkbox-label">
-			<span class="[#if !input.showLabel || !input.label?has_content]sr-only [/#if]custom-control-label-text">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</span>
+			<span class="[#if !input.showLabel || !input.label?has_content]sr-only [/#if]custom-control-label-text">
+				${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+			</span>
 		</label>
 	</div>
 

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/checkbox/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/checkbox/index.html
@@ -4,7 +4,7 @@
 	<div class="custom-checkbox custom-control [#if input.errorMessage?has_content]has-error[/#if] mb-0">
 		<input aria-describedby="${fragmentEntryLinkNamespace}-checkbox-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-checkbox-label [#if input.errorMessage?has_content]${fragmentEntryLinkNamespace}-checkbox-error-message[/#if]" class="custom-control-input" id="${fragmentEntryLinkNamespace}-checkbox" name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="checkbox" [#if input.value?? && input.value == 'true']checked[/#if] />
 
-		<label class="custom-control-label" id="${fragmentEntryLinkNamespace}-checkbox-label">
+		<label class="custom-control-label" for="${fragmentEntryLinkNamespace}-checkbox" id="${fragmentEntryLinkNamespace}-checkbox-label">
 			<span class="[#if !input.showLabel || !input.label?has_content]sr-only [/#if]custom-control-label-text">
 				${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
 			</span>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/checkbox/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/checkbox/index.js
@@ -1,7 +1,12 @@
-if (layoutMode === 'edit') {
-	const input = document.getElementById(`${fragmentNamespace}-checkbox`);
+const inputElement = document.getElementById(`${fragmentNamespace}-checkbox`);
 
-	if (input) {
-		input.setAttribute('disabled', true);
+if (inputElement) {
+	if (input.attributes?.readOnly) {
+		inputElement.addEventListener('click', (event) =>
+			event.preventDefault()
+		);
+	}
+	else if (layoutMode === 'edit') {
+		inputElement.setAttribute('disabled', true);
 	}
 }

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.html
@@ -1,8 +1,12 @@
+[#assign readOnly = input.attributes.readOnly?? && input.attributes.readOnly ]
+
 <div class="date-input">
 	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-date-input-label">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-date-input-label">
+			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+		</label>
 
-		<input aria-describedby="${fragmentEntryLinkNamespace}-date-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-date-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-date-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-date-input" max="9999-12-31" name="${input.name}" ${input.required?then('required', '')} type="date" [#if input.value??]value="${input.value}"[/#if] />
+		<input aria-describedby="${fragmentEntryLinkNamespace}-date-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-date-input-label [#if input.errorMessage?has_content]${fragmentEntryLinkNamespace}-date-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-date-input" max="9999-12-31" name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="date" [#if input.value??]value="${input.value}"[/#if] />
 
 		[#if input.errorMessage?has_content]
 			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentEntryLinkNamespace}-date-input-error-message">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.html
@@ -2,7 +2,7 @@
 
 <div class="date-input">
 	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-date-input-label">
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" for="${fragmentEntryLinkNamespace}-date-input" id="${fragmentEntryLinkNamespace}-date-input-label">
 			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
 		</label>
 

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-input/index.js
@@ -1,7 +1,14 @@
-if (layoutMode === 'edit') {
-	const input = document.getElementById(`${fragmentNamespace}-date-input`);
+const inputElement = document.getElementById(`${fragmentNamespace}-date-input`);
 
-	if (input) {
-		input.setAttribute('disabled', true);
+if (inputElement) {
+	if (input.attributes?.readOnly) {
+		inputElement.addEventListener('keydown', (event) => {
+			if (event.code === 'Space') {
+				event.preventDefault();
+			}
+		});
+	}
+	else if (layoutMode === 'edit') {
+		inputElement.setAttribute('disabled', true);
 	}
 }

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.html
@@ -1,8 +1,12 @@
-<div class="date-input">
-	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" for="${fragmentEntryLinkNamespace}-date-input">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+[#assign readOnly = input.attributes.readOnly?? && input.attributes.readOnly ]
 
-		<input aria-describedby="${fragmentEntryLinkNamespace}-date-input-help-text" class="form-control" id="${fragmentEntryLinkNamespace}-date-input" max="9999-12-31" name="${input.name}" ${input.required?then('required', '')} type="datetime-local" [#if input.value??]value="${input.value}"[/#if] />
+<div class="date-input">
+	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" for="${fragmentEntryLinkNamespace}-date-input">
+			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+		</label>
+
+		<input aria-describedby="${fragmentEntryLinkNamespace}-date-input-help-text" class="form-control" id="${fragmentEntryLinkNamespace}-date-input" max="9999-12-31" name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="datetime-local" [#if input.value??]value="${input.value}"[/#if] />
 
 		[#if input.errorMessage?has_content]
 			<p class="font-weight-semi-bold mt-1 text-danger">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.html
@@ -6,10 +6,10 @@
 			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
 		</label>
 
-		<input aria-describedby="${fragmentEntryLinkNamespace}-date-input-help-text" class="form-control" id="${fragmentEntryLinkNamespace}-date-input" max="9999-12-31" name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="datetime-local" [#if input.value??]value="${input.value}"[/#if] />
+		<input aria-describedby="${fragmentEntryLinkNamespace}-date-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-date-input-label [#if input.errorMessage?has_content]${fragmentEntryLinkNamespace}-date-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-date-input" max="9999-12-31" name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="datetime-local" [#if input.value??]value="${input.value}"[/#if] />
 
 		[#if input.errorMessage?has_content]
-			<p class="font-weight-semi-bold mt-1 text-danger">
+			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentEntryLinkNamespace}-date-input-error-message">
 				<svg class="lexicon-icon lexicon-icon-info-circle" focusable="false" role="presentation">
 					<use xlink:href="${siteSpritemap}#info-circle" />
 				</svg>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/date-time-input/index.js
@@ -1,7 +1,14 @@
-if (layoutMode === 'edit') {
-	const input = document.getElementById(`${fragmentNamespace}-date-input`);
+const inputElement = document.getElementById(`${fragmentNamespace}-date-input`);
 
-	if (input) {
-		input.setAttribute('disabled', true);
+if (inputElement) {
+	if (input.attributes?.readOnly) {
+		inputElement.addEventListener('keydown', (event) => {
+			if (event.code === 'Space') {
+				event.preventDefault();
+			}
+		});
+	}
+	else if (layoutMode === 'edit') {
+		inputElement.setAttribute('disabled', true);
 	}
 }

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/file-upload/index.html
@@ -1,5 +1,6 @@
 [#assign
 	localFileUploaded = false
+	readOnly = input.attributes.readOnly?? && input.attributes.readOnly
 	showDocumentLibrarySelector = input.attributes.selectFromDocumentLibrary?? && input.attributes.selectFromDocumentLibrary
 ]
 
@@ -9,27 +10,31 @@
 
 <div class="file-upload">
 	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-file-upload-label">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-file-upload-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
 
-		<div class="align-items-center d-flex">
-			<div class="position-relative">
-				<button class="btn btn-secondary" id="${fragmentEntryLinkNamespace}-file-upload-button-label" type="button">[@clay["icon"] className="inline-item-before" symbol="upload" /] ${htmlUtil.escape(configuration.buttonText)}</button>
+		[#if readOnly]
+			<input class="form-control" aria-labelledby="${fragmentEntryLinkNamespace}-file-upload-label" class="form-control" id="${fragmentEntryLinkNamespace}-file-upload" name="${input.name}" placeholder="${languageUtil.get(locale, "no-file-selected")}" readonly type="text" [#if input.attributes.fileName??]value="${htmlUtil.escape(input.attributes.fileName)}"[/#if] />
+		[#else]
+			<div class="align-items-center d-flex">
+				<div class="position-relative">
+					<button class="btn btn-secondary" id="${fragmentEntryLinkNamespace}-file-upload-button-label" type="button">[@clay["icon"] className="inline-item-before" symbol="upload" /] ${htmlUtil.escape(configuration.buttonText)}</button>
 
-				<input id="${fragmentEntryLinkNamespace}-file-upload-hidden" [#if localFileUploaded]name="${input.name}"[/#if] type="hidden" value="${input.value}" />
+					<input id="${fragmentEntryLinkNamespace}-file-upload-hidden" [#if localFileUploaded]name="${input.name}"[/#if] type="hidden" value="${input.value}" />
 
-				<input accept="${(input.attributes.allowedFileExtensions?has_content)?then(input.attributes.allowedFileExtensions, '*')}" aria-describedby="${fragmentEntryLinkNamespace}-file-upload-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-file-upload-label ${fragmentEntryLinkNamespace}-file-upload-button-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-file-upload-error-message[/#if]" class="file-upload-input" formenctype="multipart/form-data" id="${fragmentEntryLinkNamespace}-file-upload" [#if !localFileUploaded]name="${input.name}"[/#if] ${input.required?then('required', '' )} type="${showDocumentLibrarySelector?then('text', 'file')}" [#if input.value??]value="${input.value}"[/#if] tabIndex="-1" />
+					<input accept="${(input.attributes.allowedFileExtensions?has_content)?then(input.attributes.allowedFileExtensions, '*')}" aria-describedby="${fragmentEntryLinkNamespace}-file-upload-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-file-upload-label ${fragmentEntryLinkNamespace}-file-upload-button-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-file-upload-error-message[/#if]" class="file-upload-input" formenctype="multipart/form-data" id="${fragmentEntryLinkNamespace}-file-upload" [#if !localFileUploaded]name="${input.name}"[/#if] ${input.required?then('required', '' )} type="${showDocumentLibrarySelector?then('text', 'file')}" [#if input.value??]value="${input.value}"[/#if] tabIndex="-1" />
+				</div>
+
+				<small class="inline-item inline-item-after">
+					<strong class="forms-file-upload-file-name">
+						[#if input.attributes.fileName??]${htmlUtil.escape(input.attributes.fileName)}[/#if]
+					</strong>
+				</small>
+
+				<button class="btn btn-monospaced btn-outline-borderless btn-outline-secondary d-none ml-1" id="${fragmentEntryLinkNamespace}-file-upload-remove-button" type="button">
+					[@clay["icon"] symbol="times-circle-full" /]
+				</button>
 			</div>
-
-			<small class="inline-item inline-item-after">
-				<strong class="forms-file-upload-file-name">
-					[#if input.attributes.fileName??]${htmlUtil.escape(input.attributes.fileName)}[/#if]
-				</strong>
-			</small>
-
-			<button class="btn btn-monospaced btn-outline-borderless btn-outline-secondary d-none ml-1" id="${fragmentEntryLinkNamespace}-file-upload-remove-button" type="button">
-				[@clay["icon"] symbol="times-circle-full" /]
-			</button>
-		</div>
+		[/#if]
 
 		[#if input.errorMessage?has_content]
 			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentEntryLinkNamespace}-file-upload-error-message">
@@ -43,7 +48,7 @@
 			</p>
 		[/#if]
 
-		[#if (input.showHelpText && input.helpText?has_content) || (configuration.showSupportedFileInfo && input.attributes.allowedFileExtensions?? && input.attributes.maxFileSize??)]
+		[#if !readOnly && ((input.showHelpText && input.helpText?has_content) || (configuration.showSupportedFileInfo && input.attributes.allowedFileExtensions?? && input.attributes.maxFileSize??))]
 			<p class="mb-0 mt-1 text-secondary" id="${fragmentEntryLinkNamespace}-file-upload-help-text">${configuration.showSupportedFileInfo?then(languageUtil.format(locale, "upload-a-x-no-larger-than-x-mb", [input.attributes.allowedFileExtensions!"", input.attributes.maxFileSize!""]), '' )} ${input.showHelpText?then(htmlUtil.escape(input.helpText), '' )}</p>
 		[/#if]
 	</div>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiple-select-from-list/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiple-select-from-list/index.html
@@ -1,7 +1,9 @@
+[#assign readOnly = input.attributes.readOnly?? && input.attributes.readOnly ]
+
 <div class="multiselect-list">
-	<div class="custom-checkbox custom-control [#if  input.errorMessage?has_content]has-error[/#if] mb-0">
+	<div class="custom-checkbox custom-control [#if input.errorMessage?has_content]has-error[/#if] mb-0">
 		<span class="font-weight-semi-bold mb-1 multiselect-list-label text-3 [#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-multiselect-list-label">
-			${htmlUtil.escape(input.label)} [#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
 		</span>
 
 		<div aria-describedby="${fragmentEntryLinkNamespace}-multiselect-list-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-multiselect-list-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-multiselect-list-error-message[/#if]" class="multiselect-list-fieldset" role="group">
@@ -14,7 +16,7 @@
 				[/#if]
 
 				<div class="custom-control mb-0">
-					<input class="custom-control-input" [#if values?seq_contains(option.value)]checked[/#if] id="${fragmentEntryLinkNamespace}-checkbox-${option.value}" name="${input.name}" ${input.required?then('required', '')} type="checkbox" value="${option.value}" />
+					<input class="custom-control-input" [#if values?seq_contains(option.value)]checked[/#if] id="${fragmentEntryLinkNamespace}-checkbox-${option.value}" name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="checkbox" value="${option.value}" />
 
 					<label class="custom-control-label" for="${fragmentEntryLinkNamespace}-checkbox-${option.value}">
 						<span class="custom-control-label-text">${htmlUtil.escape(option.label)}</span>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiple-select-from-list/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/multiple-select-from-list/index.js
@@ -9,7 +9,12 @@ const allInputs = Array.from(
 	fragmentElement.querySelectorAll('.custom-control-input')
 );
 
-if (layoutMode === 'edit') {
+if (input.attributes?.readOnly) {
+	allInputs.forEach((input) => {
+		input.addEventListener('click', (event) => event.preventDefault());
+	});
+}
+else if (layoutMode === 'edit') {
 	allInputs.forEach((input) => {
 		input.setAttribute('disabled', true);
 	});

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/numeric-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/numeric-input/index.html
@@ -2,7 +2,7 @@
 
 <div class="numeric-input">
 	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-numeric-input-label">
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" for="${fragmentEntryLinkNamespace}-numeric-input" id="${fragmentEntryLinkNamespace}-numeric-input-label">
 			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
 		</label>
 

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/numeric-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/numeric-input/index.html
@@ -1,8 +1,12 @@
-<div class="numeric-input">
-	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-numeric-input-label">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+[#assign readOnly = input.attributes.readOnly?? && input.attributes.readOnly]
 
-	<input aria-describedby="${fragmentEntryLinkNamespace}-numeric-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-numeric-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-numeric-input-error-message[/#if]" class="form-control" data-validation-message-text="${languageUtil.get(locale, "enter-a-valid-value.-the-value-has-too-many-decimals")}" id="${fragmentEntryLinkNamespace}-numeric-input" [#if input.attributes.max??]max="${input.attributes.max}"[/#if] [#if input.attributes.min??]min="${input.attributes.min}"[/#if] name="${input.name}" [#if input.required]required[/#if] [#if input.attributes.dataType?? && input.attributes.dataType="decimal" && input.attributes.step??]step="${input.attributes.step}"[/#if] placeholder="${configuration.placeholder}" type="number" [#if input.value??]value="${input.value}"[/#if] />
+<div class="numeric-input">
+	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-numeric-input-label">
+			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+		</label>
+
+		<input aria-describedby="${fragmentEntryLinkNamespace}-numeric-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-numeric-input-label [#if input.errorMessage?has_content]${fragmentEntryLinkNamespace}-numeric-input-error-message[/#if]" class="form-control" data-validation-message-text="${languageUtil.get(locale, "enter-a-valid-value.-the-value-has-too-many-decimals")}" id="${fragmentEntryLinkNamespace}-numeric-input" [#if input.attributes.max??]max="${input.attributes.max}"[/#if] [#if input.attributes.min??]min="${input.attributes.min}"[/#if] name="${input.name}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} [#if input.attributes.dataType?? && input.attributes.dataType="decimal" && input.attributes.step??]step="${input.attributes.step}"[/#if] placeholder="${configuration.placeholder}" type="number" [#if input.value??]value="${input.value}"[/#if] />
 
 		[#if input.errorMessage?has_content]
 			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentEntryLinkNamespace}-numeric-input-error-message">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.css
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.css
@@ -3,3 +3,16 @@
 	pointer-events: none;
 	position: absolute;
 }
+
+.rich-text-input .form-control[aria-readonly='true'] {
+	background-color: #fff;
+	border-color: #e7e7ed;
+	cursor: text;
+	opacity: 1;
+}
+
+.rich-text-input .form-control[aria-readonly='true']:focus,
+.rich-text-input .form-control[aria-readonly='true']:focus-visible {
+	border-color: #80acff;
+	box-shadow: none;
+}

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.html
@@ -1,18 +1,22 @@
+[#assign
+	readOnly = input.attributes.readOnly?? && input.attributes.readOnly
+	showLabel = input.showLabel && input.label?has_content && (layoutMode == "edit" || readOnly)
+]
+
 <div class="rich-text-input [#if !input.showLabel || !input.label?has_content]rich-text-input--hidden-label[/#if]">
-	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0">
-		[#if layoutMode == "edit"]
-			[@liferay_editor["resources"] editorName="ckeditor" /]
+	<div class="form-group [#if input.errorMessage?has_content]has-error[/#if] mb-0">
+		<label class="[#if !showLabel]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-rich-text-input-label">
+			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+		</label>
+
+		[#if readOnly]
+			<div aria-labelledby="${fragmentEntryLinkNamespace}-rich-text-input-label" aria-multiline="true" aria-readonly="true" [#if input.required]aria-required="true"[/#if] class="form-control" contenteditable="false" id="${fragmentEntryLinkNamespace}-rich-text-input" role="textbox" tabindex="0"></div>
+		[#elseif layoutMode == "edit"]
+			[@liferay_editor["resources"]editorName="ckeditor" /]
 
 			<link href="/o/frontend-editor-ckeditor-web/ckeditor/skins/moono-lexicon/editor_gecko.css" rel="stylesheet" />
 
 			<div role="presentation">
-				[#if input.showLabel && input.label?has_content]
-					<label role="presentation">
-						${htmlUtil.escape(input.label)}
-						[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
-					</label>
-				[/#if]
-
 				<div class="cke cke_chrome cke_reset cke_ltr">
 					<div class="cke_inner">
 						<div class="cke_top cke_reset_all">
@@ -20,43 +24,33 @@
 								<div class="cke_toolbar">
 									<div class="cke_toolgroup mb-0">
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__undo_icon"></div>
+										<div class="cke_button_icon cke_button__undo_icon"></div>
 										</a>
 
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__redo_icon"></div>
+										<div class="cke_button_icon cke_button__redo_icon" />
 										</a>
 									</div>
 								</div>
 
 								<div class="cke_toolbar">
 									<a class="cke_button cke_button_disabled">
-										<div class="cke_button_label cke_button__source_label text-muted">Styles</div>
+										<div class="cke_button_label cke_button__source_label text-muted">
+											Styles
+										</div>
 									</a>
 
 									<div class="cke_toolgroup mb-0">
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__bold_icon"></div>
+										<div class="cke_button_icon cke_button__bold_icon"></div>
 										</a>
 
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__italic_icon"></div>
+										<div class="cke_button_icon cke_button__italic_icon" />
 										</a>
 
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__underline_icon"></div>
-										</a>
-									</div>
-								</div>
-
-								<div class="cke_toolbar">
-									<div class="cke_toolgroup mb-0">
-										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__bulletedlist_icon"></div>
-										</a>
-
-										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__numberedlist_icon"></div>
+										<div class="cke_button_icon cke_button__underline_icon" />
 										</a>
 									</div>
 								</div>
@@ -64,27 +58,11 @@
 								<div class="cke_toolbar">
 									<div class="cke_toolgroup mb-0">
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__link_icon"></div>
+										<div class="cke_button_icon cke_button__bulletedlist_icon" />
 										</a>
 
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__unlink_icon"></div>
-										</a>
-									</div>
-								</div>
-
-								<div class="cke_toolbar">
-									<div class="cke_toolgroup mb-0">
-										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__table_icon"></div>
-										</a>
-
-										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__image_icon"></div>
-										</a>
-
-										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__videoselector_icon"></div>
+										<div class="cke_button_icon cke_button__numberedlist_icon" />
 										</a>
 									</div>
 								</div>
@@ -92,16 +70,46 @@
 								<div class="cke_toolbar">
 									<div class="cke_toolgroup mb-0">
 										<a class="cke_button cke_button_disabled">
-											<div class="cke_button_icon cke_button__source_icon"></div>
+										<div class="cke_button_icon cke_button__link_icon" />
+										</a>
 
-											<div class="cke_button_label cke_button__source_label text-muted">Source</div>
+										<a class="cke_button cke_button_disabled">
+										<div class="cke_button_icon cke_button__unlink_icon" />
+										</a>
+									</div>
+								</div>
+
+								<div class="cke_toolbar">
+									<div class="cke_toolgroup mb-0">
+										<a class="cke_button cke_button_disabled">
+										<div class="cke_button_icon cke_button__table_icon" />
+										</a>
+
+										<a class="cke_button cke_button_disabled">
+										<div class="cke_button_icon cke_button__image_icon" />
+										</a>
+
+										<a class="cke_button cke_button_disabled">
+										<div class="cke_button_icon cke_button__videoselector_icon" />
+										</a>
+									</div>
+								</div>
+
+								<div class="cke_toolbar">
+									<div class="cke_toolgroup mb-0">
+										<a class="cke_button cke_button_disabled">
+										<div class="cke_button_icon cke_button__source_icon" />
+
+											<div class="cke_button_label cke_button__source_label text-muted">
+												Source
+											</div>
 										</a>
 									</div>
 								</div>
 							</div>
 						</div>
 
-						<div class="cke_contents cke_editable" style="height: 200px"></div>
+					<div class="cke_contents cke_editable" style="height: 200px"></div>
 					</div>
 				</div>
 			</div>

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/rich-text-input/index.js
@@ -1,9 +1,14 @@
-if (layoutMode === 'edit') {
-	const input = document.getElementById(
-		`${fragmentNamespace}-rich-text-input`
-	);
+const inputElement = document.getElementById(
+	`${fragmentNamespace}-rich-text-input`
+);
 
-	if (input) {
-		input.setAttribute('disabled', true);
+if (input.attributes?.readOnly) {
+	if (inputElement) {
+		inputElement.innerHTML = input.value;
+	}
+}
+else if (layoutMode === 'edit') {
+	if (inputElement) {
+		inputElement.setAttribute('disabled', true);
 	}
 }

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/select-from-list/index.html
@@ -1,63 +1,73 @@
+[#assign
+	readOnly = input.attributes.readOnly?? && input.attributes.readOnly
+]
+
 <div class="select-from-list">
 	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0">
-		<div class="align-items-end input-group">
-			<div class="input-group-item input-group-prepend">
-				<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-select-from-list-input-label">
-					${htmlUtil.escape(input.label)}
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-select-from-list-input-label">
+			${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
+		</label>
 
-					[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]
-				</label>
+		[#if readOnly]
+			<input aria-describedby="${fragmentEntryLinkNamespace}-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-select-from-list-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-select-from-list-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-select-from-list-input" name="${input.name}" placeholder="${languageUtil.get(locale, "choose-an-option")}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="text" [#if input.value??]value="${input.value}"[/#if] />
+		[#else]
+			<div class="align-items-end input-group">
+				<div class="input-group-item input-group-prepend">
+					<input aria-autocomplete="list" aria-controls="${fragmentEntryLinkNamespace}-listbox" aria-expanded="false" aria-labelledby="${fragmentEntryLinkNamespace}-select-from-list-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-select-from-list-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-select-from-list-input" name="" placeholder="${languageUtil.get(locale, "choose-an-option")}" role="combobox" type="text" ${input.required?then('required', '')} [#if input.attributes.selectedOptionLabel??]value="${input.attributes.selectedOptionLabel}"[/#if] />
 
-				<input aria-autocomplete="list" aria-controls="${fragmentEntryLinkNamespace}-listbox" aria-expanded="false" aria-labelledby="${fragmentEntryLinkNamespace}-select-from-list-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-select-from-list-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-select-from-list-input" name="" placeholder="${languageUtil.get(locale, "choose-an-option")}" role="combobox" type="text" ${input.required?then('required', '')} [#if input.attributes.selectedOptionLabel??]value="${input.attributes.selectedOptionLabel}"[/#if] />
+					<input id="${fragmentEntryLinkNamespace}-value-input" name="${input.name}" type="hidden" [#if input.attributes.selectedOptionValue??]value="${input.value}"[/#if] />
+					<input id="${fragmentEntryLinkNamespace}-label-input" name="${input.name}-label" type="hidden" [#if input.attributes.selectedOptionLabel??]value="${input.attributes.selectedOptionLabel}"[/#if] />
+				</div>
 
-				<input id="${fragmentEntryLinkNamespace}-value-input" name="${input.name}" type="hidden" [#if input.attributes.selectedOptionValue??]value="${input.value}"[/#if] />
-				<input id="${fragmentEntryLinkNamespace}-label-input" name="${input.name}-label" type="hidden" [#if input.attributes.selectedOptionLabel??]value="${input.attributes.selectedOptionLabel}"[/#if] />
-			</div>
+				<span class="input-group-append input-group-item input-group-item-shrink">
+					<button aria-controls="${fragmentEntryLinkNamespace}-listbox" [#if input.showHelpText && input.helpText?has_content]aria-describedby="${fragmentEntryLinkNamespace}-help-text"[/#if] aria-expanded="false" class="btn btn-secondary" type="button">
+						[@clay["icon"] symbol="caret-double" /]
+					</button>
+				</span>
 
-			<span class="input-group-append input-group-item input-group-item-shrink">
-				<button aria-controls="${fragmentEntryLinkNamespace}-listbox" [#if input.showHelpText && input.helpText?has_content]aria-describedby="${fragmentEntryLinkNamespace}-help-text"[/#if] aria-expanded="false" class="btn btn-secondary" type="button">
-					[@clay["icon"] symbol="caret-double" /]
-				</button>
-			</span>
+				<div class="d-none dropdown-menu dropdown-menu-width-sm select-from-list__dropdown-menu" id="${fragmentEntryLinkNamespace}-dropdown">
+					<p class="mb-0 px-3 py-2 text-muted" id="${fragmentEntryLinkNamespace}-choose-option-message">
+						${languageUtil.get(locale, "choose-an-option")}
+					</p>
 
-			<div class="d-none dropdown-menu dropdown-menu-width-sm select-from-list__dropdown-menu" id="${fragmentEntryLinkNamespace}-dropdown">
-				<p class="mb-0 px-3 py-2 text-muted" id="${fragmentEntryLinkNamespace}-choose-option-message">
-					${languageUtil.get(locale, "choose-an-option")}
-				</p>
+					<p class="d-none mb-0 px-3 py-2 text-muted" id="${fragmentEntryLinkNamespace}-loading-results-message">
+						${languageUtil.get(locale, "loading")}
+					</p>
 
-				<p class="d-none mb-0 px-3 py-2 text-muted" id="${fragmentEntryLinkNamespace}-loading-results-message">
-					${languageUtil.get(locale, "loading")}
-				</p>
+					<p class="d-none mb-0 px-3 py-2 text-muted" id="${fragmentEntryLinkNamespace}-no-results-message">
+						${languageUtil.get(locale, "no-results-were-found")}
+					</p>
 
-				<p class="d-none mb-0 px-3 py-2 text-muted" id="${fragmentEntryLinkNamespace}-no-results-message">
-					${languageUtil.get(locale, "no-results-were-found")}
-				</p>
+					<ul aria-labelledby="${fragmentEntryLinkNamespace}-label" class="list-unstyled" id="${fragmentEntryLinkNamespace}-listbox" role="listbox">
+						[#assign options=(input.attributes.options)![]]
+						[#assign selectedValueFoundInOptions=false]
 
-				<ul aria-labelledby="${fragmentEntryLinkNamespace}-label" class="list-unstyled" id="${fragmentEntryLinkNamespace}-listbox" role="listbox">
-					[#assign options=(input.attributes.options)![]]
-					[#assign selectedValueFoundInOptions=false]
+						[#list options as option]
+							[#if option?index == 10]
+								[#break]
+							[/#if]
 
-					[#list options as option]
-						[#assign selectedOption=false]
+							[#assign selectedOption=false]
 
-						[#if input.value?? && option.value == input.value]
-							[#assign selectedOption=true]
-							[#assign selectedValueFoundInOptions=true]
+							[#if input.value?? && option.value == input.value]
+								[#assign selectedOption=true]
+								[#assign selectedValueFoundInOptions=true]
+							[/#if]
+
+							<li [#if selectedOption]aria-selected="true"[/#if] class="[#if selectedOption]active[/#if] dropdown-item" data-option-value="${option.value}" id="${fragmentEntryLinkNamespace}-option-${option.value}" role="option">
+								${htmlUtil.escape(option.label)}
+							</li>
+						[/#list]
+
+						[#if !selectedValueFoundInOptions && input.value?? && input.attributes.selectedOptionLabel??]
+							<li class="dropdown-item" data-option-value="${input.value}" id="${fragmentEntryLinkNamespace}-option-${input.value}" role="option">
+								${htmlUtil.escape(input.attributes.selectedOptionLabel)}
+							</li>
 						[/#if]
-
-						<li [#if selectedOption]aria-selected="true"[/#if] class="[#if selectedOption]active[/#if] dropdown-item" data-option-value="${option.value}" id="${fragmentEntryLinkNamespace}-option-${option.value}" role="option">
-							${htmlUtil.escape(option.label)}
-						</li>
-					[/#list]
-
-					[#if !selectedValueFoundInOptions && input.value?? && input.attributes.selectedOptionLabel??]
-						<li class="dropdown-item" data-option-value="${input.value}" id="${fragmentEntryLinkNamespace}-option-${input.value}" role="option">
-							${htmlUtil.escape(input.attributes.selectedOptionLabel)}
-						</li>
-					[/#if]
-				</ul>
+					</ul>
+				</div>
 			</div>
-		</div>
+		[/#if]
 
 		[#if input.errorMessage?has_content]
 			<p class="font-weight-semi-bold mt-1 text-danger" id="${fragmentEntryLinkNamespace}-select-from-list-input-error-message">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/text-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/text-input/index.html
@@ -4,7 +4,7 @@
 
 <div class="text-input">
 	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0" id="${fragmentEntryLinkNamespace}-form-group">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-text-input-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" for="${fragmentEntryLinkNamespace}-text-input" id="${fragmentEntryLinkNamespace}-text-input-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
 
 		<input aria-describedby="${fragmentEntryLinkNamespace}-text-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-text-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-text-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-text-input" name="${input.name}" placeholder="${configuration.placeholder}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="text" [#if input.value??]value="${input.value}"[/#if] />
 

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/text-input/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/text-input/index.html
@@ -1,8 +1,12 @@
+[#assign
+	readOnly = input.attributes.readOnly?? && input.attributes.readOnly
+]
+
 <div class="text-input">
 	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0" id="${fragmentEntryLinkNamespace}-form-group">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-text-input-label">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-text-input-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
 
-		<input aria-describedby="${fragmentEntryLinkNamespace}-text-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-text-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-text-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-text-input" name="${input.name}" placeholder="${configuration.placeholder}" ${input.required?then('required', '')} type="text" [#if input.value??]value="${input.value}"[/#if] />
+		<input aria-describedby="${fragmentEntryLinkNamespace}-text-input-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-text-input-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-text-input-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-text-input" name="${input.name}" placeholder="${configuration.placeholder}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} type="text" [#if input.value??]value="${input.value}"[/#if] />
 
 		<p class="mt-1 text-secondary [#if !configuration.showCharactersCount]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-length-info">
 			<span class="sr-only" id="${fragmentEntryLinkNamespace}-length-warning">

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/textarea/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/textarea/index.html
@@ -4,7 +4,7 @@
 
 <div class="textarea">
 	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0" id="${fragmentEntryLinkNamespace}-form-group">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-textarea-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" for="${fragmentEntryLinkNamespace}-textarea" id="${fragmentEntryLinkNamespace}-textarea-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
 
 		<textarea aria-describedby="${fragmentEntryLinkNamespace}-textarea-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-textarea-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-textarea-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-textarea" name="${input.name}" placeholder="${configuration.placeholder}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} [#if configuration.numberOfLines > 0]rows="${configuration.numberOfLines}"[/#if] type="text">[#if input.value??]${input.value}[/#if]</textarea>
 

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/textarea/index.html
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-inputs/src/main/resources/com/liferay/fragment/collection/contributor/inputs/dependencies/textarea/index.html
@@ -1,8 +1,12 @@
+[#assign
+	readOnly = input.attributes.readOnly?? && input.attributes.readOnly
+]
+
 <div class="textarea">
 	<div class="form-group [#if  input.errorMessage?has_content]has-error[/#if] mb-0" id="${fragmentEntryLinkNamespace}-form-group">
-		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-textarea-label">${htmlUtil.escape(input.label)}[#if input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
+		<label class="[#if !input.showLabel || !input.label?has_content]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-textarea-label">${htmlUtil.escape(input.label)} [#if readOnly](${languageUtil.get(locale, "read-only")})[#elseif input.required][@clay["icon"] className="reference-mark" symbol="asterisk" /][/#if]</label>
 
-		<textarea aria-describedby="${fragmentEntryLinkNamespace}-textarea-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-textarea-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-textarea-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-textarea" name="${input.name}" placeholder="${configuration.placeholder}" ${input.required?then('required', '')} [#if configuration.numberOfLines > 0]rows="${configuration.numberOfLines}"[/#if] type="text">[#if input.value??]${input.value}[/#if]</textarea>
+		<textarea aria-describedby="${fragmentEntryLinkNamespace}-textarea-help-text" aria-labelledby="${fragmentEntryLinkNamespace}-textarea-label [#if  input.errorMessage?has_content]${fragmentEntryLinkNamespace}-textarea-error-message[/#if]" class="form-control" id="${fragmentEntryLinkNamespace}-textarea" name="${input.name}" placeholder="${configuration.placeholder}" [#if readOnly]readonly[/#if] ${input.required?then('required', '')} [#if configuration.numberOfLines > 0]rows="${configuration.numberOfLines}"[/#if] type="text">[#if input.value??]${input.value}[/#if]</textarea>
 
 		<p class="mt-1 text-secondary [#if !configuration.showCharactersCount]sr-only[/#if]" id="${fragmentEntryLinkNamespace}-length-info">
 			<span class="sr-only" id="${fragmentEntryLinkNamespace}-length-warning">

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryValidator.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker/src/main/java/com/liferay/fragment/entry/processor/freemarker/FreeMarkerFragmentEntryValidator.java
@@ -108,7 +108,7 @@ public class FreeMarkerFragmentEntryValidator
 					"input",
 					new InputTemplateNode(
 						StringPool.BLANK, StringPool.BLANK, StringPool.BLANK,
-						"name", false, false, false, "type", "value")
+						"name", false, false, false, false, "type", "value")
 				).put(
 					"layoutMode", Constants.VIEW
 				).putAll(

--- a/modules/apps/info/info-api/bnd.bnd
+++ b/modules/apps/info/info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Info API
 Bundle-SymbolicName: com.liferay.info.api
-Bundle-Version: 35.1.1
+Bundle-Version: 35.2.0
 Export-Package:\
 	com.liferay.info.collection.provider,\
 	com.liferay.info.constants,\

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/field/InfoField.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/field/InfoField.java
@@ -105,6 +105,10 @@ public class InfoField<T extends InfoFieldType> implements InfoFieldSetEntry {
 		return _builder._multivalued;
 	}
 
+	public boolean isReadOnly() {
+		return _builder._readOnly;
+	}
+
 	public boolean isRequired() {
 		return _builder._required;
 	}
@@ -140,6 +144,7 @@ public class InfoField<T extends InfoFieldType> implements InfoFieldSetEntry {
 		private boolean _multivalued;
 		private String _name;
 		private String _namespace;
+		private boolean _readOnly;
 		private boolean _required;
 		private String _uniqueId;
 
@@ -186,6 +191,12 @@ public class InfoField<T extends InfoFieldType> implements InfoFieldSetEntry {
 
 		public FinalStep<T> multivalued(boolean multivalued) {
 			_builder._multivalued = multivalued;
+
+			return this;
+		}
+
+		public FinalStep<T> readOnly(boolean readOnly) {
+			_builder._readOnly = readOnly;
 
 			return this;
 		}

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/field/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/field/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 4.2.0

--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemFormProvider.java
@@ -676,6 +676,15 @@ public class ObjectEntryInfoItemFormProvider
 						}
 					}
 
+					boolean readOnly = false;
+
+					if (Objects.equals(
+							objectField.getReadOnly(),
+							ObjectFieldConstants.READ_ONLY_TRUE)) {
+
+						readOnly = true;
+					}
+
 					unsafeConsumer.accept(
 						_addAttributes(
 							InfoField.builder(
@@ -696,6 +705,8 @@ public class ObjectEntryInfoItemFormProvider
 								).values(
 									objectField.getLabelMap()
 								).build()
+							).readOnly(
+								readOnly
 							).required(
 								objectField.isRequired()
 							),


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-198338)

Adds readOnly attribute to infoField, and adapt use cases. This PR is sent on top of the awesome [PR](https://github.com/liferay-echo/liferay-portal/pull/13925) by @veroglez to make it easier to test.

## Change summary:

* Just as the title says


## Test Scenario

* Activate the FF LPS-183727
* Go to Apps Menu > Control Panel > Objects
* Create a new Object, and add a Field to it
* Edit the field, and change so that readOnly is set to true
* Make the object either system or group object
* Go to any site and create a new page
* Add a form container, and select the object that was created
* All the fields will be displayed
* Publish the page and navigate to it
* You will see that the input is in readOnly mode

![ReadOnly](https://github.com/liferay-echo/liferay-portal/assets/4267448/2511455a-6de7-4fcb-9885-7c80c9eba661)

cc @veroglez, @p2kmgcl   