### PR TITLE
LPS-198953 Fix bugs in page audit

### DIFF
--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/ItemDetail.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/ItemDetail.js
@@ -112,7 +112,10 @@ function IssueDetail({issue}) {
 				<Html>{tips}</Html>
 			</DetailPanel>
 
-			<DetailPanel badge={badge} title={Liferay.Language.get('tips')}>
+			<DetailPanel
+				badge={badge}
+				title={Liferay.Language.get('failing-elements')}
+			>
 				<List
 					ItemComponent={FailingElement}
 					items={normalizeFailingElements(failingElements, key)}

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/ItemDetail.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/ItemDetail.js
@@ -44,7 +44,11 @@ function FragmentDetail({fragment}) {
 
 	return (
 		<>
-			<DetailPanel badge={badge} title={Liferay.Language.get('warnings')}>
+			<DetailPanel
+				badge={badge}
+				defaultExpanded
+				title={Liferay.Language.get('warnings')}
+			>
 				{warnings.length ? (
 					<List ItemComponent={Warning} items={warnings} />
 				) : (
@@ -58,7 +62,10 @@ function FragmentDetail({fragment}) {
 				)}
 			</DetailPanel>
 
-			<DetailPanel title={Liferay.Language.get('basic-information')}>
+			<DetailPanel
+				defaultExpanded
+				title={Liferay.Language.get('basic-information')}
+			>
 				<TextSection
 					text={sub(Liferay.Language.get('x-ms'), renderTime)}
 					title={Liferay.Language.get('server-render-time')}
@@ -114,6 +121,7 @@ function IssueDetail({issue}) {
 
 			<DetailPanel
 				badge={badge}
+				defaultExpanded
 				title={Liferay.Language.get('failing-elements')}
 			>
 				<List
@@ -125,11 +133,11 @@ function IssueDetail({issue}) {
 	);
 }
 
-function DetailPanel({badge, children, title}) {
+function DetailPanel({badge, children, defaultExpanded, title}) {
 	return (
 		<ClayPanel
 			collapsable
-			defaultExpanded
+			defaultExpanded={defaultExpanded}
 			displayTitle={
 				<ClayPanel.Title>
 					<ClayLayout.ContentRow className="align-items-center c-gap-2">

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/PageAudit.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/PageAudit.js
@@ -20,6 +20,7 @@ import {SET_SELECTED_ITEM} from '../constants/actionTypes';
 export default function PageAudit({panelIsOpen}) {
 	const [data, setData] = useState(null);
 	const [loading, setLoading] = useState(true);
+	const [activeTab, setActiveTab] = useState(0);
 
 	const {layoutReportsDataURL} = useContext(ConstantsContext);
 	const {selectedItem} = useContext(StoreStateContext);
@@ -79,7 +80,9 @@ export default function PageAudit({panelIsOpen}) {
 					<ItemDetail selectedItem={selectedItem} />
 				) : (
 					<Tabs
+						activeTab={activeTab}
 						segments={data.segmentsExperienceSelectorData}
+						setActiveTab={setActiveTab}
 						tabs={data.tabsData}
 					/>
 				)}

--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/Tabs.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/Tabs.js
@@ -4,7 +4,7 @@
  */
 
 import ClayTabs from '@clayui/tabs';
-import React, {useState} from 'react';
+import React from 'react';
 
 import LayoutReports from './layout_reports/LayoutReports';
 import RenderTimes from './render_times/RenderTimes';
@@ -14,8 +14,7 @@ const TAB_COMPONENTS = {
 	'performance': RenderTimes,
 };
 
-export default function Tabs({segments, tabs}) {
-	const [activeTab, setActiveTab] = useState(0);
+export default function Tabs({activeTab, segments, setActiveTab, tabs}) {
 	const {segmentsExperiences, selectedSegmentsExperience} = segments;
 
 	return (

--- a/modules/apps/layout/layout-reports-web/test/js/components/Tabs.test.js
+++ b/modules/apps/layout/layout-reports-web/test/js/components/Tabs.test.js
@@ -40,4 +40,19 @@ describe('Tabs', () => {
 		expect(screen.getByText('Performance')).toBeInTheDocument();
 		expect(screen.getByText('Page Speed')).toBeInTheDocument();
 	});
+
+	it('sets correctly the active tab', () => {
+		const setActiveTab = jest.fn(() => {});
+		render(
+			<Tabs
+				activeTab={1}
+				segments={{}}
+				setActiveTab={setActiveTab}
+				tabs={mockTabs}
+			/>
+		);
+
+		const activeTab = screen.getByText('Performance');
+		expect(activeTab.className).toContain('active');
+	});
 });

--- a/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/EmbeddingProviderValidationResultResourceImpl.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-rest-impl/src/main/java/com/liferay/search/experiences/rest/internal/resource/v1_0/EmbeddingProviderValidationResultResourceImpl.java
@@ -6,7 +6,6 @@
 package com.liferay.search.experiences.rest.internal.resource.v1_0;
 
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
-import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.search.ml.embedding.EmbeddingProviderStatus;
 import com.liferay.search.experiences.ml.embedding.text.TextEmbeddingRetriever;
@@ -80,9 +79,6 @@ public class EmbeddingProviderValidationResultResourceImpl
 			};
 		}
 	}
-
-	@Reference
-	private JSONFactory _jsonFactory;
 
 	@Reference
 	private TextEmbeddingRetriever _textEmbeddingRetriever;

--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/portlet/configuration/icon/ImportPortletConfigurationIcon.java
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/java/com/liferay/search/experiences/web/internal/blueprint/admin/portlet/configuration/icon/ImportPortletConfigurationIcon.java
@@ -11,7 +11,6 @@ import com.liferay.portal.kernel.portlet.configuration.icon.PortletConfiguration
 import com.liferay.portal.kernel.security.permission.resource.PortletResourcePermission;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.HashMapBuilder;
-import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.search.experiences.constants.SXPActionKeys;
 import com.liferay.search.experiences.constants.SXPConstants;
@@ -88,9 +87,6 @@ public class ImportPortletConfigurationIcon
 
 	@Reference
 	private Language _language;
-
-	@Reference
-	private Portal _portal;
 
 	@Reference(
 		target = "(resource.name=" + SXPConstants.RESOURCE_NAME + ")",

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAccessibility.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAccessibility.testcase
@@ -5,7 +5,7 @@ definition {
 	property portal.accessibility = "true";
 	property portal.release = "true";
 	property portal.upstream = "true";
-	property testray.component.names = "Clay";
+	property testray.component.names = "PEDS Accessibility";
 	property testray.main.component.name = "Clay";
 
 	setUp {
@@ -45,7 +45,7 @@ definition {
 		}
 	}
 
-	@description = "LPS-193598. Verifies that clay portlet tabs are accessible."
+	@description = "LPS-193598. Verifies clay sample portlet components are compliant with axe accessibility."
 	@priority = 5
 	test AccessibilitySmoke {
 		task ("When access all clay sample portlet tabs ") {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAccessibility.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/clay/ClayAccessibility.testcase
@@ -1,0 +1,68 @@
+@component-name = "portal-frontend-infrastructure"
+definition {
+
+	property osgi.modules.includes = "frontend-taglib-clay-sample-web";
+	property portal.accessibility = "true";
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.component.names = "Clay";
+	property testray.main.component.name = "Clay";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+
+		task ("Given Clay Sample Portlet") {
+			JSONLayout.addPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+
+			JSONLayout.updateLayoutTemplateOfPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				layoutTemplate = "1 Column");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page",
+				widgetName = "Clay Sample");
+
+			Navigator.gotoPage(pageName = "Clay Sample Test Page");
+		}
+	}
+
+	tearDown {
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+		else {
+			JSONLayout.deletePublicLayout(
+				groupName = "Guest",
+				layoutName = "Clay Sample Test Page");
+		}
+	}
+
+	@description = "LPS-193598. Verifies that clay portlet tabs are accessible."
+	@priority = 5
+	test AccessibilitySmoke {
+		task ("When access all clay sample portlet tabs ") {
+			for (var key_tab : list "Alerts,Badges,Dropdowns,Icons,Labels,Links,Management Toolbars,Navigation Bars,Stickers,Tabs") {
+				Click(
+					key_tab = ${key_tab},
+					locator1 = "NavTab#NAV_TABS");
+
+				task ("Then axe automation finds no accessibility issues") {
+					AssertAccessible(value1 = "moderate,minor");
+
+					// The other tabs will be included after LPS-198580 is done
+					// Buttons,Cards,Form Elements,Pagination Bars,Panel,Progress Bars,Vertical Nav
+
+				}
+			}
+		}
+	}
+
+}

--- a/source-formatter.properties
+++ b/source-formatter.properties
@@ -412,7 +412,8 @@
         modules/apps/site/site-memberships-web,\
         modules/apps/site-initializer,\
         modules/apps/site-navigation,\
-        modules/dxp/apps/analytics-batch-export-import-impl
+        modules/dxp/apps/analytics-batch-export-import-impl,\
+        modules/dxp/apps/search-experiences/search-experiences-rest-impl
 
     checkstyle.UpgradeProcessCheck.enabled=true
 


### PR DESCRIPTION
Motivation
=======
Repeated section on the PageSpeed Insights tab of Page Audit.
Some sections should appear collapsed
Repeated section on the PageSpeed Insights tab of Page Audit
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-198953)


Steps to Verify:
----------------

1. Go to a Page, example Home
2. Click on the Page Audit
3. Go to the PageSpeed Insights tab
4. Click on Configure, add you API Key and Save
5. Launch the Page Audit
6. Click on any of the elements
7. The detailed view of the element opens


