### PR TITLE
[TS] Avoiding UI Error regarding AssetListEntrySegmentsEntryRel

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/exportimport/content/processor/AssetListEntryExportImportContentProcessor.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/exportimport/content/processor/AssetListEntryExportImportContentProcessor.java
@@ -144,6 +144,10 @@ public class AssetListEntryExportImportContentProcessor
 				String queryValues = unicodeProperties.getProperty(
 					"queryValues" + index);
 
+				if (Validator.isNull(queryValues)) {
+					continue;
+				}
+
 				long[] categoryIds = GetterUtil.getLongValues(
 					queryValues.split(","));
 

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/exportimport/content/processor/AssetListEntryExportImportContentProcessor.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/exportimport/content/processor/AssetListEntryExportImportContentProcessor.java
@@ -302,6 +302,10 @@ public class AssetListEntryExportImportContentProcessor
 				String queryValues = unicodeProperties.getProperty(
 					"queryValues" + index);
 
+				if (Validator.isNull(queryValues)) {
+					continue;
+				}
+
 				long[] categoryIds = GetterUtil.getLongValues(
 					queryValues.split(","));
 


### PR DESCRIPTION
Hi team, using the customer database, when exporting their portal and trying to import, I faced some null values. This fix has the intention of solving most part/more of the empty queries verification we have through the Content Processor, avoiding UI errors such as this one reported by the customer. Let me know your thoughts about this. Thanks!

```
Se produjo un error inesperado con el proceso de publicación. Consulte la configuración de publicación y del portal.
The model.resource.com.liferay.asset.list.model.AssetListEntrySegmentsEntryRel cb1e39d2-e79b-3df7-a848-742be9fa22f1 could not be imported because of the following error: null.
```