### PR TITLE
LPS-203029 reseting page number after altering filter

### DIFF
--- a/modules/apps/fragment/fragment-collection-filter-category/src/main/java/com/liferay/fragment/collection/filter/category/display/context/FragmentCollectionFilterCategoryDisplayContext.java
+++ b/modules/apps/fragment/fragment-collection-filter-category/src/main/java/com/liferay/fragment/collection/filter/category/display/context/FragmentCollectionFilterCategoryDisplayContext.java
@@ -9,6 +9,7 @@ import com.liferay.asset.kernel.model.AssetCategory;
 import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryServiceUtil;
 import com.liferay.asset.kernel.service.AssetVocabularyServiceUtil;
+import com.liferay.fragment.constants.FragmentConfigurationFieldDataType;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.renderer.FragmentRendererContext;
 import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
@@ -90,6 +91,12 @@ public class FragmentCollectionFilterCategoryDisplayContext {
 			return _props;
 		}
 
+		String targetCollections =
+			(String)
+				_fragmentEntryConfigurationParser.getConfigurationFieldValue(
+					_fragmentEntryLink.getEditableValues(), "targetCollections",
+					FragmentConfigurationFieldDataType.STRING);
+
 		_props = HashMapBuilder.<String, Object>put(
 			"assetCategories",
 			() -> {
@@ -107,6 +114,8 @@ public class FragmentCollectionFilterCategoryDisplayContext {
 						"label",
 						assetCategory.getTitle(
 							_fragmentRendererContext.getLocale())
+					).put(
+						"targetCollections", targetCollections
 					).build());
 			}
 		).put(

--- a/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/js/SelectCategory.es.js
+++ b/modules/apps/fragment/fragment-collection-filter-category/src/main/resources/META-INF/resources/js/SelectCategory.es.js
@@ -111,13 +111,23 @@ export default function SelectCategory({
 			footerContent={
 				singleSelection ? null : (
 					<ClayButton
-						onClick={() =>
+						onClick={() => {
+							const targetCollections = assetCategories
+								.filter(({id}) =>
+									selectedCategoryIds.includes(id)
+								)
+								.map(
+									(assetCategories) =>
+										assetCategories.targetCollections
+								);
+
 							setCollectionFilterValue(
 								'category',
 								fragmentEntryLinkId,
-								selectedCategoryIds
-							)
-						}
+								selectedCategoryIds,
+								targetCollections
+							);
+						}}
 						size="sm"
 					>
 						{Liferay.Language.get('apply')}

--- a/modules/apps/fragment/fragment-renderer-collection-filter-impl/src/main/resources/META-INF/resources/js/CollectionFilterRegister.js
+++ b/modules/apps/fragment/fragment-renderer-collection-filter-impl/src/main/resources/META-INF/resources/js/CollectionFilterRegister.js
@@ -41,7 +41,8 @@ export function getCollectionFilterValue(
 export function setCollectionFilterValue(
 	filterType,
 	filterFragmentEntryLinkId,
-	value
+	value,
+	targetCollections
 ) {
 	if (document.body.classList.contains('has-edit-mode-menu')) {
 		return;
@@ -61,6 +62,19 @@ export function setCollectionFilterValue(
 		url.searchParams.set(paramName, value);
 	}
 
+	if (targetCollections) {
+		for (const targetCollection of targetCollections) {
+			if (!targetCollection) {
+				continue;
+			}
+
+			const targetCollectionJSON = JSON.parse(targetCollection);
+
+			for (const targetCollectionValue of targetCollectionJSON) {
+				url.searchParams.delete('page_number_' + targetCollectionValue);
+			}
+		}
+	}
 	window.location.href = url.toString();
 }
 


### PR DESCRIPTION
Motivation
=======
[Widget Collection Filter not filtering after paginating](https://liferay.atlassian.net/browse/LPS-203029)

Proposed Solution
========
Reseting the page parameter from the URL When the filter is applied.

Steps to Verify
========

  1- Access Site Menu > Categorization > Categories > Create a Vocabulary and 2 Categories.

  2-  Go to Content & Data > Web Content > Create at least 10 Basic Web Content, with at least one category selected. (I defined Content 1 to Category-2 and all others with Category-1)

  3- Go to Site Builder > Collection > Create a Dynamic Collection and choose Basic Web Content as the source.

  4-  In a Page add the following:

       4.1-  Collection Display

            Collection: Choose the collection created previously

            Style Display: Bordered List

            List Item Style: Title

            Pagination: Numeric

            Maximum Number of Items per Page: 5

        4.2- Collection Filter

            Target Collection: choose the collection created.

            Filter: Category

            Source: Select the Vocabulary

   5- Publish the Page

   6- Access pagination, page 2.

* Actual Behavior

    In pagination 2, when attempting to filter by Category-2, for example, "No Results Found" is displayed.

* Expected Behavior

    The search filter should work in all paginations.