### PR TITLE
[TS] LPS-200117

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/model/listener/DDMStructureModelListener.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/model/listener/DDMStructureModelListener.java
@@ -76,7 +76,8 @@ public class DDMStructureModelListener extends BaseModelListener<DDMStructure> {
 					ddmStructureIdProperty.eq(
 						originalDDMStructure.getStructureId()));
 			});
-		actionableDynamicQuery.setGroupId(originalDDMStructure.getGroupId());
+		actionableDynamicQuery.setCompanyId(
+			originalDDMStructure.getCompanyId());
 
 		ActionableDynamicQuery.PerformActionMethod<?> performActionMethod =
 			null;


### PR DESCRIPTION
Motivation
=======
This PR aims to fix LPS-200117 by updating all the web contents of a given structure without having to share the same site (group), but the same virtual instance (company).

Proposed Solution
========
Change the query executed by the related Model Listener to get all the Web Contents that shares the same DDMStructure not being limited to the same group, but limited to the same company.

Steps to Verify
========

1. Create a Web Content Structure in Global site with the schema attached in this ticket
- Fieldset (repeatable)
-- Text field 1
-- Fieldset (not repeatable)
--- Text field 2
2. Create a Web Content based off of the structure created at step 1 in Liferay site filling in with an additional repeatable field so that we introduce four values like "aa", "bb", "cc", and "dd".
3. Modify the structure created at step 1 so Text field 2 goes at the same level as Text field 1's:
-Fieldset (repeatable)
-- Text field 1
-- Text field 2
4. Edit the Web Content created at step 2

Expected result
- There are no duplicated values
- Four structured fields are shown

Actual results
- There are duplicate values
- Six structured fields are shown

