### PR TITLE
LPS-199446 | Test Fix | Master

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Staging.macro
@@ -773,10 +773,10 @@ definition {
 
 	macro gotoHistory {
 		while (IsElementNotPresent(locator1 = "Staging#HISTORY_BUTTON")) {
-			Click(locator1 = "Icon#STAGING_BAR_VERTICAL_ELLIPSIS");
+			Click.waitForMenuToggleJSClick(locator1 = "Icon#STAGING_BAR_VERTICAL_ELLIPSIS");
 		}
 
-		Click(locator1 = "Staging#HISTORY_BUTTON");
+		Click.javaScriptClick(locator1 = "Staging#HISTORY_BUTTON");
 
 		SelectFrame(locator1 = "IFrame#CONFIGURATION");
 	}


### PR DESCRIPTION
# Element is not visible at WebContentDisplayWithStagingPageVersioning#RollBackToPreviousConfigurationViaHistoryAfterDeletingPortlet

Hi! :)
This pr is corresponding to this ticket: [LPS-199446](https://liferay.atlassian.net/browse/LPS-199446)