### PR TITLE
LPS-200685 Add Site for new child doesn't show the name of the parent

### DIFF
--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SelectSiteInitializerDisplayContext.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SelectSiteInitializerDisplayContext.java
@@ -129,6 +129,9 @@ public class SelectSiteInitializerDisplayContext {
 		).setRedirect(
 			getBackURL()
 		).setParameter(
+			"backURLTitle",
+			ParamUtil.getString(_httpServletRequest, "backURLTitle")
+		).setParameter(
 			"parentGroupId", getParentGroupId()
 		).buildPortletURL();
 	}

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/display/context/SiteAdminManagementToolbarDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
 import com.liferay.portal.kernel.service.permission.PortalPermissionUtil;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -112,6 +113,22 @@ public class SiteAdminManagementToolbarDisplayContext
 							"/site_admin/select_site_initializer"
 						).setRedirect(
 							themeDisplay.getURLCurrent()
+						).setParameter(
+							"backURLTitle",
+							() -> {
+								Group group =
+									_siteAdminDisplayContext.getGroup();
+
+								if (group != null) {
+									return group.getDescriptiveName(
+										themeDisplay.getLocale());
+								}
+
+								PortletDisplay portletDisplay =
+									themeDisplay.getPortletDisplay();
+
+								return portletDisplay.getPortletDisplayName();
+							}
 						).setParameter(
 							"parentGroupId",
 							() -> {

--- a/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/servlet/taglib/util/SiteActionDropdownItemsProvider.java
+++ b/modules/apps/site/site-admin-web/src/main/java/com/liferay/site/admin/web/internal/servlet/taglib/util/SiteActionDropdownItemsProvider.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserGroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -154,11 +155,21 @@ public class SiteActionDropdownItemsProvider {
 	private UnsafeConsumer<DropdownItem, Exception>
 		_getAddChildSiteActionUnsafeConsumer() {
 
+		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
+
 		return dropdownItem -> {
+			String backURLTitle = portletDisplay.getPortletDisplayName();
+
+			if (_group != null) {
+				backURLTitle = _group.getDescriptiveName(
+					_themeDisplay.getLocale());
+			}
+
 			dropdownItem.setHref(
-				_liferayPortletResponse.createRenderURL(),
-				"mvcRenderCommandName", "/site_admin/select_site_initializer",
-				"redirect", _themeDisplay.getURLCurrent(), "parentGroupId",
+				_liferayPortletResponse.createRenderURL(), "backURLTitle",
+				backURLTitle, "mvcRenderCommandName",
+				"/site_admin/select_site_initializer", "redirect",
+				_themeDisplay.getURLCurrent(), "parentGroupId",
 				String.valueOf(_group.getGroupId()));
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "add-child-site"));

--- a/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
+++ b/modules/apps/site/site-admin-web/src/main/resources/META-INF/resources/select_site_initializer.jsp
@@ -12,7 +12,7 @@ SelectSiteInitializerDisplayContext selectSiteInitializerDisplayContext = new Se
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(selectSiteInitializerDisplayContext.getBackURL());
-portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
+portletDisplay.setURLBackTitle(ParamUtil.getString(request, "backURLTitle"));
 
 renderResponse.setTitle(LanguageUtil.get(request, "select-template"));
 %>


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-200685)

## Steps 

1. Go to Control Panel > Sites > Create a site 
2. Create a child site inside the previous site
3. Click blue add button in the child site and see the button with parent label 
<img width="141" alt="Screenshot 2023-11-02 at 18 30 39" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/0ba77e0c-b0e4-4d3d-a22e-c1811a0687f6">
