### PR TITLE
LPS-199891 Hide folder selection when setting structure default values

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -1230,7 +1230,10 @@ public class JournalEditArticleDisplayContext {
 
 		_showSelectFolder = false;
 
-		if (_article == null) {
+		if ((_article == null) &&
+			(getClassNameId() ==
+				JournalArticleConstants.CLASS_NAME_ID_DEFAULT)) {
+
 			_showSelectFolder = ParamUtil.getBoolean(
 				_httpServletRequest, "showSelectFolder", true);
 		}


### PR DESCRIPTION
Previously sent #14093 

Motivation
=======
Fix for [LPS-199891](https://liferay.atlassian.net/browse/LPS-199891)

[LPS-133629](https://liferay.atlassian.net/browse/LPS-133629) added the capacity to select a folder when adding a new web content from the asset publisher widget. This folder selector is being shown (I think unintentionally) when editing the default values of a structure.

The aim of this pr is to hide this selector in the mentioned use case.

Proposed Solution
========
As suggested in #14093 I'm changing the logic of isShowSelectFolder() to check the classNameId and identify the case in which default structure values are being created

Steps to Verify
========
1. From Web Content Administration, go to structures and create simple structure (in my case with text field)
1. In the structure go to the three dots and select Edit Default Values

- **Expected behavior**
In web content edit page, the folder selector is not shown

- **Actual behavior**
In web content edit page, the folder selection is shown

![image](https://github.com/liferay-echo/liferay-portal/assets/28562091/bf234d7b-fd1f-451c-ba33-99ddf2ddc66b)

