### PR TITLE
LPS-202182 Use type=module in fragments scripts

### DIFF
--- a/modules/apps/fragment/fragment-collection-contributor/.eslintrc.js
+++ b/modules/apps/fragment/fragment-collection-contributor/.eslintrc.js
@@ -8,6 +8,7 @@ module.exports = {
 		YT: true,
 		configuration: true,
 		fragmentElement: true,
+		fragmentEntryLinkNamespace: true,
 		fragmentNamespace: true,
 		input: true,
 		layoutMode: true,

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/slider/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-basic-component/src/main/resources/com/liferay/fragment/collection/contributor/basic/component/dependencies/slider/index.js
@@ -10,8 +10,17 @@ const items = [].slice.call(fragmentElement.querySelectorAll('.carousel-item'));
 
 const next = fragmentElement.querySelector('.carousel-control-next');
 const prev = fragmentElement.querySelector('.carousel-control-prev');
+const nextItemIndexKey = `${fragmentEntryLinkNamespace}-next-item-index`;
 
 let moving = false;
+
+function getNextItemIndex() {
+	return window[nextItemIndexKey] || 0;
+}
+
+function setNextItemIndex(index) {
+	window[nextItemIndexKey] = index;
+}
 
 function getActiveIndicator() {
 	return fragmentElement.querySelector('.carousel-navigation .active');
@@ -24,7 +33,7 @@ function activateIndicator(activeItem, nextItem, movement) {
 	}
 
 	getActiveIndicator().classList.remove('active');
-	indicators[this.nextItemIndex].classList.add('active');
+	indicators[getNextItemIndex()].classList.add('active');
 }
 
 function activateItem(activeItem, nextItem, movement) {
@@ -47,18 +56,20 @@ function move(movement, index = null) {
 	const activeItem = fragmentElement.querySelector('.carousel-item.active');
 	const indexActiveItem = items.indexOf(activeItem);
 
-	this.nextItemIndex =
-		indexActiveItem < 1 ? items.length - 1 : indexActiveItem - 1;
+	setNextItemIndex(
+		indexActiveItem < 1 ? items.length - 1 : indexActiveItem - 1
+	);
 
 	if (index !== null) {
-		this.nextItemIndex = index;
+		setNextItemIndex(index);
 	}
 	else if (movement === MOVE_RIGHT) {
-		this.nextItemIndex =
-			indexActiveItem >= items.length - 1 ? 0 : indexActiveItem + 1;
+		setNextItemIndex(
+			indexActiveItem >= items.length - 1 ? 0 : indexActiveItem + 1
+		);
 	}
 
-	const nextItem = items[this.nextItemIndex];
+	const nextItem = items[getNextItemIndex()];
 
 	activateIndicator(activeItem, nextItem, movement);
 
@@ -89,11 +100,11 @@ function createInterval() {
 (function main() {
 	let intervalId = createInterval();
 
-	if (this.nextItemIndex && this.nextItemIndex < items.length) {
+	if (getNextItemIndex() < items.length) {
 		const activeItem = fragmentElement.querySelector(
 			'.carousel-item.active'
 		);
-		const nextItem = items[this.nextItemIndex];
+		const nextItem = items[getNextItemIndex()];
 
 		activateIndicator(activeItem, nextItem);
 		activateItem(activeItem, nextItem);

--- a/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-featured-content/src/main/resources/com/liferay/fragment/collection/contributor/featured/content/dependencies/banner-slider/index.js
+++ b/modules/apps/fragment/fragment-collection-contributor/fragment-collection-contributor-featured-content/src/main/resources/com/liferay/fragment/collection/contributor/featured/content/dependencies/banner-slider/index.js
@@ -7,8 +7,17 @@ const indicators = [].slice.call(
 	fragmentElement.querySelectorAll('.carousel-navigation button')
 );
 const items = [].slice.call(fragmentElement.querySelectorAll('.carousel-item'));
+const nextItemIndexKey = `${fragmentEntryLinkNamespace}-next-item-index`;
 
 let moving = false;
+
+function getNextItemIndex() {
+	return window[nextItemIndexKey] || 0;
+}
+
+function setNextItemIndex(index) {
+	window[nextItemIndexKey] = index;
+}
 
 function getActiveIndicator() {
 	return fragmentElement.querySelector('.carousel-navigation .active');
@@ -21,7 +30,7 @@ function activateIndicator(activeItem, nextItem, movement) {
 	}
 
 	getActiveIndicator().classList.remove('active');
-	indicators[this.nextItemIndex].classList.add('active');
+	indicators[getNextItemIndex()].classList.add('active');
 }
 
 function activateItem(activeItem, nextItem, movement) {
@@ -44,14 +53,15 @@ function move(movement, index = null) {
 	const activeItem = fragmentElement.querySelector('.carousel-item.active');
 	const indexActiveItem = items.indexOf(activeItem);
 
-	this.nextItemIndex = index;
+	setNextItemIndex(index);
 
 	if (index === null) {
-		this.nextItemIndex =
-			indexActiveItem >= items.length - 1 ? 0 : indexActiveItem + 1;
+		setNextItemIndex(
+			indexActiveItem >= items.length - 1 ? 0 : indexActiveItem + 1
+		);
 	}
 
-	const nextItem = items[this.nextItemIndex];
+	const nextItem = items[getNextItemIndex()];
 
 	activateIndicator(activeItem, nextItem, movement);
 
@@ -82,11 +92,11 @@ function createInterval() {
 (function main() {
 	let intervalId = createInterval();
 
-	if (this.nextItemIndex && this.nextItemIndex < items.length) {
+	if (getNextItemIndex() < items.length) {
 		const activeItem = fragmentElement.querySelector(
 			'.carousel-item.active'
 		);
-		const nextItem = items[this.nextItemIndex];
+		const nextItem = items[getNextItemIndex()];
 
 		activateIndicator(activeItem, nextItem);
 		activateItem(activeItem, nextItem);

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java
@@ -294,11 +294,11 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 		}
 
 		if (Validator.isNotNull(fragmentEntryLink.getJs())) {
-			sb.append("<script");
+			sb.append("<script type=\"module\"");
 			sb.append(
 				ContentSecurityPolicyNonceProviderUtil.getNonceAttribute(
 					httpServletRequest));
-			sb.append(">(function() {const configuration = ");
+			sb.append(">const configuration = ");
 			sb.append(configuration);
 			sb.append("; const fragmentElement = document.querySelector('#");
 			sb.append(fragmentRendererContext.getFragmentElementId());
@@ -326,7 +326,7 @@ public class FragmentEntryFragmentRenderer implements FragmentRenderer {
 						"p_l_mode", Constants.VIEW)));
 			sb.append("';");
 			sb.append(fragmentEntryLink.getJs());
-			sb.append(";}());</script>");
+			sb.append(";</script>");
 		}
 
 		return sb.toString();

--- a/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/fragments/group/marketplace-base-fragments/fragments/slider-marketplace/index.js
+++ b/modules/apps/site-initializer/site-initializer-liferay-marketplace/src/main/resources/site-initializer/fragments/group/marketplace-base-fragments/fragments/slider-marketplace/index.js
@@ -16,8 +16,17 @@ const items = [].slice.call(fragmentElement.querySelectorAll('.carousel-item'));
 
 const next = fragmentElement.querySelector('.carousel-control-next');
 const prev = fragmentElement.querySelector('.carousel-control-prev');
+const nextItemIndexKey = `${fragmentEntryLinkNamespace}-next-item-index`;
 
 let moving = false;
+
+function getNextItemIndex() {
+	return window[nextItemIndexKey] || 0;
+}
+
+function setNextItemIndex(index) {
+	window[nextItemIndexKey] = index;
+}
 
 function getActiveIndicator() {
 	return fragmentElement.querySelector('.carousel-navigation .active');
@@ -30,7 +39,7 @@ function activateIndicator(activeItem, nextItem, movement) {
 	}
 
 	getActiveIndicator().classList.remove('active');
-	indicators[this.nextItemIndex].classList.add('active');
+	indicators[getNextItemIndex()].classList.add('active');
 }
 
 function activateItem(activeItem, nextItem, movement) {
@@ -53,18 +62,20 @@ function move(movement, index = null) {
 	const activeItem = fragmentElement.querySelector('.carousel-item.active');
 	const indexActiveItem = items.indexOf(activeItem);
 
-	this.nextItemIndex =
-		indexActiveItem < 1 ? items.length - 1 : indexActiveItem - 1;
+	setNextItemIndex(
+		indexActiveItem < 1 ? items.length - 1 : indexActiveItem - 1
+	);
 
 	if (index !== null) {
-		this.nextItemIndex = index;
+		setNextItemIndex(index);
 	}
 	else if (movement === MOVE_RIGHT) {
-		this.nextItemIndex =
-			indexActiveItem >= items.length - 1 ? 0 : indexActiveItem + 1;
+		setNextItemIndex(
+			indexActiveItem >= items.length - 1 ? 0 : indexActiveItem + 1
+		);
 	}
 
-	const nextItem = items[this.nextItemIndex];
+	const nextItem = items[getNextItemIndex()];
 
 	activateIndicator(activeItem, nextItem, movement);
 
@@ -95,11 +106,11 @@ function createInterval() {
 (function main() {
 	let intervalId = createInterval();
 
-	if (this.nextItemIndex && this.nextItemIndex < items.length) {
+	if (getNextItemIndex() < items.length) {
 		const activeItem = fragmentElement.querySelector(
 			'.carousel-item.active'
 		);
-		const nextItem = items[this.nextItemIndex];
+		const nextItem = items[getNextItemIndex()];
 
 		activateIndicator(activeItem, nextItem);
 		activateItem(activeItem, nextItem);

--- a/modules/apps/site-initializer/site-initializer-liferaybotics/src/main/resources/site-initializer/fragments/liferaybotics/fragments/slider/index.js
+++ b/modules/apps/site-initializer/site-initializer-liferaybotics/src/main/resources/site-initializer/fragments/liferaybotics/fragments/slider/index.js
@@ -16,8 +16,17 @@ const items = [].slice.call(fragmentElement.querySelectorAll('.carousel-item'));
 
 const next = fragmentElement.querySelector('.carousel-control-next');
 const prev = fragmentElement.querySelector('.carousel-control-prev');
+const nextItemIndexKey = `${fragmentEntryLinkNamespace}-next-item-index`;
 
 let moving = false;
+
+function getNextItemIndex() {
+	return window[nextItemIndexKey] || 0;
+}
+
+function setNextItemIndex(index) {
+	window[nextItemIndexKey] = index;
+}
 
 function getActiveIndicator() {
 	return fragmentElement.querySelector('.carousel-navigation .active');
@@ -34,22 +43,23 @@ function move(movement, index = null) {
 	const indexActiveItem = items.indexOf(activeItem);
 	const activeIndicator = getActiveIndicator();
 
-	let nextItemIndex =
-		indexActiveItem < 1 ? items.length - 1 : indexActiveItem - 1;
+	setNextItemIndex(
+		indexActiveItem < 1 ? items.length - 1 : indexActiveItem - 1
+	);
 
 	if (index !== null) {
-		nextItemIndex = index;
+		setNextItemIndex(index);
 	}
 	else if (movement === MOVE_RIGHT) {
-		nextItemIndex = indexActiveItem >= 2 ? 0 : indexActiveItem + 1;
+		setNextItemIndex(indexActiveItem >= 2 ? 0 : indexActiveItem + 1);
 	}
 
-	const nextItem = items[nextItemIndex];
+	const nextItem = items[getNextItemIndex()];
 
 	activeItem.classList.add(movement);
 	nextItem.classList.add(movement);
 	activeIndicator.classList.remove('active');
-	indicators[nextItemIndex].classList.add('active');
+	indicators[getNextItemIndex()].classList.add('active');
 
 	setTimeout(() => {
 		activeItem.classList.remove('active', movement);

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/src/main/resources/site-initializer/fragments/group/evp/fragments/evp-process-steps-slider/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/src/main/resources/site-initializer/fragments/group/evp/fragments/evp-process-steps-slider/index.js
@@ -25,8 +25,17 @@ const indicators = [].slice.call(
 	fragmentElement.querySelectorAll('.carousel-navigation button')
 );
 const items = [].slice.call(fragmentElement.querySelectorAll('.carousel-item'));
+const nextItemIndexKey = `${fragmentEntryLinkNamespace}-next-item-index`;
 
 let moving = false;
+
+function getNextItemIndex() {
+	return window[nextItemIndexKey] || 0;
+}
+
+function setNextItemIndex(index) {
+	window[nextItemIndexKey] = index;
+}
 
 function getActiveIndicator() {
 	return fragmentElement.querySelector('.carousel-navigation .active');
@@ -39,7 +48,7 @@ function activateIndicator(activeItem, nextItem, movement) {
 	}
 
 	getActiveIndicator().classList.remove('active');
-	indicators[this.nextItemIndex].classList.add('active');
+	indicators[getNextItemIndex()].classList.add('active');
 }
 
 function activateItem(activeItem, nextItem, movement) {
@@ -62,18 +71,20 @@ function move(movement, index = null) {
 	const activeItem = fragmentElement.querySelector('.carousel-item.active');
 	const indexActiveItem = items.indexOf(activeItem);
 
-	this.nextItemIndex =
-		indexActiveItem < 1 ? items.length - 1 : indexActiveItem - 1;
+	setNextItemIndex(
+		indexActiveItem < 1 ? items.length - 1 : indexActiveItem - 1
+	);
 
 	if (index !== null) {
-		this.nextItemIndex = index;
+		setNextItemIndex(index);
 	}
 	else if (movement === MOVE_RIGHT) {
-		this.nextItemIndex =
-			indexActiveItem >= items.length - 1 ? 0 : indexActiveItem + 1;
+		setNextItemIndex(
+			indexActiveItem >= items.length - 1 ? 0 : indexActiveItem + 1
+		);
 	}
 
-	const nextItem = items[this.nextItemIndex];
+	const nextItem = items[getNextItemIndex()];
 
 	activateIndicator(activeItem, nextItem, movement);
 
@@ -104,11 +115,11 @@ function createInterval() {
 function main() {
 	let intervalId = createInterval();
 
-	if (this.nextItemIndex && this.nextItemIndex < items.length) {
+	if (getNextItemIndex() < items.length) {
 		const activeItem = fragmentElement.querySelector(
 			'.carousel-item.active'
 		);
-		const nextItem = items[this.nextItemIndex];
+		const nextItem = items[getNextItemIndex()];
 
 		activateIndicator(activeItem, nextItem);
 		activateItem(activeItem, nextItem);

--- a/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/src/main/resources/site-initializer/fragments/group/evp/fragments/evp-slider/index.js
+++ b/modules/dxp/apps/osb/osb-site-initializer/osb-site-initializer-evp/src/main/resources/site-initializer/fragments/group/evp/fragments/evp-slider/index.js
@@ -13,8 +13,17 @@ const indicators = [].slice.call(
 	fragmentElement.querySelectorAll('.carousel-navigation button')
 );
 const items = [].slice.call(fragmentElement.querySelectorAll('.carousel-item'));
+const nextItemIndexKey = `${fragmentEntryLinkNamespace}-next-item-index`;
 
 let moving = false;
+
+function getNextItemIndex() {
+	return window[nextItemIndexKey] || 0;
+}
+
+function setNextItemIndex(index) {
+	window[nextItemIndexKey] = index;
+}
 
 function getActiveIndicator() {
 	return fragmentElement.querySelector('.carousel-navigation .active');
@@ -27,7 +36,7 @@ function activateIndicator(activeItem, nextItem, movement) {
 	}
 
 	getActiveIndicator().classList.remove('active');
-	indicators[this.nextItemIndex].classList.add('active');
+	indicators[getNextItemIndex()].classList.add('active');
 }
 
 function activateItem(activeItem, nextItem, movement) {
@@ -50,18 +59,20 @@ function move(movement, index = null) {
 	const activeItem = fragmentElement.querySelector('.carousel-item.active');
 	const indexActiveItem = items.indexOf(activeItem);
 
-	this.nextItemIndex =
-		indexActiveItem < 1 ? items.length - 1 : indexActiveItem - 1;
+	setNextItemIndex(
+		indexActiveItem < 1 ? items.length - 1 : indexActiveItem - 1
+	);
 
 	if (index !== null) {
-		this.nextItemIndex = index;
+		setNextItemIndex(index);
 	}
 	else if (movement === MOVE_RIGHT) {
-		this.nextItemIndex =
-			indexActiveItem >= items.length - 1 ? 0 : indexActiveItem + 1;
+		setNextItemIndex(
+			indexActiveItem >= items.length - 1 ? 0 : indexActiveItem + 1
+		);
 	}
 
-	const nextItem = items[this.nextItemIndex];
+	const nextItem = items[nextItemIndex];
 
 	activateIndicator(activeItem, nextItem, movement);
 
@@ -92,11 +103,11 @@ function createInterval() {
 function main() {
 	let intervalId = createInterval();
 
-	if (this.nextItemIndex && this.nextItemIndex < items.length) {
+	if (nextItemIndex && nextItemIndex < items.length) {
 		const activeItem = fragmentElement.querySelector(
 			'.carousel-item.active'
 		);
-		const nextItem = items[this.nextItemIndex];
+		const nextItem = items[nextItemIndex];
 
 		activateIndicator(activeItem, nextItem);
 		activateItem(activeItem, nextItem);


### PR DESCRIPTION
This should have no effect on existing fragments, but enable developers to use top-level imports (`import Taca from 'toco'`) in fragment scripts.