### PR TITLE
[TS] LPS-201295 & LPS-201299 Display fragment should not show resource warning for Guest users

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentObjectFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/ContentObjectFragmentRenderer.java
@@ -222,18 +222,17 @@ public class ContentObjectFragmentRenderer implements FragmentRenderer {
 		}
 
 		if (!_hasPermission(httpServletRequest, className, displayObject)) {
-			if (!FeatureFlagManagerUtil.isEnabled("LPS-169923")) {
-				FragmentRendererUtil.printPortletMessageInfo(
-					httpServletRequest, httpServletResponse,
-					"you-do-not-have-permission-to-access-the-requested-" +
-						"resource");
-
-				return;
-			}
-
 			if (FragmentRendererUtil.isEditMode(httpServletRequest)) {
-				FragmentRendererUtil.printRestrictedContentMessage(
-					httpServletRequest, httpServletResponse);
+				if (!FeatureFlagManagerUtil.isEnabled("LPS-169923")) {
+					FragmentRendererUtil.printPortletMessageInfo(
+						httpServletRequest, httpServletResponse,
+						"you-do-not-have-permission-to-access-the-requested-" +
+							"resource");
+				}
+				else {
+					FragmentRendererUtil.printRestrictedContentMessage(
+						httpServletRequest, httpServletResponse);
+				}
 			}
 
 			return;

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/display/context/ContentPageEditorDisplayContext.java
@@ -817,7 +817,7 @@ public class ContentPageEditorDisplayContext {
 
 	public String getPublishURL() {
 		return getFragmentEntryActionURL(
-			"/layout_content_page_editor/publish_layout");
+			"/layout_content_page_editor/publish_layout", null, Constants.VIEW);
 	}
 
 	public String getSaveVariantSegmentsExperienceURL() {
@@ -889,10 +889,16 @@ public class ContentPageEditorDisplayContext {
 	}
 
 	protected String getFragmentEntryActionURL(String action) {
-		return getFragmentEntryActionURL(action, null);
+		return getFragmentEntryActionURL(action, null, Constants.EDIT);
 	}
 
 	protected String getFragmentEntryActionURL(String action, String command) {
+		return getFragmentEntryActionURL(action, command, Constants.EDIT);
+	}
+
+	protected String getFragmentEntryActionURL(
+		String action, String command, String mode) {
+
 		return HttpComponentsUtil.addParameter(
 			PortletURLBuilder.createActionURL(
 				renderResponse
@@ -911,7 +917,7 @@ public class ContentPageEditorDisplayContext {
 					portal.getOriginalServletRequest(httpServletRequest),
 					"p_l_back_url", themeDisplay.getURLCurrent())
 			).buildString(),
-			"p_l_mode", Constants.EDIT);
+			"p_l_mode", mode);
 	}
 
 	protected long getGroupId() {


### PR DESCRIPTION
Motivation
=======
Having a restricted content displayed on a content page with a Content Display fragment will show a warning to Guest users both on the page and in search results
[LPS-201295](https://liferay.atlassian.net/browse/LPS-201295)
[LPS-201299](https://liferay.atlassian.net/browse/LPS-201299)


Proposed Solution
========
The warning message should be only visible in Edit mode, like how other such messages are handled in ContentObjectFragmentRenderer.
The Page Editor could use p_l_mode = view when publishing a page to not trigger `FragmentRendererUtil.isEditMode` during search document creation. Given that after pressing the Publish button the user is taken to the published page, so I don't see a reason to keep p_l_mode = edit.

Steps to Verify
========

1. Create a web content
   * Name: Secret
   * Content: Guest users should not see this
   * Permissions: Viewable by: Site Members
5. Create a page
   * Page template: Blank
   * Name: Test
8. Add a Content Display fragment to the page
9. Configure content display fragment to display 'Secret'
10. Publish the page
11. Log out and visit the page

**Expected Behavior:** The page is empty
**Actual Behavior:** The following message is displayed: You do not have permission to access the requested resource.

1. Use the search bar to search for ‘Test’

**Expected Behavior:** The resulting Test page should not have a resource warning message in its description.
**Actual Behavior:** The resulting Test page has “You do not have permission to access the requested resource.” in its description.
