### PR TITLE
[TS] LPS-200487 Sites are not browsable for Guests in Breadcrumb portlet

### DIFF
--- a/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/util/BreadcrumbUtil.java
+++ b/modules/apps/site-navigation/site-navigation-taglib/src/main/java/com/liferay/site/navigation/taglib/servlet/taglib/util/BreadcrumbUtil.java
@@ -31,7 +31,7 @@ import com.liferay.portal.kernel.service.LayoutServiceUtil;
 import com.liferay.portal.kernel.service.LayoutSetLocalServiceUtil;
 import com.liferay.portal.kernel.service.OrganizationLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
-import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.service.permission.LayoutPermissionUtil;
 import com.liferay.portal.kernel.servlet.taglib.ui.BreadcrumbEntry;
 import com.liferay.portal.kernel.theme.PortletDisplay;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -287,7 +287,7 @@ public class BreadcrumbUtil {
 			return;
 		}
 
-		if (group.isActive() && _hasViewPermissions(group, themeDisplay)) {
+		if (group.isActive() && _hasViewPermissions(layoutSet, themeDisplay)) {
 			String layoutSetFriendlyURL = PortalUtil.getLayoutSetFriendlyURL(
 				layoutSet, themeDisplay);
 
@@ -416,11 +416,13 @@ public class BreadcrumbUtil {
 	}
 
 	private static boolean _hasViewPermissions(
-		Group group, ThemeDisplay themeDisplay) {
+		LayoutSet layoutSet, ThemeDisplay themeDisplay) {
 
 		try {
-			if (GroupPermissionUtil.contains(
-					themeDisplay.getPermissionChecker(), group,
+			if (LayoutPermissionUtil.contains(
+					themeDisplay.getPermissionChecker(),
+					LayoutLocalServiceUtil.getDefaultPlid(
+						layoutSet.getGroupId(), layoutSet.isPrivateLayout()),
 					ActionKeys.VIEW)) {
 
 				return true;


### PR DESCRIPTION
Motivation
=======
Sites are not browsable for non-admin users in Breadcrumb portlet, even the user has permission to access the group. It occurs when site has Membership type != "Open".
- https://liferay.atlassian.net/browse/LPS-200487
- Previous Pull Requests: 
   - https://github.com/liferay-echo/liferay-portal/pull/14159
   - https://github.com/liferay-echo/liferay-portal/pull/14221

Proposed Solution
========
- Replacing Default Layout permission to current Group check.
- Disable Group membership checking since it has no relantionship to layout browsability

Steps to Verify
========
Steps to reproduce:
1. Start Liferay, create a new site “Test”, and select select “private” or “protected” membership for this site.
2. Add a homepage with a breadcrumb portlet (“horizontal” template, default config).
3. Check “Show current Site” is enabled
4. Logout and reload this page with the Guest user

**Current behavior**: Site “Test” does not have href attribute (breadcrumbEntry.isBrowsable() = false)
**Expected behavior**: The link is enabled and can be used since Guest users have access to the homepage of this site.

It also affects in the opposite way: Open Membership with a Private home layout. In this case, a link with href is visible but 404 error is present when clicking on it.

Alternative Solutions that were discarded
========
1. Adding Layout Permission instead of adding it to current implementation. Discarded since it does not cover both use cases (open / private group membership).
2. Do not consider any kind of permission since current site may be browsable.
