### PR TITLE
[TS] LPS-198081 and LPS-198082

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/LayoutImportController.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/LayoutImportController.java
@@ -375,6 +375,7 @@ public class LayoutImportController implements ImportController {
 		portletDataContext.setExportImportProcessId(
 			String.valueOf(
 				exportImportConfiguration.getExportImportConfigurationId()));
+		portletDataContext.setOriginalPrivateLayout(privateLayout);
 		portletDataContext.setPrivateLayout(privateLayout);
 
 		return portletDataContext;

--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/lar/PortletDataContextImpl.java
@@ -1561,6 +1561,11 @@ public class PortletDataContextImpl implements PortletDataContext {
 	}
 
 	@Override
+	public boolean isOriginalPrivateLayout() {
+		return _originalPrivateLayout;
+	}
+
+	@Override
 	public boolean isPathExportedInScope(String path) {
 		return addScopedPrimaryKey(String.class, path);
 	}
@@ -1705,6 +1710,10 @@ public class PortletDataContextImpl implements PortletDataContext {
 	@Override
 	public void setNewLayouts(List<Layout> newLayouts) {
 		_newLayouts = newLayouts;
+	}
+
+	public void setOriginalPrivateLayout(boolean originalPrivateLayout) {
+		_originalPrivateLayout = originalPrivateLayout;
 	}
 
 	@Override
@@ -2765,6 +2774,7 @@ public class PortletDataContextImpl implements PortletDataContext {
 	private final Map<String, Map<?, ?>> _newPrimaryKeysMaps = new HashMap<>();
 	private final Set<String> _notUniquePerLayout = new HashSet<>();
 	private final Map<String, Object> _objectsMap = new HashMap<>();
+	private boolean _originalPrivateLayout;
 	private Map<String, String[]> _parameterMap;
 	private final Map<String, List<KeyValuePair>> _permissionsMap =
 		new HashMap<>();

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/GroupPagesPortletDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/GroupPagesPortletDataHandler.java
@@ -17,7 +17,6 @@ import com.liferay.exportimport.portlet.data.handler.helper.PortletDataHandlerHe
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
 import com.liferay.layout.admin.constants.LayoutAdminPortletKeys;
 import com.liferay.layout.page.template.constants.LayoutPageTemplateConstants;
-import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.layout.utility.page.constants.LayoutUtilityPageConstants;
@@ -201,26 +200,8 @@ public class GroupPagesPortletDataHandler extends BasePortletDataHandler {
 			for (Element layoutPageTemplateEntryElement :
 					layoutPageTemplateEntryElements) {
 
-				LayoutPageTemplateEntry layoutPageTemplateEntry =
-					(LayoutPageTemplateEntry)
-						portletDataContext.getZipEntryAsObject(
-							layoutPageTemplateEntryElement.attributeValue(
-								"path"));
-
-				boolean privateLayout = portletDataContext.isPrivateLayout();
-
-				if ((layoutPageTemplateEntry.getType() ==
-						LayoutPageTemplateEntryTypeConstants.BASIC) ||
-					(layoutPageTemplateEntry.getType() ==
-						LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT)) {
-
-					portletDataContext.setPrivateLayout(true);
-				}
-
 				StagedModelDataHandlerUtil.importStagedModel(
 					portletDataContext, layoutPageTemplateEntryElement);
-
-				portletDataContext.setPrivateLayout(privateLayout);
 			}
 		}
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateEntryStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutPageTemplateEntryStagedModelDataHandler.java
@@ -414,16 +414,6 @@ public class LayoutPageTemplateEntryStagedModelDataHandler
 			return;
 		}
 
-		Layout draftLayout = layout.fetchDraftLayout();
-
-		if (_layoutExportImportConfiguration.exportDraftLayout() &&
-			(draftLayout != null)) {
-
-			StagedModelDataHandlerUtil.exportReferenceStagedModel(
-				portletDataContext, layoutPageTemplateEntry, draftLayout,
-				PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
-		}
-
 		StagedModelDataHandlerUtil.exportReferenceStagedModel(
 			portletDataContext, layoutPageTemplateEntry, layout,
 			PortletDataContext.REFERENCE_TYPE_DEPENDENCY);

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -462,7 +462,7 @@ public class LayoutStagedModelDataHandler
 
 		boolean privateLayout = false;
 
-		if ((portletDataContext.isPrivateLayout() &&
+		if ((portletDataContext.isOriginalPrivateLayout() &&
 			 !layout.isTypeAssetDisplay()) ||
 			GetterUtil.getBoolean(
 				layoutElement.attributeValue("layout-content-page-template")) ||
@@ -471,6 +471,8 @@ public class LayoutStagedModelDataHandler
 
 			privateLayout = true;
 		}
+
+		portletDataContext.setPrivateLayout(privateLayout);
 
 		Map<Long, Layout> layouts =
 			(Map<Long, Layout>)portletDataContext.getNewPrimaryKeysMap(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -467,6 +467,8 @@ public class LayoutStagedModelDataHandler
 			GetterUtil.getBoolean(
 				layoutElement.attributeValue("layout-content-page-template")) ||
 			GetterUtil.getBoolean(
+				layoutElement.attributeValue("layout-layout-prototype")) ||
+			GetterUtil.getBoolean(
 				layoutElement.attributeValue("layout-master-page-template"))) {
 
 			privateLayout = true;

--- a/modules/apps/layout/layout-prototype-impl/src/main/java/com/liferay/layout/prototype/internal/exportimport/data/handler/LayoutPrototypeStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-prototype-impl/src/main/java/com/liferay/layout/prototype/internal/exportimport/data/handler/LayoutPrototypeStagedModelDataHandler.java
@@ -207,6 +207,12 @@ public class LayoutPrototypeStagedModelDataHandler
 				StagedModelDataHandlerUtil.exportReferenceStagedModel(
 					portletDataContext, layoutPrototype, layout,
 					PortletDataContext.REFERENCE_TYPE_EMBEDDED);
+
+				Element layoutElement = portletDataContext.getExportDataElement(
+					layout);
+
+				layoutElement.addAttribute(
+					"layout-layout-prototype", Boolean.TRUE.toString());
 			}
 		}
 		finally {
@@ -236,7 +242,6 @@ public class LayoutPrototypeStagedModelDataHandler
 		throws Exception {
 
 		long groupId = portletDataContext.getGroupId();
-		boolean privateLayout = portletDataContext.isPrivateLayout();
 		long scopeGroupId = portletDataContext.getScopeGroupId();
 
 		Map<String, String[]> parameterMap =
@@ -247,7 +252,6 @@ public class LayoutPrototypeStagedModelDataHandler
 
 		try {
 			portletDataContext.setGroupId(importedGroupId);
-			portletDataContext.setPrivateLayout(true);
 			portletDataContext.setScopeGroupId(importedGroupId);
 
 			if (!portletDataContext.isDataStrategyMirror()) {
@@ -264,7 +268,6 @@ public class LayoutPrototypeStagedModelDataHandler
 		}
 		finally {
 			portletDataContext.setGroupId(groupId);
-			portletDataContext.setPrivateLayout(privateLayout);
 			portletDataContext.setScopeGroupId(scopeGroupId);
 
 			if (Validator.isNull(layoutsImportMode)) {

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataContext.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataContext.java
@@ -354,6 +354,10 @@ public interface PortletDataContext extends Serializable {
 
 	public boolean isModelCounted(String className, Serializable classPK);
 
+	public default boolean isOriginalPrivateLayout() {
+		return false;
+	}
+
 	public boolean isPathExportedInScope(String path);
 
 	public boolean isPathNotProcessed(String path);
@@ -402,6 +406,8 @@ public interface PortletDataContext extends Serializable {
 	public void setMissingReferencesElement(Element missingReferencesElement);
 
 	public void setNewLayouts(List<Layout> newLayouts);
+
+	public void setOriginalPrivateLayout(boolean originalPrivateLayout);
 
 	public void setParameterMap(Map<String, String[]> parameterMap);
 

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/packageinfo
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/packageinfo
@@ -1,1 +1,1 @@
-version 5.2.0
+version 5.3.0


### PR DESCRIPTION
Forwarding from: https://github.com/liferay-staging/liferay-portal/pull/443

[LPS-198081](https://liferay.atlassian.net/browse/LPS-198081)
[LPS-198082](https://liferay.atlassian.net/browse/LPS-198082)

I've checked whether there's viable a solution that does not add extra parameter to `PortletDataContext`. However, it seems like we can't avoid setting `privateLayout` in `PortletDataContext` during import, as the dependencies of pages use it.
 * `privateLayout` contains the information whether we are importing something in the context of a private or public page (can change during import process, e.g.: when we are processing page templates and their dependencies)
 * `originalPrivateLayout` this will contain the original intention, whether we are importing into a public/private LayoutSet, and we don't change this during the import process

cc: @balazssk