### PR TITLE
[TS] LPS-202785 Add temporary indexes on the relevant tables and columns to improve the performance of the LayoutPageTemplateStructureUpgradeProcess

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_0/LayoutPageTemplateStructureUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_0/LayoutPageTemplateStructureUpgradeProcess.java
@@ -5,6 +5,7 @@
 
 package com.liferay.layout.page.template.internal.upgrade.v5_1_0;
 
+import com.liferay.petra.lang.SafeCloseable;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -39,7 +40,11 @@ public class LayoutPageTemplateStructureUpgradeProcess extends UpgradeProcess {
 	protected void doUpgrade() throws Exception {
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
 				"select layoutPageTemplateStructureId, companyId, userId," +
-					"classPK from LayoutPageTemplateStructure")) {
+					"classPK from LayoutPageTemplateStructure");
+			SafeCloseable safeCloseable1 = addTemporaryIndex(
+				"FragmentEntryLink", false, "segmentsExperienceId", "plid");
+			SafeCloseable safeCloseable2 = addTemporaryIndex(
+				"SegmentsExperiment", false, "plid", "segmentsExperienceId")) {
 
 			try (ResultSet resultSet = preparedStatement1.executeQuery()) {
 				while (resultSet.next()) {


### PR DESCRIPTION
Please note: I put the "segmentsExperienceId" and "plid" columns in an inconsistent order on purpose.

For the FragmentEntryLink table, I concluded that (segmentsExperienceId, plid) is the optimal order for the index, because there is only one query on that table, and its WHERE clause looks like "segmentsExperienceId = ? and (plid = ? or plid = ?)". So, having segmentsExperienceId come first means that it only has to do 3 binary searches instead of the 4 it would have to do if plid came first.

However, for the SegmentsExperience table, I concluded that (plid, segmentsExperienceId) was the optimal order for the index, because there are two queries on this table (one is actually a subquery of a larger query on a different table). One of those queries is similar to the FragmentEntryLink query. However, the other one only queries by plid (it does not take segmentsExperienceId) into account at all. So, it's better to put plid first here so that we don't have to do n binary searches, where n is the number of distinct segmentsExperienceIds.

If you must put them in a consistent order, then please put them both in the order (plid, segmentsExperienceId), since I think the difference between the two is pretty negligible for the FragmentEntryLink table, but could be substantial for the SegmentsExperienceTable if there are a lot of distinct segmentsExperienceIds.

Motivation
=======
A customer found that the `com.liferay.layout.page.template.internal.upgrade.v5_1_0.LayoutPageTemplateStructureUpgradeProcess` was taking over 19 hours for them. This upgrade process iterates over all the LayoutPageTemplateStructures and adds the Default Experience to the database for each. This process entails several update queries to be run on different tables that are inefficient because their WHERE clauses do not take into account existing SQL indexes. If these tables are very large, then this upgrade process will take a very long time to complete.

Ticket: [LPS-202785](https://liferay.atlassian.net/browse/LPS-202785)

Proposed Solution
========
Added temporary indexes during this upgrade to make it complete much more quickly. When I did this I saw that this upgrade process completed within about 6 minutes when connected to the customer's database, a massive improvement over 19+ hours.

Steps to Verify
========
1. Start up Liferay 7.3 and log in as the admin user.
2. Create 15,000 Sites.
3. On each Site, create 20 Content Pages, each with a Fragment on them.
4. Upgrade to master.

**Expected Result:** The upgrade would complete within a reasonable timeframe
**Actual Result:** The `com.liferay.layout.page.template.internal.upgrade.v5_1_0.LayoutPageTemplateStructureUpgradeProcess` takes over 19 hours to complete.