### PR TITLE
LPS-200946 AUI migration to purely javascript in iframe-web and portal-settings-web modules

### DIFF
--- a/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/iframe/iframe-web/src/main/resources/META-INF/resources/view.jsp
@@ -30,8 +30,6 @@
 
 <c:if test="<%= iFramePortletInstanceConfiguration.dynamicUrlEnabled() %>">
 	<aui:script use="aui-base,querystring">
-		var A = AUI();
-
 		function init() {
 			var hash = document.location.hash.replace('#', '');
 
@@ -43,7 +41,7 @@
 				hash = String(hash);
 			}
 
-			var iframe = A.one('#<portlet:namespace />iframe');
+			const iframe = document.getElementById('<portlet:namespace />iframe');
 
 			if (iframe) {
 				if (hash) {
@@ -52,17 +50,13 @@
 					var baseSrc =
 						'<%= HtmlUtil.escapeJS(iFrameDisplayContext.getIframeBaseSrc()) %>';
 
-					if (
-						!/^https?\:\/\//.test(hash) ||
-						!A.Lang.String.startsWith(hash, baseSrc)
-					) {
-						src = A.QueryString.unescape(hash);
+					if (!/^https?\:\/\//.test(hash) || !hash.startsWith(baseSrc)) {
+						src = unescape(hash);
 					}
-
-					iframe.attr('src', baseSrc + src);
+					iframe.src = baseSrc + src;
 				}
 
-				iframe.on('load', monitorIframe);
+				iframe.addEventListener('load', monitorIframe);
 			}
 		}
 
@@ -84,7 +78,7 @@
 				'<%= HtmlUtil.escapeJS(iFrameDisplayContext.getIframeBaseSrc()) %>';
 			var iframeSrc =
 				'<%= HtmlUtil.escapeJS(iFrameDisplayContext.getIframeSrc()) %>';
-			var hasBaseSrc = A.Lang.String.startsWith(url, baseSrc);
+			var hasBaseSrc = url.startsWith(baseSrc);
 
 			if (hasBaseSrc) {
 				url = url.substring(baseSrc.length);
@@ -107,26 +101,14 @@
 
 			hash = hashSearch.toString();
 
-			var maximize = A.one(
-				'#p_p_id<portlet:namespace /> .portlet-maximize-icon a'
-			);
-
-			if (maximize) {
-				var maximizeUrl = maximize.attr('href');
-
-				maximizeUrl = maximizeUrl.split('#')[0];
-
-				maximize.attr('href', maximizeUrl + '#' + hash);
-			}
-
-			var restore = A.one('#p_p_id<portlet:namespace /> a.portlet-icon-back');
+			const restore = document.getElementsByClassName('portlet-icon-back')[0];
 
 			if (restore) {
-				var restoreHREF = restore.attr('href');
+				var restoreHREF = restore.getAttribute('href');
 
 				restoreHREF = restoreHREF.split('#')[0];
 
-				restore.attr('href', restoreHREF + '#' + hash);
+				restore.setAttribute('href', restoreHREF + '#' + hash);
 			}
 
 			location.hash = hash;
@@ -137,7 +119,7 @@
 </c:if>
 
 <aui:script use="aui-autosize-iframe">
-	var iframe = A.one('#<portlet:namespace />iframe');
+	const iframe = document.getElementById('<portlet:namespace />iframe');
 
 	function isNested(initial = window, parentUrls = []) {
 		var isTop = initial === initial.Liferay.Util.getTop();
@@ -157,18 +139,18 @@
 
 	if (iframe) {
 		if (!isNested()) {
-			iframe.set(
+			iframe.setAttribute(
 				'src',
 				'<%= HtmlUtil.escapeJS(iFrameDisplayContext.getIframeSrc()) %>'
 			);
 		}
 
-		iframe.plug(A.Plugin.AutosizeIframe, {
-			monitorHeight: <%= iFramePortletInstanceConfiguration.resizeAutomatically() %>,
-		});
+		if (<%= iFramePortletInstanceConfiguration.resizeAutomatically() %>) {
+			iframe.height = document.body.scrollHeight;
+		}
 
-		iframe.on('load', () => {
-			var height = A.Plugin.AutosizeIframe.getContentHeight(iframe);
+		iframe.addEventListener('load', () => {
+			let height = iframe.getAttribute('height');
 
 			if (height == null) {
 				height =
@@ -179,9 +161,7 @@
 						'<%= HtmlUtil.escapeJS(iFramePortletInstanceConfiguration.heightMaximized()) %>';
 				}
 
-				iframe.setStyle('height', height);
-
-				iframe.autosizeiframe.set('monitorHeight', false);
+				iframe.height = height;
 			}
 		});
 	}

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/language.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/language.jsp
@@ -102,10 +102,12 @@
 </aui:fieldset>
 
 <aui:script use="aui-alert,aui-base">
-	var languageSelectInput = A.one('#<portlet:namespace />languageId');
+	const languageSelectInput = document.getElementById(
+		'<portlet:namespace />languageId'
+	);
 
 	if (languageSelectInput) {
-		languageSelectInput.on('change', () => {
+		languageSelectInput.addEventListener('change', () => {
 			new A.Alert({
 				bodyContent:
 					'<liferay-ui:message key="this-change-will-only-affect-the-newly-created-localized-content" />',

--- a/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/ratings.jsp
+++ b/modules/apps/portal-settings/portal-settings-web/src/main/resources/META-INF/resources/ratings.jsp
@@ -62,13 +62,13 @@ CompanyPortletRatingsDefinitionDisplayContext companyPortletRatingsDefinitionDis
 </aui:fieldset>
 
 <aui:script use="aui-base">
-	var ratingsSettingsContainer = A.one(
-		'#<portlet:namespace />ratingsSettingsContainer'
+	const ratingsSettingsContainer = document.getElementById(
+		'<portlet:namespace />ratingsSettingsContainer'
 	);
 
 	var ratingsTypeChanged = false;
 
-	ratingsSettingsContainer.delegate(
+	ratingsSettingsContainer.addEventListener(
 		'change',
 		(event) => {
 			ratingsTypeChanged = true;
@@ -76,9 +76,9 @@ CompanyPortletRatingsDefinitionDisplayContext companyPortletRatingsDefinitionDis
 		'select'
 	);
 
-	var form = A.one('#<portlet:namespace />fm');
+	const form = document.getElementById('<portlet:namespace />fm');
 
-	form.on('submit', (event) => {
+	form.addEventListener('submit', (event) => {
 		if (ratingsTypeChanged) {
 			Liferay.Util.openConfirmModal({
 				message:


### PR DESCRIPTION
Motivation
=======
The motivation behind this ticket is removal of AUI code and use native functions instead.
https://liferay.atlassian.net/browse/LPS-199672
https://liferay.atlassian.net/browse/LPS-199681

Steps to Verify
========
For portal-settings-web:
    1. Go to Instance Settings -> Content and Data -> Community Tools -> Ratings
    2. Make changes in the ratings parameters and save them checking that the request works fine.

    1. Go to Instance Settings -> Platform -> Localization -> Language
    2. Change the Default Language and save it. Check that an alert message appears.
    3. Change the content of the tables by moving languages from to another. Save the changes and check that they've  been made

For iframe-web:
    1.  Add a Iframe to a the home content page by going to the Page Editor -> add a Iframe widget -> configure with a source url and check that works correctly.
    3. Create an widget page and configure it to show Maximize/minimize links. In the Pages view -> Click on the Widget Page ellipsis button -> Configure -> Designs -> allow the Maximize/minimize by selecting the checkbox -> save the change.
    4. Add an iframe and add a source url to a page that is in the liferay domain (you can add the the url of the home page).
    5. In the configuration of the Iframe check the Autosize parameter and check that works correctly.
    6. Then uncheck the autosize parameter, set a manual size and check that works correctly.