### PR TITLE
[TS] LPS-201930

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/provider/LayoutStructureProviderImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/provider/LayoutStructureProviderImpl.java
@@ -36,6 +36,17 @@ public class LayoutStructureProviderImpl implements LayoutStructureProvider {
 		try {
 			Layout layout = _getLayout(plid);
 
+			if (layout.isTypePortlet()) {
+				String masterLayoutData = _getMasterLayoutData(
+					layout.getMasterLayoutPlid());
+
+				if (Validator.isNotNull(masterLayoutData)) {
+					return LayoutStructure.of(masterLayoutData);
+				}
+
+				return null;
+			}
+
 			LayoutPageTemplateStructure layoutPageTemplateStructure =
 				_layoutPageTemplateStructureLocalService.
 					fetchLayoutPageTemplateStructure(

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/LayoutStructureCommonStylesCSSServlet.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/LayoutStructureCommonStylesCSSServlet.java
@@ -139,7 +139,8 @@ public class LayoutStructureCommonStylesCSSServlet extends HttpServlet {
 		}
 
 		if ((layout == null) ||
-			(!layout.isTypeAssetDisplay() && !layout.isTypeContent())) {
+			(!layout.isTypeAssetDisplay() && !layout.isTypeContent() &&
+			 !layout.isTypePortlet())) {
 
 			httpServletResponse.setStatus(HttpServletResponse.SC_NOT_FOUND);
 

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
@@ -56,7 +56,9 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 
 		Layout layout = themeDisplay.getLayout();
 
-		if (!layout.isTypeAssetDisplay() && !layout.isTypeContent()) {
+		if (!layout.isTypeAssetDisplay() && !layout.isTypeContent() &&
+			!layout.isTypePortlet()) {
+
 			return;
 		}
 

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/servlet/taglib/LayoutStructureCommonStylesCSSTopHeadDynamicInclude.java
@@ -57,7 +57,7 @@ public class LayoutStructureCommonStylesCSSTopHeadDynamicInclude
 		Layout layout = themeDisplay.getLayout();
 
 		if (!layout.isTypeAssetDisplay() && !layout.isTypeContent() &&
-			!layout.isTypePortlet()) {
+			(!layout.isTypePortlet() || (layout.getMasterLayoutPlid() == 0))) {
 
 			return;
 		}


### PR DESCRIPTION
Motivation
=======
This is a PR that aims to fix the lack of Master Page's styles in Widget pages which are configured with a non-default Master page.

Proposed Solution
========
This PR aims to fix LPS-201930 by relying on the layout structure of the master page related to a widget page.

Steps to Verify
========
1. Create a Master page template "master1".
2. Add a Container to "master1", above Drop Zone:
- Height: 50px
- Background color: any color (i.e. #FABADA)
3. Publish "master1" and mark it as default master page.
4. Add a Widget page "wp1" (using "master1" as master page).
5. Navigate to "wp1".

Actual behavior the container's styles are not visible.

References to existing code
========
Full Page Application pages, Panel pages and Embedded pages have been left out of this PR since other LPS tickets should be created first to address the adaptations to Master Pages of their corresponding Layout Type Controllers.