### PR TITLE
[TS] LPS-200940 Add option to skip unwrapping the request

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java
@@ -701,6 +701,12 @@ public class LayoutServiceContextHelperImpl
 							return themeDisplay.getLayout();
 						}
 
+						if (Objects.equals(
+								name, "liferay-portlet:runtime:skipUnwrap")) {
+
+							return true;
+						}
+
 						if (Objects.equals(name, WebKeys.THEME_DISPLAY)) {
 							return themeDisplay;
 						}

--- a/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
+++ b/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java
@@ -183,8 +183,15 @@ public class RuntimeTag extends TagSupport implements DirectTag {
 			}
 		}
 
-		HttpServletRequest originalHttpServletRequest =
-			PortalUtil.getOriginalServletRequest(httpServletRequest);
+		HttpServletRequest originalHttpServletRequest = httpServletRequest;
+
+		Boolean skipUnwrap = (Boolean)httpServletRequest.getAttribute(
+			"liferay-portlet:runtime:skipUnwrap");
+
+		if ((skipUnwrap == null) || !skipUnwrap) {
+			originalHttpServletRequest = PortalUtil.getOriginalServletRequest(
+				httpServletRequest);
+		}
 
 		RestrictPortletServletRequest restrictPortletServletRequest =
 			new RestrictPortletServletRequest(originalHttpServletRequest);


### PR DESCRIPTION
Motivation
=======
During Content Page indexing, [RuntimeTag](https://github.com/liferay/liferay-portal/blob/master/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java#L187) unwraps the `companyHttpServletRequest` created in [LayoutServiceContextHelperImpl#_getHttpServletRequest](https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutServiceContextHelperImpl.java#L691) removing all the request overrides set up for index rendering.
This unwrapping was introduced as part of https://liferay.atlassian.net/browse/LPSA-39344
[LPS-200940](https://liferay.atlassian.net/browse/LPS-200940)

Proposed Solution
========
By adding the option to skip this request unwrapping we should be able render widgets sufficiently to create a search document from them.

Steps to Verify
========
1. Go to Content & Data > Web Content
2. Click the blue + to add a new Web Content
3. Add an easily recognisable text to its content, like “unique” and press Publish
4. Create a content page
5. Add a Web Content Display widget
6. Select the “unique” Web Content to be displayed in the widget
7. Press Publish
8. Use the page’s search bar to look for “unique”
9. 2 results should appear: the web content and the page
11. Go To Control Panel > Search
12. Switch to the Index actions tab
13. Looks for “Page (com.liferay.portal.kernel.model.Layout)”
14. Press the Reindex button next to it, accept the prompt
15. Return to the page and use the search bar to look for “unique”

**Expected behavior:** 2 results should appear: the web content and the page
**Actual behavior:** Only the web content appears