### PR TITLE
LPS-195551

### DIFF
--- a/modules/apps/asset/asset-api/bnd.bnd
+++ b/modules/apps/asset/asset-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset API
 Bundle-SymbolicName: com.liferay.asset.api
-Bundle-Version: 8.1.2
+Bundle-Version: 8.2.0
 Export-Package:\
 	com.liferay.asset.constants,\
 	com.liferay.asset.exception,\

--- a/modules/apps/asset/asset-api/src/main/java/com/liferay/asset/util/PortletLayoutAssetEntryProvider.java
+++ b/modules/apps/asset/asset-api/src/main/java/com/liferay/asset/util/PortletLayoutAssetEntryProvider.java
@@ -1,0 +1,21 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.util;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.portal.kernel.model.Layout;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * @author Roberto Díaz
+ */
+public interface PortletLayoutAssetEntryProvider {
+
+	public AssetEntry getLayoutAssetEntry(
+		HttpServletRequest httpServletRequest, Layout layout);
+
+}

--- a/modules/apps/asset/asset-api/src/main/java/com/liferay/asset/util/PortletLayoutAssetEntryProviderRegistry.java
+++ b/modules/apps/asset/asset-api/src/main/java/com/liferay/asset/util/PortletLayoutAssetEntryProviderRegistry.java
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.util;
+
+/**
+ * @author Roberto Díaz
+ */
+public interface PortletLayoutAssetEntryProviderRegistry {
+
+	public PortletLayoutAssetEntryProvider getPortletLayoutAssetEntryProvider(
+		String portletId);
+
+}

--- a/modules/apps/asset/asset-api/src/main/resources/com/liferay/asset/util/packageinfo
+++ b/modules/apps/asset/asset-api/src/main/resources/com/liferay/asset/util/packageinfo
@@ -1,1 +1,1 @@
-version 4.0.0
+version 4.1.0

--- a/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/PortletLayoutAssetEntryProviderRegistryImpl.java
+++ b/modules/apps/asset/asset-service/src/main/java/com/liferay/asset/internal/util/PortletLayoutAssetEntryProviderRegistryImpl.java
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.asset.internal.util;
+
+import com.liferay.asset.util.PortletLayoutAssetEntryProvider;
+import com.liferay.asset.util.PortletLayoutAssetEntryProviderRegistry;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
+import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
+
+import org.osgi.framework.BundleContext;
+import org.osgi.service.component.annotations.Activate;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Deactivate;
+import org.osgi.service.component.annotations.Modified;
+
+/**
+ * @author Roberto Díaz
+ */
+@Component(service = PortletLayoutAssetEntryProviderRegistry.class)
+public class PortletLayoutAssetEntryProviderRegistryImpl
+	implements PortletLayoutAssetEntryProviderRegistry {
+
+	@Override
+	public PortletLayoutAssetEntryProvider getPortletLayoutAssetEntryProvider(
+		String className) {
+
+		return _serviceTrackerMap.getService(className);
+	}
+
+	@Activate
+	@Modified
+	protected void activate(BundleContext bundleContext) {
+		_serviceTrackerMap = ServiceTrackerMapFactory.openSingleValueMap(
+			bundleContext, PortletLayoutAssetEntryProvider.class,
+			"javax.portlet.name");
+	}
+
+	@Deactivate
+	protected void deactivate() {
+		_serviceTrackerMap.close();
+	}
+
+	private volatile ServiceTrackerMap<String, PortletLayoutAssetEntryProvider>
+		_serviceTrackerMap;
+
+}

--- a/modules/apps/comment/comment-page-comments-web/build.gradle
+++ b/modules/apps/comment/comment-page-comments-web/build.gradle
@@ -7,6 +7,7 @@ dependencies {
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
 	compileOnly group: "org.osgi", name: "osgi.core", version: "6.0.0"
+	compileOnly project(":apps:asset:asset-api")
 	compileOnly project(":apps:comment:comment-api")
 	compileOnly project(":apps:comment:comment-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")

--- a/modules/apps/comment/comment-page-comments-web/src/main/java/com/liferay/comment/page/comments/web/internal/asset/PageCommentPortletLayoutAssetEntryProvider.java
+++ b/modules/apps/comment/comment-page-comments-web/src/main/java/com/liferay/comment/page/comments/web/internal/asset/PageCommentPortletLayoutAssetEntryProvider.java
@@ -1,0 +1,60 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.comment.page.comments.web.internal.asset;
+
+import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.kernel.service.AssetEntryLocalService;
+import com.liferay.asset.util.PortletLayoutAssetEntryProvider;
+import com.liferay.comment.page.comments.web.internal.constants.PageCommentsPortletKeys;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.util.ParamUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Validator;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+/**
+ * @author Roberto Díaz
+ */
+@Component(
+	property = "javax.portlet.name=" + PageCommentsPortletKeys.PAGE_COMMENTS,
+	service = PortletLayoutAssetEntryProvider.class
+)
+public class PageCommentPortletLayoutAssetEntryProvider
+	implements PortletLayoutAssetEntryProvider {
+
+	@Override
+	public AssetEntry getLayoutAssetEntry(
+		HttpServletRequest httpServletRequest, Layout layout) {
+
+		if (layout.isTypeAssetDisplay()) {
+			String portletNamespace = _portal.getPortletNamespace(
+				ParamUtil.getString(httpServletRequest, "p_p_id"));
+
+			String className = ParamUtil.getString(
+				httpServletRequest, portletNamespace + "className");
+
+			long classPK = ParamUtil.getLong(
+				httpServletRequest, portletNamespace + "classPK");
+
+			if (Validator.isNotNull(className) && (classPK != 0)) {
+				return _assetEntryLocalService.fetchEntry(className, classPK);
+			}
+		}
+
+		return null;
+	}
+
+	@Reference
+	private AssetEntryLocalService _assetEntryLocalService;
+
+	@Reference
+	private Portal _portal;
+
+}

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/DisplayPageLayoutTypeController.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-display-page/src/main/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/DisplayPageLayoutTypeController.java
@@ -7,6 +7,8 @@ package com.liferay.layout.type.controller.display.page.internal.layout.type.con
 
 import com.liferay.asset.display.page.portlet.AssetDisplayPageFriendlyURLProvider;
 import com.liferay.asset.kernel.model.AssetEntry;
+import com.liferay.asset.util.PortletLayoutAssetEntryProvider;
+import com.liferay.asset.util.PortletLayoutAssetEntryProviderRegistry;
 import com.liferay.info.display.request.attributes.contributor.InfoDisplayRequestAttributesContributor;
 import com.liferay.info.item.ClassPKInfoItemIdentifier;
 import com.liferay.info.item.InfoItemReference;
@@ -71,12 +73,34 @@ public class DisplayPageLayoutTypeController
 			return null;
 		}
 
-		Object object = httpServletRequest.getAttribute(
-			WebKeys.LAYOUT_ASSET_ENTRY);
+		AssetEntry assetEntry = null;
 
-		if ((object != null) && (object instanceof AssetEntry)) {
-			AssetEntry assetEntry = (AssetEntry)object;
+		try {
+			assetEntry = (AssetEntry)httpServletRequest.getAttribute(
+				WebKeys.LAYOUT_ASSET_ENTRY);
+		}
+		catch (Exception exception) {
+			if (_log.isDebugEnabled()) {
+				_log.debug("Unable to retrieve asset entry", exception);
+			}
+		}
 
+		if (assetEntry == null) {
+			String portletId = ParamUtil.getString(
+				httpServletRequest, "p_p_id");
+
+			PortletLayoutAssetEntryProvider portletLayoutAssetEntryProvider =
+				_portletLayoutAssetEntryProviderRegistry.
+					getPortletLayoutAssetEntryProvider(portletId);
+
+			if (portletLayoutAssetEntryProvider != null) {
+				assetEntry =
+					portletLayoutAssetEntryProvider.getLayoutAssetEntry(
+						httpServletRequest, layout);
+			}
+		}
+
+		if (assetEntry != null) {
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)httpServletRequest.getAttribute(
 					WebKeys.THEME_DISPLAY);
@@ -370,6 +394,10 @@ public class DisplayPageLayoutTypeController
 	@Reference
 	private LayoutPageTemplateEntryLocalService
 		_layoutPageTemplateEntryLocalService;
+
+	@Reference
+	private PortletLayoutAssetEntryProviderRegistry
+		_portletLayoutAssetEntryProviderRegistry;
 
 	@Reference(
 		target = "(osgi.web.symbolicname=com.liferay.layout.type.controller.display.page)"


### PR DESCRIPTION
**Motivation**
https://liferay.atlassian.net/browse/LPS-195551
Assets in the request are lost when a widget is refreshed.


**Proposed Solution**
Create a mechanism to get the layout asset entry if it's not a request attribute, so it's friendly url could be used

@jkappler should have some context for this issue if we could assign it to him.

/cc @robertoDiaz