### PR TITLE
LPS-200877 Simplify sign in process

### DIFF
--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/js/signInButtonPropsTransformer.js
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/js/signInButtonPropsTransformer.js
@@ -5,104 +5,64 @@
 
 import {addParams, fetch, navigate, openModal} from 'frontend-js-web';
 
-export default function propsTransformer({additionalProps, ...props}) {
-	const {signInURL} = additionalProps;
+async function fetchModalContent(url) {
+	try {
+		const modalSignInURL = addParams('windowState=exclusive', url);
 
-	const signInLink = document.querySelector('.sign-in > div > button');
+		const response = await fetch(modalSignInURL);
+		const responseText = await response.text();
 
-	const modalSignInURL = addParams('windowState=exclusive', signInURL);
-
-	const setModalContent = function (html) {
-		const modalBody = document.querySelector('.liferay-modal-body');
-
-		if (modalBody) {
-			const fragment = document
-				.createRange()
-				.createContextualFragment(html);
-
-			modalBody.innerHTML = '';
-
-			modalBody.appendChild(fragment);
+		return responseText;
+	}
+	catch (error) {
+		if (process.env.NODE_ENV === 'development') {
+			console.error(error);
 		}
-	};
 
-	let loading = false;
-	let html = '';
-	let {redirect} = additionalProps;
-	let modalOpen = false;
+		return '';
+	}
+}
 
-	const fetchModalSignIn = function () {
-		if (loading || html) {
+export default function propsTransformer({
+	additionalProps: {redirect, signInURL},
+	...props
+}) {
+	const onClick = async () => {
+		if (redirect) {
+			navigate(signInURL);
+
 			return;
 		}
 
-		loading = true;
+		const modalContentPromise = fetchModalContent(signInURL);
 
-		fetch(modalSignInURL)
-			.then((response) => {
-				return response.text();
-			})
-			.then((response) => {
-				if (!loading) {
-					return;
+		openModal({
+			bodyHTML: '<span class="loading-animation"></span>',
+			containerProps: {className: ''},
+			onOpen: async () => {
+				const modalBody = document.querySelector('.liferay-modal-body');
+
+				try {
+					const modalContent = await modalContentPromise;
+
+					if (modalBody && modalContent) {
+						modalBody.innerHTML = modalContent;
+					}
+					else {
+						navigate(signInURL);
+					}
 				}
-
-				loading = false;
-
-				if (!response) {
-					redirect = true;
-
-					return;
+				catch (error) {
+					navigate(signInURL);
 				}
-
-				html = response;
-
-				if (modalOpen) {
-					setModalContent(response);
-				}
-			})
-			.catch(() => {
-				redirect = true;
-			});
+			},
+			size: 'md',
+			title: Liferay.Language.get('sign-in'),
+		});
 	};
 
 	return {
 		...props,
-		onClick() {
-			fetchModalSignIn();
-
-			if (redirect) {
-				navigate(signInURL);
-
-				return;
-			}
-
-			if (signInLink) {
-				openModal({
-					bodyHTML: html ? html : '<span class="loading-animation">',
-					containerProps: {
-						className: '',
-					},
-					onClose() {
-						loading = false;
-						redirect = false;
-						html = '';
-						modalOpen = false;
-					},
-					onOpen() {
-						modalOpen = true;
-
-						if (
-							html &&
-							document.querySelector('.loading-animation')
-						) {
-							setModalContent(html);
-						}
-					},
-					size: 'md',
-					title: Liferay.Language.get('sign-in'),
-				});
-			}
-		},
+		onClick,
 	};
 }

--- a/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/js/signInButtonPropsTransformer.js
+++ b/modules/apps/product-navigation/product-navigation-user-personal-bar-web/src/main/resources/META-INF/resources/js/signInButtonPropsTransformer.js
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-import {addParams, fetch, openModal} from 'frontend-js-web';
+import {addParams, fetch, navigate, openModal} from 'frontend-js-web';
 
 export default function propsTransformer({additionalProps, ...props}) {
-	const {redirect: signInRedirect, signInURL} = additionalProps;
+	const {signInURL} = additionalProps;
 
 	const signInLink = document.querySelector('.sign-in > div > button');
 
@@ -27,8 +27,8 @@ export default function propsTransformer({additionalProps, ...props}) {
 	};
 
 	let loading = false;
-	let redirect = false;
 	let html = '';
+	let {redirect} = additionalProps;
 	let modalOpen = false;
 
 	const fetchModalSignIn = function () {
@@ -71,13 +71,13 @@ export default function propsTransformer({additionalProps, ...props}) {
 		onClick() {
 			fetchModalSignIn();
 
-			if (signInLink && !signInRedirect) {
-				if (redirect) {
-					Liferay.Util.navigate(signInURL);
+			if (redirect) {
+				navigate(signInURL);
 
-					return;
-				}
+				return;
+			}
 
+			if (signInLink) {
 				openModal({
 					bodyHTML: html ? html : '<span class="loading-animation">',
 					containerProps: {


### PR DESCRIPTION
@DiegoHu97 Instead of maintaining multiple variables to handle the state logic, try to create a linear flow that is easier to follow. When user clicks the "sign in" button:

1. If we should redirect to other page, do it and stop the process.
2. Otherwise, start loading the modal content.
   a. Open the modal.
   b. Wait until the modal content has finished loading.
   c. Show the modal content.
3. If anything unexpected happens (no modal content, some error...), just redirect.