### PR TITLE
[TS] LPS-202901 User correct title

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/asset_selection_order_down_action.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/asset_selection_order_down_action.jsp
@@ -51,7 +51,7 @@ boolean last = position == (searchContainer.getTotal() - 1);
 			cssClass="lfr-portal-tooltip"
 			href="<%= moveAssetEntrySelectionUpURL %>"
 			icon="angle-up"
-			title='<%= LanguageUtil.get(request, "down") %>'
+			title='<%= LanguageUtil.get(request, "up") %>'
 		/>
 	</c:when>
 </c:choose>


### PR DESCRIPTION
Motivation
=======
"Down" tooltip is displayed for an "angle-up" icon
[LPS-202901](https://liferay.atlassian.net/browse/LPS-202901)

Proposed Solution
========
Use "up" for title

Steps to Verify
========

1. Create 2 Web Contents
2. Create a Manual Collection for Web Contents
3. Add the 2 Web Contents to the Collection
4. Check the ^ icon for a tooltip

Expected behaviour: The tooltip is Up
Actual behaviour: The tooltip is Down