### PR TITLE
[TS] LPS-201959

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryLinkStagedModelDataHandler.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/data/handler/FragmentEntryLinkStagedModelDataHandler.java
@@ -11,6 +11,7 @@ import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
 import com.liferay.fragment.model.FragmentEntry;
@@ -97,19 +98,24 @@ public class FragmentEntryLinkStagedModelDataHandler
 			_fragmentEntryLocalService.fetchFragmentEntry(
 				fragmentEntryLink.getFragmentEntryId());
 
-		if ((fragmentEntry != null) &&
-			(fragmentEntry.getGroupId() != fragmentEntryLink.getGroupId())) {
+		if (fragmentEntry != null) {
+			if (fragmentEntry.getGroupId() != fragmentEntryLink.getGroupId()) {
+				Group group = _groupLocalService.fetchGroup(
+					fragmentEntry.getGroupId());
 
-			Group group = _groupLocalService.fetchGroup(
-				fragmentEntry.getGroupId());
+				if (group != null) {
+					fragmentEntryLinkElement.addAttribute(
+						"fragment-entry-group-key", group.getGroupKey());
+				}
 
-			if (group != null) {
 				fragmentEntryLinkElement.addAttribute(
-					"fragment-entry-group-key", group.getGroupKey());
+					"fragment-entry-key", fragmentEntry.getFragmentEntryKey());
 			}
-
-			fragmentEntryLinkElement.addAttribute(
-				"fragment-entry-key", fragmentEntry.getFragmentEntryKey());
+			else {
+				StagedModelDataHandlerUtil.exportReferenceStagedModel(
+					portletDataContext, fragmentEntryLink, fragmentEntry,
+					PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
+			}
 		}
 
 		portletDataContext.addClassedModel(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/data/handler/test/FragmentEntryLinkStagedModelDataHandlerTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/exportimport/data/handler/test/FragmentEntryLinkStagedModelDataHandlerTest.java
@@ -7,6 +7,7 @@ package com.liferay.fragment.internal.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
 import com.liferay.fragment.constants.FragmentConstants;
 import com.liferay.fragment.model.FragmentCollection;
@@ -144,18 +145,18 @@ public class FragmentEntryLinkStagedModelDataHandlerTest
 		StagedModel stagedModel = addStagedModel(
 			stagingGroup, dependentStagedModelsMap);
 
-		try {
-			exportImportStagedModel(stagedModel);
-		}
-		finally {
-			ExportImportThreadLocal.setPortletImportInProcess(false);
-		}
-
 		FragmentEntryLink fragmentEntryLink = (FragmentEntryLink)stagedModel;
 
 		Assert.assertNotNull(
 			_fragmentEntryLocalService.getFragmentEntry(
 				fragmentEntryLink.getFragmentEntryId()));
+
+		try {
+			_exportImportStagedModel(stagedModel, true);
+		}
+		finally {
+			ExportImportThreadLocal.setPortletImportInProcess(false);
+		}
 
 		StagedModel importedStagedModel = getStagedModel(
 			stagedModel.getUuid(), liveGroup);
@@ -244,6 +245,40 @@ public class FragmentEntryLinkStagedModelDataHandlerTest
 		Assert.assertEquals(
 			importedFragmentEntryLink.getPosition(),
 			fragmentEntryLink.getPosition());
+	}
+
+	private void _exportImportStagedModel(
+			StagedModel stagedModel,
+			boolean deleteFragmentEntryAndFragmentEntryLinkBeforeImport)
+		throws Exception {
+
+		if (!deleteFragmentEntryAndFragmentEntryLinkBeforeImport) {
+			exportImportStagedModel(stagedModel);
+
+			return;
+		}
+
+		initExport();
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, stagedModel);
+
+		FragmentEntryLink fragmentEntryLink = (FragmentEntryLink)stagedModel;
+
+		_fragmentEntryLinkLocalService.deleteFragmentEntryLink(
+			fragmentEntryLink);
+
+		_fragmentEntryLocalService.deleteFragmentEntry(
+			fragmentEntryLink.getFragmentEntryId());
+
+		initImport();
+
+		StagedModel exportedStagedModel = readExportedStagedModel(stagedModel);
+
+		Assert.assertNotNull(exportedStagedModel);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedStagedModel);
 	}
 
 	private String _read(String fileName) throws Exception {


### PR DESCRIPTION
# Motivation

When a Display Page Template that includes a custom Fragment, is exported and then imported to a new site, the imported Display Page Template fails to show the proper title of the custom Fragment.

The root issue is that during the import process, the associated FragmentEntryLink fails to retrieve the associated FragmentEntry's fragmentEntryId during import. As a result, the reference is lost and the title is not properly shown.

**Ticket:** [LPS-201959](https://liferay.atlassian.net/browse/LPS-201959)

# Proposed Solution

Add the associated FragmentEntry as a dependency for exporting a FragmentEntryLink. This would make it so the FragmentEntry is able to be retrieved during the import of FragmentEntryLink, which would allow for the import to set the correct fragmentEntryId.

For additional details, please see: [PTR-4475](https://liferay.atlassian.net/browse/PTR-4475)

# Steps to Verify

1. Navigate to Control Panel > Sites
    1. Create Blank Site: TestSite
2. In TestSite
3. Navigate to Design > Fragments
    1. Add Fragment Set: TestFragmentSet
    2. Add Basic Fragment: TestFragment with the following HTML content:
		```
		<div class="fragment_1">
			abc
		</div>
		```
4. Navigate to Design > Page Templates
    1. Navigate to Display Page Templates
        1. Add Display Page Template:
            1. Name: TestDisplayPageTemplate
            2. Content Type: Web Content Article
            3. Sub Type: Basic Web Content
        2. In the editor for our created: TestDisplayPageTemplate
            1. Add our created TestFragment to the page
            2. In the left side menu, click Browser and confirm the fragment name displays as expected (TestFragment)
            3. Click Publish
5. Navigate to Content & Data > Web Content
    1. Click [+] to add a new Basic Web Content
        1. Title: TestContent
        2. Display Page: Specific
        3. Select TestDisplayPageTemplate
        4. Click Publish
6. Navigate to Publishing > Export
    1. Click [+] to export our created site
        1. Uncheck Utility Pages to work around a different bug
        2. Click Export
    2. Download our created lar file
7. Navigate to Control Panel > Sites
    1. Delete our created TestSite
    2. Create Blank Site: NewImportedTestSite
8. Navigate to Publishing > Import
    1. Click [+] to import our lar file
        1. Select our lar file
        2. Click Continue
        3. Click Import
9. Navigate to Design > Page Templates
    1. Navigate to Display Page Templates
        1. Click Edit for our imported TestDisplayPageTemplate
        2. In the left side menu, click Browser and confirm the fragment name displayed

**Expected Result**
The shown fragment name is TestFragment

**Actual Result**
The shown fragment name is the generic default name: Fragment

----

Please let me know if you have any questions.
Thanks!