### PR TITLE
LPS-179670 Do not allow to drag a disabled element

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
@@ -97,9 +97,13 @@ export default function TabItem({displayStyle, item, onRemoveHighlighted}) {
 					parentItemId: parentId,
 					position,
 				})
-			).catch(() => {
-				setDisabled(false);
-			});
+			)
+				.then(() => {
+					setDisabled(false);
+				})
+				.catch(() => {
+					setDisabled(false);
+				});
 		}
 	);
 
@@ -113,7 +117,7 @@ export default function TabItem({displayStyle, item, onRemoveHighlighted}) {
 	) : (
 		<ListItem
 			disabled={disabled || isDraggingSource || item.disabled}
-			handlerRef={item.disabled ? null : sourceRef}
+			handlerRef={item.disabled || disabled ? null : sourceRef}
 			item={item}
 			onToggleHighlighted={onToggleHighlighted}
 		/>


### PR DESCRIPTION
 Motivation
=======
This is the second PR of this bug because the bug was still reproducible
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-179670)

Proposed Solution
========
Do not allow to drag a disabled element and set enabled again when the action has finished

Steps to Verify:
----------------
1. Check the ticket video
