### PR TITLE
[TS] LPS-201388 | Sitemap uses wrong domain when site has multiple virtual hosts

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/RobotsStrutsAction.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/RobotsStrutsAction.java
@@ -70,7 +70,7 @@ public class RobotsStrutsAction implements StrutsAction {
 			}
 
 			String robots = RobotsUtil.getRobots(
-				layoutSet, httpServletRequest.isSecure());
+				layoutSet, httpServletRequest.isSecure(), virtualHost);
 
 			ServletResponseUtil.sendFile(
 				httpServletRequest, httpServletResponse, null,

--- a/portal-impl/src/com/liferay/portal/util/RobotsUtil.java
+++ b/portal-impl/src/com/liferay/portal/util/RobotsUtil.java
@@ -10,6 +10,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.VirtualHost;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
@@ -25,7 +26,8 @@ import java.util.TreeMap;
  */
 public class RobotsUtil {
 
-	public static String getRobots(LayoutSet layoutSet, boolean secure)
+	public static String getRobots(
+			LayoutSet layoutSet, boolean secure, VirtualHost virtualHost)
 		throws PortalException {
 
 		if (layoutSet == null) {
@@ -50,7 +52,12 @@ public class RobotsUtil {
 		String virtualHostname = StringPool.BLANK;
 
 		if (!virtualHostnames.isEmpty()) {
-			virtualHostname = virtualHostnames.firstKey();
+			if (virtualHostnames.containsKey(virtualHost.getHostname())) {
+				virtualHostname = virtualHost.getHostname();
+			}
+			else {
+				virtualHostname = virtualHostnames.firstKey();
+			}
 		}
 
 		String robotsTxt = null;

--- a/portal-impl/src/com/liferay/portal/util/packageinfo
+++ b/portal-impl/src/com/liferay/portal/util/packageinfo
@@ -1,1 +1,1 @@
-version 58.0.0
+version 59.0.0


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPS-201388
best,
Attila

-----

The root cause of the issue is that the robot's action uses the first virtualhost from the map and does not consider the currently used host in the request. As a solution, I forwarded the virtualhost to the getRobots util method. First, it should try to use the virtualhost from the request and use the previous logic as a fallback.