### PR TITLE
LPS-201506 & LPS-201822: Replace AUI() usages in commerce-subscription-web and commerce-theme-speedwell

### DIFF
--- a/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/commerce_subscription_entry/general.jsp
+++ b/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/commerce_subscription_entry/general.jsp
@@ -142,11 +142,11 @@ if (deliveryMaxSubscriptionCycles > 0) {
 					</aui:select>
 
 					<div class="never-ends-header">
-						<aui:input checked="<%= ending ? false : true %>" name="neverEnds" type="toggle-switch" />
+						<aui:input checked="<%= ending ? false : true %>" name="neverEnds" onClick='<%= liferayPortletResponse.getNamespace() + "neverEndsToggle();" %>' type="toggle-switch" />
 					</div>
 
-					<div class="never-ends-content">
-						<aui:input disabled="<%= ending ? false : true %>" helpMessage="max-subscription-cycles-help" label="end-after" name="maxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(maxSubscriptionCycles) %>">
+					<div class="never-ends-content <%= ending ? StringPool.BLANK : "hide" %>">
+						<aui:input helpMessage="max-subscription-cycles-help" label="end-after" name="maxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(maxSubscriptionCycles) %>">
 							<aui:validator name="digits" />
 
 							<aui:validator errorMessage='<%= LanguageUtil.format(request, "please-enter-a-value-greater-than-or-equal-to-x", 1) %>' name="custom">
@@ -267,11 +267,11 @@ if (deliveryMaxSubscriptionCycles > 0) {
 					</aui:select>
 
 					<div class="delivery-never-ends-header">
-						<aui:input checked="<%= deliveryEnding ? false : true %>" label="never-ends" name="deliveryNeverEnds" type="toggle-switch" />
+						<aui:input checked="<%= deliveryEnding ? false : true %>" label="never-ends" name="deliveryNeverEnds" onClick='<%= liferayPortletResponse.getNamespace() + "deliveryNeverEndsToggle();" %>' type="toggle-switch" />
 					</div>
 
-					<div class="delivery-never-ends-content">
-						<aui:input disabled="<%= deliveryEnding ? false : true %>" helpMessage="max-subscription-cycles-help" label="end-after" name="deliveryMaxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(deliveryMaxSubscriptionCycles) %>">
+					<div class="never-ends-content <%= ending ? StringPool.BLANK : "hide" %>">
+						<aui:input helpMessage="max-subscription-cycles-help" label="end-after" name="deliveryMaxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(deliveryMaxSubscriptionCycles) %>">
 							<aui:validator name="digits" />
 
 							<aui:validator errorMessage='<%= LanguageUtil.format(request, "please-enter-a-value-greater-than-or-equal-to-x", 1) %>' name="custom">
@@ -387,19 +387,17 @@ if (deliveryMaxSubscriptionCycles > 0) {
 		window,
 		'<portlet:namespace />selectSubscriptionType',
 		() => {
-			var A = AUI();
+			const subscriptionLength = document.getElementById(
+				'<portlet:namespace />subscriptionLength'
+			).value;
+			const subscriptionType = document.getElementById(
+				'<portlet:namespace />subscriptionType'
+			).value;
+			const maxSubscriptionCycles = document.getElementById(
+				'<portlet:namespace />maxSubscriptionCycles'
+			).value;
 
-			var subscriptionLength = A.one(
-				'#<portlet:namespace />subscriptionLength'
-			).val();
-			var subscriptionType = A.one(
-				'#<portlet:namespace />subscriptionType'
-			).val();
-			var maxSubscriptionCycles = A.one(
-				'#<portlet:namespace />maxSubscriptionCycles'
-			).val();
-
-			var portletURL = new Liferay.PortletURL.createURL(
+			const portletURL = new Liferay.PortletURL.createURL(
 				'<%= currentURLObj %>'
 			);
 
@@ -416,19 +414,17 @@ if (deliveryMaxSubscriptionCycles > 0) {
 		window,
 		'<portlet:namespace />selectDeliverySubscriptionType',
 		() => {
-			var A = AUI();
+			const deliverySubscriptionLength = document.getElementById(
+				'<portlet:namespace />deliverySubscriptionLength'
+			).value;
+			const deliverySubscriptionType = document.getElementById(
+				'<portlet:namespace />deliverySubscriptionType'
+			).value;
+			const deliveryMaxSubscriptionCycles = document.getElementById(
+				'<portlet:namespace />deliveryMaxSubscriptionCycles'
+			).value;
 
-			var deliverySubscriptionLength = A.one(
-				'#<portlet:namespace />deliverySubscriptionLength'
-			).val();
-			var deliverySubscriptionType = A.one(
-				'#<portlet:namespace />deliverySubscriptionType'
-			).val();
-			var deliveryMaxSubscriptionCycles = A.one(
-				'#<portlet:namespace />deliveryMaxSubscriptionCycles'
-			).val();
-
-			var portletURL = new Liferay.PortletURL.createURL(
+			const portletURL = new Liferay.PortletURL.createURL(
 				'<%= currentURLObj %>'
 			);
 
@@ -452,69 +448,39 @@ if (deliveryMaxSubscriptionCycles > 0) {
 </aui:script>
 
 <aui:script use="liferay-form">
-	A.one('#<portlet:namespace />neverEnds').on('change', (event) => {
-		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
-			.formValidator;
+	document
+		.getElementById('<portlet:namespace />neverEnds')
+		.addEventListener('change', (event) => {
+			const formValidator = Liferay.Form.get('<portlet:namespace />fm')
+				.formValidator;
 
-		formValidator.validateField('<portlet:namespace />maxSubscriptionCycles');
-	});
+			formValidator.validateField(
+				'<portlet:namespace />maxSubscriptionCycles'
+			);
+		});
 
-	A.one('#<portlet:namespace />deliveryNeverEnds').on('change', (event) => {
-		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
-			.formValidator;
+	document
+		.getElementById('<portlet:namespace />deliveryNeverEnds')
+		.addEventListener('change', (event) => {
+			const formValidator = Liferay.Form.get('<portlet:namespace />fm')
+				.formValidator;
 
-		formValidator.validateField(
-			'<portlet:namespace />deliveryMaxSubscriptionCycles'
-		);
-	});
+			formValidator.validateField(
+				'<portlet:namespace />deliveryMaxSubscriptionCycles'
+			);
+		});
 </aui:script>
 
-<aui:script use="aui-toggler">
-	new A.Toggler({
-		animated: true,
-		content: '.never-ends-content',
-		expanded: <%= ending %>,
-		header: '#<portlet:namespace />neverEnds',
-		on: {
-			animatingChange: function (event) {
-				var instance = this;
+<aui:script>
+	function <portlet:namespace />neverEndsToggle() {
+		document.querySelector('.never-ends-content').classList.toggle('hide');
+	}
 
-				if (!instance.get('expanded')) {
-					A.one('#<portlet:namespace />maxSubscriptionCycles').attr(
-						'disabled',
-						false
-					);
-				}
-				else {
-					A.one('#<portlet:namespace />maxSubscriptionCycles').attr(
-						'disabled',
-						true
-					);
-				}
-			},
-		},
-	});
-
-	new A.Toggler({
-		animated: true,
-		content: '.delivery-never-ends-content',
-		expanded: <%= deliveryEnding %>,
-		header: '#<portlet:namespace />deliveryNeverEnds',
-		on: {
-			animatingChange: function (event) {
-				var instance = this;
-
-				if (!instance.get('expanded')) {
-					A.one(
-						'#<portlet:namespace />deliveryMaxSubscriptionCycles'
-					).attr('disabled', false);
-				}
-				else {
-					A.one(
-						'#<portlet:namespace />deliveryMaxSubscriptionCycles'
-					).attr('disabled', true);
-				}
-			},
-		},
-	});
+	function <portlet:namespace />deliveryNeverEndsToggle() {
+		document
+			.querySelector(
+				'#<portlet:namespace />deliveryNeverEndsContainer .never-ends-content'
+			)
+			.classList.toggle('hide');
+	}
 </aui:script>

--- a/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/definition/edit_definition_subscription_info.jsp
+++ b/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/definition/edit_definition_subscription_info.jsp
@@ -146,11 +146,11 @@ if (deliveryMaxSubscriptionCycles > 0) {
 
 		<div id="<portlet:namespace />neverEndsContainer">
 			<div class="never-ends-header">
-				<aui:input checked="<%= ending ? false : true %>" name="neverEnds" type="toggle-switch" />
+				<aui:input checked="<%= ending ? false : true %>" name="neverEnds" onClick='<%= liferayPortletResponse.getNamespace() + "neverEndsToggle();" %>' type="toggle-switch" />
 			</div>
 
-			<div class="never-ends-content">
-				<aui:input disabled="<%= ending ? false : true %>" helpMessage="max-subscription-cycles-help" label="end-after" name="maxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(maxSubscriptionCycles) %>">
+			<div class="never-ends-content <%= ending ? StringPool.BLANK : "hide" %>">
+				<aui:input helpMessage="max-subscription-cycles-help" label="end-after" name="maxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(maxSubscriptionCycles) %>">
 					<aui:validator name="digits" />
 
 					<aui:validator errorMessage='<%= LanguageUtil.format(request, "please-enter-a-value-greater-than-or-equal-to-x", 1) %>' name="custom">
@@ -242,11 +242,11 @@ if (deliveryMaxSubscriptionCycles > 0) {
 
 		<div id="<portlet:namespace />deliveryNeverEndsContainer">
 			<div class="never-ends-header">
-				<aui:input checked="<%= deliveryEnding ? false : true %>" label="never-ends" name="deliveryNeverEnds" type="toggle-switch" />
+				<aui:input checked="<%= deliveryEnding ? false : true %>" label="never-ends" name="deliveryNeverEnds" onClick='<%= liferayPortletResponse.getNamespace() + "deliveryNeverEndsToggle();" %>' type="toggle-switch" />
 			</div>
 
-			<div class="never-ends-content">
-				<aui:input disabled="<%= deliveryEnding ? false : true %>" helpMessage="max-subscription-cycles-help" label="end-after" name="deliveryMaxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(deliveryMaxSubscriptionCycles) %>">
+			<div class="never-ends-content <%= ending ? StringPool.BLANK : "hide" %>">
+				<aui:input helpMessage="max-subscription-cycles-help" label="end-after" name="deliveryMaxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(deliveryMaxSubscriptionCycles) %>">
 					<aui:validator name="digits" />
 
 					<aui:validator errorMessage='<%= LanguageUtil.format(request, "please-enter-a-value-greater-than-or-equal-to-x", 1) %>' name="custom">
@@ -279,36 +279,33 @@ if (deliveryMaxSubscriptionCycles > 0) {
 				return;
 			}
 
-			var A = AUI();
-
-			var subscriptionType = A.one(element).val();
-			var subscriptionTypeLabel = A.one(element)
-				.get('children')
-				.filter((item) => {
-					return item.get('selected');
-				})
-				.first();
+			const subscriptionType = element.value;
+			let subscriptionTypeLabel = element.options[element.selectedIndex];
 
 			if (subscriptionTypeLabel) {
-				subscriptionTypeLabel = subscriptionTypeLabel.getData('label');
+				subscriptionTypeLabel = subscriptionTypeLabel.dataset.label;
 			}
 
-			A.one('#<portlet:namespace />subscriptionTypeContributors')
-				.get('children')
-				.hide();
+			Array.from(
+				document.getElementById(
+					'<portlet:namespace />subscriptionTypeContributors'
+				).children
+			).forEach((child) => {
+				child.classList.add('hide');
+			});
 
-			var subscriptionTypeContributor = A.one(
-				'#<portlet:namespace />subscriptionTypeContributor' +
+			const subscriptionTypeContributor = document.getElementById(
+				'<portlet:namespace />subscriptionTypeContributor' +
 					subscriptionType
 			);
 
 			if (subscriptionTypeContributor) {
-				subscriptionTypeContributor.show();
+				subscriptionTypeContributor.classList.remove('hide');
 			}
 
-			A.one(
+			document.querySelector(
 				'#<portlet:namespace />cycleLengthContainer .input-group-text'
-			).html(subscriptionTypeLabel);
+			).innerHTML = subscriptionTypeLabel;
 		},
 		['liferay-portlet-url']
 	);
@@ -321,107 +318,76 @@ if (deliveryMaxSubscriptionCycles > 0) {
 				return;
 			}
 
-			var A = AUI();
-
-			var subscriptionType = A.one(element).val();
-			var subscriptionTypeLabel = A.one(element)
-				.get('children')
-				.filter((item) => {
-					return item.get('selected');
-				})
-				.first();
+			const subscriptionType = element.value;
+			let subscriptionTypeLabel = element.options[element.selectedIndex];
 
 			if (subscriptionTypeLabel) {
-				subscriptionTypeLabel = subscriptionTypeLabel.getData('label');
+				subscriptionTypeLabel = subscriptionTypeLabel.dataset.label;
 			}
 
-			A.one('#<portlet:namespace />deliverySubscriptionTypeContributors')
-				.get('children')
-				.hide();
+			Array.from(
+				document.getElementById(
+					'<portlet:namespace />deliverySubscriptionTypeContributors'
+				).children
+			).forEach((child) => {
+				child.classList.add('hide');
+			});
 
-			var deliverySubscriptionTypeContributor = A.one(
-				'#<portlet:namespace />deliverySubscriptionTypeContributor' +
+			const deliverySubscriptionTypeContributor = document.getElementById(
+				'<portlet:namespace />deliverySubscriptionTypeContributor' +
 					subscriptionType
 			);
 
 			if (deliverySubscriptionTypeContributor) {
-				deliverySubscriptionTypeContributor.show();
+				deliverySubscriptionTypeContributor.classList.remove('hide');
 			}
 
-			A.one(
+			document.querySelector(
 				'#<portlet:namespace />deliveryCycleLengthContainer .input-group-text'
-			).html(subscriptionTypeLabel);
+			).innerHTML = subscriptionTypeLabel;
 		},
 		['liferay-portlet-url']
 	);
 </aui:script>
 
-<aui:script use="liferay-form">
-	A.one('#<portlet:namespace />neverEnds').on('change', (event) => {
-		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
-			.formValidator;
+<aui:script>
+	document
+		.getElementById('<portlet:namespace />neverEnds')
+		.addEventListener('change', (event) => {
+			const formValidator = Liferay.Form.get('<portlet:namespace />fm')
+				.formValidator;
 
-		formValidator.validateField('<portlet:namespace />maxSubscriptionCycles');
-	});
+			formValidator.validateField(
+				'<portlet:namespace />maxSubscriptionCycles'
+			);
+		});
 
-	A.one('#<portlet:namespace />deliveryNeverEnds').on('change', (event) => {
-		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
-			.formValidator;
+	document
+		.getElementById('<portlet:namespace />deliveryNeverEnds')
+		.addEventListener('change', (event) => {
+			const formValidator = Liferay.Form.get('<portlet:namespace />fm')
+				.formValidator;
 
-		formValidator.validateField(
-			'<portlet:namespace />deliveryMaxSubscriptionCycles'
-		);
-	});
+			formValidator.validateField(
+				'<portlet:namespace />deliveryMaxSubscriptionCycles'
+			);
+		});
 </aui:script>
 
-<aui:script use="aui-toggler">
-	new A.Toggler({
-		animated: true,
-		content: '#<portlet:namespace />neverEndsContainer .never-ends-content',
-		expanded: <%= ending %>,
-		header: '#<portlet:namespace />neverEndsContainer .never-ends-header',
-		on: {
-			animatingChange: function (event) {
-				var instance = this;
+<aui:script>
+	function <portlet:namespace />neverEndsToggle() {
+		document
+			.querySelector(
+				'#<portlet:namespace />neverEndsContainer .never-ends-content'
+			)
+			.classList.toggle('hide');
+	}
 
-				if (!instance.get('expanded')) {
-					A.one('#<portlet:namespace />maxSubscriptionCycles').attr(
-						'disabled',
-						false
-					);
-				}
-				else {
-					A.one('#<portlet:namespace />maxSubscriptionCycles').attr(
-						'disabled',
-						true
-					);
-				}
-			},
-		},
-	});
-
-	new A.Toggler({
-		animated: true,
-		content:
-			'#<portlet:namespace />deliveryNeverEndsContainer .never-ends-content',
-		expanded: <%= deliveryEnding %>,
-		header:
-			'#<portlet:namespace />deliveryNeverEndsContainer .never-ends-header',
-		on: {
-			animatingChange: function (event) {
-				var instance = this;
-
-				if (!instance.get('expanded')) {
-					A.one(
-						'#<portlet:namespace />deliveryMaxSubscriptionCycles'
-					).attr('disabled', false);
-				}
-				else {
-					A.one(
-						'#<portlet:namespace />deliveryMaxSubscriptionCycles'
-					).attr('disabled', true);
-				}
-			},
-		},
-	});
-</aui:script>
+	function <portlet:namespace />deliveryNeverEndsToggle() {
+		document
+			.querySelector(
+				'#<portlet:namespace />deliveryNeverEndsContainer .never-ends-content'
+			)
+			.classList.toggle('hide');
+	}
+	</aui:script>

--- a/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/definition/edit_instance_subscription_info.jsp
+++ b/modules/apps/commerce/commerce-subscription-web/src/main/resources/META-INF/resources/definition/edit_instance_subscription_info.jsp
@@ -162,11 +162,11 @@ if (deliveryMaxSubscriptionCycles > 0) {
 
 				<div id="<portlet:namespace />neverEndsContainer">
 					<div class="never-ends-header">
-						<aui:input checked="<%= ending ? false : true %>" name="neverEnds" type="toggle-switch" />
+						<aui:input checked="<%= ending ? false : true %>" name="neverEnds" onClick='<%= liferayPortletResponse.getNamespace() + "neverEndsToggle();" %>' type="toggle-switch" />
 					</div>
 
-					<div class="never-ends-content">
-						<aui:input disabled="<%= ending ? false : true %>" helpMessage="max-subscription-cycles-help" label="end-after" name="maxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(maxSubscriptionCycles) %>">
+					<div class="never-ends-content <%= ending ? StringPool.BLANK : "hide" %>">
+						<aui:input helpMessage="max-subscription-cycles-help" label="end-after" name="maxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(maxSubscriptionCycles) %>">
 							<aui:validator name="digits" />
 
 							<aui:validator errorMessage='<%= LanguageUtil.format(request, "please-enter-a-value-greater-than-or-equal-to-x", 1) %>' name="custom">
@@ -258,11 +258,11 @@ if (deliveryMaxSubscriptionCycles > 0) {
 
 				<div id="<portlet:namespace />deliveryNeverEndsContainer">
 					<div class="never-ends-header">
-						<aui:input checked="<%= deliveryEnding ? false : true %>" label="never-ends" name="deliveryNeverEnds" type="toggle-switch" />
+						<aui:input checked="<%= deliveryEnding ? false : true %>" label="never-ends" name="deliveryNeverEnds" onClick='<%= liferayPortletResponse.getNamespace() + "deliveryNeverEndsToggle();" %>' type="toggle-switch" />
 					</div>
 
-					<div class="never-ends-content">
-						<aui:input disabled="<%= deliveryEnding ? false : true %>" helpMessage="max-subscription-cycles-help" label="end-after" name="deliveryMaxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(deliveryMaxSubscriptionCycles) %>">
+					<div class="never-ends-content <%= ending ? StringPool.BLANK : "hide" %>">
+						<aui:input helpMessage="max-subscription-cycles-help" label="end-after" name="deliveryMaxSubscriptionCycles" suffix='<%= LanguageUtil.get(request, "cycles") %>' value="<%= String.valueOf(deliveryMaxSubscriptionCycles) %>">
 							<aui:validator name="digits" />
 
 							<aui:validator errorMessage='<%= LanguageUtil.format(request, "please-enter-a-value-greater-than-or-equal-to-x", 1) %>' name="custom">
@@ -308,36 +308,33 @@ if (deliveryMaxSubscriptionCycles > 0) {
 				return;
 			}
 
-			var A = AUI();
-
-			var subscriptionType = A.one(element).val();
-			var subscriptionTypeLabel = A.one(element)
-				.get('children')
-				.filter((item) => {
-					return item.get('selected');
-				})
-				.first();
+			const subscriptionType = element.value;
+			let subscriptionTypeLabel = element.options[element.selectedIndex];
 
 			if (subscriptionTypeLabel) {
-				subscriptionTypeLabel = subscriptionTypeLabel.getData('label');
+				subscriptionTypeLabel = subscriptionTypeLabel.dataset.label;
 			}
 
-			A.one('#<portlet:namespace />subscriptionTypeContributors')
-				.get('children')
-				.hide();
+			Array.from(
+				document.getElementById(
+					'<portlet:namespace />subscriptionTypeContributors'
+				).children
+			).forEach((child) => {
+				child.classList.add('hide');
+			});
 
-			var subscriptionTypeContributor = A.one(
-				'#<portlet:namespace />subscriptionTypeContributor' +
+			const subscriptionTypeContributor = document.getElementById(
+				'<portlet:namespace />subscriptionTypeContributor' +
 					subscriptionType
 			);
 
 			if (subscriptionTypeContributor) {
-				subscriptionTypeContributor.show();
+				subscriptionTypeContributor.classList.remove('hide');
 			}
 
-			A.one(
+			document.querySelector(
 				'#<portlet:namespace />cycleLengthContainer .input-group-text'
-			).html(subscriptionTypeLabel);
+			).innerHTML = subscriptionTypeLabel;
 		},
 		['liferay-portlet-url']
 	);
@@ -349,108 +346,76 @@ if (deliveryMaxSubscriptionCycles > 0) {
 			if (!element) {
 				return;
 			}
-
-			var A = AUI();
-
-			var subscriptionType = A.one(element).val();
-			var subscriptionTypeLabel = A.one(element)
-				.get('children')
-				.filter((item) => {
-					return item.get('selected');
-				})
-				.first();
+			const subscriptionType = element.value;
+			let subscriptionTypeLabel = element.options[element.selectedIndex];
 
 			if (subscriptionTypeLabel) {
-				subscriptionTypeLabel = subscriptionTypeLabel.getData('label');
+				subscriptionTypeLabel = subscriptionTypeLabel.dataset.label;
 			}
 
-			A.one('#<portlet:namespace />deliverySubscriptionTypeContributors')
-				.get('children')
-				.hide();
+			Array.from(
+				document.getElementById(
+					'<portlet:namespace />deliverySubscriptionTypeContributors'
+				).children
+			).forEach((child) => {
+				child.classList.add('hide');
+			});
 
-			var deliverySubscriptionTypeContributor = A.one(
-				'#<portlet:namespace />deliverySubscriptionTypeContributor' +
+			const deliverySubscriptionTypeContributor = document.getElementById(
+				'<portlet:namespace />deliverySubscriptionTypeContributor' +
 					subscriptionType
 			);
 
 			if (deliverySubscriptionTypeContributor) {
-				deliverySubscriptionTypeContributor.show();
+				deliverySubscriptionTypeContributor.classList.remove('hide');
 			}
 
-			A.one(
+			document.querySelector(
 				'#<portlet:namespace />deliveryCycleLengthContainer .input-group-text'
-			).html(subscriptionTypeLabel);
+			).innerHTML = subscriptionTypeLabel;
 		},
 		['liferay-portlet-url']
 	);
 </aui:script>
 
-<aui:script use="liferay-form">
-	A.one('#<portlet:namespace />neverEnds').on('change', (event) => {
-		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
-			.formValidator;
+<aui:script>
+	document
+		.getElementById('<portlet:namespace />neverEnds')
+		.addEventListener('change', (event) => {
+			const formValidator = Liferay.Form.get('<portlet:namespace />fm')
+				.formValidator;
 
-		formValidator.validateField('<portlet:namespace />maxSubscriptionCycles');
-	});
+			formValidator.validateField(
+				'<portlet:namespace />maxSubscriptionCycles'
+			);
+		});
 
-	A.one('#<portlet:namespace />deliveryNeverEnds').on('change', (event) => {
-		var formValidator = Liferay.Form.get('<portlet:namespace />fm')
-			.formValidator;
+	document
+		.getElementById('<portlet:namespace />deliveryNeverEnds')
+		.addEventListener('change', (event) => {
+			const formValidator = Liferay.Form.get('<portlet:namespace />fm')
+				.formValidator;
 
-		formValidator.validateField(
-			'<portlet:namespace />deliveryMaxSubscriptionCycles'
-		);
-	});
+			formValidator.validateField(
+				'<portlet:namespace />deliveryMaxSubscriptionCycles'
+			);
+		});
 </aui:script>
 
-<aui:script use="aui-toggler">
-	new A.Toggler({
-		animated: true,
-		content: '#<portlet:namespace />neverEndsContainer .never-ends-content',
-		expanded: <%= ending %>,
-		header: '#<portlet:namespace />neverEndsContainer .never-ends-header',
-		on: {
-			animatingChange: function (event) {
-				var instance = this;
+<aui:script>
+	function <portlet:namespace />neverEndsToggle() {
+		document
+			.querySelector(
+				'#<portlet:namespace />neverEndsContainer .never-ends-content'
+			)
+			.classList.toggle('hide');
+	}
 
-				if (!instance.get('expanded')) {
-					A.one('#<portlet:namespace />maxSubscriptionCycles').attr(
-						'disabled',
-						false
-					);
-				}
-				else {
-					A.one('#<portlet:namespace />maxSubscriptionCycles').attr(
-						'disabled',
-						true
-					);
-				}
-			},
-		},
-	});
-
-	new A.Toggler({
-		animated: true,
-		content:
-			'#<portlet:namespace />deliveryNeverEndsContainer .never-ends-content',
-		expanded: <%= deliveryEnding %>,
-		header:
-			'#<portlet:namespace />deliveryNeverEndsContainer .never-ends-header',
-		on: {
-			animatingChange: function (event) {
-				var instance = this;
-
-				if (!instance.get('expanded')) {
-					A.one(
-						'#<portlet:namespace />deliveryMaxSubscriptionCycles'
-					).attr('disabled', false);
-				}
-				else {
-					A.one(
-						'#<portlet:namespace />deliveryMaxSubscriptionCycles'
-					).attr('disabled', true);
-				}
-			},
-		},
-	});
+	function <portlet:namespace />deliveryNeverEndsToggle() {
+		document
+			.querySelector(
+				'#<portlet:namespace />deliveryNeverEndsContainer .never-ends-content'
+			)
+			.classList.toggle('hide');
+	}
 </aui:script>

--- a/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell/src/js/main.js
+++ b/modules/apps/commerce/commerce-theme-speedwell/commerce-theme-speedwell/src/js/main.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-AUI().ready(() => {
+document.addEventListener('DOMContentLoaded', () => {
 	const Speedwell = window.Speedwell;
 
 	const RETRY_TIMES = 3;


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-201506)

## Steps 

**edit_definition_subscription_info.jsp**

- Go to Control Panel > Sites > Create a Minium site
- Go to Control Menu > Commerce > Product Management > Products
- Edit a Product > go to Subscription tab

https://github.com/liferay-echo/liferay-portal/assets/91208451/4202254e-230b-467d-9801-dc343df4d7b6

**edit_instance_subscription_info.jsp**

- Go to Control Panel > Sites > Create a Minium site
- Go to Control Menu > Commerce > Product Management > Products
- Edit a Product > go to SKUs tab > Edit an item 
- Go to Subscriptions tab

https://github.com/liferay-echo/liferay-portal/assets/91208451/c60bd143-9b5d-41db-b67a-0fbbcb62ce19

**general.jsp**
I have not found this in the UI, but the use case is the same as the two before, so I think there is no need to find it


