### PR TITLE
[technical-support] LPS-199595 - ArticleUsage not working when version is removed.

### DIFF
--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalService.java
@@ -1305,6 +1305,9 @@ public interface JournalArticleLocalService
 		long resourcePrimKey);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public int getArticlesByResourcePrimKeyCount(long resourcePrimKey);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<JournalArticle> getArticlesByReviewDate(
 		Date previousCheckDate, Date reviewDate);
 

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceUtil.java
@@ -1536,6 +1536,10 @@ public class JournalArticleLocalServiceUtil {
 		return getService().getArticlesByResourcePrimKey(resourcePrimKey);
 	}
 
+	public static int getArticlesByResourcePrimKeyCount(long resourcePrimKey) {
+		return getService().getArticlesByResourcePrimKeyCount(resourcePrimKey);
+	}
+
 	public static List<JournalArticle> getArticlesByReviewDate(
 		java.util.Date previousCheckDate, java.util.Date reviewDate) {
 

--- a/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
+++ b/modules/apps/journal/journal-api/src/main/java/com/liferay/journal/service/JournalArticleLocalServiceWrapper.java
@@ -1633,6 +1633,12 @@ public class JournalArticleLocalServiceWrapper
 	}
 
 	@Override
+	public int getArticlesByResourcePrimKeyCount(long resourcePrimKey) {
+		return _journalArticleLocalService.getArticlesByResourcePrimKeyCount(
+			resourcePrimKey);
+	}
+
+	@Override
 	public java.util.List<JournalArticle> getArticlesByReviewDate(
 		java.util.Date previousCheckDate, java.util.Date reviewDate) {
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/model/listener/JournalArticleModelListener.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/model/listener/JournalArticleModelListener.java
@@ -6,6 +6,7 @@
 package com.liferay.journal.internal.model.listener;
 
 import com.liferay.journal.model.JournalArticle;
+import com.liferay.journal.service.JournalArticleLocalService;
 import com.liferay.journal.util.JournalContent;
 import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.portal.kernel.model.BaseModelListener;
@@ -29,9 +30,21 @@ public class JournalArticleModelListener
 	public void onAfterRemove(JournalArticle journalArticle) {
 		clearCache(journalArticle);
 
-		_layoutClassedModelUsageLocalService.deleteLayoutClassedModelUsages(
-			_portal.getClassNameId(JournalArticle.class),
-			journalArticle.getResourcePrimKey());
+		boolean areThereOtherVersions = false;
+
+		int versionsCount =
+			_journalArticleLocalService.getArticlesByResourcePrimKeyCount(
+				journalArticle.getResourcePrimKey());
+
+		if (versionsCount > 0) {
+			areThereOtherVersions = true;
+		}
+
+		if (!areThereOtherVersions) {
+			_layoutClassedModelUsageLocalService.deleteLayoutClassedModelUsages(
+				_portal.getClassNameId(JournalArticle.class),
+				journalArticle.getResourcePrimKey());
+		}
 	}
 
 	@Override
@@ -56,6 +69,9 @@ public class JournalArticleModelListener
 
 		CacheUtil.clearCache(journalArticle.getCompanyId());
 	}
+
+	@Reference
+	private JournalArticleLocalService _journalArticleLocalService;
 
 	@Reference
 	private JournalContent _journalContent;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -2783,6 +2783,12 @@ public class JournalArticleLocalServiceImpl
 	}
 
 	@Override
+	public int getArticlesByResourcePrimKeyCount(long resourcePrimKey) {
+		return journalArticlePersistence.countByResourcePrimKey(
+			resourcePrimKey);
+	}
+
+	@Override
 	public List<JournalArticle> getArticlesByReviewDate(
 		Date previousCheckDate, Date reviewDate) {
 


### PR DESCRIPTION
Hi Team,

This PR is a proposed solution to [LPS-199595](https://liferay.atlassian.net/browse/LPS-199595)

Motivation: If we delete one version of a JournalArticle (but we still have other versions), the delete process involves deleting all usages of that JournalArticle from the layoutClassedModelUsage table. This creates a bug, where the "show usages" option shows no usage, despite the JournalArticle still being used in a page. 

Proposed solution: Create a check in the onAfterRemove method within JournalArticleModelListener for only deleting the usages if there are no other versions exist for the JournalArticle.

Steps to Verify:

Reproduction steps:

1.) Start vanilla Liferay DXP 7.4 update 92 instance.
2.) Create a new widget page.
3.) Add Web Content portlet.
4.) Create new JournalArticle and add multiple versions.
5.) Add this JournalArcticle to Web Content portlet which was added earlier.
6.) Check Article usage in Site Administration --> Content&Dara --> Web Content. The result should be correct.
7.) Remove latest or any other version from JournalArticle.
8.) Check article usage again.

Expected result: There should be usage because JournalContent portlet still has this article.