### PR TITLE
[TECHNICAL SUPPORT] LPS-201821 The system tries to use a Deleted user's ID to convert a Widget Page to a Content Page.

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/helper/LayoutCopyHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/helper/LayoutCopyHelperImpl.java
@@ -27,6 +27,8 @@ import com.liferay.layout.util.structure.LayoutStructure;
 import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.comment.CommentManager;
+import com.liferay.portal.kernel.exception.NoSuchUserException;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Image;
@@ -267,14 +269,13 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 					targetLayout.getGroupId(), targetLayout.getPlid());
 
 		if (targetLayoutPageTemplateStructure == null) {
-			_layoutPageTemplateStructureLocalService.
-				addLayoutPageTemplateStructure(
-					targetLayout.getUserId(), targetLayout.getGroupId(),
-					targetLayout.getPlid(),
-					_segmentsExperienceLocalService.
-						fetchDefaultSegmentsExperienceId(
-							targetLayout.getPlid()),
-					null, ServiceContextThreadLocal.getServiceContext());
+			try {
+				_addLayoutPageTemplateStructure(targetLayout.getUserId(),
+					targetLayout.getGroupId(), targetLayout.getPlid());
+			} catch (NoSuchUserException noSuchUserException) {
+				_addLayoutPageTemplateStructure(sourceLayout.getUserId(),
+					targetLayout.getGroupId(), targetLayout.getPlid());
+			}
 		}
 
 		Map<Long, Long> segmentsExperienceIdsMap = _getSegmentsExperienceIds(
@@ -301,6 +302,16 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 					targetLayout.getGroupId(), targetLayout.getPlid(),
 					entry.getValue(), dataJSONObject.toString());
 		}
+	}
+
+	private void _addLayoutPageTemplateStructure(long userId, long groupId,
+												 long plid)
+		throws PortalException {
+		_layoutPageTemplateStructureLocalService.addLayoutPageTemplateStructure(
+			userId, groupId, plid,
+			_segmentsExperienceLocalService.
+				fetchDefaultSegmentsExperienceId(plid),
+			null, ServiceContextThreadLocal.getServiceContext());
 	}
 
 	private void _copyLayoutPageTemplateStructureFromSegmentsExperience(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/helper/LayoutCopyHelperImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/helper/LayoutCopyHelperImpl.java
@@ -124,6 +124,17 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 			segmentsExperiencesIds);
 	}
 
+	private void _addLayoutPageTemplateStructure(
+			long userId, long groupId, long plid)
+		throws PortalException {
+
+		_layoutPageTemplateStructureLocalService.addLayoutPageTemplateStructure(
+			userId, groupId, plid,
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				plid),
+			null, ServiceContextThreadLocal.getServiceContext());
+	}
+
 	private void _copyAssetCategoryIdsAndAssetTagNames(
 			Layout sourceLayout, Layout targetLayout)
 		throws Exception {
@@ -270,11 +281,19 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 
 		if (targetLayoutPageTemplateStructure == null) {
 			try {
-				_addLayoutPageTemplateStructure(targetLayout.getUserId(),
-					targetLayout.getGroupId(), targetLayout.getPlid());
-			} catch (NoSuchUserException noSuchUserException) {
-				_addLayoutPageTemplateStructure(sourceLayout.getUserId(),
-					targetLayout.getGroupId(), targetLayout.getPlid());
+				_addLayoutPageTemplateStructure(
+					targetLayout.getUserId(), targetLayout.getGroupId(),
+					targetLayout.getPlid());
+			}
+			catch (PortalException portalException) {
+				if (portalException instanceof NoSuchUserException) {
+					_addLayoutPageTemplateStructure(
+						sourceLayout.getUserId(), targetLayout.getGroupId(),
+						targetLayout.getPlid());
+				}
+				else {
+					throw portalException;
+				}
 			}
 		}
 
@@ -302,16 +321,6 @@ public class LayoutCopyHelperImpl implements LayoutCopyHelper {
 					targetLayout.getGroupId(), targetLayout.getPlid(),
 					entry.getValue(), dataJSONObject.toString());
 		}
-	}
-
-	private void _addLayoutPageTemplateStructure(long userId, long groupId,
-												 long plid)
-		throws PortalException {
-		_layoutPageTemplateStructureLocalService.addLayoutPageTemplateStructure(
-			userId, groupId, plid,
-			_segmentsExperienceLocalService.
-				fetchDefaultSegmentsExperienceId(plid),
-			null, ServiceContextThreadLocal.getServiceContext());
 	}
 
 	private void _copyLayoutPageTemplateStructureFromSegmentsExperience(


### PR DESCRIPTION
### 📖  Content

- LPS-201821
  - Created the `LayoutCopyHelperImpl._addLayoutPageTemplateStructure` method. 
  - Handled the `NoSuchUserException` thrown in the `LayoutCopyHelperImpl._copyLayoutPageTemplateStructure` method by using the `userId` from the `sourceLayout` when the `userId` associated with the `targetLayout` is not found.
  - Code format in the `LayoutCopyHelperImpl`.
  - Processed the exception thrown by the `_addLayoutPageTemplateStructure` method to avoid the failure of `UnprocessedExceptionCheck`.

### 🧪  How To Test
- Start DXP
- Open the main menu on the top right
  - Go To: `Control Panel`
    - `Users`
      - `Users and Organizations`
        - Add a new User
        - Assign to them the Administrator Role
- Go To: `Users` page, click on the **kebab** menu beside the **new** User, and select "**Impersonate User**”.
- Now as the new User Go To: `DXP Site`
  - `Site Builder`
    - `Pages`
      - Add a **Widget Page**
- Click on the user profile icon on the upper right and select "**Be yourself again**".
- As yourself (admin user) Go To: `Control Panel`
  - `Users`
    - `Users and Organizations`
      - Beside the new user click on the kebab menu and select "**Deactivate**" to deactivate the new user.
      - Click on **Filter and Find** and select "**Inactive**" to see the inactive users then remove the new user by clicking the kebab menu beside it and selecting "**Delete**".
- Go To: `Site Builder`
  - `Pages`
    - Click on the kebab menu beside the widget page and select "**Convert to content page**".
**Checkpoint**: The page is opened in edit mode with the following note:
The page conversion is shown in the preview below. Make modifications needed before publishing the conversion, or discard the draft to leave the widget page in its original state.
- Publish the Page.

### ✅ Expected result
**The Page is successfully converted to a Content Page.**

🙏🏻  Thanks for the review in advance.

Regards,
Márkó