### PR TITLE
LPS-199434 Fix preview icons in fragment editor

### DIFF
--- a/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/fragment-editor/FragmentPreview.js
+++ b/modules/apps/fragment/fragment-web/src/main/resources/META-INF/resources/js/fragment-editor/FragmentPreview.js
@@ -27,11 +27,11 @@ const SIZE_RATIOS = {
 		height: '',
 		width: '',
 	},
-	'portrait-phone': {
+	'mobile-portrait': {
 		height: 16,
 		width: 10,
 	},
-	'tablet': {
+	'tablet-portrait': {
 		height: 3,
 		width: 4,
 	},
@@ -40,13 +40,18 @@ const SIZE_RATIOS = {
 /**
  * Available preview sizes in order.
  */
-const PREVIEW_SIZES = ['desktop', 'tablet', 'portrait-phone', 'full-size'];
+const PREVIEW_SIZES = [
+	'desktop',
+	'tablet-portrait',
+	'mobile-portrait',
+	'full-size',
+];
 
 const PREVIEW_SIZES_LABELS = {
 	'desktop': Liferay.Language.get('desktop'),
 	'full-size': Liferay.Language.get('full-size'),
-	'portrait-phone': Liferay.Language.get('portrait-phone'),
-	'tablet': Liferay.Language.get('tablet'),
+	'mobile-portrait': Liferay.Language.get('portrait-phone'),
+	'tablet-portrait': Liferay.Language.get('tablet'),
 };
 
 const stopEventPropagation = (event) => {


### PR DESCRIPTION
Motivation
=======
Fragment Editor used to contain icons for “Desktop”, “Tablet”, “Portrait Phone” and “Full Size”.
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-199434)

Steps to Verify:
----------------
1. Go to Design -> Fragments
2. Click on create a new fragment
3. In the fragment editor check that preview icons (desktop, tablet, portrait phone and full size) are visible.

