### PR TITLE
[TS] LPS-200549

### DIFF
--- a/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/model/listener/UserGroupModelListener.java
+++ b/modules/apps/blogs/blogs-service/src/main/java/com/liferay/blogs/internal/model/listener/UserGroupModelListener.java
@@ -15,9 +15,13 @@ import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.UserGroupLocalService;
+import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.SetUtil;
 
 import java.util.List;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -75,12 +79,41 @@ public class UserGroupModelListener extends BaseModelListener<UserGroup> {
 			long groupId, long userGroupId)
 		throws PortalException {
 
-		for (long userId :
-				_userGroupLocalService.getUserPrimaryKeys(userGroupId)) {
+		Set<Long> userGroupUserIds = SetUtil.fromArray(
+			_userGroupLocalService.getUserPrimaryKeys(userGroupId));
 
-			if (!_groupLocalService.hasUserGroup(userId, groupId)) {
-				_blogsEntryLocalService.unsubscribe(userId, groupId);
+		userGroupUserIds.removeAll(
+			SetUtil.fromArray(_groupLocalService.getUserPrimaryKeys(groupId)));
+
+		long[] organizationIds = _groupLocalService.getOrganizationPrimaryKeys(
+			groupId);
+
+		Group group = _groupLocalService.getGroup(groupId);
+
+		if (group.getOrganizationId() > 0) {
+			organizationIds = ArrayUtil.append(
+				organizationIds, group.getOrganizationId());
+		}
+
+		for (long organizationId : organizationIds) {
+			userGroupUserIds.removeAll(
+				SetUtil.fromArray(
+					_userLocalService.getOrganizationUserIds(organizationId)));
+		}
+
+		for (long userGroupPK :
+				_groupLocalService.getUserGroupPrimaryKeys(groupId)) {
+
+			if (userGroupPK != userGroupId) {
+				userGroupUserIds.removeAll(
+					SetUtil.fromArray(
+						_userGroupLocalService.getUserPrimaryKeys(
+							userGroupPK)));
 			}
+		}
+
+		for (long userId : userGroupUserIds) {
+			_blogsEntryLocalService.unsubscribe(userId, groupId);
 		}
 	}
 
@@ -92,5 +125,8 @@ public class UserGroupModelListener extends BaseModelListener<UserGroup> {
 
 	@Reference
 	private UserGroupLocalService _userGroupLocalService;
+
+	@Reference
+	private UserLocalService _userLocalService;
 
 }


### PR DESCRIPTION
**Motivation**
User Groups with hundreds of thousands of users take a long time to be removed from site membership.  Although some time is necessary, there are un-optimized areas of code, which take roughly 15x times longer than my optimizations.  For large User Groups, this can save several minutes.

**Proposed Solution**
Rather than check each user individually to see if they should be unsubscribed from blogs, we now create a Set of userIds which should be unsubscribed.  This Set initially starts as each user belonging to the removed User Group, but as we determine which user(s) have valid group access (through group/org/user-group membership), we remove these entries from the Set.  **This removes 4 DB transactions per user** in favor of 4 + (number of orgs and User Groups associated to the group) DB transactions total.

So, in the case where we are removing a User Group full of users who are also site members, then we are now performing no DB transactions, resulting in a huge performance boost (~15s -> ~25ms in my testing of 13k users). 

**Steps to verify**
1. Create a User Group with many users (13k in my testing)
2. Assign the User Group to a site.
3. Remove the User Group from the site.

**Testing done** (all User Groups are identical with the same 13k members): 

- 1 User Group assigned to site, 1 User Group being removed → ~15 seconds
- 2 User Groups assigned to site, 1 User Groups being removed → ~15 seconds
- 2 User Groups assigned to site, 2 User Groups being removed → ~30 seconds

**Testing done with proposed solution:**

- 1 User Group assigned to site, 1 User Group being removed → ~1 second
- 2 User Groups assigned to site, 1 User Groups being removed → ~25 ms
- 2 User Groups assigned to site, 2 User Groups being removed → ~1 second

You can either use the StopWatch class for timing data, or set breakpoints in the debugger.  Please let me know if you have any questions, thanks!