### PR TITLE
LPS-199337 Turn interactive the paths on Web Content

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -85,6 +85,7 @@ import com.liferay.portal.kernel.search.Sort;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
@@ -575,6 +576,28 @@ public class JournalDisplayContext {
 				_trashHelper);
 
 		return folderActionDropdownItems.getActionDropdownItems();
+	}
+
+	public List<BreadcrumbEntry> getFolderBreadcrumbEntries(
+			JournalFolder folder)
+		throws Exception {
+
+		PortletURL folderURL = PortletURLBuilder.createRenderURL(
+			_liferayPortletResponse
+		).setParameter(
+			"folderId", folder.getFolderId()
+		).buildPortletURL();
+
+		List<BreadcrumbEntry> breadcrumbEntries =
+			JournalPortletUtil.getPortletBreadcrumbEntries(
+				folder, _httpServletRequest, folderURL);
+
+		BreadcrumbEntry breadcrumbEntry = breadcrumbEntries.get(
+			breadcrumbEntries.size() - 1);
+
+		breadcrumbEntry.setURL(folderURL.toString());
+
+		return breadcrumbEntries;
 	}
 
 	public long getFolderId() {

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalPortletUtil.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/util/JournalPortletUtil.java
@@ -159,6 +159,11 @@ public class JournalPortletUtil {
 			breadcrumbEntries.add(folderBreadcrumbEntry);
 		}
 
+		BreadcrumbEntry lastBreadcrumbEntry = breadcrumbEntries.get(
+			breadcrumbEntries.size() - 1);
+
+		lastBreadcrumbEntry.setURL(null);
+
 		return breadcrumbEntries;
 	}
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -117,7 +117,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 								</c:choose>
 							</div>
 
-							<span class="text-secondary">
+							<span class="c-pt-1 text-secondary">
 								<liferay-ui:message arguments="<%= new String[] {modifiedDateDescription, HtmlUtil.escape(curArticle.getStatusByUserName())} %>" key="modified-x-ago-by-x" />
 							</span>
 
@@ -345,7 +345,7 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 								</c:choose>
 							</div>
 
-							<span class="text-secondary">
+							<span class="c-pt-1 text-secondary">
 								<liferay-ui:message arguments="<%= new String[] {createDateDescription, HtmlUtil.escape(curFolder.getUserName())} %>" key="modified-x-ago-by-x" />
 							</span>
 

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/view_entries.jsp
@@ -122,9 +122,9 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 							</span>
 
 							<c:if test="<%= journalDisplayContext.isSearch() && ((curArticle.getFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curArticle.getFolder(), ActionKeys.VIEW)) %>">
-								<h5>
-									<%= journalDisplayContext.getAbsolutePath(curArticle.getFolderId()) %>
-								</h5>
+								<liferay-site-navigation:breadcrumb
+									breadcrumbEntries="<%= journalDisplayContext.getFolderBreadcrumbEntries(curArticle.getFolder()) %>"
+								/>
 							</c:if>
 
 							<span class="text-default">
@@ -350,9 +350,9 @@ Map<String, Object> componentContext = journalDisplayContext.getComponentContext
 							</span>
 
 							<c:if test="<%= journalDisplayContext.isSearch() && ((curFolder.getParentFolderId() <= 0) || JournalFolderPermission.contains(permissionChecker, curFolder.getParentFolder(), ActionKeys.VIEW)) %>">
-								<h5>
-									<%= journalDisplayContext.getAbsolutePath(curFolder.getParentFolderId()) %>
-								</h5>
+								<liferay-site-navigation:breadcrumb
+									breadcrumbEntries="<%= journalDisplayContext.getFolderBreadcrumbEntries(curFolder) %>"
+								/>
 							</c:if>
 						</liferay-ui:search-container-column-text>
 

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/breadcrumb/page.jsp
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/breadcrumb/page.jsp
@@ -14,8 +14,7 @@ List<BreadcrumbEntry> breadcrumbEntries = (List<BreadcrumbEntry>)request.getAttr
 <ol class="breadcrumb">
 
 	<%
-	for (int i = 0; i < breadcrumbEntries.size(); i++) {
-		BreadcrumbEntry breadcrumbEntry = breadcrumbEntries.get(i);
+	for (BreadcrumbEntry breadcrumbEntry : breadcrumbEntries) {
 	%>
 
 		<c:choose>

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/breadcrumb/page.jsp
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/breadcrumb/page.jsp
@@ -11,7 +11,7 @@
 List<BreadcrumbEntry> breadcrumbEntries = (List<BreadcrumbEntry>)request.getAttribute("liferay-site-navigation:breadcrumb:breadcrumbEntries");
 %>
 
-<ol class="breadcrumb">
+<ol class="breadcrumb c-pl-0 c-pt-0">
 
 	<%
 	for (BreadcrumbEntry breadcrumbEntry : breadcrumbEntries) {

--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/breadcrumb/page.jsp
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/resources/META-INF/resources/breadcrumb/page.jsp
@@ -19,7 +19,7 @@ List<BreadcrumbEntry> breadcrumbEntries = (List<BreadcrumbEntry>)request.getAttr
 	%>
 
 		<c:choose>
-			<c:when test="<%= (i < (breadcrumbEntries.size() - 1)) && Validator.isNotNull(breadcrumbEntry.getURL()) %>">
+			<c:when test="<%= Validator.isNotNull(breadcrumbEntry.getURL()) %>">
 				<li class="breadcrumb-item">
 					<a class="breadcrumb-link" href="<%= breadcrumbEntry.getURL() %>">
 						<span class="breadcrumb-text-truncate"><%= HtmlUtil.escape(breadcrumbEntry.getTitle()) %></span>


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-199337)

### Changes

Turn the WC path interactive by modifying the breadcrumb taglib and adding a method	

## Test scenario 1

1. Create a few Web Contents and folders creating different paths 
2. Using the search bar look for web contents and folders and check the paths

## Results


https://github.com/liferay-echo/liferay-portal/assets/93203423/7ee580b2-abda-4da3-912e-ad728d492d6d


