### PR TITLE
LPS-197353 Multiple AssertionErrors in TaxonomyVocabularyResourceTest

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -371,6 +371,57 @@ public class TaxonomyVocabularyResourceTest
 
 	@Override
 	@Test
+	public void testGetSiteTaxonomyVocabulariesPageWithPagination()
+		throws Exception {
+
+		Long siteId = testGetSiteTaxonomyVocabulariesPage_getSiteId();
+
+		TaxonomyVocabulary taxonomyVocabulary1 =
+			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				siteId, randomTaxonomyVocabulary());
+
+		TaxonomyVocabulary taxonomyVocabulary2 =
+			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				siteId, randomTaxonomyVocabulary());
+
+		TaxonomyVocabulary taxonomyVocabulary3 =
+			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				siteId, randomTaxonomyVocabulary());
+
+		Page<TaxonomyVocabulary> page1 =
+			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+				siteId, null, null, null, Pagination.of(1, 3), null);
+
+		List<TaxonomyVocabulary> taxonomyVocabularies1 =
+			(List<TaxonomyVocabulary>)page1.getItems();
+
+		Assert.assertEquals(
+			taxonomyVocabularies1.toString(), 3, taxonomyVocabularies1.size());
+
+		Page<TaxonomyVocabulary> page2 =
+			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+				siteId, null, null, null, Pagination.of(2, 3), null);
+
+		Assert.assertEquals(6, page2.getTotalCount());
+
+		List<TaxonomyVocabulary> taxonomyVocabularies2 =
+			(List<TaxonomyVocabulary>)page2.getItems();
+
+		Assert.assertEquals(
+			taxonomyVocabularies2.toString(), 3, taxonomyVocabularies2.size());
+
+		Page<TaxonomyVocabulary> page3 =
+			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+				siteId, null, null, null, Pagination.of(2, 3), null);
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(
+				taxonomyVocabulary1, taxonomyVocabulary2, taxonomyVocabulary3),
+			(List<TaxonomyVocabulary>)page3.getItems());
+	}
+
+	@Override
+	@Test
 	public void testGetSiteTaxonomyVocabulariesPageWithSortString()
 		throws Exception {
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -210,6 +210,48 @@ public class TaxonomyVocabularyResourceTest
 
 	@Override
 	@Test
+	public void testGetAssetLibraryTaxonomyVocabulariesPageWithPagination()
+		throws Exception {
+
+		Long assetLibraryId =
+			testGetAssetLibraryTaxonomyVocabulariesPage_getAssetLibraryId();
+
+		TaxonomyVocabulary taxonomyVocabulary1 =
+			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				assetLibraryId, randomTaxonomyVocabulary());
+
+		TaxonomyVocabulary taxonomyVocabulary2 =
+			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				assetLibraryId, randomTaxonomyVocabulary());
+
+		TaxonomyVocabulary taxonomyVocabulary3 =
+			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				assetLibraryId, randomTaxonomyVocabulary());
+
+		Page<TaxonomyVocabulary> page1 =
+			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
+				assetLibraryId, null, null, null, Pagination.of(1, 3), null);
+
+		List<TaxonomyVocabulary> taxonomyVocabularies1 =
+			(List<TaxonomyVocabulary>)page1.getItems();
+
+		Assert.assertEquals(
+			taxonomyVocabularies1.toString(), 3, taxonomyVocabularies1.size());
+
+		Assert.assertEquals(6, page1.getTotalCount());
+
+		Page<TaxonomyVocabulary> page2 =
+			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
+				assetLibraryId, null, null, null, Pagination.of(2, 3), null);
+
+		assertEqualsIgnoringOrder(
+			Arrays.asList(
+				taxonomyVocabulary1, taxonomyVocabulary2, taxonomyVocabulary3),
+			(List<TaxonomyVocabulary>)page2.getItems());
+	}
+
+	@Override
+	@Test
 	public void testGetAssetLibraryTaxonomyVocabularyByExternalReferenceCode()
 		throws Exception {
 

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -20,8 +20,11 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.odata.entity.EntityField;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
@@ -39,8 +42,6 @@ public class TaxonomyVocabularyResourceTest
 	@Test
 	public void testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode()
 		throws Exception {
-
-		super.testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode();
 
 		testDeleteAssetLibraryTaxonomyVocabularyByExternalReferenceCode_addTaxonomyVocabulary();
 
@@ -71,19 +72,61 @@ public class TaxonomyVocabularyResourceTest
 	@Override
 	@Test
 	public void testGetAssetLibraryTaxonomyVocabulariesPage() throws Exception {
-		super.testGetAssetLibraryTaxonomyVocabulariesPage();
+		Long assetLibraryId =
+			testGetAssetLibraryTaxonomyVocabulariesPage_getAssetLibraryId();
 
-		TaxonomyVocabulary taxonomyVocabulary =
+		Page<TaxonomyVocabulary> page =
+			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
+				assetLibraryId, null, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(3, page.getTotalCount());
+
+		TaxonomyVocabulary taxonomyVocabulary1 =
+			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				assetLibraryId, randomTaxonomyVocabulary());
+
+		TaxonomyVocabulary taxonomyVocabulary2 =
+			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				assetLibraryId, randomTaxonomyVocabulary());
+
+		List<TaxonomyVocabulary> expectedTaxonomyVocabularies =
+			new ArrayList<>();
+
+		expectedTaxonomyVocabularies.add(taxonomyVocabulary1);
+		expectedTaxonomyVocabularies.add(taxonomyVocabulary2);
+		expectedTaxonomyVocabularies.addAll(page.getItems());
+
+		page =
+			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
+				assetLibraryId, null, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(5, page.getTotalCount());
+
+		assertEqualsIgnoringOrder(
+			expectedTaxonomyVocabularies,
+			(List<TaxonomyVocabulary>)page.getItems());
+		assertValid(
+			page,
+			testGetAssetLibraryTaxonomyVocabulariesPage_getExpectedActions(
+				assetLibraryId));
+
+		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
+			taxonomyVocabulary1.getId());
+
+		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
+			taxonomyVocabulary2.getId());
+
+		TaxonomyVocabulary taxonomyVocabulary3 =
 			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
 				testGetAssetLibraryTaxonomyVocabulariesPage_getAssetLibraryId(),
 				randomTaxonomyVocabulary());
 
-		Page<TaxonomyVocabulary> page =
+		page =
 			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
 				testGetAssetLibraryTaxonomyVocabulariesPage_getAssetLibraryId(),
 				null, null, null, Pagination.of(1, 10), null);
 
-		Assert.assertEquals(1, page.getTotalCount());
+		Assert.assertEquals(4, page.getTotalCount());
 
 		assertValid(
 			page,
@@ -143,9 +186,13 @@ public class TaxonomyVocabularyResourceTest
 					"id,numberOfTaxonomyCategories"
 		).build();
 
+		List<EntityField> entityFields = getEntityFields(
+			EntityField.Type.STRING);
+
 		page =
 			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
-				testDepotEntry.getDepotEntryId(), null, null, null,
+				testDepotEntry.getDepotEntryId(), null, null,
+				getFilterString(entityFields.get(0), "eq", taxonomyVocabulary3),
 				Pagination.of(1, 10), null);
 
 		Assert.assertEquals(1, page.getTotalCount());
@@ -153,7 +200,7 @@ public class TaxonomyVocabularyResourceTest
 		assertEquals(
 			new TaxonomyVocabulary() {
 				{
-					name = taxonomyVocabulary.getName();
+					name = taxonomyVocabulary3.getName();
 				}
 			},
 			page.fetchFirstItem());

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -309,18 +309,57 @@ public class TaxonomyVocabularyResourceTest
 	@Override
 	@Test
 	public void testGetSiteTaxonomyVocabulariesPage() throws Exception {
-		super.testGetSiteTaxonomyVocabulariesPage();
+		Long siteId = testGetSiteTaxonomyVocabulariesPage_getSiteId();
+
+		Page<TaxonomyVocabulary> page =
+			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+				siteId, null, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(3, page.getTotalCount());
+
+		TaxonomyVocabulary taxonomyVocabulary1 =
+			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				siteId, randomTaxonomyVocabulary());
+
+		TaxonomyVocabulary taxonomyVocabulary2 =
+			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				siteId, randomTaxonomyVocabulary());
+
+		List<TaxonomyVocabulary> expectedTaxonomyVocabularies =
+			new ArrayList<>();
+
+		expectedTaxonomyVocabularies.add(taxonomyVocabulary1);
+		expectedTaxonomyVocabularies.add(taxonomyVocabulary2);
+		expectedTaxonomyVocabularies.addAll(page.getItems());
+
+		page = taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+			siteId, null, null, null, Pagination.of(1, 10), null);
+
+		Assert.assertEquals(5, page.getTotalCount());
+
+		assertEqualsIgnoringOrder(
+			expectedTaxonomyVocabularies,
+			(List<TaxonomyVocabulary>)page.getItems());
+
+		assertValid(
+			page,
+			testGetSiteTaxonomyVocabulariesPage_getExpectedActions(siteId));
+
+		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
+			taxonomyVocabulary1.getId());
+
+		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
+			taxonomyVocabulary2.getId());
 
 		testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
 			testGetSiteTaxonomyVocabulariesPage_getSiteId(),
 			randomTaxonomyVocabulary());
 
-		Page<TaxonomyVocabulary> page =
-			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-				testGetSiteTaxonomyVocabulariesPage_getSiteId(), null, null,
-				null, Pagination.of(1, 10), null);
+		page = taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+			testGetSiteTaxonomyVocabulariesPage_getSiteId(), null, null, null,
+			Pagination.of(1, 10), null);
 
-		Assert.assertEquals(1, page.getTotalCount());
+		Assert.assertEquals(4, page.getTotalCount());
 
 		assertValid(
 			page,

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -404,24 +404,68 @@ public class TaxonomyVocabularyResourceTest
 	@Override
 	@Test
 	public void testGraphQLGetSiteTaxonomyVocabulariesPage() throws Exception {
-		super.testGraphQLGetSiteTaxonomyVocabulariesPage();
+		Long siteId = testGetSiteTaxonomyVocabulariesPage_getSiteId();
+
+		GraphQLField graphQLField = new GraphQLField(
+			"taxonomyVocabularies",
+			HashMapBuilder.<String, Object>put(
+				"page", 1
+			).put(
+				"pageSize", 10
+			).put(
+				"siteKey", "\"" + siteId + "\""
+			).build(),
+			new GraphQLField("items", getGraphQLFields()),
+			new GraphQLField("page"), new GraphQLField("totalCount"));
+
+		JSONObject taxonomyVocabulariesJSONObject =
+			JSONUtil.getValueAsJSONObject(
+				invokeGraphQLQuery(graphQLField), "JSONObject/data",
+				"JSONObject/taxonomyVocabularies");
+
+		Assert.assertEquals(
+			3, taxonomyVocabulariesJSONObject.get("totalCount"));
 
 		Page<TaxonomyVocabulary> page =
 			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-				testGroup.getGroupId(), null, null, null, Pagination.of(1, 10),
-				null);
-
-		for (TaxonomyVocabulary taxonomyVocabulary : page.getItems()) {
-			taxonomyVocabularyResource.deleteTaxonomyVocabulary(
-				taxonomyVocabulary.getId());
-		}
+				siteId, null, null, null, Pagination.of(1, 10), null);
 
 		TaxonomyVocabulary taxonomyVocabulary1 =
 			testGraphQLGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary();
 		TaxonomyVocabulary taxonomyVocabulary2 =
 			testGraphQLGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary();
 
-		GraphQLField graphQLField = new GraphQLField(
+		taxonomyVocabulariesJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(graphQLField), "JSONObject/data",
+			"JSONObject/taxonomyVocabularies");
+
+		Assert.assertEquals(
+			5, taxonomyVocabulariesJSONObject.getLong("totalCount"));
+
+		List<TaxonomyVocabulary> expectedTaxonomyVocabularies =
+			new ArrayList<>();
+
+		expectedTaxonomyVocabularies.add(taxonomyVocabulary1);
+		expectedTaxonomyVocabularies.add(taxonomyVocabulary2);
+		expectedTaxonomyVocabularies.addAll(page.getItems());
+
+		assertEqualsIgnoringOrder(
+			expectedTaxonomyVocabularies,
+			Arrays.asList(
+				TaxonomyVocabularySerDes.toDTOs(
+					taxonomyVocabulariesJSONObject.getString("items"))));
+
+		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
+			taxonomyVocabulary1.getId());
+		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
+			taxonomyVocabulary2.getId());
+
+		taxonomyVocabulary1 =
+			testGraphQLGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary();
+		taxonomyVocabulary2 =
+			testGraphQLGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary();
+
+		graphQLField = new GraphQLField(
 			"taxonomyVocabularies",
 			HashMapBuilder.<String, Object>put(
 				"aggregation", "[\"id\"]"
@@ -437,13 +481,12 @@ public class TaxonomyVocabularyResourceTest
 			new GraphQLField("items", getGraphQLFields()),
 			new GraphQLField("totalCount"));
 
-		JSONObject taxonomyVocabulariesJSONObject =
-			JSONUtil.getValueAsJSONObject(
-				invokeGraphQLQuery(graphQLField), "JSONObject/data",
-				"JSONObject/taxonomyVocabularies");
+		taxonomyVocabulariesJSONObject = JSONUtil.getValueAsJSONObject(
+			invokeGraphQLQuery(graphQLField), "JSONObject/data",
+			"JSONObject/taxonomyVocabularies");
 
 		Assert.assertEquals(
-			2, taxonomyVocabulariesJSONObject.getLong("totalCount"));
+			5, taxonomyVocabulariesJSONObject.getLong("totalCount"));
 		Assert.assertEquals(
 			"id",
 			taxonomyVocabulariesJSONObject.getJSONArray(
@@ -476,7 +519,7 @@ public class TaxonomyVocabularyResourceTest
 				).getJSONArray(
 					"facetValues"
 				).getJSONObject(
-					0
+					3
 				).getString(
 					"term"
 				)));
@@ -503,13 +546,19 @@ public class TaxonomyVocabularyResourceTest
 				).getJSONArray(
 					"facetValues"
 				).getJSONObject(
-					1
+					4
 				).getString(
 					"term"
 				)));
 
+		expectedTaxonomyVocabularies = new ArrayList<>();
+
+		expectedTaxonomyVocabularies.add(taxonomyVocabulary1);
+		expectedTaxonomyVocabularies.add(taxonomyVocabulary2);
+		expectedTaxonomyVocabularies.addAll(page.getItems());
+
 		assertEqualsIgnoringOrder(
-			Arrays.asList(taxonomyVocabulary1, taxonomyVocabulary2),
+			expectedTaxonomyVocabularies,
 			Arrays.asList(
 				TaxonomyVocabularySerDes.toDTOs(
 					taxonomyVocabulariesJSONObject.getString("items"))));

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -17,11 +17,15 @@ import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
+import com.liferay.portal.test.rule.Inject;
 
 import java.lang.reflect.Method;
 
@@ -32,6 +36,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -41,6 +46,37 @@ import org.junit.runner.RunWith;
 @RunWith(Arquillian.class)
 public class TaxonomyVocabularyResourceTest
 	extends BaseTaxonomyVocabularyResourceTestCase {
+
+	@BeforeClass
+	public static void setUpClass() throws Exception {
+		_company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		TaxonomyVocabularyResource.Builder builder =
+			TaxonomyVocabularyResource.builder();
+
+		TaxonomyVocabularyResource taxonomyVocabularyResource =
+			builder.authentication(
+				"test@liferay.com", "test"
+			).locale(
+				LocaleUtil.getDefault()
+			).build();
+
+		Page<TaxonomyVocabulary> page =
+			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+				_company.getGroupId(), null, null, null, Pagination.of(1, 100),
+				null);
+
+		_globalTaxonomyVocabularies = (List<TaxonomyVocabulary>)page.getItems();
+
+		_globalTaxonomyVocabulariesTotalCount = page.getTotalCount();
+
+		_pageSize = Math.toIntExact(_globalTaxonomyVocabulariesTotalCount);
+
+		if (_pageSize == 0) {
+			_pageSize = 3;
+		}
+	}
 
 	@Override
 	@Test
@@ -81,44 +117,47 @@ public class TaxonomyVocabularyResourceTest
 
 		Page<TaxonomyVocabulary> page =
 			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
-				assetLibraryId, null, null, null, Pagination.of(1, 10), null);
+				assetLibraryId, null, null, null, Pagination.of(1, _pageSize),
+				null);
 
-		Assert.assertEquals(3, page.getTotalCount());
+		Assert.assertEquals(
+			_globalTaxonomyVocabulariesTotalCount, page.getTotalCount());
 
-		TaxonomyVocabulary taxonomyVocabulary1 =
-			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
-				assetLibraryId, randomTaxonomyVocabulary());
+		List<TaxonomyVocabulary> taxonomyVocabularies = new ArrayList<>();
 
-		TaxonomyVocabulary taxonomyVocabulary2 =
-			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
-				assetLibraryId, randomTaxonomyVocabulary());
-
-		List<TaxonomyVocabulary> expectedTaxonomyVocabularies =
-			new ArrayList<>();
-
-		expectedTaxonomyVocabularies.add(taxonomyVocabulary1);
-		expectedTaxonomyVocabularies.add(taxonomyVocabulary2);
-		expectedTaxonomyVocabularies.addAll(page.getItems());
+		for (int i = 0; i < _pageSize; i++) {
+			taxonomyVocabularies.add(
+				testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+					assetLibraryId, randomTaxonomyVocabulary()));
+		}
 
 		page =
 			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
-				assetLibraryId, null, null, null, Pagination.of(1, 10), null);
+				assetLibraryId, null, null, null,
+				Pagination.of(1, _pageSize * 2), null);
 
-		Assert.assertEquals(5, page.getTotalCount());
+		Assert.assertEquals(
+			_globalTaxonomyVocabulariesTotalCount + _pageSize,
+			page.getTotalCount());
+
+		List<TaxonomyVocabulary> expectedTaxonomyVocabularies = new ArrayList<>(
+			taxonomyVocabularies);
+
+		expectedTaxonomyVocabularies.addAll(_globalTaxonomyVocabularies);
 
 		assertEqualsIgnoringOrder(
 			expectedTaxonomyVocabularies,
 			(List<TaxonomyVocabulary>)page.getItems());
+
 		assertValid(
 			page,
 			testGetAssetLibraryTaxonomyVocabulariesPage_getExpectedActions(
 				assetLibraryId));
 
-		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
-			taxonomyVocabulary1.getId());
-
-		taxonomyVocabularyResource.deleteTaxonomyVocabulary(
-			taxonomyVocabulary2.getId());
+		for (TaxonomyVocabulary taxonomyVocabulary : taxonomyVocabularies) {
+			taxonomyVocabularyResource.deleteTaxonomyVocabulary(
+				taxonomyVocabulary.getId());
+		}
 
 		TaxonomyVocabulary taxonomyVocabulary3 =
 			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
@@ -128,9 +167,10 @@ public class TaxonomyVocabularyResourceTest
 		page =
 			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
 				testGetAssetLibraryTaxonomyVocabulariesPage_getAssetLibraryId(),
-				null, null, null, Pagination.of(1, 10), null);
+				null, null, null, Pagination.of(1, _pageSize + 1), null);
 
-		Assert.assertEquals(4, page.getTotalCount());
+		Assert.assertEquals(
+			_globalTaxonomyVocabulariesTotalCount + 1, page.getTotalCount());
 
 		assertValid(
 			page,
@@ -220,37 +260,38 @@ public class TaxonomyVocabularyResourceTest
 		Long assetLibraryId =
 			testGetAssetLibraryTaxonomyVocabulariesPage_getAssetLibraryId();
 
-		TaxonomyVocabulary taxonomyVocabulary1 =
-			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
-				assetLibraryId, randomTaxonomyVocabulary());
+		List<TaxonomyVocabulary> expectedTaxonomyVocabularies =
+			new ArrayList<>();
 
-		TaxonomyVocabulary taxonomyVocabulary2 =
-			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
-				assetLibraryId, randomTaxonomyVocabulary());
-
-		TaxonomyVocabulary taxonomyVocabulary3 =
-			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
-				assetLibraryId, randomTaxonomyVocabulary());
+		for (int i = 0; i < _pageSize; i++) {
+			expectedTaxonomyVocabularies.add(
+				testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+					assetLibraryId, randomTaxonomyVocabulary()));
+		}
 
 		Page<TaxonomyVocabulary> page1 =
 			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
-				assetLibraryId, null, null, null, Pagination.of(1, 3), null);
+				assetLibraryId, null, null, null, Pagination.of(1, _pageSize),
+				null);
 
 		List<TaxonomyVocabulary> taxonomyVocabularies1 =
 			(List<TaxonomyVocabulary>)page1.getItems();
 
 		Assert.assertEquals(
-			taxonomyVocabularies1.toString(), 3, taxonomyVocabularies1.size());
+			taxonomyVocabularies1.toString(), _pageSize,
+			taxonomyVocabularies1.size());
 
-		Assert.assertEquals(6, page1.getTotalCount());
+		Assert.assertEquals(
+			_globalTaxonomyVocabulariesTotalCount + _pageSize,
+			page1.getTotalCount());
 
 		Page<TaxonomyVocabulary> page2 =
 			taxonomyVocabularyResource.getAssetLibraryTaxonomyVocabulariesPage(
-				assetLibraryId, null, null, null, Pagination.of(2, 3), null);
+				assetLibraryId, null, null, null, Pagination.of(2, _pageSize),
+				null);
 
 		assertEqualsIgnoringOrder(
-			Arrays.asList(
-				taxonomyVocabulary1, taxonomyVocabulary2, taxonomyVocabulary3),
+			expectedTaxonomyVocabularies,
 			(List<TaxonomyVocabulary>)page2.getItems());
 	}
 
@@ -313,9 +354,10 @@ public class TaxonomyVocabularyResourceTest
 
 		Page<TaxonomyVocabulary> page =
 			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-				siteId, null, null, null, Pagination.of(1, 10), null);
+				siteId, null, null, null, Pagination.of(1, _pageSize), null);
 
-		Assert.assertEquals(3, page.getTotalCount());
+		Assert.assertEquals(
+			_globalTaxonomyVocabulariesTotalCount, page.getTotalCount());
 
 		TaxonomyVocabulary taxonomyVocabulary1 =
 			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
@@ -328,14 +370,15 @@ public class TaxonomyVocabularyResourceTest
 		List<TaxonomyVocabulary> expectedTaxonomyVocabularies =
 			new ArrayList<>();
 
+		expectedTaxonomyVocabularies.addAll(_globalTaxonomyVocabularies);
 		expectedTaxonomyVocabularies.add(taxonomyVocabulary1);
 		expectedTaxonomyVocabularies.add(taxonomyVocabulary2);
-		expectedTaxonomyVocabularies.addAll(page.getItems());
 
 		page = taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-			siteId, null, null, null, Pagination.of(1, 10), null);
+			siteId, null, null, null, Pagination.of(1, _pageSize + 2), null);
 
-		Assert.assertEquals(5, page.getTotalCount());
+		Assert.assertEquals(
+			_globalTaxonomyVocabulariesTotalCount + 2, page.getTotalCount());
 
 		assertEqualsIgnoringOrder(
 			expectedTaxonomyVocabularies,
@@ -357,9 +400,10 @@ public class TaxonomyVocabularyResourceTest
 
 		page = taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
 			testGetSiteTaxonomyVocabulariesPage_getSiteId(), null, null, null,
-			Pagination.of(1, 10), null);
+			Pagination.of(1, _pageSize + 1), null);
 
-		Assert.assertEquals(4, page.getTotalCount());
+		Assert.assertEquals(
+			_globalTaxonomyVocabulariesTotalCount + 1, page.getTotalCount());
 
 		assertValid(
 			page,
@@ -415,48 +459,44 @@ public class TaxonomyVocabularyResourceTest
 
 		Long siteId = testGetSiteTaxonomyVocabulariesPage_getSiteId();
 
-		TaxonomyVocabulary taxonomyVocabulary1 =
-			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
-				siteId, randomTaxonomyVocabulary());
+		List<TaxonomyVocabulary> expectedTaxonomyVocabularies =
+			new ArrayList<>();
 
-		TaxonomyVocabulary taxonomyVocabulary2 =
-			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
-				siteId, randomTaxonomyVocabulary());
-
-		TaxonomyVocabulary taxonomyVocabulary3 =
-			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
-				siteId, randomTaxonomyVocabulary());
+		for (int i = 0; i < _pageSize; i++) {
+			expectedTaxonomyVocabularies.add(
+				testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+					siteId, randomTaxonomyVocabulary()));
+		}
 
 		Page<TaxonomyVocabulary> page1 =
 			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-				siteId, null, null, null, Pagination.of(1, 3), null);
+				siteId, null, null, null, Pagination.of(1, _pageSize), null);
 
 		List<TaxonomyVocabulary> taxonomyVocabularies1 =
 			(List<TaxonomyVocabulary>)page1.getItems();
 
 		Assert.assertEquals(
-			taxonomyVocabularies1.toString(), 3, taxonomyVocabularies1.size());
+			taxonomyVocabularies1.toString(), _pageSize,
+			taxonomyVocabularies1.size());
 
 		Page<TaxonomyVocabulary> page2 =
 			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-				siteId, null, null, null, Pagination.of(2, 3), null);
+				siteId, null, null, null, Pagination.of(2, _pageSize), null);
 
-		Assert.assertEquals(6, page2.getTotalCount());
+		Assert.assertEquals(
+			_globalTaxonomyVocabulariesTotalCount + _pageSize,
+			page2.getTotalCount());
 
 		List<TaxonomyVocabulary> taxonomyVocabularies2 =
 			(List<TaxonomyVocabulary>)page2.getItems();
 
 		Assert.assertEquals(
-			taxonomyVocabularies2.toString(), 3, taxonomyVocabularies2.size());
-
-		Page<TaxonomyVocabulary> page3 =
-			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-				siteId, null, null, null, Pagination.of(2, 3), null);
+			taxonomyVocabularies2.toString(), _pageSize,
+			taxonomyVocabularies2.size());
 
 		assertEqualsIgnoringOrder(
-			Arrays.asList(
-				taxonomyVocabulary1, taxonomyVocabulary2, taxonomyVocabulary3),
-			(List<TaxonomyVocabulary>)page3.getItems());
+			expectedTaxonomyVocabularies,
+			(List<TaxonomyVocabulary>)page2.getItems());
 	}
 
 	@Override
@@ -540,16 +580,15 @@ public class TaxonomyVocabularyResourceTest
 	@Override
 	@Test
 	public void testGraphQLGetSiteTaxonomyVocabulariesPage() throws Exception {
-		Long siteId = testGetSiteTaxonomyVocabulariesPage_getSiteId();
-
 		GraphQLField graphQLField = new GraphQLField(
 			"taxonomyVocabularies",
 			HashMapBuilder.<String, Object>put(
 				"page", 1
 			).put(
-				"pageSize", 10
+				"pageSize", _pageSize + 2
 			).put(
-				"siteKey", "\"" + siteId + "\""
+				"siteKey",
+				"\"" + testGetSiteTaxonomyVocabulariesPage_getSiteId() + "\""
 			).build(),
 			new GraphQLField("items", getGraphQLFields()),
 			new GraphQLField("page"), new GraphQLField("totalCount"));
@@ -560,11 +599,8 @@ public class TaxonomyVocabularyResourceTest
 				"JSONObject/taxonomyVocabularies");
 
 		Assert.assertEquals(
-			3, taxonomyVocabulariesJSONObject.get("totalCount"));
-
-		Page<TaxonomyVocabulary> page =
-			taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
-				siteId, null, null, null, Pagination.of(1, 10), null);
+			Math.toIntExact(_globalTaxonomyVocabulariesTotalCount),
+			taxonomyVocabulariesJSONObject.get("totalCount"));
 
 		TaxonomyVocabulary taxonomyVocabulary1 =
 			testGraphQLGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary();
@@ -576,14 +612,15 @@ public class TaxonomyVocabularyResourceTest
 			"JSONObject/taxonomyVocabularies");
 
 		Assert.assertEquals(
-			5, taxonomyVocabulariesJSONObject.getLong("totalCount"));
+			_globalTaxonomyVocabulariesTotalCount + 2,
+			taxonomyVocabulariesJSONObject.getLong("totalCount"));
 
 		List<TaxonomyVocabulary> expectedTaxonomyVocabularies =
 			new ArrayList<>();
 
+		expectedTaxonomyVocabularies.addAll(_globalTaxonomyVocabularies);
 		expectedTaxonomyVocabularies.add(taxonomyVocabulary1);
 		expectedTaxonomyVocabularies.add(taxonomyVocabulary2);
-		expectedTaxonomyVocabularies.addAll(page.getItems());
 
 		assertEqualsIgnoringOrder(
 			expectedTaxonomyVocabularies,
@@ -622,7 +659,8 @@ public class TaxonomyVocabularyResourceTest
 			"JSONObject/taxonomyVocabularies");
 
 		Assert.assertEquals(
-			5, taxonomyVocabulariesJSONObject.getLong("totalCount"));
+			_globalTaxonomyVocabulariesTotalCount + 2,
+			taxonomyVocabulariesJSONObject.getLong("totalCount"));
 		Assert.assertEquals(
 			"id",
 			taxonomyVocabulariesJSONObject.getJSONArray(
@@ -645,6 +683,10 @@ public class TaxonomyVocabularyResourceTest
 			).getInt(
 				"numberOfOccurrences"
 			));
+
+		int globalTaxonomyVocabulariesTotalCount = Math.toIntExact(
+			_globalTaxonomyVocabulariesTotalCount);
+
 		Assert.assertEquals(
 			taxonomyVocabulary1.getId(),
 			Long.valueOf(
@@ -655,10 +697,11 @@ public class TaxonomyVocabularyResourceTest
 				).getJSONArray(
 					"facetValues"
 				).getJSONObject(
-					3
+					globalTaxonomyVocabulariesTotalCount
 				).getString(
 					"term"
 				)));
+
 		Assert.assertEquals(
 			1,
 			taxonomyVocabulariesJSONObject.getJSONArray(
@@ -682,16 +725,16 @@ public class TaxonomyVocabularyResourceTest
 				).getJSONArray(
 					"facetValues"
 				).getJSONObject(
-					4
+					globalTaxonomyVocabulariesTotalCount + 1
 				).getString(
 					"term"
 				)));
 
 		expectedTaxonomyVocabularies = new ArrayList<>();
 
+		expectedTaxonomyVocabularies.addAll(_globalTaxonomyVocabularies);
 		expectedTaxonomyVocabularies.add(taxonomyVocabulary1);
 		expectedTaxonomyVocabularies.add(taxonomyVocabulary2);
-		expectedTaxonomyVocabularies.addAll(page.getItems());
 
 		assertEqualsIgnoringOrder(
 			expectedTaxonomyVocabularies,
@@ -987,5 +1030,14 @@ public class TaxonomyVocabularyResourceTest
 				(List<TaxonomyVocabulary>)descPage.getItems());
 		}
 	}
+
+	private static Company _company;
+
+	@Inject
+	private static CompanyLocalService _companyLocalService;
+
+	private static List<TaxonomyVocabulary> _globalTaxonomyVocabularies;
+	private static long _globalTaxonomyVocabulariesTotalCount;
+	private static int _pageSize;
 
 }

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -13,6 +13,7 @@ import com.liferay.headless.admin.taxonomy.client.pagination.Pagination;
 import com.liferay.headless.admin.taxonomy.client.problem.Problem;
 import com.liferay.headless.admin.taxonomy.client.resource.v1_0.TaxonomyVocabularyResource;
 import com.liferay.headless.admin.taxonomy.client.serdes.v1_0.TaxonomyVocabularySerDes;
+import com.liferay.petra.function.UnsafeTriConsumer;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -22,8 +23,11 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.odata.entity.EntityField;
 
+import java.lang.reflect.Method;
+
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -346,6 +350,65 @@ public class TaxonomyVocabularyResourceTest
 
 	@Override
 	@Test
+	public void testGetSiteTaxonomyVocabulariesPageWithSortString()
+		throws Exception {
+
+		testGetSiteTaxonomyVocabulariesPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, taxonomyVocabulary1, taxonomyVocabulary2) -> {
+				Class<?> clazz = taxonomyVocabulary1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				Class<?> returnType = method.getReturnType();
+
+				if (returnType.isAssignableFrom(Map.class)) {
+					BeanTestUtil.setProperty(
+						taxonomyVocabulary1, entityFieldName,
+						Collections.singletonMap("Aaa", "Aaa"));
+					BeanTestUtil.setProperty(
+						taxonomyVocabulary2, entityFieldName,
+						Collections.singletonMap("Bbb", "Bbb"));
+				}
+				else if (entityFieldName.contains("email")) {
+					BeanTestUtil.setProperty(
+						taxonomyVocabulary1, entityFieldName,
+						StringBundler.concat(
+							"aaa",
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()),
+							"@liferay.com"));
+					BeanTestUtil.setProperty(
+						taxonomyVocabulary2, entityFieldName,
+						StringBundler.concat(
+							"bbb",
+							StringUtil.toLowerCase(
+								RandomTestUtil.randomString()),
+							"@liferay.com"));
+				}
+				else {
+					String randomString1 = StringUtil.toLowerCase(
+						RandomTestUtil.randomString());
+
+					BeanTestUtil.setProperty(
+						taxonomyVocabulary1, entityFieldName,
+						"aaa" + randomString1);
+
+					String randomString2 = StringUtil.toLowerCase(
+						RandomTestUtil.randomString());
+
+					BeanTestUtil.setProperty(
+						taxonomyVocabulary2, entityFieldName,
+						"bbb" + randomString2);
+				}
+			});
+	}
+
+	@Override
+	@Test
 	public void testGetTaxonomyVocabulary() throws Exception {
 		super.testGetTaxonomyVocabulary();
 
@@ -653,6 +716,69 @@ public class TaxonomyVocabularyResourceTest
 		throws Exception {
 
 		return testDepotEntry.getDepotEntryId();
+	}
+
+	@Override
+	protected void testGetSiteTaxonomyVocabulariesPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer
+				<EntityField, TaxonomyVocabulary, TaxonomyVocabulary, Exception>
+					unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long siteId = testGetSiteTaxonomyVocabulariesPage_getSiteId();
+
+		TaxonomyVocabulary taxonomyVocabulary1 = randomTaxonomyVocabulary();
+		TaxonomyVocabulary taxonomyVocabulary2 = randomTaxonomyVocabulary();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(
+				entityField, taxonomyVocabulary1, taxonomyVocabulary2);
+		}
+
+		taxonomyVocabulary1 =
+			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				siteId, taxonomyVocabulary1);
+
+		taxonomyVocabulary2 =
+			testGetSiteTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				siteId, taxonomyVocabulary2);
+
+		for (EntityField entityField : entityFields) {
+			Page<TaxonomyVocabulary> ascPage =
+				taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+					siteId, null, null,
+					StringBundler.concat(
+						getFilterString(entityField, "eq", taxonomyVocabulary1),
+						" or ",
+						getFilterString(
+							entityField, "eq", taxonomyVocabulary2)),
+					Pagination.of(1, 2), entityField.getName() + ":asc");
+
+			assertEquals(
+				Arrays.asList(taxonomyVocabulary1, taxonomyVocabulary2),
+				(List<TaxonomyVocabulary>)ascPage.getItems());
+
+			Page<TaxonomyVocabulary> descPage =
+				taxonomyVocabularyResource.getSiteTaxonomyVocabulariesPage(
+					siteId, null, null,
+					StringBundler.concat(
+						getFilterString(entityField, "eq", taxonomyVocabulary1),
+						" or ",
+						getFilterString(
+							entityField, "eq", taxonomyVocabulary2)),
+					Pagination.of(1, 2), entityField.getName() + ":desc");
+
+			assertEquals(
+				Arrays.asList(taxonomyVocabulary2, taxonomyVocabulary1),
+				(List<TaxonomyVocabulary>)descPage.getItems());
+		}
 	}
 
 	@Override

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-test/src/testIntegration/java/com/liferay/headless/admin/taxonomy/resource/v1_0/test/TaxonomyVocabularyResourceTest.java
@@ -256,6 +256,27 @@ public class TaxonomyVocabularyResourceTest
 
 	@Override
 	@Test
+	public void testGetAssetLibraryTaxonomyVocabulariesPageWithSortString()
+		throws Exception {
+
+		_testAssetLibrarySiteTaxonomyVocabulariesPageWithSort(
+			EntityField.Type.STRING,
+			(entityField, taxonomyVocabulary1, taxonomyVocabulary2) -> {
+				Class<?> clazz = taxonomyVocabulary1.getClass();
+
+				String entityFieldName = entityField.getName();
+
+				Method method = clazz.getMethod(
+					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
+
+				_setEntityFieldNames(
+					taxonomyVocabulary1, taxonomyVocabulary2, entityFieldName,
+					method.getReturnType());
+			});
+	}
+
+	@Override
+	@Test
 	public void testGetAssetLibraryTaxonomyVocabularyByExternalReferenceCode()
 		throws Exception {
 
@@ -363,47 +384,9 @@ public class TaxonomyVocabularyResourceTest
 				Method method = clazz.getMethod(
 					"get" + StringUtil.upperCaseFirstLetter(entityFieldName));
 
-				Class<?> returnType = method.getReturnType();
-
-				if (returnType.isAssignableFrom(Map.class)) {
-					BeanTestUtil.setProperty(
-						taxonomyVocabulary1, entityFieldName,
-						Collections.singletonMap("Aaa", "Aaa"));
-					BeanTestUtil.setProperty(
-						taxonomyVocabulary2, entityFieldName,
-						Collections.singletonMap("Bbb", "Bbb"));
-				}
-				else if (entityFieldName.contains("email")) {
-					BeanTestUtil.setProperty(
-						taxonomyVocabulary1, entityFieldName,
-						StringBundler.concat(
-							"aaa",
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()),
-							"@liferay.com"));
-					BeanTestUtil.setProperty(
-						taxonomyVocabulary2, entityFieldName,
-						StringBundler.concat(
-							"bbb",
-							StringUtil.toLowerCase(
-								RandomTestUtil.randomString()),
-							"@liferay.com"));
-				}
-				else {
-					String randomString1 = StringUtil.toLowerCase(
-						RandomTestUtil.randomString());
-
-					BeanTestUtil.setProperty(
-						taxonomyVocabulary1, entityFieldName,
-						"aaa" + randomString1);
-
-					String randomString2 = StringUtil.toLowerCase(
-						RandomTestUtil.randomString());
-
-					BeanTestUtil.setProperty(
-						taxonomyVocabulary2, entityFieldName,
-						"bbb" + randomString2);
-				}
+				_setEntityFieldNames(
+					taxonomyVocabulary1, taxonomyVocabulary2, entityFieldName,
+					method.getReturnType());
 			});
 	}
 
@@ -803,6 +786,116 @@ public class TaxonomyVocabularyResourceTest
 		throws Exception {
 
 		return testDepotEntry.getDepotEntryId();
+	}
+
+	private void _setEntityFieldNames(
+			TaxonomyVocabulary taxonomyVocabulary1,
+			TaxonomyVocabulary taxonomyVocabulary2, String entityFieldName,
+			Class<?> returnType)
+		throws Exception {
+
+		if (returnType.isAssignableFrom(Map.class)) {
+			BeanTestUtil.setProperty(
+				taxonomyVocabulary1, entityFieldName,
+				Collections.singletonMap("Aaa", "Aaa"));
+			BeanTestUtil.setProperty(
+				taxonomyVocabulary2, entityFieldName,
+				Collections.singletonMap("Bbb", "Bbb"));
+		}
+		else if (entityFieldName.contains("email")) {
+			BeanTestUtil.setProperty(
+				taxonomyVocabulary1, entityFieldName,
+				StringBundler.concat(
+					"aaa",
+					StringUtil.toLowerCase(RandomTestUtil.randomString()),
+					"@liferay.com"));
+			BeanTestUtil.setProperty(
+				taxonomyVocabulary2, entityFieldName,
+				StringBundler.concat(
+					"bbb",
+					StringUtil.toLowerCase(RandomTestUtil.randomString()),
+					"@liferay.com"));
+		}
+		else {
+			String randomString1 = StringUtil.toLowerCase(
+				RandomTestUtil.randomString());
+
+			BeanTestUtil.setProperty(
+				taxonomyVocabulary1, entityFieldName, "aaa" + randomString1);
+
+			String randomString2 = StringUtil.toLowerCase(
+				RandomTestUtil.randomString());
+
+			BeanTestUtil.setProperty(
+				taxonomyVocabulary2, entityFieldName, "bbb" + randomString2);
+		}
+	}
+
+	private void _testAssetLibrarySiteTaxonomyVocabulariesPageWithSort(
+			EntityField.Type type,
+			UnsafeTriConsumer
+				<EntityField, TaxonomyVocabulary, TaxonomyVocabulary, Exception>
+					unsafeTriConsumer)
+		throws Exception {
+
+		List<EntityField> entityFields = getEntityFields(type);
+
+		if (entityFields.isEmpty()) {
+			return;
+		}
+
+		Long assetLibraryId =
+			testGetAssetLibraryTaxonomyVocabulariesPage_getAssetLibraryId();
+
+		TaxonomyVocabulary taxonomyVocabulary1 = randomTaxonomyVocabulary();
+		TaxonomyVocabulary taxonomyVocabulary2 = randomTaxonomyVocabulary();
+
+		for (EntityField entityField : entityFields) {
+			unsafeTriConsumer.accept(
+				entityField, taxonomyVocabulary1, taxonomyVocabulary2);
+		}
+
+		taxonomyVocabulary1 =
+			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				assetLibraryId, taxonomyVocabulary1);
+
+		taxonomyVocabulary2 =
+			testGetAssetLibraryTaxonomyVocabulariesPage_addTaxonomyVocabulary(
+				assetLibraryId, taxonomyVocabulary2);
+
+		for (EntityField entityField : entityFields) {
+			Page<TaxonomyVocabulary> ascPage =
+				taxonomyVocabularyResource.
+					getAssetLibraryTaxonomyVocabulariesPage(
+						assetLibraryId, null, null,
+						StringBundler.concat(
+							getFilterString(
+								entityField, "eq", taxonomyVocabulary1),
+							" or ",
+							getFilterString(
+								entityField, "eq", taxonomyVocabulary2)),
+						Pagination.of(1, 2), entityField.getName() + ":asc");
+
+			assertEquals(
+				Arrays.asList(taxonomyVocabulary1, taxonomyVocabulary2),
+				(List<TaxonomyVocabulary>)ascPage.getItems());
+
+			Page<TaxonomyVocabulary> descPage =
+				taxonomyVocabularyResource.
+					getAssetLibraryTaxonomyVocabulariesPage(
+						assetLibraryId, null, null,
+						StringBundler.concat(
+							getFilterString(
+								entityField, "eq", taxonomyVocabulary1),
+							" or ",
+							getFilterString(
+								entityField, "eq", taxonomyVocabulary2)),
+						Pagination.of(1, 2), entityField.getName() + ":desc");
+
+			assertEquals(
+				Arrays.asList(taxonomyVocabulary2, taxonomyVocabulary1),
+				(List<TaxonomyVocabulary>)descPage.getItems());
+		}
 	}
 
 }


### PR DESCRIPTION
Fix related to this comment: https://github.com/brianchandotcom/liferay-portal/pull/142812#issuecomment-1782845245

This is a temporal solution until headless team take into account the global resources in the test generation using buildRest gradle task.

bug: https://liferay.atlassian.net/browse/LPS-197353