### PR TITLE
[TS] [Urgent] LPS-201860 Menu Display Configuration Window frequently shows wrong information in Preview Pane

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/init.jsp
@@ -1,6 +1,6 @@
 <%--
 /**
- * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-FileCopyrightText: (c) 2023 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 --%>

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/js/NavigationMenuConfiguration.js
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/js/NavigationMenuConfiguration.js
@@ -5,6 +5,7 @@
 
 import {
 	addParams,
+	debounce,
 	delegate,
 	getFormElement,
 	openSelectionModal,
@@ -75,8 +76,10 @@ export default function NavigationMenuConfiguration({
 		Liferay.Portlet.refresh(`#p_p_id_${portletResource}_`, data);
 	};
 
-	form.addEventListener('change', resetPreview);
-	form.addEventListener('select', resetPreview);
+	const debouncedResetPreview = debounce(resetPreview, 200);
+
+	form.addEventListener('change', debouncedResetPreview);
+	form.addEventListener('select', debouncedResetPreview);
 
 	const chooseRootMenuItemButton = document.getElementById(
 		`${namespace}chooseRootMenuItem`
@@ -124,7 +127,7 @@ export default function NavigationMenuConfiguration({
 						rootMenuItemNameSpan.innerText =
 							selectedItem.selectSiteNavigationMenuItemName;
 
-						resetPreview();
+						debouncedResetPreview();
 					}
 				},
 				selectEventName: rootMenuItemEventName,
@@ -166,7 +169,7 @@ export default function NavigationMenuConfiguration({
 
 							removeSiteNavigationMenu.classList.toggle('hide');
 
-							resetPreview();
+							debouncedResetPreview();
 						}
 					},
 					selectEventName: siteNavigationMenuEventName,
@@ -196,7 +199,7 @@ export default function NavigationMenuConfiguration({
 
 				removeSiteNavigationMenu.classList.toggle('hide');
 
-				resetPreview();
+				debouncedResetPreview();
 			});
 		}
 
@@ -277,13 +280,13 @@ export default function NavigationMenuConfiguration({
 
 					removeSiteNavigationMenu.classList.add('hide');
 
-					resetPreview();
+					debouncedResetPreview();
 				}
 			);
 		}
 	}
 
 	Liferay.on('templateSelector:changedTemplate', (event) => {
-		resetPreview(event.value);
+		debouncedResetPreview(event.value);
 	});
 }

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/js/NavigationMenuConfiguration.js
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/resources/META-INF/resources/js/NavigationMenuConfiguration.js
@@ -24,13 +24,13 @@ export default function NavigationMenuConfiguration({
 }) {
 	const form = document.getElementById(`${namespace}fm`);
 
-	const displayStyleValue = document.getElementById(
+	const displayStyle = document.getElementById(
 		`${namespace}preferences--displayStyle--`
 	);
 
 	const resetPreview = (option) => {
 		const displayDepthSelect = getFormElement(form, 'displayDepth');
-		const displayStyle = option || displayStyleValue;
+		const displayStyleValue = option || displayStyle.value;
 		const expandedLevelsSelect = getFormElement(form, 'expandedLevels');
 		const rootMenuItemIdInput = getFormElement(form, 'rootMenuItemId');
 		const rootMenuItemLevelSelect = getFormElement(
@@ -62,7 +62,7 @@ export default function NavigationMenuConfiguration({
 			siteNavigationMenuTypeInput
 		) {
 			data.displayDepth = displayDepthSelect.value;
-			data.displayStyle = displayStyle;
+			data.displayStyle = displayStyleValue;
 			data.expandedLevels = expandedLevelsSelect.value;
 			data.rootMenuItemLevel = rootMenuItemLevelSelect.value;
 			data.rootMenuItemType = rootMenuItemTypeSelect.value;


### PR DESCRIPTION
Motivation
=======
When configuring a Menu Display widget, a Preview Pane is shown to allow the user to see what the menu will look like when rendered with the selected configuration. Unfortunately, however, the updated values are often not sent properly to the backend, so the Preview Pane renders the menu using the old values instead of the newly selected ones. This causes a misleading and confusing user experience for the user who is trying to configure the Menu Display widget.

See my comment [here](https://liferay.atlassian.net/browse/LPP-51699?focusedCommentId=2510314) and Minhchau's comment [here](https://liferay.atlassian.net/browse/LPP-51699?focusedCommentId=2510470) for further explanation about the root cause.

A similar bug, which Minhchau alluded to in his comment, was occurring where the default template was being used any time the form was updated except for the times that the template dropdown specifically was the thing that was updated. This was because `displayStyle` was gibberish, because it was using the _element_, rather than the _value_ of the element, as Minhchau mentioned in his comment.

Ticket : [LPS-201860](https://liferay.atlassian.net/browse/LPS-201860)

Proposed Solution
========
* Debounce the "resetPreview" method to ensure that it always gets called with the correct parameters having been set.
* Fix the problem where we were passing in the display style _element_, rather than the _value_, if option was null, by using the value of the element. Also rename the variables to be more accurate ("displayStyle" should refer to the element to be consistent with how the other variables were named. "displayStyleValue" can refer to the value).

Steps to Verify
========
1. Add a Navigation Menu named “Test Navigation Menu” (you can just leave it blank).
2. Create a Widget Page.
3. Add a Menu Display Widget to the Widget Page.
4. Open up the Configuration Menu for the Menu Display Widget.

**Checkpoint:** Observe that the Pages Hierarchy Navigation is selected and the Preview pane shows the Pages navigation.

5. Select the “Choose Menu” radio option, then press the Select button and select the “Test Navigation Menu”.

**Checkpoint:** Observe that the Preview pane now shows an empty window (since the Test Navigation Menu is empty).

6. Select the “Select Navigation” radio option again.

**Expected Result:** The Preview Pane would be updated to show the Pages navigation.
**Actual Result:** The Preview Pane stays blank.
