### PR TITLE
[TS] LPS-202937 | Previous versions of the resource files (CSS and JS) are not available during a long propagation

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -409,6 +409,10 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 			Map<String, String> zipEntryNames, Repository repository)
 		throws Exception {
 
+		Map<String, Long> folderIdsMap = HashMapBuilder.put(
+			StringPool.BLANK, fragmentCollection.getResourcesFolderId()
+		).build();
+
 		if (repository != null) {
 			FragmentServiceConfiguration fragmentServiceConfiguration =
 				_configurationProvider.getCompanyConfiguration(
@@ -427,6 +431,31 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 					if (fragmentServiceConfiguration.propagateChanges()) {
 						PortletFileRepositoryUtil.deletePortletFileEntry(
 							fileEntry.getFileEntryId());
+
+						String fileName = entry.getKey();
+						String folderPath = StringPool.BLANK;
+
+						int index = fileName.lastIndexOf(StringPool.SLASH);
+
+						if (index != -1) {
+							folderPath = fileName.substring(0, index);
+							fileName = fileName.substring(index + 1);
+						}
+
+						PortletFileRepositoryUtil.addPortletFileEntry(
+							null, groupId, userId,
+							FragmentCollection.class.getName(),
+							fragmentCollection.getFragmentCollectionId(),
+							FragmentPortletKeys.FRAGMENT,
+							_getOrCreateFolderId(
+								folderIdsMap, folderPath,
+								repository.getRepositoryId(), userId),
+							_getInputStream(
+								zipFile, zipEntryNames.get(fileName)),
+							fileName, MimeTypesUtil.getContentType(fileName),
+							false);
+
+						zipEntryNames.remove(fileEntry.getFileName());
 					}
 					else {
 						String folderPath = StringPool.BLANK;
@@ -463,10 +492,6 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 			repository = PortletFileRepositoryUtil.addPortletRepository(
 				groupId, FragmentPortletKeys.FRAGMENT, serviceContext);
 		}
-
-		Map<String, Long> folderIdsMap = HashMapBuilder.put(
-			StringPool.BLANK, fragmentCollection.getResourcesFolderId()
-		).build();
 
 		for (Map.Entry<String, String> entry : zipEntryNames.entrySet()) {
 			String fileName = entry.getKey();


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPS-202937
best,
Attila

---------

This behavior was considered a bug based on this [PTR](https://liferay.atlassian.net/browse/PTR-4511).
This pull changed the previous behavior in a way that after every resource file is deleted the new version of this file is imported in. This way there is no moment where all the resources are missing. It also greatly reduces the chance of experiencing a case where a resource is not visible to the user.