### PR TITLE
LPS-202334 Can not switch between publication and production via Publications indicator button

### DIFF
--- a/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingIndicator.js
+++ b/modules/apps/change-tracking/change-tracking-web/src/main/resources/META-INF/resources/publications/js/components/ChangeTrackingIndicator.js
@@ -64,7 +64,7 @@ export default function ChangeTrackingIndicator({
 		});
 
 		if (action) {
-			submitForm(document.hrefFm, portletURL);
+			submitForm(document.hrefFm, portletURL.toString());
 
 			return;
 		}


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-202334)

## Steps 

**Case 1**
- Go to Control Menu > Applications > Publications
- Create some Publications
- At the top center click on the dropdown > Select a Publication
- Change between publications

**case 2**

- With the publications created before
- At the top center click on the dropdown > Work on Production

https://github.com/liferay-echo/liferay-portal/assets/91208451/24383e3a-7fa8-4b84-8ead-689a47663ac9





