### PR TITLE
LPS-199858 UI adjustments in Page Audit warnings

### DIFF
--- a/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/ItemDetail.js
+++ b/modules/apps/layout/layout-reports-web/src/main/resources/META-INF/resources/js/components/ItemDetail.js
@@ -288,13 +288,14 @@ function TextSection({labelType, text, title}) {
 function Warning({item}) {
 	return (
 		<ClayList.Item className="border-0 c-p-0">
-			<ClayAlert displayType="warning" role="none" variant="feedback">
-				<span className="c-mb-3 d-block text-weight-semi-bold">
-					{item.title}
-				</span>
+			<ClayAlert
+				displayType="warning"
+				role="none"
+				title={item.title}
+				variant="feedback"
+			/>
 
-				<span>{item.description}</span>
-			</ClayAlert>
+			<p className="c-mb-0 c-mt-3 text-warning">{item.description}</p>
 		</ClayList.Item>
 	);
 }

--- a/modules/apps/layout/layout-reports-web/test/js/components/PageAudit.test.js
+++ b/modules/apps/layout/layout-reports-web/test/js/components/PageAudit.test.js
@@ -96,8 +96,8 @@ describe('PageAudit', () => {
 
 	it('shows alerts according to the number of warnings', async () => {
 		const warnings = [
-			{description: 'Warning 1', title: ''},
-			{description: 'Warning 2', title: ''},
+			{description: 'Warning 1', title: 'Title 1'},
+			{description: 'Warning 2', title: 'Title 2'},
 		];
 
 		const selectedItem = {
@@ -110,10 +110,11 @@ describe('PageAudit', () => {
 
 		for (const warning of warnings) {
 			const element = screen.getByText(warning.description);
+			const elementTitle = screen.getByText(warning.title);
 
 			expect(element).toBeInTheDocument();
 
-			expect(element.closest('.alert-warning')).not.toBeNull();
+			expect(elementTitle.closest('.alert-warning')).not.toBeNull();
 		}
 	});
 });


### PR DESCRIPTION
Motivation
=======

Fix left margin in warning description
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-199858)


Steps to Verify:
----------------
1. In Documents and Media add a big image (>500kb)
2. Go to home page and add an image fragment with the image uploaded in step 1
3. In the image fragment configuration select resolution: auto
4. Publish the page
5. Open the Page Audit and click on the image fragment

