### PR TITLE
LPS-201523 Change back button title when editing a Collection

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListDisplayContext.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.portlet.SearchOrderByUtil;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.ResourceActionsUtil;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -387,6 +388,14 @@ public class AssetListDisplayContext {
 				_themeDisplay.getURLCurrent()
 			).setParameter(
 				"assetListEntryId", assetListEntry.getAssetListEntryId()
+			).setParameter(
+				"backURLTitle",
+				() -> {
+					PortletDisplay portletDisplay =
+						_themeDisplay.getPortletDisplay();
+
+					return portletDisplay.getPortletDisplayName();
+				}
 			).buildString();
 		}
 

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListManagementToolbarDisplayContext.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/AssetListManagementToolbarDisplayContext.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.WebKeys;
 
@@ -99,6 +100,8 @@ public class AssetListManagementToolbarDisplayContext
 
 	@Override
 	public CreationMenu getCreationMenu() {
+		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
+
 		return CreationMenuBuilder.addPrimaryDropdownItem(
 			dropdownItem -> {
 				dropdownItem.putData("action", "addAssetListEntry");
@@ -108,6 +111,8 @@ public class AssetListManagementToolbarDisplayContext
 						liferayPortletResponse
 					).setActionName(
 						"/asset_list/add_asset_list_entry"
+					).setParameter(
+						"backURLTitle", portletDisplay.getPortletDisplayName()
 					).setParameter(
 						"type", AssetListEntryTypeConstants.TYPE_MANUAL
 					).buildString());
@@ -129,6 +134,8 @@ public class AssetListManagementToolbarDisplayContext
 						liferayPortletResponse
 					).setActionName(
 						"/asset_list/add_asset_list_entry"
+					).setParameter(
+						"backURLTitle", portletDisplay.getPortletDisplayName()
 					).setParameter(
 						"type", AssetListEntryTypeConstants.TYPE_DYNAMIC
 					).buildString());

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/action/AddAssetListEntryMVCActionCommand.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/portlet/action/AddAssetListEntryMVCActionCommand.java
@@ -124,6 +124,8 @@ public class AddAssetListEntryMVCActionCommand extends BaseMVCActionCommand {
 			}
 		).setParameter(
 			"assetListEntryId", assetListEntry.getAssetListEntryId()
+		).setParameter(
+			"backURLTitle", ParamUtil.getString(actionRequest, "backURLTitle")
 		).buildString();
 	}
 

--- a/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/servlet/taglib/util/AssetListEntryActionDropdownItemsProvider.java
+++ b/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/servlet/taglib/util/AssetListEntryActionDropdownItemsProvider.java
@@ -21,6 +21,7 @@ import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 import com.liferay.portal.kernel.portlet.LiferayWindowState;
 import com.liferay.portal.kernel.portlet.url.builder.PortletURLBuilder;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
+import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -138,9 +139,12 @@ public class AssetListEntryActionDropdownItemsProvider {
 	private UnsafeConsumer<DropdownItem, Exception>
 		_getEditAssetListEntryActionUnsafeConsumer() {
 
+		PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
+
 		return dropdownItem -> {
 			dropdownItem.setHref(
-				_liferayPortletResponse.createRenderURL(), "mvcPath",
+				_liferayPortletResponse.createRenderURL(), "backURLTitle",
+				portletDisplay.getPortletDisplayName(), "mvcPath",
 				"/edit_asset_list_entry.jsp", "redirect",
 				_themeDisplay.getURLCurrent(), "assetListEntryId",
 				_assetListEntry.getAssetListEntryId());

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_dynamic.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_dynamic.jsp
@@ -9,7 +9,7 @@
 
 <%
 portletDisplay.setURLBack(editAssetListDisplayContext.getBackURL());
-portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
+portletDisplay.setURLBackTitle(ParamUtil.getString(request, "backURLTitle"));
 
 AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 %>

--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/edit_asset_list_entry_manual.jsp
@@ -9,7 +9,7 @@
 
 <%
 portletDisplay.setURLBack(editAssetListDisplayContext.getBackURL());
-portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
+portletDisplay.setURLBackTitle(ParamUtil.getString(request, "backURLTitle"));
 
 AssetListEntry assetListEntry = assetListDisplayContext.getAssetListEntry();
 %>

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectCollectionManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectCollectionManagementToolbarDisplayContext.java
@@ -124,6 +124,9 @@ public class SelectCollectionManagementToolbarDisplayContext
 				).setBackURL(
 					_themeDisplay.getURLCurrent()
 				).setParameter(
+					"backURLTitle",
+					LanguageUtil.get(httpServletRequest, "select-collection")
+				).setParameter(
 					"type", type
 				).buildString());
 


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-201523)

## Steps 

**edit_asset_list_entry_dynamic.jsp and edit_asset_list_entry_manual.jsp**

These two clases are the common classes to retrieve the "backURLTitle"

**AddAssetListEntryMVCActionCommand.java: this one is to set the "backURLTitle" when adding a Collection, we can add a Collection in two different ways**

**Case 1: From Collections - AssetListManagementToolbarDisplayContext.java**

- Go to Site Builder > Collections > Create a Manual Collection and see the back button title 
![Screenshot 2023-11-14 at 12 26 22](https://github.com/liferay-echo/liferay-portal/assets/91208451/b276251a-7b62-471a-91df-bce3c542dcda)

**Case 2: From Collection Pages - SelectCollectionManagementToolbarDisplayContext.java**

- Go to Site Builder > Pages > Add a Collection Page > Choose or create a manual collection > see the title of back button 
![Screenshot 2023-11-14 at 12 28 37](https://github.com/liferay-echo/liferay-portal/assets/91208451/549ff8a9-e3d2-46f2-8524-50d2ea716228)

**AssetListDisplayContext.java**

- Go to Site Builder > Collections > Create a Manual Collection > Go to Collections tab to see the list of Collections
- Click on the collection name > see the back button title 
![Screenshot 2023-11-14 at 12 32 56](https://github.com/liferay-echo/liferay-portal/assets/91208451/6954f5f9-5778-4c67-ae8b-a7a1cf89456d)

**AssetListEntryActionDropdownItemsProvider.java**

- Go to Site Builder > Collections > Create a Manual Collection > Go to Collections tab to see the list of Collections
- Click on the collection ellipsis > edit > see the back button title 
![Screenshot 2023-11-14 at 12 35 24](https://github.com/liferay-echo/liferay-portal/assets/91208451/ffe80c27-6bc4-4bef-9374-08478a42db6d)