### PR TITLE
LPS-198507 Two web content are created when the related display page is previewed during the creation of a new web content

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -247,6 +247,8 @@ export default function _JournalPortlet({
 				: '/journal/add_data_engine_default_values';
 		}
 		else {
+			articleId = document.getElementById(`${namespace}articleId`).value;
+
 			actionInput.value = articleId
 				? '/journal/update_article'
 				: '/journal/add_article';


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-198507)

### Changes

Update the articleId value

## Test scenario 1

1.  Create a Display Page.
2. Go to Web Content and try to add a web content.
3. Inside this edit mode, choose the DPT created before as the display page related.
4. Click on preview (you should have the name of the WC already because it will create a draft).
5. After seeing the preview, click on “save as a draft” and then publish.

https://github.com/liferay-echo/liferay-portal/assets/93203423/62b67a5d-0866-4732-adf6-2a24cb063d36


