### PR TITLE
LPS-198901 Make Filter section more responsive

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/AssetFilterBuilder/index.js
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/js/components/AssetFilterBuilder/index.js
@@ -147,7 +147,7 @@ function Rule({
 	return (
 		<div className="align-items-baseline c-gap-3 d-flex justify-content-between">
 			<div className="border-top-0 panel panel-default">
-				<div className="align-items-baseline c-gap-3 d-flex mb-0 panel-body">
+				<div className="align-items-baseline c-gap-3 d-flex flex-wrap mb-0 panel-body">
 					<ClayForm.Group className="flex-shrink-0">
 						<ClaySelectWithOption
 							aria-label={Liferay.Language.get('query-contains')}


### PR DESCRIPTION
Motivation
=======
The Filter section in the dynamic collection form was not responsive
[Link to bug](https://liferay.atlassian.net/browse/LPS-198901)


Steps to Verify:
----------------

1. Go to Site Builder -> Collections -> + and create a dynamic collection.
2. Change the screen size.
