### PR TITLE
LPS-199202 Make a copy seems to be disabled in copied Master Pages and Display Pages but allows copying

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/DisplayPageActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/DisplayPageActionDropdownItemsProvider.java
@@ -140,7 +140,7 @@ public class DisplayPageActionDropdownItemsProvider {
 						() ->
 							FeatureFlagManagerUtil.isEnabled("LPS-195263") &&
 							hasUpdatePermission,
-						_getCopyDisplayPageActionUnsafeConsumer()
+						_getCopyDisplayPageWithPermissionsActionUnsafeConsumer()
 					).add(
 						() ->
 							_layoutPageTemplateEntry.getLayoutPrototypeId() ==
@@ -219,7 +219,7 @@ public class DisplayPageActionDropdownItemsProvider {
 	}
 
 	private UnsafeConsumer<DropdownContextItem, Exception>
-		_getCopyDisplayPageActionUnsafeConsumer() {
+		_getCopyDisplayPageWithPermissionsActionUnsafeConsumer() {
 
 		return dropdownContextItem -> {
 			dropdownContextItem.setDropdownItems(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/DisplayPageActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/DisplayPageActionDropdownItemsProvider.java
@@ -222,31 +222,36 @@ public class DisplayPageActionDropdownItemsProvider {
 		_getCopyDisplayPageWithPermissionsActionUnsafeConsumer() {
 
 		return dropdownContextItem -> {
-			dropdownContextItem.setDropdownItems(
-				DropdownItemListBuilder.add(
-					dropdownItem -> {
-						dropdownItem.putData("action", "copyDisplayPage");
-						dropdownItem.putData(
-							"copyDisplayPageURL", _getCopyURL(false));
-						dropdownItem.setLabel(
-							LanguageUtil.get(
-								_httpServletRequest, "display-page"));
-					}
-				).add(
-					dropdownItem -> {
-						dropdownItem.putData("action", "copyDisplayPage");
-						dropdownItem.putData(
-							"copyDisplayPageURL", _getCopyURL(true));
-						dropdownItem.setLabel(
-							LanguageUtil.get(
-								_httpServletRequest,
-								"display-page-with-permissions"));
-					}
-				).build());
+			if (_layoutPageTemplateEntry.isDraft()) {
+				dropdownContextItem.setDisabled(true);
+			}
+			else {
+				dropdownContextItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						dropdownItem -> {
+							dropdownItem.putData("action", "copyDisplayPage");
+							dropdownItem.putData(
+								"copyDisplayPageURL", _getCopyURL(false));
+							dropdownItem.setLabel(
+								LanguageUtil.get(
+									_httpServletRequest, "display-page"));
+						}
+					).add(
+						dropdownItem -> {
+							dropdownItem.putData("action", "copyDisplayPage");
+							dropdownItem.putData(
+								"copyDisplayPageURL", _getCopyURL(true));
+							dropdownItem.setLabel(
+								LanguageUtil.get(
+									_httpServletRequest,
+									"display-page-with-permissions"));
+						}
+					).build());
+			}
+
 			dropdownContextItem.setIcon("copy");
 			dropdownContextItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "make-a-copy"));
-			dropdownContextItem.setDisabled(_layoutPageTemplateEntry.isDraft());
 		};
 	}
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/MasterLayoutActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/MasterLayoutActionDropdownItemsProvider.java
@@ -220,31 +220,36 @@ public class MasterLayoutActionDropdownItemsProvider {
 		_getCopyMasterLayoutWithPermissionsActionUnsafeConsumer() {
 
 		return dropdownContextItem -> {
-			dropdownContextItem.setDropdownItems(
-				DropdownItemListBuilder.add(
-					dropdownItem -> {
-						dropdownItem.putData("action", "copyMasterLayout");
-						dropdownItem.putData(
-							"copyMasterLayoutURL", _getCopyURL(false));
-						dropdownItem.setLabel(
-							LanguageUtil.get(
-								_httpServletRequest, "master-page"));
-					}
-				).add(
-					dropdownItem -> {
-						dropdownItem.putData("action", "copyMasterLayout");
-						dropdownItem.putData(
-							"copyMasterLayoutURL", _getCopyURL(true));
-						dropdownItem.setLabel(
-							LanguageUtil.get(
-								_httpServletRequest,
-								"master-page-with-permissions"));
-					}
-				).build());
+			if (_layoutPageTemplateEntry.isDraft()) {
+				dropdownContextItem.setDisabled(true);
+			}
+			else {
+				dropdownContextItem.setDropdownItems(
+					DropdownItemListBuilder.add(
+						dropdownItem -> {
+							dropdownItem.putData("action", "copyMasterLayout");
+							dropdownItem.putData(
+								"copyMasterLayoutURL", _getCopyURL(false));
+							dropdownItem.setLabel(
+								LanguageUtil.get(
+									_httpServletRequest, "master-page"));
+						}
+					).add(
+						dropdownItem -> {
+							dropdownItem.putData("action", "copyMasterLayout");
+							dropdownItem.putData(
+								"copyMasterLayoutURL", _getCopyURL(true));
+							dropdownItem.setLabel(
+								LanguageUtil.get(
+									_httpServletRequest,
+									"master-page-with-permissions"));
+						}
+					).build());
+			}
+
 			dropdownContextItem.setIcon("copy");
 			dropdownContextItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "make-a-copy"));
-			dropdownContextItem.setDisabled(_layoutPageTemplateEntry.isDraft());
 		};
 	}
 

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/MasterLayoutActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/MasterLayoutActionDropdownItemsProvider.java
@@ -170,7 +170,7 @@ public class MasterLayoutActionDropdownItemsProvider {
 							(layoutPageTemplateEntryId > 0) &&
 							hasUpdatePermission &&
 							FeatureFlagManagerUtil.isEnabled("LPS-197408"),
-						_getCopyMasterLayoutActionUnsafeConsumerWithPermissions()
+						_getCopyMasterLayoutWithPermissionsActionUnsafeConsumer()
 					).build());
 				dropdownGroupItem.setSeparator(true);
 			}
@@ -217,7 +217,7 @@ public class MasterLayoutActionDropdownItemsProvider {
 	}
 
 	private UnsafeConsumer<DropdownContextItem, Exception>
-		_getCopyMasterLayoutActionUnsafeConsumerWithPermissions() {
+		_getCopyMasterLayoutWithPermissionsActionUnsafeConsumer() {
 
 		return dropdownContextItem -> {
 			dropdownContextItem.setDropdownItems(


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-199202) and [Link to ticket](https://liferay.atlassian.net/browse/LPS-199211) 

### Changes and recommendations 

Don't allow copy Master Pages or Display Pages when it's a draft.
You will need the Feature Flag LPS-197408 and the LPS-195263.

## Test scenario 1

1.Add feature.flag.LPS-195263=true to portal-ext.properties.
2. Add feature.flag.LPS-197408=true to portal-ext.properties.
3. Create a Master Page named “MP”
4. Publish the page.
5. Navigate to Page Templates > Master
6. Click the Ellipsis menu of the page you published.
7. Make a Copy should be deactivated. 
8. Master Page with permissions or Master Page options should not be displayed.
9. Redo steps from 3 to 8 for Display Pages.
