### PR TITLE
[TS] [Urgent] LPS-199141 Improve performance in PortletDocumentFragmentEntryProcessor.java

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletDocumentFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletDocumentFragmentEntryProcessor.java
@@ -353,12 +353,15 @@ public class PortletDocumentFragmentEntryProcessor
 		for (com.liferay.portal.kernel.model.PortletPreferences
 				portletPreferencesImpl : portletPreferencesList) {
 
+			if (plid != portletPreferencesImpl.getPlid()) {
+				continue;
+			}
+
 			PortletPreferences currentPortletPreferences =
 				_portletPreferenceValueLocalService.getPreferences(
 					portletPreferencesImpl);
 
-			if ((plid != portletPreferencesImpl.getPlid()) ||
-				_comparePreferences(
+			if (_comparePreferences(
 					currentPortletPreferences, jxPortletPreferences)) {
 
 				continue;

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletDocumentFragmentEntryProcessor.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/PortletDocumentFragmentEntryProcessor.java
@@ -34,7 +34,6 @@ import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
-import com.liferay.portlet.PortletPreferencesImpl;
 import com.liferay.portlet.exportimport.staging.StagingAdvicesThreadLocal;
 
 import java.util.Arrays;
@@ -310,14 +309,12 @@ public class PortletDocumentFragmentEntryProcessor
 		String portletId = _getPortletId(
 			portletName, fragmentEntryLink.getNamespace(), id);
 
-		List<com.liferay.portal.kernel.model.PortletPreferences>
-			portletPreferencesList =
-				_portletPreferencesLocalService.getPortletPreferences(
-					fragmentEntryLink.getCompanyId(),
-					PortletKeys.PREFS_OWNER_ID_DEFAULT,
-					PortletKeys.PREFS_OWNER_TYPE_LAYOUT, portletId);
+		com.liferay.portal.kernel.model.PortletPreferences portletPreferences =
+			_portletPreferencesLocalService.fetchPortletPreferences(
+				PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, plid, portletId);
 
-		if (ListUtil.isNotEmpty(portletPreferencesList)) {
+		if (portletPreferences != null) {
 			jxPortletPreferences =
 				PortletPreferencesFactoryUtil.getLayoutPortletSetup(
 					fragmentEntryLink.getCompanyId(),
@@ -326,8 +323,21 @@ public class PortletDocumentFragmentEntryProcessor
 					fragmentEntryLink.getPlid(), portletId,
 					PortletPreferencesFactoryUtil.toXML(jxPortletPreferences));
 
-			_updateLayoutPortletSetup(
-				plid, portletPreferencesList, jxPortletPreferences);
+			_updateLayoutPortletSetup(portletPreferences, jxPortletPreferences);
+		}
+		else if (ListUtil.isNotEmpty(
+					_portletPreferencesLocalService.getPortletPreferences(
+						fragmentEntryLink.getCompanyId(),
+						PortletKeys.PREFS_OWNER_ID_DEFAULT,
+						PortletKeys.PREFS_OWNER_TYPE_LAYOUT, portletId))) {
+
+			jxPortletPreferences =
+				PortletPreferencesFactoryUtil.getLayoutPortletSetup(
+					fragmentEntryLink.getCompanyId(),
+					PortletKeys.PREFS_OWNER_ID_DEFAULT,
+					PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+					fragmentEntryLink.getPlid(), portletId,
+					PortletPreferencesFactoryUtil.toXML(jxPortletPreferences));
 		}
 
 		Document preferencesDocument = _getDocument(
@@ -339,40 +349,23 @@ public class PortletDocumentFragmentEntryProcessor
 	}
 
 	private void _updateLayoutPortletSetup(
-		long layoutPlid,
-		List<com.liferay.portal.kernel.model.PortletPreferences>
-			portletPreferencesList,
+		com.liferay.portal.kernel.model.PortletPreferences portletPreferences,
 		PortletPreferences jxPortletPreferences) {
 
-		long plid = 0;
+		PortletPreferences currentPortletPreferences =
+			_portletPreferenceValueLocalService.getPreferences(
+				portletPreferences);
 
-		if (jxPortletPreferences instanceof PortletPreferencesImpl) {
-			plid = layoutPlid;
+		if (_comparePreferences(
+				currentPortletPreferences, jxPortletPreferences)) {
+
+			return;
 		}
 
-		for (com.liferay.portal.kernel.model.PortletPreferences
-				portletPreferencesImpl : portletPreferencesList) {
-
-			if (plid != portletPreferencesImpl.getPlid()) {
-				continue;
-			}
-
-			PortletPreferences currentPortletPreferences =
-				_portletPreferenceValueLocalService.getPreferences(
-					portletPreferencesImpl);
-
-			if (_comparePreferences(
-					currentPortletPreferences, jxPortletPreferences)) {
-
-				continue;
-			}
-
-			_portletPreferencesLocalService.updatePreferences(
-				portletPreferencesImpl.getOwnerId(),
-				portletPreferencesImpl.getOwnerType(),
-				portletPreferencesImpl.getPlid(),
-				portletPreferencesImpl.getPortletId(), jxPortletPreferences);
-		}
+		_portletPreferencesLocalService.updatePreferences(
+			portletPreferences.getOwnerId(), portletPreferences.getOwnerType(),
+			portletPreferences.getPlid(), portletPreferences.getPortletId(),
+			jxPortletPreferences);
 	}
 
 	private void _validateFragmentEntryHTMLDocument(


### PR DESCRIPTION
Motivation
=======
The `PortletDocumentFragmentEntryProcessor.java` class exhibits poor performance if there are a large number of pages that inherit a Page Template. It gets all the `PortletPreferences` that share a specific portletId, and iterates over them one-by-one and fetches more `PortletPreferenceValues` from the database for each of them, which is something that it doesn't need to actually do the vast majority of the time.

This is causing slow page loads for a client who has thousands of pages inherited from the same page template. The customer ticket was marked as priority.

Please see [LPS-199141](https://liferay.atlassian.net/browse/LPS-199141) for more detailed information about the issue.

Proposed Solution
========
Refactor the `PortletDocumentFragmentEntryProcessor._getPreferences` and `PortletDocumentFragmentEntryProcessor._updateLayoutPortletSetup` methods to only fetch `PortletPreferenceValues` once at most, instead of once for every `PortletPreferences` object that was returned. Additionally, avoid unnecessarily fetching a large number of `PortletPreferences` from the database in the most common case.

Steps to Verify
========
Please see [LPS-199141](https://liferay.atlassian.net/browse/LPS-199141) for detailed steps to reproduce. I consider it busywork to copy those steps onto here and reformat them for GitHub's text editor.