### PR TITLE
LPS-200973 Change property list keyboard navigation in segment editor

### DIFF
--- a/modules/apps/segments/segments-web/package.json
+++ b/modules/apps/segments/segments-web/package.json
@@ -13,6 +13,7 @@
 		"@clayui/link": "3.106.1",
 		"@clayui/loading-indicator": "3.106.1",
 		"@clayui/panel": "3.106.1",
+		"@liferay/frontend-js-react-web": "*",
 		"@liferay/layout-js-components-web": "*",
 		"classnames": "2.3.1",
 		"date-fns": "2.29.3",

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/_criteria_sidebar.scss
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/css/_criteria_sidebar.scss
@@ -48,9 +48,11 @@
 		}
 
 		&:hover,
-		&:focus-visible {
+		&:focus-visible,
+		&--active {
 			border-color: $blue;
-			box-shadow: 0 0 0 2px $primary-l1, 0 4px 8px fade_out($gray-900, 0.9);
+			box-shadow: 0 0 0 2px $primary-l1,
+				0 4px 8px fade_out($gray-900, 0.9);
 			cursor: grab;
 			outline: 0;
 			transform: translateX(-4px);
@@ -60,6 +62,21 @@
 				'border-left-color',
 				'color--'
 			);
+		}
+
+		&--active,
+		&:focus-visible {
+			background-color: $primary-l3;
+
+			& > span:focus-visible {
+				border-radius: 4px;
+				box-shadow: 0 0 0 2px $primary-l1;
+				outline: 0;
+			}
+
+			.sticker-dark {
+				background-color: $primary-l3;
+			}
 		}
 	}
 }

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarCollapse.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarCollapse.js
@@ -7,9 +7,11 @@ import ClayBadge from '@clayui/badge';
 import ClayPanel from '@clayui/panel';
 import {parse} from 'date-fns';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useEffect} from 'react';
 
+import useKeyboardNavigation from '../../hooks/useKeyboardNavigation';
 import {PROPERTY_TYPES} from '../../utils/constants';
+import {LIST_ITEM_TYPES} from '../../utils/listItemTypes';
 import {propertyGroupShape} from '../../utils/types.es';
 import {jsDatetoYYYYMMDD} from '../../utils/utils';
 import CriteriaSidebarItem from './CriteriaSidebarItem';
@@ -69,101 +71,124 @@ function filterProperties(properties, searchValue) {
 	});
 }
 
-const CriteriaSidebarCollapse = ({
+const PanelWrapper = ({
 	onCollapseClick,
-	propertyGroups,
+	propertyGroup,
 	propertyKey,
 	searchValue,
 }) => {
 	const _handleClick = (key, editing) => () => onCollapseClick(key, editing);
+	const key = propertyGroup.propertyKey;
+	const active = key === propertyKey;
+	const properties = propertyGroup ? propertyGroup.properties : [];
 
+	const filteredProperties = searchValue
+		? filterProperties(properties, searchValue)
+		: properties;
+
+	const {isTarget, setElement} = useKeyboardNavigation({
+		handleOpen: onCollapseClick,
+		key,
+		type: LIST_ITEM_TYPES.header,
+	});
+
+	useEffect(() => {
+		const panelButton = document.querySelector(`#${key} button`);
+
+		if (panelButton) {
+			setElement(panelButton);
+		}
+	}, [key, setElement]);
+
+	useEffect(() => {
+		const panelButton = document.querySelector(`#${key} button`);
+
+		if (isTarget) {
+			panelButton.setAttribute('tabindex', 0);
+		}
+		else {
+			panelButton.setAttribute('tabindex', -1);
+		}
+	}, [isTarget, key]);
+
+	return (
+		<ClayPanel
+			collapsable={true}
+			displayTitle={
+				<div className="c-inner" tabIndex="-1">
+					<ClayPanel.Title className="d-flex justify-content-between text-uppercase">
+						{propertyGroup.name}
+
+						{searchValue && (
+							<ClayBadge
+								displayType="secondary"
+								label={filteredProperties.length}
+							/>
+						)}
+					</ClayPanel.Title>
+				</div>
+			}
+			displayType="unstyled"
+			expanded={active}
+			id={key}
+			onExpandedChange={_handleClick(key, active)}
+		>
+			<ClayPanel.Body className="c-px-0">
+				<p className="c-pt-1 text-secondary">
+					{Liferay.Language.get(
+						'inherited-attributes-are-not-taken-into-account-to-include-members-in-segments'
+					)}
+				</p>
+
+				<ul className="c-pl-0">
+					{!filteredProperties.length && (
+						<li className="align-items-center d-flex empty-message h-100 justify-content-center position-relative">
+							{Liferay.Language.get('no-results-were-found')}
+						</li>
+					)}
+
+					{!!filteredProperties.length &&
+						filteredProperties.map(
+							({icon, label, name, options, type}) => {
+								const defaultValue = getDefaultValue({
+									label,
+									name,
+									options,
+									type,
+								});
+
+								return (
+									<CriteriaSidebarItem
+										className={`color--${key}`}
+										defaultValue={defaultValue}
+										icon={icon}
+										key={name}
+										label={label}
+										name={name}
+										propertyKey={key}
+										type={type}
+									/>
+								);
+							}
+						)}
+				</ul>
+			</ClayPanel.Body>
+		</ClayPanel>
+	);
+};
+
+const CriteriaSidebarCollapse = ({propertyGroups, ...props}) => {
 	return (
 		<ClayPanel.Group>
 			{propertyGroups.map((propertyGroup) => {
 				const key = propertyGroup.propertyKey;
 
-				const active = key === propertyKey;
-				const properties = propertyGroup
-					? propertyGroup.properties
-					: [];
-
-				const filteredProperties = searchValue
-					? filterProperties(properties, searchValue)
-					: properties;
-
 				return (
-					<ClayPanel
-						collapsable={true}
-						displayTitle={
-							<div className="c-inner" tabIndex="-1">
-								<ClayPanel.Title className="d-flex justify-content-between text-uppercase">
-									{propertyGroup.name}
-
-									{searchValue && (
-										<ClayBadge
-											displayType="secondary"
-											label={filteredProperties.length}
-										/>
-									)}
-								</ClayPanel.Title>
-							</div>
-						}
-						displayType="unstyled"
-						expanded={active}
+					<PanelWrapper
 						key={key}
-						onExpandedChange={_handleClick(key, active)}
-					>
-						<ClayPanel.Body className="c-px-0">
-							<p className="c-pt-1 text-secondary">
-								{Liferay.Language.get(
-									'inherited-attributes-are-not-taken-into-account-to-include-members-in-segments'
-								)}
-							</p>
-
-							<ul className="c-pl-0">
-								{!filteredProperties.length && (
-									<li className="align-items-center d-flex empty-message h-100 justify-content-center position-relative">
-										{Liferay.Language.get(
-											'no-results-were-found'
-										)}
-									</li>
-								)}
-
-								{!!filteredProperties.length &&
-									filteredProperties.map(
-										({
-											icon,
-											label,
-											name,
-											options,
-											type,
-										}) => {
-											const defaultValue = getDefaultValue(
-												{
-													label,
-													name,
-													options,
-													type,
-												}
-											);
-
-											return (
-												<CriteriaSidebarItem
-													className={`color--${key}`}
-													defaultValue={defaultValue}
-													icon={icon}
-													key={name}
-													label={label}
-													name={name}
-													propertyKey={key}
-													type={type}
-												/>
-											);
-										}
-									)}
-							</ul>
-						</ClayPanel.Body>
-					</ClayPanel>
+						propertyGroup={propertyGroup}
+						{...props}
+					/>
 				);
 			})}
 		</ClayPanel.Group>

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarItem.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarItem.js
@@ -9,8 +9,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import {DragSource as dragSource} from 'react-dnd';
 
+import useKeyboardNavigation from '../../hooks/useKeyboardNavigation';
 import {PROPERTY_TYPES} from '../../utils/constants';
 import {DragTypes} from '../../utils/drag-types';
+import {LIST_ITEM_TYPES} from '../../utils/listItemTypes';
 
 const TYPE_ICON_MAP = {
 	[PROPERTY_TYPES.BOOLEAN]: 'check-circle',
@@ -31,6 +33,10 @@ function CriteriaSidebarItem({
 	label,
 	type,
 }) {
+	const {isTarget, setElement} = useKeyboardNavigation({
+		type: LIST_ITEM_TYPES.listItem,
+	});
+
 	return connectDragSource(
 		<li
 			className={classNames(
@@ -38,9 +44,11 @@ function CriteriaSidebarItem({
 				{dragging},
 				className
 			)}
-			tabIndex="0"
+			ref={setElement}
+			role="menuitem"
+			tabIndex={isTarget ? 0 : -1}
 		>
-			<span className="c-p-2 inline-item">
+			<span className="c-p-2 inline-item" tabIndex={isTarget ? 0 : -1}>
 				<ClayIcon symbol="drag" />
 			</span>
 

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarItem.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/components/criteria_sidebar/CriteriaSidebarItem.js
@@ -6,7 +6,7 @@
 import ClayIcon from '@clayui/icon';
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useState} from 'react';
 import {DragSource as dragSource} from 'react-dnd';
 
 import useKeyboardNavigation from '../../hooks/useKeyboardNavigation';
@@ -33,6 +33,7 @@ function CriteriaSidebarItem({
 	label,
 	type,
 }) {
+	const [isActive, setIsActive] = useState(false);
 	const {isTarget, setElement} = useKeyboardNavigation({
 		type: LIST_ITEM_TYPES.listItem,
 	});
@@ -41,14 +42,22 @@ function CriteriaSidebarItem({
 		<li
 			className={classNames(
 				'align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex ',
-				{dragging},
+				{
+					'criteria-sidebar-item-root--active': isActive,
+					dragging,
+				},
 				className
 			)}
 			ref={setElement}
 			role="menuitem"
 			tabIndex={isTarget ? 0 : -1}
 		>
-			<span className="c-p-2 inline-item" tabIndex={isTarget ? 0 : -1}>
+			<span
+				className="c-p-2 inline-item"
+				onBlur={() => setIsActive(false)}
+				onFocus={() => setIsActive(true)}
+				tabIndex={isTarget ? 0 : -1}
+			>
 				<ClayIcon symbol="drag" />
 			</span>
 

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/hooks/useKeyboardNavigation.js
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/hooks/useKeyboardNavigation.js
@@ -1,0 +1,191 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useEventListener} from '@liferay/frontend-js-react-web';
+import {useEffect, useState} from 'react';
+
+import {
+	ARROW_DOWN_KEY_CODE,
+	ARROW_LEFT_KEY_CODE,
+	ARROW_RIGHT_KEY_CODE,
+	ARROW_UP_KEY_CODE,
+} from '../utils/keyboardCodes';
+import {LIST_ITEM_TYPES} from '../utils/listItemTypes';
+
+const ALLOWED_KEY_CODES = [
+	ARROW_DOWN_KEY_CODE,
+	ARROW_LEFT_KEY_CODE,
+	ARROW_RIGHT_KEY_CODE,
+	ARROW_UP_KEY_CODE,
+];
+
+export default function useKeyboardNavigation({handleOpen, key, type}) {
+	const [element, setElement] = useState(null);
+	const [isTarget, setIsTarget] = useState(false);
+
+	useEffect(() => {
+		const list = element?.closest('.panel-group');
+		const listItem = element?.closest('.panel');
+
+		const isFirstChild = list && listItem && listItem === list?.firstChild;
+
+		setIsTarget(isFirstChild && element.tagName === 'BUTTON');
+	}, [element]);
+
+	const rtl =
+		Liferay.Language.direction?.[themeDisplay?.getLanguageId()] === 'rtl';
+
+	useEventListener(
+		'keydown',
+		(event) => {
+			const {code} = event;
+
+			if (!ALLOWED_KEY_CODES.includes(code)) {
+				return;
+			}
+
+			event.preventDefault();
+
+			let nextCode = code;
+
+			if (rtl && code === ARROW_RIGHT_KEY_CODE) {
+				nextCode = ARROW_LEFT_KEY_CODE;
+			}
+
+			if (rtl && code === ARROW_LEFT_KEY_CODE) {
+				nextCode = ARROW_RIGHT_KEY_CODE;
+			}
+
+			if (type === LIST_ITEM_TYPES.header) {
+				onHeaderKeyDown(element, nextCode, handleOpen, key);
+			}
+			else if (type === LIST_ITEM_TYPES.listItem) {
+				onListItemKeyDown(element, nextCode);
+			}
+		},
+		true,
+		element
+	);
+
+	useEventListener('focus', () => setIsTarget(true), true, element);
+
+	useEventListener(
+		'blur',
+		(event) => {
+			const list = event.target.closest('.panel-group');
+
+			const nextActiveElement = event.relatedTarget;
+
+			if (list.contains(nextActiveElement)) {
+				setIsTarget(false);
+			}
+		},
+		true,
+		element
+	);
+
+	return {isTarget, setElement};
+}
+
+function onHeaderKeyDown(element, keyCode, handleOpen, key) {
+	if (keyCode === ARROW_DOWN_KEY_CODE) {
+
+		// Target first item of the list. If it's collapsed, target next header
+
+		const panel = element.closest('.panel');
+		const firstItem = panel.querySelector('li');
+		const isCollapsed = panel.querySelector('.collapsed');
+
+		if (!isCollapsed && firstItem) {
+			firstItem.focus();
+		}
+		else {
+			const nextCollapse = panel.nextSibling;
+			const nextHeader = nextCollapse?.querySelector('button');
+
+			nextHeader?.focus();
+		}
+	}
+	else if (keyCode === ARROW_UP_KEY_CODE) {
+
+		// Target last item of the previous list. If it's collapsed, target previous header
+
+		const panel = element.closest('.panel');
+		const previousCollapse = panel.previousSibling;
+
+		if (!previousCollapse) {
+			return;
+		}
+
+		const isPreviousCollapse = previousCollapse.querySelector('.collapsed');
+
+		const previousList = previousCollapse.querySelector('ul');
+
+		if (!isPreviousCollapse && previousList) {
+			const lastItem = previousList.lastChild;
+
+			lastItem.focus();
+		}
+		else {
+			const previousHeader = previousCollapse.querySelector('button');
+
+			previousHeader.focus();
+		}
+	}
+	else if (keyCode === ARROW_RIGHT_KEY_CODE) {
+		handleOpen(key, false);
+	}
+	else if (keyCode === ARROW_LEFT_KEY_CODE) {
+		handleOpen(key, true);
+	}
+}
+
+function onListItemKeyDown(element, keyCode) {
+	if (keyCode === ARROW_UP_KEY_CODE) {
+
+		// Target previous list item. If it's the first one, target header
+
+		if (element.previousSibling) {
+			element.previousSibling.focus();
+		}
+		else {
+			const panel = element.closest('.panel');
+			const header = panel.querySelector('.panel-header');
+
+			header.focus();
+		}
+	}
+	else if (keyCode === ARROW_DOWN_KEY_CODE) {
+
+		// Target next list item. If it's the last one, target next header
+
+		if (element.nextSibling) {
+			element.nextSibling.focus();
+		}
+		else {
+			const panel = element.closest('.panel');
+			const nextPanel = panel.nextSibling;
+			const nextHeader = nextPanel?.querySelector('.panel-header');
+
+			nextHeader?.focus();
+		}
+	}
+	else if (keyCode === ARROW_RIGHT_KEY_CODE) {
+
+		// If the active element is the list item itself, target first option button
+
+		if (document.activeElement === element) {
+			const dragSpan = element.querySelector('span');
+
+			dragSpan.focus();
+		}
+	}
+	else if (keyCode === ARROW_LEFT_KEY_CODE) {
+
+		// Focus the list element
+
+		element.focus();
+	}
+}

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/utils/keyboardCodes.ts
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/utils/keyboardCodes.ts
@@ -1,0 +1,34 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const ARROW_DOWN_KEY_CODE = 'ArrowDown';
+
+export const ARROW_LEFT_KEY_CODE = 'ArrowLeft';
+
+export const ARROW_RIGHT_KEY_CODE = 'ArrowRight';
+
+export const ARROW_UP_KEY_CODE = 'ArrowUp';
+
+export const BACKSPACE_KEY_CODE = 'Backspace';
+
+export const D_KEY_CODE = 'KeyD';
+
+export const END_KEY_CODE = 'End';
+
+export const ENTER_KEY_CODE = 'Enter';
+
+export const ESCAPE_KEY_CODE = 'Escape';
+
+export const HOME_KEY_CODE = 'Home';
+
+export const PERIOD_KEY_CODE = 'Period';
+
+export const S_KEY_CODE = 'KeyS';
+
+export const SPACE_KEY_CODE = 'Space';
+
+export const TAB_KEY_CODE = 'Tab';
+
+export const Z_KEY_CODE = 'KeyZ';

--- a/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/utils/listItemTypes.ts
+++ b/modules/apps/segments/segments-web/src/main/resources/META-INF/resources/js/utils/listItemTypes.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const LIST_ITEM_TYPES = {
+	header: 'header',
+	listItem: 'listItem',
+} as const;

--- a/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/ContributorsBuilder.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_builder/__snapshots__/ContributorsBuilder.test.js.snap
@@ -69,12 +69,14 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
           >
             <div
               class="panel panel-unstyled"
+              id="user"
               role="tablist"
             >
               <button
                 aria-expanded="true"
                 class="panel-header panel-header-link collapse-icon collapse-icon-middle show btn btn-unstyled"
                 role="tab"
+                tabindex="0"
                 type="button"
               >
                 <div
@@ -130,10 +132,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -165,10 +169,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -200,10 +206,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -235,10 +243,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -270,10 +280,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -305,10 +317,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -340,10 +354,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -375,10 +391,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -410,10 +428,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -445,10 +465,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -480,10 +502,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -515,10 +539,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -550,10 +576,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -585,10 +613,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -620,10 +650,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -655,10 +687,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -690,10 +724,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -725,10 +761,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -763,12 +801,14 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
             </div>
             <div
               class="panel panel-unstyled"
+              id="user-organization"
               role="tablist"
             >
               <button
                 aria-expanded="false"
                 class="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
                 role="tab"
+                tabindex="-1"
                 type="button"
               >
                 <div
@@ -824,10 +864,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -859,10 +901,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -894,10 +938,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -929,10 +975,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -964,10 +1012,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -999,10 +1049,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1034,10 +1086,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1069,10 +1123,12 @@ exports[`ContributorsBuilder renders builder with sidebar: initialRenderEditing 
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1239,12 +1295,14 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
           >
             <div
               class="panel panel-unstyled"
+              id="user"
               role="tablist"
             >
               <button
                 aria-expanded="true"
                 class="panel-header panel-header-link collapse-icon collapse-icon-middle show btn btn-unstyled"
                 role="tab"
+                tabindex="0"
                 type="button"
               >
                 <div
@@ -1300,10 +1358,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1335,10 +1395,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1370,10 +1432,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1405,10 +1469,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1440,10 +1506,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1475,10 +1543,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1510,10 +1580,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1545,10 +1617,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1580,10 +1654,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1615,10 +1691,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1650,10 +1728,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1685,10 +1765,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1720,10 +1802,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1755,10 +1839,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1790,10 +1876,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1825,10 +1913,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1860,10 +1950,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1895,10 +1987,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -1933,12 +2027,14 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
             </div>
             <div
               class="panel panel-unstyled"
+              id="user-organization"
               role="tablist"
             >
               <button
                 aria-expanded="false"
                 class="panel-header panel-header-link collapse-icon collapse-icon-middle collapsed btn btn-unstyled"
                 role="tab"
+                tabindex="-1"
                 type="button"
               >
                 <div
@@ -1994,10 +2090,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -2029,10 +2127,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -2064,10 +2164,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -2099,10 +2201,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -2134,10 +2238,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -2169,10 +2275,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -2204,10 +2312,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"
@@ -2239,10 +2349,12 @@ exports[`ContributorsBuilder renders builder without sidebar: initialRenderNotEd
                     <li
                       class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--user-organization"
                       draggable="true"
-                      tabindex="0"
+                      role="menuitem"
+                      tabindex="-1"
                     >
                       <span
                         class="c-p-2 inline-item"
+                        tabindex="-1"
                       >
                         <svg
                           class="lexicon-icon lexicon-icon-drag"

--- a/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebarItem.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/criteria_sidebar/__snapshots__/CriteriaSidebarItem.test.js.snap
@@ -4,10 +4,12 @@ exports[`CriteriaSidebarItem renders 1`] = `
 <DocumentFragment>
   <li
     class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex "
-    tabindex="0"
+    role="menuitem"
+    tabindex="-1"
   >
     <span
       class="c-p-2 inline-item"
+      tabindex="-1"
     >
       <svg
         class="lexicon-icon lexicon-icon-drag"

--- a/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.test.js.snap
+++ b/modules/apps/segments/segments-web/test/js/components/segment_edit/__snapshots__/SegmentEdit.test.js.snap
@@ -490,12 +490,14 @@ exports[`SegmentEdit renders with given values 1`] = `
               >
                 <div
                   class="panel panel-unstyled"
+                  id="first-test-values-group"
                   role="tablist"
                 >
                   <button
                     aria-expanded="true"
                     class="panel-header panel-header-link collapse-icon collapse-icon-middle show btn btn-unstyled"
                     role="tab"
+                    tabindex="0"
                     type="button"
                   >
                     <div
@@ -551,10 +553,12 @@ exports[`SegmentEdit renders with given values 1`] = `
                         <li
                           class="align-items-center criteria-sidebar-item-root c-py-2 c-pr-3 c-pl-1 c-my-1 d-flex  color--first-test-values-group"
                           draggable="true"
-                          tabindex="0"
+                          role="menuitem"
+                          tabindex="-1"
                         >
                           <span
                             class="c-p-2 inline-item"
+                            tabindex="-1"
                           >
                             <svg
                               class="lexicon-icon lexicon-icon-drag"

--- a/modules/apps/segments/segments-web/tsconfig.json
+++ b/modules/apps/segments/segments-web/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"@generated": "475031cb71ea397a7c7a63fc8c533fde5928a18e",
+	"@generated": "02e5ccfb52bf8477b9708219c4d0c3cd3d326345",
 	"@overrides": {
 	},
 	"@readonly": "** AUTO-GENERATED: DO NOT EDIT OUTSIDE @overrides **",
@@ -13,6 +13,9 @@
 		"moduleResolution": "node",
 		"outDir": "./types",
 		"paths": {
+			"@liferay/frontend-js-react-web": [
+				"../../frontend-js/frontend-js-react-web/src/main/resources/META-INF/resources/js/index.ts"
+			],
 			"@liferay/layout-js-components-web": [
 				"../../layout/layout-js-components-web/src/main/resources/META-INF/resources/js/index.ts"
 			],
@@ -38,6 +41,9 @@
 		"../../../global.d.ts"
 	],
 	"references": [
+		{
+			"path": "../../frontend-js/frontend-js-react-web"
+		},
 		{
 			"path": "../../layout/layout-js-components-web"
 		},

--- a/modules/apps/segments/segments-web/types/src/main/resources/META-INF/resources/js/utils/keyboardCodes.d.ts
+++ b/modules/apps/segments/segments-web/types/src/main/resources/META-INF/resources/js/utils/keyboardCodes.d.ts
@@ -1,0 +1,20 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export declare const ARROW_DOWN_KEY_CODE = 'ArrowDown';
+export declare const ARROW_LEFT_KEY_CODE = 'ArrowLeft';
+export declare const ARROW_RIGHT_KEY_CODE = 'ArrowRight';
+export declare const ARROW_UP_KEY_CODE = 'ArrowUp';
+export declare const BACKSPACE_KEY_CODE = 'Backspace';
+export declare const D_KEY_CODE = 'KeyD';
+export declare const END_KEY_CODE = 'End';
+export declare const ENTER_KEY_CODE = 'Enter';
+export declare const ESCAPE_KEY_CODE = 'Escape';
+export declare const HOME_KEY_CODE = 'Home';
+export declare const PERIOD_KEY_CODE = 'Period';
+export declare const S_KEY_CODE = 'KeyS';
+export declare const SPACE_KEY_CODE = 'Space';
+export declare const TAB_KEY_CODE = 'Tab';
+export declare const Z_KEY_CODE = 'KeyZ';

--- a/modules/apps/segments/segments-web/types/src/main/resources/META-INF/resources/js/utils/listItemTypes.d.ts
+++ b/modules/apps/segments/segments-web/types/src/main/resources/META-INF/resources/js/utils/listItemTypes.d.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export declare const LIST_ITEM_TYPES: {
+	readonly header: 'header';
+	readonly listItem: 'listItem';
+};


### PR DESCRIPTION
Motivation
=======
We want to unify the keyboard navigation with the one in page editor fragment list.
[Link to story or ticket](https://liferay.atlassian.net/browse/LPS-200973)


Steps to Verify:
----------------
1. Go to People -> Segments
1. Click on add new user segment
1. Navigate through the Properties sidebar using the keyboard and check that everything works as describe in the ticket.