### PR TITLE
[TS] LPS-202412 Content Dashboard displays the first web content author and not the last editor

### DIFF
--- a/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/JournalArticleContentDashboardItem.java
+++ b/modules/apps/content-dashboard/content-dashboard-journal-impl/src/main/java/com/liferay/content/dashboard/journal/internal/item/JournalArticleContentDashboardItem.java
@@ -156,7 +156,7 @@ public class JournalArticleContentDashboardItem
 						journalArticle.getStatus())),
 				themeDisplay.getLocale(),
 				WorkflowConstants.getStatusStyle(journalArticle.getStatus()),
-				journalArticle.getUserName(),
+				journalArticle.getStatusByUserName(),
 				String.valueOf(journalArticle.getVersion())));
 	}
 
@@ -397,19 +397,19 @@ public class JournalArticleContentDashboardItem
 	@Override
 	public long getUserId() {
 		if (_latestApprovedJournalArticle != null) {
-			return _latestApprovedJournalArticle.getUserId();
+			return _latestApprovedJournalArticle.getStatusByUserId();
 		}
 
-		return _journalArticle.getUserId();
+		return _journalArticle.getStatusByUserId();
 	}
 
 	@Override
 	public String getUserName() {
 		if (_latestApprovedJournalArticle != null) {
-			return _latestApprovedJournalArticle.getUserName();
+			return _latestApprovedJournalArticle.getStatusByUserName();
 		}
 
-		return _journalArticle.getUserName();
+		return _journalArticle.getStatusByUserName();
 	}
 
 	@Override
@@ -588,7 +588,7 @@ public class JournalArticleContentDashboardItem
 				locale,
 				WorkflowConstants.getStatusLabel(journalArticle.getStatus())),
 			null, WorkflowConstants.getStatusStyle(journalArticle.getStatus()),
-			journalArticle.getUserName(),
+			journalArticle.getStatusByUserName(),
 			String.valueOf(journalArticle.getVersion()));
 	}
 


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPS-202412
best,
Attila

------

Reproduction Steps:

1. Open the main menu on the top right --> Control Panel --> Users --> Users and Organizations --> add a user and assignn administrator role to it.
2. Go to the Users page, click on the kebab menu beside new user, and select “Impersonate User”.
3. Go to DXP Site --> Content & Data --> Web Content and add basic web content.
4. Click on the user profile icon on the upper right and select "Be yourself again".
5. Go to DXP Site --> Content & Data --> Web Content, edit the previously created web content, and publish it.
6. Open the main menu on the top right --> Applications --> CONTENT --> and select Content Dashboard.
7. Check the Content list, check under the Author the user icon, and click on the info icon "i" to open the info pane and check the author details.

**Actual Result**: On the content list the author displays the new user and on the info panel it also displays the new user and for the edited content it also displays new user as the author.
**Expected Result**: The author icon under the Content list should display "Test Test" and on the info panel "Test Test" should be displayed as the author of the content latest version.