### PR TITLE
LPS-201622 When defining the search URL, take into account the DDMStructureId so that only results for it are shown

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
@@ -474,6 +474,20 @@ public class JournalManagementToolbarDisplayContext
 		return PortletURLBuilder.createRenderURL(
 			liferayPortletResponse
 		).setParameter(
+			"ddmStructureId",
+			() -> {
+				long ddmStructureId =
+					_journalDisplayContext.getDDMStructureId();
+
+				if (FeatureFlagManagerUtil.isEnabled("LPS-194763") &&
+					(ddmStructureId > 0)) {
+
+					return _journalDisplayContext.getDDMStructureId();
+				}
+
+				return null;
+			}
+		).setParameter(
 			"folderId", _journalDisplayContext.getFolderId()
 		).setParameter(
 			"status", _journalDisplayContext.getStatus()


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-201622

How to test:

1. Enable: `LPS-194763` and `LPS-197692` feature flags.
2. Go to Web Content Admin and create 2 structures
3. Create a web content for each structure with a common keyword, for example Notebook 1 and NoteBook 2
4. Go inside of the configuration and select both structures as highlighted and save
5. Back in the main view, click on the vertical nav menu on any structure
6. Search for Notebook

Only the web content for that structure will be shown