### PR TITLE
[TS] LPS-202245 URLs for Embedded Page type is not being encoded properly

### DIFF
--- a/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-embedded/src/main/resources/META-INF/resources/layout/view/embedded_js.jspf
@@ -40,7 +40,7 @@
 			UnicodeProperties typeSettingsUnicodeProperties = layout.getTypeSettingsProperties();
 			%>
 
-			'<%= HtmlUtil.escapeHREF(typeSettingsUnicodeProperties.getProperty("embeddedLayoutURL")) %>'
+			'<%= HtmlUtil.escapeJS(typeSettingsUnicodeProperties.getProperty("embeddedLayoutURL")) %>'
 		);
 	}
 </aui:script>


### PR DESCRIPTION
Dear Team,

Could you please review this pull request?

Motivation
=======
When a Page is configured with the Embedded template, the URL of the embedded page in the iFrame will be encoded.
For example,  the `&` character will be encoded as `&amp;`

and an URL like `www.google.com?embedded=true&userid=test` will be turned into `www.google.com?embedded=true&amp;userid=test` .

This does not pose a problem for internal URLs like `/group/guest/{etc}` , but if external URLs are encoded, the pages won’t load properly.

Proposed Solution
========
Using `HtmlUtil.escapeJS` instead of `HtmlUtil.escapeHREF` as it is sufficient in preventing script execution.

Steps to Verify
========
Please see the linked LPS for the reproduction steps.
https://liferay.atlassian.net/browse/LPS-202245

Thank you and best regards,
István