### PR TITLE
LPS-198982 Set layout status to approved when LayoutPageTemplateEntry is published

### DIFF
--- a/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-service/src/main/java/com/liferay/change/tracking/service/impl/CTCollectionLocalServiceImpl.java
@@ -1383,9 +1383,8 @@ public class CTCollectionLocalServiceImpl
 	}
 
 	private static final int[] _STATUSES = {
-		WorkflowConstants.STATUS_APPROVED, WorkflowConstants.STATUS_DRAFT,
-		WorkflowConstants.STATUS_EXPIRED, WorkflowConstants.STATUS_IN_TRASH,
-		WorkflowConstants.STATUS_SCHEDULED
+		WorkflowConstants.STATUS_APPROVED, WorkflowConstants.STATUS_EXPIRED,
+		WorkflowConstants.STATUS_IN_TRASH, WorkflowConstants.STATUS_SCHEDULED
 	};
 
 	private static final Log _log = LogFactoryUtil.getLog(

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/change/tracking/spi/display/LayoutCTDisplayRenderer.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/change/tracking/spi/display/LayoutCTDisplayRenderer.java
@@ -23,6 +23,7 @@ import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.style.book.model.StyleBookEntry;
 import com.liferay.style.book.service.StyleBookEntryLocalService;
 
@@ -102,6 +103,12 @@ public class LayoutCTDisplayRenderer extends BaseCTDisplayRenderer<Layout> {
 
 	@Override
 	public boolean isHideable(Layout layout) {
+		if (layout.isDraftLayout() &&
+			(layout.getStatus() == WorkflowConstants.STATUS_DRAFT)) {
+
+			return false;
+		}
+
 		return layout.isSystem();
 	}
 

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,6 +1,6 @@
 <%--
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 --%>

--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,6 +1,6 @@
 <%--
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 --%>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutPageTemplateEntryMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutPageTemplateEntryMVCActionCommand.java
@@ -148,6 +148,10 @@ public class PublishLayoutPageTemplateEntryMVCActionCommand
 
 		layout = _layoutLocalService.fetchLayout(layout.getPlid());
 
+		layout.setStatus(WorkflowConstants.STATUS_APPROVED);
+
+		layout = _layoutLocalService.updateLayout(layout);
+
 		_layoutLocalService.updateLayout(
 			layout.getGroupId(), layout.isPrivateLayout(), layout.getLayoutId(),
 			_copySEOTypeSettingsUnicodeProperties(

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/change/tracking/display/LayoutPageTemplateCollectionCTDisplayRenderer.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/change/tracking/display/LayoutPageTemplateCollectionCTDisplayRenderer.java
@@ -10,7 +10,6 @@ import com.liferay.change.tracking.spi.display.CTDisplayRenderer;
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.model.LayoutPageTemplateCollection;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.util.Portal;
 
@@ -62,9 +61,6 @@ public class LayoutPageTemplateCollectionCTDisplayRenderer
 
 		return layoutPageTemplateCollection.getName();
 	}
-
-	@Reference
-	private Language _language;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/change/tracking/display/LayoutPageTemplateEntryCTDisplayRenderer.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/change/tracking/display/LayoutPageTemplateEntryCTDisplayRenderer.java
@@ -1,0 +1,67 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.admin.web.internal.change.tracking.display;
+
+import com.liferay.change.tracking.spi.display.BaseCTDisplayRenderer;
+import com.liferay.change.tracking.spi.display.CTDisplayRenderer;
+import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
+import com.liferay.portal.kernel.util.Portal;
+
+import java.util.Locale;
+
+import javax.portlet.PortletRequest;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author David Truong
+ */
+@Component(service = CTDisplayRenderer.class)
+public class LayoutPageTemplateEntryCTDisplayRenderer
+	extends BaseCTDisplayRenderer<LayoutPageTemplateEntry> {
+
+	@Override
+	public String getEditURL(
+			HttpServletRequest httpServletRequest,
+			LayoutPageTemplateEntry layoutPageTemplateEntry)
+		throws PortalException {
+
+		return PortletURLBuilder.create(
+			_portal.getControlPanelPortletURL(
+				httpServletRequest,
+				LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES,
+				PortletRequest.RENDER_PHASE)
+		).setMVCRenderCommandName(
+			"/layout_page_template_admin/edit_layout_page_template_entry"
+		).setParameter(
+			"layoutPageTemplateEntryId",
+			layoutPageTemplateEntry.getLayoutPageTemplateEntryId()
+		).buildString();
+	}
+
+	@Override
+	public Class<LayoutPageTemplateEntry> getModelClass() {
+		return LayoutPageTemplateEntry.class;
+	}
+
+	@Override
+	public String getTitle(
+			Locale locale, LayoutPageTemplateEntry layoutPageTemplateEntry)
+		throws PortalException {
+
+		return layoutPageTemplateEntry.getName();
+	}
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/change/tracking/display/LayoutPageTemplateEntryCTDisplayRenderer.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/change/tracking/display/LayoutPageTemplateEntryCTDisplayRenderer.java
@@ -1,5 +1,5 @@
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
@@ -8,6 +8,7 @@ package com.liferay.layout.page.template.admin.web.internal.change.tracking.disp
 import com.liferay.change.tracking.spi.display.BaseCTDisplayRenderer;
 import com.liferay.change.tracking.spi.display.CTDisplayRenderer;
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
@@ -42,6 +43,30 @@ public class LayoutPageTemplateEntryCTDisplayRenderer
 				PortletRequest.RENDER_PHASE)
 		).setMVCRenderCommandName(
 			"/layout_page_template_admin/edit_layout_page_template_entry"
+		).setTabs1(
+			() -> {
+				if ((layoutPageTemplateEntry.getType() ==
+						LayoutPageTemplateEntryTypeConstants.BASIC) ||
+					(layoutPageTemplateEntry.getType() ==
+						LayoutPageTemplateEntryTypeConstants.WIDGET_PAGE)) {
+
+					return "page-templates";
+				}
+
+				if (layoutPageTemplateEntry.getType() ==
+						LayoutPageTemplateEntryTypeConstants.DISPLAY_PAGE) {
+
+					return "display-page-templates";
+				}
+
+				if (layoutPageTemplateEntry.getType() ==
+						LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT) {
+
+					return "master-layouts";
+				}
+
+				return null;
+			}
 		).setParameter(
 			"layoutPageTemplateEntryId",
 			layoutPageTemplateEntry.getLayoutPageTemplateEntryId()

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/change/tracking/display/LayoutPrototypeCTDisplayRenderer.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/change/tracking/display/LayoutPrototypeCTDisplayRenderer.java
@@ -9,7 +9,6 @@ import com.liferay.change.tracking.spi.display.BaseCTDisplayRenderer;
 import com.liferay.change.tracking.spi.display.CTDisplayRenderer;
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.LayoutPrototype;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.util.Portal;
@@ -59,9 +58,6 @@ public class LayoutPrototypeCTDisplayRenderer
 
 		return layoutPrototype.getName(locale);
 	}
-
-	@Reference
-	private Language _language;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,6 +1,6 @@
 <%--
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 --%>

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view.jsp
@@ -1,6 +1,6 @@
 <%--
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 --%>


### PR DESCRIPTION
### Motivation
While working on https://liferay.atlassian.net/browse/LPS-198982, we noticed that the status of the layout associated with the LayoutPageTemplateEntry is updated to `draft` when LayoutPageTemplateEntry is published. The layout and draftLayout have `approved` status when the LayoutPageTemplateEntry is created. During publish, [LayoutStructureUtil.deleteMarkedForDeletionItems](https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutPageTemplateEntryMVCActionCommand.java#L116-L117) sets the draftLayout's status to `draft`, then layout's status gets updated when the draftLayout is copied to the layout in [_layoutCopyHelper.copyLayoutContent(draftLayout, layout)](https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutPageTemplateEntryMVCActionCommand.java#L122C3-L122C59).

### Proposed Solution
Manually updates the status of the layout to `approved` at the end of the publish as done in https://github.com/liferay-echo/liferay-portal/pull/14104/commits/148c09eef4e602290891c2ce7f88cd8412e2ecea.

### Steps to Verify
1. Add a page template
2. Verify the two layouts associated with the page template has `approved` status=0
3. Publish the page template
4. Verify the page template layout has `draft` status=2.

Only the change in https://github.com/liferay-echo/liferay-portal/pull/14104/commits/148c09eef4e602290891c2ce7f88cd8412e2ecea is relevant for your team's review. Feel free to ignore the other commits.

Please prioritize this PR because we need to provide a fix for a customer. Thank you!