### PR TITLE
LPS-199463 Use Site language when adding the suffix to make copies

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLocalServiceImpl.java
@@ -1001,7 +1001,7 @@ public class FragmentEntryLocalServiceImpl
 	}
 
 	private String _getUniqueCopyName(FragmentEntry fragmentEntry) {
-		String copy = _language.get(LocaleUtil.getMostRelevantLocale(), "copy");
+		String copy = _language.get(LocaleUtil.getSiteDefault(), "copy");
 
 		String name = StringUtil.appendParentheticalSuffix(
 			fragmentEntry.getName(), copy);

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/CopyFragmentEntryMVCActionCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/CopyFragmentEntryMVCActionCommandTest.java
@@ -1,0 +1,265 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.internal.portlet.action.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.constants.FragmentConstants;
+import com.liferay.fragment.constants.FragmentPortletKeys;
+import com.liferay.fragment.contributor.FragmentCollectionContributorRegistry;
+import com.liferay.fragment.model.FragmentComposition;
+import com.liferay.fragment.model.FragmentEntry;
+import com.liferay.fragment.service.FragmentCompositionLocalService;
+import com.liferay.fragment.service.FragmentEntryLocalService;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.LayoutTypePortlet;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.security.permission.PermissionThreadLocal;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionRequest;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletActionResponse;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+import java.util.Objects;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Bárbara Cabrera
+ */
+@RunWith(Arquillian.class)
+public class CopyFragmentEntryMVCActionCommandTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+
+		_fragmentEntry = _fragmentEntryLocalService.addFragmentEntry(
+			TestPropsValues.getUserId(), _group.getGroupId(), 0,
+			StringPool.BLANK, StringUtil.randomString(), StringPool.BLANK,
+			StringUtil.randomString(), StringPool.BLANK, false,
+			StringPool.BLANK, StringPool.BLANK, 0,
+			FragmentConstants.TYPE_COMPONENT, StringPool.BLANK,
+			WorkflowConstants.STATUS_APPROVED, _serviceContext);
+
+		_fragmentComposition =
+			_fragmentCollectionContributorRegistry.getFragmentComposition(
+				"FEATURED_CONTENT-composition-banner-center");
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext);
+	}
+
+	@After
+	public void tearDown() {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testCopyFragmentComposition() throws Exception {
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setParameter(
+			"contributedEntryKeys",
+			_fragmentComposition.getFragmentCompositionKey());
+
+		_mvcActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		List<FragmentComposition> actualFragmentCompositions =
+			_fragmentCompositionLocalService.getFragmentCompositions(
+				_group.getGroupId(), 0, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				null);
+
+		Assert.assertEquals(
+			actualFragmentCompositions.toString(), 1,
+			actualFragmentCompositions.size());
+
+		int hits = 0;
+
+		for (FragmentComposition actualFragmentComposition :
+				actualFragmentCompositions) {
+
+			if (Objects.equals(
+					actualFragmentComposition.getName(),
+					StringBundler.concat(
+						_fragmentComposition.getName(), " (",
+						_language.get(LocaleUtil.getSiteDefault(), "copy"),
+						")"))) {
+
+				hits += 1;
+			}
+		}
+
+		Assert.assertEquals(1, hits);
+	}
+
+	@Test
+	public void testCopyFragmentEntry() throws Exception {
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setParameter(
+			"fragmentEntryIds",
+			String.valueOf(_fragmentEntry.getFragmentEntryId()));
+
+		List<FragmentEntry> originalFragmentEntries =
+			_fragmentEntryLocalService.getFragmentEntries(
+				_fragmentEntry.getGroupId(),
+				_fragmentEntry.getFragmentCollectionId(),
+				_fragmentEntry.getName(), QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				null);
+
+		Assert.assertEquals(
+			originalFragmentEntries.toString(), 1,
+			originalFragmentEntries.size());
+
+		_mvcActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		List<FragmentEntry> actualFragmentEntries =
+			_fragmentEntryLocalService.getFragmentEntries(
+				_fragmentEntry.getGroupId(),
+				_fragmentEntry.getFragmentCollectionId(), QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		Assert.assertEquals(
+			actualFragmentEntries.toString(),
+			originalFragmentEntries.size() + 1, actualFragmentEntries.size());
+
+		int hits = 0;
+
+		for (FragmentEntry actualFragmentEntry : actualFragmentEntries) {
+			if (Objects.equals(
+					actualFragmentEntry.getName(),
+					StringBundler.concat(
+						_fragmentEntry.getName(), " (",
+						_language.get(LocaleUtil.getSiteDefault(), "copy"),
+						")"))) {
+
+				hits += 1;
+			}
+		}
+
+		Assert.assertEquals(1, hits);
+	}
+
+	private MockLiferayPortletActionRequest
+			_getMockLiferayPortletActionRequest()
+		throws Exception {
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			new MockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_RESPONSE,
+			new MockLiferayPortletActionResponse());
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay());
+		mockLiferayPortletActionRequest.setParameter(
+			"fragmentCollectionId",
+			String.valueOf(_fragmentEntry.getFragmentCollectionId()));
+		mockLiferayPortletActionRequest.setAttribute(
+			WebKeys.PORTLET_ID, FragmentPortletKeys.FRAGMENT);
+
+		return mockLiferayPortletActionRequest;
+	}
+
+	private ThemeDisplay _getThemeDisplay() throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(
+			_companyLocalService.getCompany(_group.getCompanyId()));
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		themeDisplay.setLayout(layout);
+		themeDisplay.setLayoutTypePortlet(
+			(LayoutTypePortlet)layout.getLayoutType());
+
+		LayoutSet layoutSet = layout.getLayoutSet();
+
+		themeDisplay.setLayoutSet(layoutSet);
+
+		themeDisplay.setLookAndFeel(layoutSet.getTheme(), null);
+
+		themeDisplay.setPermissionChecker(
+			PermissionThreadLocal.getPermissionChecker());
+		themeDisplay.setRealUser(TestPropsValues.getUser());
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private FragmentCollectionContributorRegistry
+		_fragmentCollectionContributorRegistry;
+
+	private FragmentComposition _fragmentComposition;
+
+	@Inject
+	private FragmentCompositionLocalService _fragmentCompositionLocalService;
+
+	private FragmentEntry _fragmentEntry;
+
+	@Inject
+	private FragmentEntryLocalService _fragmentEntryLocalService;
+
+	private Group _group;
+
+	@Inject
+	private Language _language;
+
+	@Inject(filter = "mvc.command.name=/fragment/copy_fragment_entry")
+	private MVCActionCommand _mvcActionCommand;
+
+	private ServiceContext _serviceContext;
+
+}

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentEntryLocalServiceTest.java
@@ -15,9 +15,11 @@ import com.liferay.fragment.util.FragmentEntryTestUtil;
 import com.liferay.fragment.util.FragmentTestUtil;
 import com.liferay.fragment.util.comparator.FragmentEntryCreateDateComparator;
 import com.liferay.fragment.util.comparator.FragmentEntryNameComparator;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
+import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -29,6 +31,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.transaction.Propagation;
 import com.liferay.portal.kernel.util.FileUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
 import com.liferay.portal.test.rule.Inject;
@@ -477,6 +480,12 @@ public class FragmentEntryLocalServiceTest {
 		Assert.assertEquals(
 			fragmentEntry.getFragmentCollectionId(),
 			copyFragmentEntry.getFragmentCollectionId());
+
+		Assert.assertEquals(
+			StringBundler.concat(
+				fragmentEntry.getName(), " (",
+				_language.get(LocaleUtil.getSiteDefault(), "copy"), ")"),
+			copyFragmentEntry.getName());
 	}
 
 	@Test
@@ -1123,6 +1132,9 @@ public class FragmentEntryLocalServiceTest {
 
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private Language _language;
 
 	private FragmentCollection _updatedFragmentCollection;
 

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/CopyFragmentEntryMVCActionCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/CopyFragmentEntryMVCActionCommand.java
@@ -152,7 +152,7 @@ public class CopyFragmentEntryMVCActionCommand extends BaseMVCActionCommand {
 			StringBundler.concat(
 				fragmentComposition.getName(), StringPool.SPACE,
 				StringPool.OPEN_PARENTHESIS,
-				_language.get(LocaleUtil.getMostRelevantLocale(), "copy"),
+				_language.get(LocaleUtil.getSiteDefault(), "copy"),
 				StringPool.CLOSE_PARENTHESIS),
 			null, fragmentComposition.getData(), previewFileEntryId,
 			WorkflowConstants.STATUS_APPROVED, serviceContext);
@@ -180,7 +180,7 @@ public class CopyFragmentEntryMVCActionCommand extends BaseMVCActionCommand {
 			StringBundler.concat(
 				fragmentEntry.getName(), StringPool.SPACE,
 				StringPool.OPEN_PARENTHESIS,
-				_language.get(LocaleUtil.getMostRelevantLocale(), "copy"),
+				_language.get(LocaleUtil.getSiteDefault(), "copy"),
 				StringPool.CLOSE_PARENTHESIS),
 			fragmentEntry.getCss(), fragmentEntry.getHtml(),
 			fragmentEntry.getJs(), fragmentEntry.isCacheable(),

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -7821,7 +7821,7 @@ public class JournalArticleLocalServiceImpl
 	private String _getUniqueUrlTitle(
 		long groupId, String articleId, String urlTitle) {
 
-		String copy = _language.get(LocaleUtil.getMostRelevantLocale(), "copy");
+		String copy = _language.get(LocaleUtil.getSiteDefault(), "copy");
 		String prefix = urlTitle;
 		String title = urlTitle;
 

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleLocalServiceTest.java
@@ -579,7 +579,7 @@ public class JournalArticleLocalServiceTest {
 				draftJournalArticle.getVersion());
 
 		Assert.assertEquals(
-			_getNewTitle(locale, draftJournalArticle.getTitle(locale)),
+			_getNewTitle(draftJournalArticle.getTitle(locale)),
 			newJournalArticle.getTitle(locale));
 
 		_assertAssetCategoryIds(
@@ -660,7 +660,7 @@ public class JournalArticleLocalServiceTest {
 				draftJournalArticle.getVersion());
 
 		Assert.assertEquals(
-			_getNewTitle(locale, draftJournalArticle.getTitle(locale)),
+			_getNewTitle(draftJournalArticle.getTitle(locale)),
 			newJournalArticle.getTitle(locale));
 
 		_assertAssetLinkEntryId(
@@ -715,7 +715,7 @@ public class JournalArticleLocalServiceTest {
 				draftJournalArticle.getVersion());
 
 		Assert.assertEquals(
-			_getNewTitle(locale, draftJournalArticle.getTitle(locale)),
+			_getNewTitle(draftJournalArticle.getTitle(locale)),
 			newJournalArticle.getTitle(locale));
 
 		_assertAssetTagIds(
@@ -764,7 +764,7 @@ public class JournalArticleLocalServiceTest {
 				sourceJournalArticle.getVersion());
 
 		Assert.assertEquals(
-			_getNewTitle(locale, sourceJournalArticle.getTitle(locale)),
+			_getNewTitle(sourceJournalArticle.getTitle(locale)),
 			newJournalArticle.getTitle(locale));
 
 		_assertAssetCategoryIds(
@@ -818,7 +818,7 @@ public class JournalArticleLocalServiceTest {
 				sourceJournalArticle.getVersion());
 
 		Assert.assertEquals(
-			_getNewTitle(locale, sourceJournalArticle.getTitle(locale)),
+			_getNewTitle(sourceJournalArticle.getTitle(locale)),
 			newJournalArticle.getTitle(locale));
 
 		_assertAssetLinkEntryId(
@@ -860,7 +860,7 @@ public class JournalArticleLocalServiceTest {
 				sourceJournalArticle.getVersion());
 
 		Assert.assertEquals(
-			_getNewTitle(locale, sourceJournalArticle.getTitle(locale)),
+			_getNewTitle(sourceJournalArticle.getTitle(locale)),
 			newJournalArticle.getTitle(locale));
 
 		_assertAssetTagIds(
@@ -1727,10 +1727,11 @@ public class JournalArticleLocalServiceTest {
 		return new Tuple(article, ddmStructure);
 	}
 
-	private String _getNewTitle(Locale locale, String title) {
+	private String _getNewTitle(String title) {
 		return StringBundler.concat(
 			title, StringPool.SPACE, StringPool.OPEN_PARENTHESIS,
-			_language.get(locale, "copy"), StringPool.CLOSE_PARENTHESIS);
+			_language.get(LocaleUtil.getSiteDefault(), "copy"),
+			StringPool.CLOSE_PARENTHESIS);
 	}
 
 	private ThemeDisplay _getThemeDisplay() throws Exception {

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleServiceTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/service/test/JournalArticleServiceTest.java
@@ -241,7 +241,7 @@ public class JournalArticleServiceTest {
 		Assert.assertEquals(
 			StringBundler.concat(
 				_article.getTitle(), " (",
-				_language.get(LocaleUtil.getDefault(), "copy"), ")"),
+				_language.get(LocaleUtil.getSiteDefault(), "copy"), ")"),
 			journalArticle.getTitle());
 		Assert.assertEquals(
 			_article.getTreePath(), journalArticle.getTreePath());

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/CopyLayoutPageTemplateEntryMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/CopyLayoutPageTemplateEntryMVCActionCommandTest.java
@@ -30,6 +30,7 @@ import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -169,7 +170,7 @@ public class CopyLayoutPageTemplateEntryMVCActionCommandTest {
 				_group.getGroupId(),
 				StringUtil.appendParentheticalSuffix(
 					_layoutPageTemplateEntry.getName(),
-					LanguageUtil.get(_serviceContext.getLocale(), "copy") +
+					LanguageUtil.get(LocaleUtil.getSiteDefault(), "copy") +
 						StringPool.SPACE + 1),
 				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT);
 

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/service/impl/LayoutPageTemplateEntryLocalServiceImpl.java
@@ -266,8 +266,7 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 
 		String name = _getUniqueCopyName(
 			groupId, sourceLayoutPageTemplateEntry.getName(),
-			sourceLayoutPageTemplateEntry.getType(),
-			serviceContext.getLocale());
+			sourceLayoutPageTemplateEntry.getType());
 
 		long masterLayoutPlid = 0;
 
@@ -998,9 +997,9 @@ public class LayoutPageTemplateEntryLocalServiceImpl
 	}
 
 	private String _getUniqueCopyName(
-		long groupId, String sourceName, int type, Locale locale) {
+		long groupId, String sourceName, int type) {
 
-		String copy = _language.get(locale, "copy");
+		String copy = _language.get(LocaleUtil.getSiteDefault(), "copy");
 
 		String name = StringUtil.appendParentheticalSuffix(sourceName, copy);
 

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryServiceTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/service/test/LayoutPageTemplateEntryServiceTest.java
@@ -283,7 +283,7 @@ public class LayoutPageTemplateEntryServiceTest {
 				copiedLayoutPageTemplateEntry.getName(),
 				StringBundler.concat(
 					layoutPageTemplateEntry.getName(), " (",
-					_language.get(LocaleUtil.getDefault(), "copy"), ")")));
+					_language.get(LocaleUtil.getSiteDefault(), "copy"), ")")));
 		Assert.assertEquals(
 			layoutPageTemplateEntry.getType(),
 			copiedLayoutPageTemplateEntry.getType());

--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -140,7 +140,7 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 
 		String name = _getUniqueCopyName(
 			groupId, sourceLayoutUtilityPageEntry.getName(),
-			sourceLayoutUtilityPageEntry.getType(), serviceContext.getLocale());
+			sourceLayoutUtilityPageEntry.getType());
 
 		long masterLayoutPlid = 0;
 
@@ -503,9 +503,9 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 	}
 
 	private String _getUniqueCopyName(
-		long groupId, String sourceName, String type, Locale locale) {
+		long groupId, String sourceName, String type) {
 
-		String copy = _language.get(locale, "copy");
+		String copy = _language.get(LocaleUtil.getSiteDefault(), "copy");
 
 		String name = StringUtil.appendParentheticalSuffix(sourceName, copy);
 

--- a/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryServiceTest.java
+++ b/modules/apps/layout/layout-utility-page-test/src/testIntegration/java/com/liferay/layout/utility/page/service/test/LayoutUtilityPageEntryServiceTest.java
@@ -124,7 +124,7 @@ public class LayoutUtilityPageEntryServiceTest {
 				copiedLayoutUtilityPageEntry.getName(),
 				StringBundler.concat(
 					layoutUtilityPageEntry.getName(), " (",
-					_language.get(LocaleUtil.getDefault(), "copy"), ")")));
+					_language.get(LocaleUtil.getSiteDefault(), "copy"), ")")));
 		Assert.assertEquals(
 			layoutUtilityPageEntry.getType(),
 			copiedLayoutUtilityPageEntry.getType());

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -486,7 +486,7 @@ public class StyleBookEntryLocalServiceImpl
 	}
 
 	private String _getUniqueCopyName(StyleBookEntry styleBookEntry) {
-		String copy = _language.get(LocaleUtil.getMostRelevantLocale(), "copy");
+		String copy = _language.get(LocaleUtil.getSiteDefault(), "copy");
 
 		String name = StringUtil.appendParentheticalSuffix(
 			styleBookEntry.getName(), copy);

--- a/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/StyleBookEntryServiceTest.java
+++ b/modules/apps/style-book/style-book-web-test/src/testIntegration/java/com/liferay/style/book/web/internal/portlet/action/test/StyleBookEntryServiceTest.java
@@ -71,7 +71,7 @@ public class StyleBookEntryServiceTest {
 			StringBundler.concat(
 				sourceStyleBookEntry.getName(), StringPool.SPACE,
 				StringPool.OPEN_PARENTHESIS,
-				_language.get(LocaleUtil.getDefault(), "copy"),
+				_language.get(LocaleUtil.getSiteDefault(), "copy"),
 				StringPool.CLOSE_PARENTHESIS));
 		Assert.assertEquals(
 			sourceStyleBookEntry.getPreviewFileEntryId(),


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-199463)

### Changes

Change the getMostRelevantLocale() to the getDefault() to use the site language instead of the user one.

## Test scenario

Change the user language to Spanish.

## Test scenario 1

1. Create a Web Content.
2. Make a copy.
3. Check that the suffix it’s in English instead of Spanish.
<img width="1237" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/b81e12fc-33e7-42a9-aaac-f8b6b94a7331">

## Test scenario 2

1. Create a Fragment.
2. Make a copy.
3. Check that the suffix it’s in English instead of Spanish.
<img width="911" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/22ffeb2f-5ae2-42fd-860e-1a50b79dd2a7">

## Test scenario 3

1. Create a StyleBook.
2. Make a copy.
3. Check that the suffix it’s in English instead of Spanish.
<img width="980" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/bff52e9e-850a-471c-8f7c-f7e7928f26d1">

## Test scenario 4

1. Create a Master page.
2. Make a copy.
3. Check that the suffix it’s in English instead of Spanish.
<img width="939" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/de31a6f5-626c-4e18-a675-b0c539447686">

## Test scenario 5

1. Create a Display Page Template.
2. Make a copy.
3. Check that the suffix it’s in English instead of Spanish.
<img width="643" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/9d2d3f74-16af-4a5d-93b1-b270d3b10643">

## Test scenario 6

1. Create a Utility Page.
2. Make a copy.
3. Check that the suffix it’s in English instead of Spanish.
<img width="723" alt="image" src="https://github.com/liferay-echo/liferay-portal/assets/93203423/d31087f3-fc5a-4cd9-9757-9a341cd38e5e">
