### PR TITLE
LRQA-83850 Refactoring | Modal

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/Modal.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/Modal.macro
@@ -17,7 +17,7 @@ definition {
 
 		AssertTextEquals(
 			index = ${index},
-			locator1 = "Modal#BODY_MESSAGE",
+			locator1 = "Modal#BODY_MESSAGE_WARNING",
 			value1 = ${warningMessage});
 
 		if (${action} == "Cancel") {

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Modal.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/Modal.path
@@ -16,7 +16,7 @@
 	<td></td>
 </tr>
 <tr>
-	<td>BODY_MESSAGE</td>
+	<td>BODY_MESSAGE_WARNING</td>
 	<td>xpath=(//*[contains(@class,'modal-dialog')]//*[contains(@class,'modal-body')]/p)[${index}]</td>
 	<td></td>
 </tr>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/outoftheboxfragments/formcomponents/SubmitButton.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/outoftheboxfragments/formcomponents/SubmitButton.testcase
@@ -508,7 +508,7 @@ definition {
 			task ("Assert there's a Submit Button Missing warning message shown") {
 				AssertTextEquals(
 					index = 1,
-					locator1 = "Modal#BODY_MESSAGE",
+					locator1 = "Modal#BODY_MESSAGE_WARNING",
 					value1 = "Purchase Order form has a hidden or missing submit button. If you continue, your users may not be able to submit the form. Are you sure you want to publish it?");
 			}
 		}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/structure/WebContentStructures.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/structure/WebContentStructures.testcase
@@ -323,17 +323,17 @@ definition {
 
 			AssertTextEquals(
 				index = 1,
-				locator1 = "Modal#BODY_MESSAGE",
+				locator1 = "Modal#BODY_MESSAGE_WARNING",
 				value1 = "Changing the structure key will reindex all the web content articles with this structure. This action may take some time, and the affected items may not be available during this process.");
 
 			AssertTextEquals(
 				index = 2,
-				locator1 = "Modal#BODY_MESSAGE",
+				locator1 = "Modal#BODY_MESSAGE_WARNING",
 				value1 = "Remember that all places where the structure key was changed manually must be reviewed to be consistent with the new key. Otherwise, the relationship will be lost.");
 
 			AssertTextEquals(
 				index = 3,
-				locator1 = "Modal#BODY_MESSAGE",
+				locator1 = "Modal#BODY_MESSAGE_WARNING",
 				value1 = "Are you sure you want to continue and save the key?");
 		}
 


### PR DESCRIPTION
Renaming of body text path of modal because it is for warning modal. See info modal: [PR](https://github.com/liferay-staging/liferay-portal/pull/450)