### PR TITLE
LPS-199316 Fix order and pattern of labels in the header

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info_panel.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/info_panel.jsp
@@ -192,19 +192,19 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 					cssClass="c-mt-2"
 				>
 					<clay:content-col>
+						<div>
+							<clay:label
+								displayType="info"
+								label='<%= LanguageUtil.format(request, "version-x", article.getVersion()) %>'
+							/>
+						</div>
+					</clay:content-col>
+
+					<clay:content-col>
 						<liferay-portal-workflow:status
 							showStatusLabel="<%= false %>"
 							status="<%= article.getStatus() %>"
 						/>
-					</clay:content-col>
-
-					<clay:content-col>
-						<div>
-							<clay:label
-								displayType="info"
-								label='<%= LanguageUtil.format(request, "version-x", article.getVersion(), false) %>'
-							/>
-						</div>
 					</clay:content-col>
 				</clay:content-row>
 			</c:if>


### PR DESCRIPTION
Motivation
=======
The order and pattern of labels are wrong on the header
[Link to impedibug](https://liferay.atlassian.net/browse/LPS-199316)

Steps to Verify:
----------------

1. Add feature.flag.LPS-197307=true to portal-ext.properties
2. Navigate to the Web Content admin
3. Add a web content
4. Select the web content
5. Open the info panel via the management bar

