### PR TITLE
LPS-202718 Use index keys since current sub implementation does not support named keys

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLFolderSelector.js
+++ b/modules/apps/document-library/document-library-web/src/main/resources/META-INF/resources/document_library/js/DLFolderSelector.js
@@ -16,7 +16,7 @@ import {
 } from 'frontend-js-web';
 import React, {useEffect, useState} from 'react';
 
-const TPL_ERROR_MESSAGES = `<span>{title}</span><ul class="mb-0 mt-2 pl-3">{messages}</ul>`;
+const TPL_ERROR_MESSAGES = `<span>{0}</span><ul class="mb-0 mt-2 pl-3">{1}</ul>`;
 
 const DLFolderSelector = ({
 	copyActionURL,
@@ -90,19 +90,18 @@ const DLFolderSelector = ({
 			})
 			.join('');
 
-		return sub(TPL_ERROR_MESSAGES, {
-			messages: errors,
-			title:
-				failedItems > 1
-					? sub(
-							Liferay.Language.get('x-items-could-not-be-copied'),
-							failedItems
-					  )
-					: sub(
-							Liferay.Language.get('x-item-could-not-be-copied'),
-							failedItems
-					  ),
-		});
+		return sub(TPL_ERROR_MESSAGES, [
+			failedItems > 1
+				? sub(
+						Liferay.Language.get('x-items-could-not-be-copied'),
+						failedItems
+				  )
+				: sub(
+						Liferay.Language.get('x-item-could-not-be-copied'),
+						failedItems
+				  ),
+			errors,
+		]);
 	};
 
 	const showErrorMessage = (message) => {


### PR DESCRIPTION
With the latest sub update we have (accidentally) remove support for named keys in translations. It is very difficult to add this functionality since we need to deal with mixed arrays + objects + react nodes, and it did not add much value, so for now we can just rely on indices.