### PR TITLE
LPS-199861 Second level child Site doesn't show the name of the parent

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -24,6 +24,12 @@ if (group != null) {
 		).buildString());
 	portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
+	Group parentGroup = group.getParentGroup();
+
+	if (parentGroup != null) {
+		portletDisplay.setURLBackTitle(parentGroup.getDescriptiveName(locale));
+	}
+
 	renderResponse.setTitle(group.getDescriptiveName(locale));
 }
 


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-199861)

## Steps 

1. Go to Control Panel > Sites > Create a site 
2. Create a child site inside the previous site
3. See the button titles in the child site (parent site name) and in the parent site (Go to Sites label)

![Screenshot 2023-10-24 at 15 25 46](https://github.com/liferay-echo/liferay-portal/assets/91208451/19111a8d-38c1-448c-a2b9-81935d030b55)
![Screenshot 2023-10-24 at 15 25 59](https://github.com/liferay-echo/liferay-portal/assets/91208451/1ddcbeef-4edf-43c2-8106-f347bff22dd7)

