### PR TITLE
LPS-200496 Replace AUI() usages in change-tracking-web

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/view_move_changes.jsp
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/view_move_changes.jsp
@@ -68,18 +68,22 @@ renderResponse.setTitle(LanguageUtil.get(request, "move-changes"));
 </clay:container-fluid>
 
 <aui:script use="aui-base">
-	A.one('#<portlet:namespace />toPublication').on('change', (event) => {
-		var selection = A.one('#<portlet:namespace />toPublication').get('value');
+	const toPublicationSelector = document.getElementById(
+		'<portlet:namespace />toPublication'
+	);
 
-		var button = A.one('#<portlet:namespace />submitMove');
+	toPublicationSelector.addEventListener('change', (event) => {
+		const selection = toPublicationSelector.value;
+
+		const button = document.getElementById('<portlet:namespace />submitMove');
 
 		if (selection) {
-			button.removeClass('disabled');
-			button.attr('disabled', false);
+			button.classList.remove('disabled');
+			button.disabled = false;
 		}
 		else {
-			button.addClass('disabled');
-			button.attr('disabled', true);
+			button.classList.add('disabled');
+			button.disabled = true;
 		}
 	});
 </aui:script>


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is removal of AUI code and use native functions instead.
https://liferay.atlassian.net/browse/LPS-200496

Steps to Verify
========
1. Enable LPS-171364 feature flag.
2. Enable Publications by going to Applications Menu -> Publications
3. Create two different publications and go to one of them by clicking on the button on the top of the portal view -> then select a publication
4. In one of the publications make some changes, like adding a paragraph to the Home page view
5. Go to publications like in step 2
6. Click on the publication you made changes on -> Click on the change you've made -> in the change view click on the dropdown button on the right -> Move Changes
7. In the Move Changes view go to the bottom -> in the Publications section select the other publication and see that the Move Changes button is disabled and enabled.