### PR TITLE
[TS] LPS-198515 Error message not displayed on UI after exceeding the Upload Servlet Request limit

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js
@@ -153,6 +153,10 @@ const doEvaluate = debounce((fieldName, evaluatorContext, callback) => {
 		url: EVALUATOR_URL,
 	})
 		.then((newPages) => {
+			if (newPages.statusCode) {
+				callback(newPages);
+			}
+
 			const mergedPages = mergePages(
 				defaultLanguageId,
 				editingLanguageId,

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormContextProviderServlet.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-renderer/src/main/java/com/liferay/dynamic/data/mapping/form/renderer/internal/servlet/DDMFormContextProviderServlet.java
@@ -22,12 +22,14 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.servlet.ServletResponseUtil;
+import com.liferay.portal.kernel.upload.UploadException;
 import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.HtmlParser;
 import com.liferay.portal.kernel.util.LocaleThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.util.PropsValues;
 
 import java.io.IOException;
@@ -62,6 +64,23 @@ public class DDMFormContextProviderServlet extends HttpServlet {
 			HttpServletRequest httpServletRequest,
 			HttpServletResponse httpServletResponse)
 		throws IOException, ServletException {
+
+		UploadException uploadException =
+			(UploadException)httpServletRequest.getAttribute(
+				WebKeys.UPLOAD_EXCEPTION);
+
+		if ((uploadException != null) &&
+			(uploadException.isExceededFileSizeLimit() ||
+			 uploadException.isExceededLiferayFileItemSizeLimit() ||
+			 uploadException.isExceededUploadRequestSizeLimit())) {
+
+			httpServletResponse.sendError(
+				HttpServletResponse.SC_REQUEST_ENTITY_TOO_LARGE,
+				_language.get(
+					httpServletRequest, "upload-size-limit-has-been-exceeded"));
+
+			return;
+		}
 
 		createContext(httpServletRequest, httpServletResponse);
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -139,12 +139,12 @@ export default function _JournalPortlet({
 		}
 	};
 
-	const handleDDMFormError = (error) => {
+	const handleDDMFormError = ({error}) => {
 		publishingLock.unlock();
 		console.error(error);
 
-		if (error.error?.statusCode) {
-			showAlert(error.error.message);
+		if (error.statusCode) {
+			showAlert(error.message);
 		}
 
 		const workflowActionInput = document.getElementById(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/JournalPortlet.es.js
@@ -143,6 +143,10 @@ export default function _JournalPortlet({
 		publishingLock.unlock();
 		console.error(error);
 
+		if (error.error?.statusCode) {
+			showAlert(error.error.message);
+		}
+
 		const workflowActionInput = document.getElementById(
 			`${namespace}workflowAction`
 		);

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language.properties
@@ -19646,6 +19646,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes.
 upload-resume=Upload Resume
 upload-servlet-request-configuration-name=Upload Servlet Request
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded.
 upload-thumbnail=Upload Thumbnail
 upload-x=Upload {0}
 upload-your-talend-job-file=Upload your Talend job file.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ar.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=تحميل أو تحدي
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=وصل طلب التحميل إلى الحد الأقصى المسموح به لحجم {0} بايت.
 upload-resume=تحميل السيرة الذاتية
 upload-servlet-request-configuration-name=تحميل طلب Servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=تحميل صورة مصغرة
 upload-x=تحميل {0}
 upload-your-talend-job-file=قم بتحميل ملف مهمة Talend الخاص بك.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_bg.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Подновяване на качването
 upload-servlet-request-configuration-name=Заявка за качване на услуга (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Качване на миниатюра (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Качете файла с вашата работа на Таландд. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ca.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Pugeu o seleccioneu des 
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La sol·licitud de càrrega ha assolit la mida màxima permesa de {0} bytes.
 upload-resume=Puja el curriculum vitae
 upload-servlet-request-configuration-name=Sol·licitud del servlet de càrrega
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Penja la miniatura
 upload-x=Carrega {0}
 upload-your-talend-job-file=Pugeu el vostre fitxer de treball Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_cs.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Pokračovat v nahrávání.
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_da.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Overfør resume
 upload-servlet-request-configuration-name=Overfør Servlet-anmodning (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Miniaturebillede af overførsel (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Overfør din Talend-jobfil. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_de.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Hochladen oder Auswähle
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload-Anfrage hat die maximal zulässige Größe von {0} Bytes erreicht.
 upload-resume=Upload fortsetzen
 upload-servlet-request-configuration-name=Servlet Upload-Request
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Thumbnail hochladen
 upload-x={0} hochladen
 upload-your-talend-job-file=Laden Sie Ihre Talend-Job-Datei hoch.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_el.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Ανέβασμα βιογραφικού
 upload-servlet-request-configuration-name=Αποστολή αιτήματος σερβλετών (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Αποστολή μικρογραφίας (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Ανεβάστε το αρχείο εργασίας talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en.properties
@@ -19646,6 +19646,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes.
 upload-resume=Upload Resume
 upload-servlet-request-configuration-name=Upload Servlet Request
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded.
 upload-thumbnail=Upload Thumbnail
 upload-x=Upload {0}
 upload-your-talend-job-file=Upload your Talend job file.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_AU.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes.
 upload-resume=Upload Resume (Automatic Copy)
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_en_GB.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes.
 upload-resume=Upload Resume (Automatic Copy)
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Cargue o seleccione arch
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La solicitud de carga alcanzó el tamaño máximo permitido de {0} bytes.
 upload-resume=Subir curriculum vitae
 upload-servlet-request-configuration-name=Solicitud de carga de servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Cargar miniatura
 upload-x=Cargar {0}
 upload-your-talend-job-file=Cargue un archivo de trabajo de Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_AR.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Cargue o seleccione arch
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La solicitud de carga alcanzó el tamaño máximo permitido de {0} bytes.
 upload-resume=Subir curriculum vitae
 upload-servlet-request-configuration-name=Solicitud de carga de servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Cargar miniatura
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Cargue un archivo de trabajo de Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_CO.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Cargue o seleccione arch
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La solicitud de carga alcanzó el tamaño máximo permitido de {0} bytes.
 upload-resume=Subir curriculum vitae
 upload-servlet-request-configuration-name=Solicitud de carga de servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Cargar miniatura
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Cargue un archivo de trabajo de Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_es_MX.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Cargue o seleccione arch
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La solicitud de carga alcanzó el tamaño máximo permitido de {0} bytes.
 upload-resume=Subir curriculum vitae
 upload-servlet-request-configuration-name=Solicitud de carga de servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Cargar miniatura
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Cargue un archivo de trabajo de Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_et.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Laadi üles resümee
 upload-servlet-request-configuration-name=Servleti taotluse üleslaadimine (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Pisipildi üleslaadimine (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Laadige üles oma Talendi tööfail. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_eu.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Igo curriculum vitae
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fa.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=بارگذاری رزومه
 upload-servlet-request-configuration-name=آپلود درخواست سرولت (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=آپلود بندانگشتی (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=فایل شغلی تالند خود را آپلود کنید. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fi.properties
@@ -19638,6 +19638,7 @@ upload-or-select-from-documents-and-media-item-selector=Lataa tai valitse asiaki
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Latauspyyntö saavutti sallitun enimmäiskoon {0} tavua.
 upload-resume=Lataa ansioluettelo
 upload-servlet-request-configuration-name=Sisääntuonnin Palvelinsovelman Pyyntö
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Lataa Pikkukuva
 upload-x=Lataa {0}
 upload-your-talend-job-file=Lataa Talend-työtiedostosi palvelimeen.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Téléverser ou sélecti
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La demande de téléversement a atteint la taille autorisée maximum de {0} octets.
 upload-resume=Reprendre le téléchargement
 upload-servlet-request-configuration-name=Requête servlet de téléversement
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Téléverser une vignette
 upload-x=Téléverser {0}
 upload-your-talend-job-file=Téléchargez votre fichier de job Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_fr_CA.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=La demande de téléversement a atteint la taille autorisée maximum de {0} octets.
 upload-resume=Reprendre le téléchargement
 upload-servlet-request-configuration-name=Requête servlet de téléversement
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Téléverser une vignette
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Téléchargez votre fichier de job Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_gl.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Subir curriculum vitae
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hi_IN.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=अपलोड Resume
 upload-servlet-request-configuration-name=सर्वलेट अनुरोध अपलोड करें (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=थंबनेल अपलोड करें (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=अपनी टैलेंड जॉब फाइल अपलोड करें। (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hr.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Upload-aj sažetak
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_hu.properties
@@ -19643,6 +19643,7 @@ upload-or-select-from-documents-and-media-item-selector=Töltse fel, vagy válas
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=A feltöltési kérelem elérte a {0} bájtos maximális megengedett méretet.
 upload-resume=Önéletrajz feltöltése
 upload-servlet-request-configuration-name=Servlet feltöltési kérelem
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Bélyegkép feltöltése
 upload-x={0} feltöltése
 upload-your-talend-job-file=Töltse fel a Talend feladatfájlját.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_in.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Lanjutkan Meng-Upload
 upload-servlet-request-configuration-name=Unggah Permintaan Servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Unggah Gambar Mini (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Unggah file lowongan Kerja Talend Anda. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_it.properties
@@ -19641,6 +19641,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Riprendi Caricamento
 upload-servlet-request-configuration-name=Carica richiesta Servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Carica miniatura (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Caricare il file di lavoro di Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_iw.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=בקשת ההעלאה הגיעה לגודל המרבי המותר של {0} בתים.
 upload-resume=המשך העלאה
 upload-servlet-request-configuration-name=העלה בקשת Servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=העלה תמונה ממוזערת (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=העלה את קובץ העבודה של טאלנד. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ja.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=ドキュメントとメ
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=アップロードリクエストが最大許容サイズに達しました({0} バイト)
 upload-resume=概要の更新
 upload-servlet-request-configuration-name=アップロードサーブレットリクエスト
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=サムネイルをアップロード
 upload-x={0}をアップロード
 upload-your-talend-job-file=Talend ジョブファイルをアップロードしてください。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_kk.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Upload Resume (Automatic Copy)
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_km.properties
@@ -19646,6 +19646,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes.
 upload-resume=Upload Resume
 upload-servlet-request-configuration-name=Upload Servlet Request
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ko.properties
@@ -19639,6 +19639,7 @@ upload-or-select-from-documents-and-media-item-selector=문서 및 미디어 항
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=업로드 요청이 {0}바이트의 최대 허용 크기에 도달했습니다.
 upload-resume=올려주기 이력서
 upload-servlet-request-configuration-name=서블릿 요청 업로드
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=썸네일 업로드
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Talend 작업 파일을 업로드합니다.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lo.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=ອັບໂຫຼດຄືນ
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_lt.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Nusiuntimo tęsimas (Automatic Translation)
 upload-servlet-request-configuration-name=Įkelti servlet užklausą (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Įkelti miniatiūrą (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Įkelkite savo Talend darbo failą. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ms.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Muat Naik Sambung Semula (Automatic Translation)
 upload-servlet-request-configuration-name=Muat Naik Permintaan Servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Muat naik Lakaran Kenit (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Muat naik fail kerja Talend anda. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nb.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Gjennoppta opplastning
 upload-servlet-request-configuration-name=Last opp Servlet-forespørsel (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Last opp thumbnail
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Last opp talend jobbfilen din. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl.properties
@@ -19643,6 +19643,7 @@ upload-or-select-from-documents-and-media-item-selector=Uploaden of selecteren m
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Het uploadverzoek heeft de maximale toegestane grootte van {0} bytes bereikt.
 upload-resume=Samenvatting uploaden
 upload-servlet-request-configuration-name=Uploadverzoek servlet
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Miniatuur uploaden
 upload-x={0} uploaden
 upload-your-talend-job-file=Upload uw Talend-taakbestand.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_nl_BE.properties
@@ -19643,6 +19643,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Samenvatting uploaden
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pl.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Załaduj streszczenie
 upload-servlet-request-configuration-name=Przekaż żądanie servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Przekaż miniaturę (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Prześlij swój plik pracy Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_BR.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Carregue ou selecione do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=A solicitação de envio alcançou o tamanho máximo permitido de {0} bytes.
 upload-resume=Resumir o upload
 upload-servlet-request-configuration-name=Solicitação de servlet de upload
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Carregar Miniatura
 upload-x=Upload {0}
 upload-your-talend-job-file=Faça o upload de seu arquivo de trabalho Talend.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_pt_PT.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Continuar o Upload
 upload-servlet-request-configuration-name=Upload de solicitação de servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Carregar miniatura (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Faça o upload do seu arquivo de trabalho talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ro.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Reia Incarcarea
 upload-servlet-request-configuration-name=Încărcare solicitare Servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Încărcare miniatură (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Încărcați fișierul de lucru Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ru.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Загрузить резюме
 upload-servlet-request-configuration-name=Загрузить запрос на сервлет (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Загрузить Thumbnail (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Загрузите файл задания Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sk.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Nahrať resumé
 upload-servlet-request-configuration-name=Nahrať požiadavku na Servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Nahrať miniatúru (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Nahrajte súbor úlohy Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sl.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Nadaljuj prenos
 upload-servlet-request-configuration-name=Nalaganje zahteve za servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Nalaganje sličice (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Naložite datoteko projekta Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Настави Отпремање
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sr_RS_latin.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Nastavi Otpremanje
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_sv.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Ladda upp eller välj fr
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Begäran för överföring har maximalt tillåten storlek på {0} byte.
 upload-resume=Återuppta uppladdning
 upload-servlet-request-configuration-name=Överför servlet-begäran
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Ladda upp miniatyr
 upload-x=Ladda upp {0}
 upload-your-talend-job-file=Ladda upp din Talend-jobbfil.

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_ta_IN.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=பதிவேற்ற கோரிக்கை, அதிகபட்ச அளவான {0} பைட்டுக்களை அடைந்திருக்கிறது.
 upload-resume=Resume பதிவேற்றவும்
 upload-servlet-request-configuration-name=Upload Servlet Request (Automatic Copy)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Upload Thumbnail (Automatic Copy)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Upload your Talend job file. (Automatic Copy)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_th.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=อัปโหลดห
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=คำขออัปโหลดถึงขนาดสูงสุดที่อนุญาต {0} ไบต์
 upload-resume=อัพโหลดรีซูเม่
 upload-servlet-request-configuration-name=อัปโหลดคำขอเซิร์ฟเล็ต
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=อัพโหลดธัมเนล
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=อัพโหลดไฟล์งาน Talend ของคุณ

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_tr.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Eski Halini Yükle
 upload-servlet-request-configuration-name=Servlet İsteğini Karşıya Yükle (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Küçük Resmi Karşıya Yükle (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Talend iş dosyanızı yükleyin. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_uk.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Завантажити резюме
 upload-servlet-request-configuration-name=Запит на вивантаження серверів (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Передати ескіз (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Завантажте файл завдання Talend. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_vi.properties
@@ -19640,6 +19640,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=Upload request reached the maximum permitted size of {0} bytes. (Automatic Copy)
 upload-resume=Tiếp tục tải lên
 upload-servlet-request-configuration-name=Tải lên yêu cầu Servlet (Automatic Translation)
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=Tải lên Hình thu nhỏ (Automatic Translation)
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=Tải lên tệp công việc Talend của bạn. (Automatic Translation)

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_CN.properties
@@ -19642,6 +19642,7 @@ upload-or-select-from-documents-and-media-item-selector=上传或从"文档与�
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=上传请求已达到 {0} 字节的最大允许大小。
 upload-resume=上传履历
 upload-servlet-request-configuration-name=上传Servlet请求
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=上传缩略图
 upload-x=上传{0}
 upload-your-talend-job-file=上传您的 Talend 作业文件。

--- a/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
+++ b/modules/apps/portal-language/portal-language-lang/src/main/resources/content/Language_zh_TW.properties
@@ -19641,6 +19641,7 @@ upload-or-select-from-documents-and-media-item-selector=Upload or Select from Do
 upload-request-reached-the-maximum-permitted-size-of-x-bytes=上傳請求已達到 {0} 位元組的最大允許大小。
 upload-resume=恢復上傳
 upload-servlet-request-configuration-name=上傳 Servlet 請求
+upload-size-limit-has-been-exceeded=Upload size limit has been exceeded. (Automatic Copy)
 upload-thumbnail=上傳縮圖
 upload-x=Upload {0} (Automatic Copy)
 upload-your-talend-job-file=上船您的 Talend 工作檔案。


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

The changes made by the solution are mostly in the BPM components, therefore it is being reviewed by their team:
https://github.com/liferay-forms/liferay-portal/pull/2362

However, one part of the solution is made in the `journal-web` module, therefore I would like your team to review it as well.

Thank you!

---

Motivation
=======
If the length of a Journal Article's content exceeds the configured Upload Servlet Request limit (in bytes) the creation of the Article fails but no message is displayed on the UI indicating the cause of the error.
Only a warning is logged to the console which may not be readily visible to the end user.
The root cause of the issue is that the POST request initiated [here](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/utils/evaluation.es.js#L135-L167) will fail because of the `UploadException` but it is not handled properly on the backend, in the class `DDMFormContextProviderServlet`. 

Proposed Solution
========
Adding logic that processes the exception in `DDMFormContextProviderServlet` and displays the error message on the front end.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://liferay.atlassian.net/browse/LPS-198515

Thank you and best regards,
István