### PR TITLE
LPS-198977 Add context title to back button in fragment import and configuration

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/configuration/icon/configuration.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/configuration/icon/configuration.jsp
@@ -10,6 +10,7 @@
 <%
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(ParamUtil.getString(request, "backURL", String.valueOf(renderResponse.createRenderURL())));
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle(LanguageUtil.get(request, "fragment-configuration"));
 

--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_import.jsp
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/view_import.jsp
@@ -10,6 +10,7 @@
 <%
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(ParamUtil.getString(request, "backURL", String.valueOf(renderResponse.createRenderURL())));
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle(LanguageUtil.get(request, "import"));
 


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-198977)

## Steps 
**- Case 1**
- Go to Design > Fragments > Next to fragment set > Click on ellipsis > Import File > See back button
![import](https://github.com/liferay-echo/liferay-portal/assets/91208451/51591c52-9801-430e-86d2-d784054d68be)

**- Case 2**
- Go to Design > Fragments > Upper right click on ellipsis button > Configuration > See back button 
![config](https://github.com/liferay-echo/liferay-portal/assets/91208451/1981c359-b6c8-4e9c-96d3-a8f815065027)

