### PR TITLE
[TS] [Urgent] LPS-200518 When upgrading from before U84 to U84+, existing Object Collection Provider configurations become invalid

### DIFF
--- a/modules/apps/layout/layout-page-template-service/bnd.bnd
+++ b/modules/apps/layout/layout-page-template-service/bnd.bnd
@@ -5,6 +5,6 @@ Import-Package:\
 	com.liferay.layout.page.template.util.comparator,\
 	\
 	*
-Liferay-Require-SchemaVersion: 5.3.1
+Liferay-Require-SchemaVersion: 5.4.0
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/registry/LayoutPageTemplateServiceUpgradeStepRegistrator.java
@@ -196,6 +196,11 @@ public class LayoutPageTemplateServiceUpgradeStepRegistrator
 			"5.2.0", "5.3.0", new LayoutPageTemplateCollectionUpgradeProcess());
 
 		registry.register("5.3.0", "5.3.1", new DummyUpgradeProcess());
+
+		registry.register(
+			"5.3.1", "5.4.0",
+			new com.liferay.layout.page.template.internal.upgrade.v5_4_0.
+				LayoutPageTemplateStructureRelUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_4_0/LayoutPageTemplateStructureRelUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_4_0/LayoutPageTemplateStructureRelUpgradeProcess.java
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.page.template.internal.upgrade.v5_4_0;
+
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+
+/**
+ * @author Michael Bowerman
+ */
+public class LayoutPageTemplateStructureRelUpgradeProcess
+	extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		runSQL(
+			StringBundler.concat(
+				"update LayoutPageTemplateStructureRel set data_ =",
+				"REPLACE(data_, '", _OLD_CLASS_NAME, "' , '", _NEW_CLASS_NAME,
+				"') where data_ is not null and data_ != ''"));
+	}
+
+	private static final String _NEW_CLASS_NAME =
+		"com.liferay.object.web.internal.info.collection.provider." +
+			"ObjectEntrySingleFormVariationInfoCollectionProvider";
+
+	private static final String _OLD_CLASS_NAME =
+		"com.liferay.object.internal.info.collection.provider." +
+			"ObjectEntrySingleFormVariationInfoCollectionProvider";
+
+}


### PR DESCRIPTION
Motivation
=======
In [LPS-189110](https://liferay.atlassian.net/browse/LPS-189110), we moved the `ObjectEntrySingleFormVariationInfoCollectionProvider` class into a different package. This is problematic because Collection Providers for the Objects portlet reference the fully qualified class names of this class. Unfortunately, there was no upgrade process created to update any references to this class, so any portlet that has been configured to display an Objects Collection Provider became broken after the upgrade.

Ticket: [LPS-200518](https://liferay.atlassian.net/browse/LPS-200518)

Proposed Solution
========
Add an upgrade process to upgrade the references to the fully-qualified class name of the `ObjectEntrySingleFormVariationInfoCollectionProvider` class inside the `LayoutPageTemplateStructureRel` table.

Steps to Verify
========
1. Startup a clean instance of 7.4 U73.
2. Navigate to Control Panel > Objects, and create a new Object definition as follows:
* Name it “Test Object”
* Set its Panel Category Key to Control Panel > Object
* In the Fields tab, create a new field with any name and type.
* Publish the object.
3. Navigate to Control Panel > Objects > Test Objects.
4. Add 2 entries.
5. On the Home page, add a Collection Display fragment.
6. Map the Collection Display to the “Test Object” Collection Provider
7. Verify the table shows the expected entries from the previous steps
8. Shut down the server.
9. Upgrade your bundle to master.
10. Perform a full reindex from Control Panel > Search > Index Actions.
11. Navigate to the home page where the Collection Display was added.

**Expected Result:** The object collection display appears (or at least correctly shows 2 entries).
**Actual Result:** The object collection display does not appear and there is a UI message in its place that just says: ‘No Results Found’.

Note that there is another Objects regression caused by [LPS-195264](https://liferay.atlassian.net/browse/LPS-195264) that also causes the items not to render properly (although the count should at least be correct), at least for certain Display Styles. This bug is not intended to address that regression. It is only intended to ensure that the Collection Display is fetching the correct data, even if it does not actually render it on the page.