### PR TITLE
LPS-199891 Hide folder selection when setting structure default values

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/DDMStructureActionDropdownItemsProvider.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/servlet/taglib/util/DDMStructureActionDropdownItemsProvider.java
@@ -208,6 +208,8 @@ public class DDMStructureActionDropdownItemsProvider {
 					"ddmStructureId", _ddmStructure.getStructureId()
 				).setParameter(
 					"groupId", _ddmStructure.getGroupId()
+				).setParameter(
+					"showSelectFolder", false
 				).buildString());
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "edit-default-values"));


### PR DESCRIPTION
Motivation
=======
Fix for [LPS-199891](https://liferay.atlassian.net/browse/LPS-199891)

[LPS-133629](https://liferay.atlassian.net/browse/LPS-133629) added the capacity to select a folder when adding a new web content from the asset publisher widget. This folder selector is being shown (I think unintentionally) when editing the default values of a structure.

The aim of this pr is to hide this selector in the mentioned use case.

Proposed Solution
========
I added the parameter "showSelectFolder=false" in the url used to edit the default values of a structure

Steps to Verify
========
1. Go to web content view and create a folder 
1. Go to structures and create simple structure (in my case with text field)
1. In the structure go to the three dots and select Edit Default Values

- **Expected behavior**
In web content edit page, the folder selector is not shown

- **Actual behavior**
In web content edit page, the folder selection is shown

References to existing code
========
I'm using the same approach as when we generate the new journal content creation urls. See https://github.com/liferay/liferay-portal/blob/3232daa27fac352511e4270ab6a474abffdfeeca/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java#L580