### PR TITLE
[TS] LPS-200487 Sites are not browsable for Guests in Breadcrumb portlet

### DIFF
--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/util/BreadcrumbUtil.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/util/BreadcrumbUtil.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -307,7 +308,9 @@ public class BreadcrumbUtil {
 			return;
 		}
 
-		if (group.isActive() && _hasViewPermissions(group, themeDisplay)) {
+		if (group.isActive() &&
+			_hasViewPermissions(group, layoutSet, themeDisplay)) {
+
 			String layoutSetFriendlyURL = PortalUtil.getLayoutSetFriendlyURL(
 				layoutSet, themeDisplay);
 
@@ -460,11 +463,16 @@ public class BreadcrumbUtil {
 	}
 
 	private static boolean _hasViewPermissions(
-		Group group, ThemeDisplay themeDisplay) {
+		Group group, LayoutSet layoutSet, ThemeDisplay themeDisplay) {
 
 		try {
 			if (GroupPermissionUtil.contains(
 					themeDisplay.getPermissionChecker(), group,
+					ActionKeys.VIEW) ||
+				LayoutPermissionUtil.contains(
+					themeDisplay.getPermissionChecker(),
+					LayoutLocalServiceUtil.getDefaultPlid(
+						layoutSet.getGroupId(), layoutSet.isPrivateLayout()),
 					ActionKeys.VIEW)) {
 
 				return true;


### PR DESCRIPTION
Motivation
=======
Sites are not browsable for non-admin users in Breadcrumb portlet, even the user has permission to access the group. It occurs when site has Membership type != "Open".
- https://liferay.atlassian.net/browse/LPS-200487
- Previous Pull Request: https://github.com/liferay-echo/liferay-portal/pull/14159
- PTR-4461 helped

Proposed Solution
========
Adding Default Layout permission to current Group check.

Steps to Verify
========
Steps to reproduce:
1. Start Liferay, create a new site “Test”, and select select “private” or “protected” membership for this site.
2. Add a homepage with a breadcrumb portlet (“horizontal” template, default config).
3. Check “Show current Site” is enabled
4. Logout and reload this page with the Guest user

**Current behavior**: Site “Test” does not have href attribute (breadcrumbEntry.isBrowsable() = false)
**Expected behavior**: The link is enabled and can be used since Guest users have access to the homepage of this site.

Alternative Solutions that were discarded
========
1. Replace Layout Permission instead of adding it to current implementation. Check **PTR-4461** for details.
2. Do not consider any kind of permission since current site may be browsable. In this case, the user will click on the breadcrumb and find a missing permission error. 
