### PR TITLE
LPS-202014 Add title to back button when importing display page templates

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_import.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_import.jsp
@@ -12,6 +12,7 @@ ImportDisplayContext importDisplayContext = new ImportDisplayContext(request, re
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(ParamUtil.getString(request, "backURL", String.valueOf(renderResponse.createRenderURL())));
+portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
 renderResponse.setTitle(LanguageUtil.get(request, "import"));
 %>


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-202014)

## Steps

- Go to Design > Page Templates > Display Page Templates
- Click on the ellipsis menu upper right
- Select import
- Import page is automatically open
- Hover over the back button
<img width="168" alt="Screenshot 2023-11-17 at 13 01 32" src="https://github.com/liferay-echo/liferay-portal/assets/91208451/150a8bca-0253-4397-afd7-33f04764cf54">
