### PR TITLE
[TS] Friendly url input is not loaded correctly when web content's language is different from site's language

### DIFF
--- a/modules/apps/asset/asset-display-page-api/bnd.bnd
+++ b/modules/apps/asset/asset-display-page-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Asset Display Page API
 Bundle-SymbolicName: com.liferay.asset.display.page.api
-Bundle-Version: 14.0.1
+Bundle-Version: 14.1.0
 Export-Package:\
 	com.liferay.asset.display.page.configuration,\
 	com.liferay.asset.display.page.constants,\

--- a/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/model/packageinfo
+++ b/modules/apps/asset/asset-display-page-api/src/main/resources/com/liferay/asset/display/page/model/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.0
+version 5.1.0

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/HideOptionsForEntitiesInImportAndExport.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/HideOptionsForEntitiesInImportAndExport.testcase
@@ -176,26 +176,6 @@ definition {
 	}
 
 	@priority = 4
-	test CanDisplayIncludeHeadersWithExportObjectDefinitionCSVFormat {
-		property custom.properties = "feature.flag.LPS-173135=true";
-		property portal.acceptance = "true";
-
-		task ("When I select CSV format to export ObjectDefinition") {
-			ImportExport.gotoExport();
-
-			ImportExport.configureExport(
-				entityType = "ObjectDefinition (v1_0 - Liferay Object Admin REST)",
-				exportFileFormat = "CSV");
-		}
-
-		task ("Then the Include Headers is checked") {
-			AssertChecked.assertCheckedNotVisible(
-				checkboxName = "Include Headers",
-				locator1 = "Checkbox#ANY_CHECKBOX");
-		}
-	}
-
-	@priority = 4
 	test CannotDisplayIncludeHeaderWithExportBlogPostingJOSNLFormat {
 		property portal.acceptance = "true";
 

--- a/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
+++ b/modules/apps/batch-planner/batch-planner-test/src/testFunctional/tests/ImportExport.testcase
@@ -382,7 +382,6 @@ definition {
 	@description = "Verify users can filter Import/Export executions by Action."
 	@priority = 3
 	test CanFilterExecutionsByAction {
-		property custom.properties = "feature.flag.LPS-173135=true";
 		property portal.acceptance = "true";
 
 		task ("Given Object Definition import and export") {
@@ -656,7 +655,6 @@ definition {
 	@description = "Verify users can order Import/Export executions by Create Date."
 	@priority = 3
 	test CanOrderExecutionsByCreateDate {
-		property custom.properties = "feature.flag.LPS-173135=true";
 		property portal.acceptance = "true";
 
 		task ("Given Object Definition import and export") {
@@ -942,7 +940,6 @@ definition {
 	@description = "Verify users can search Import/Exports templates by name and action."
 	@priority = 3
 	test CanSearchTemplates {
-		property custom.properties = "feature.flag.LPS-173135=true";
 		property portal.acceptance = "true";
 
 		task ("Given object definition import and export templates") {
@@ -1079,7 +1076,6 @@ definition {
 	@description = "Verify users receive a notification when an export is triggered."
 	@priority = 3
 	test CanViewExportNotifications {
-		property custom.properties = "feature.flag.LPS-173135=true";
 		property portal.acceptance = "true";
 
 		task ("Given a failed export") {

--- a/modules/apps/depot/depot-test/src/testFunctional/tests/DepotWorkflow.testcase
+++ b/modules/apps/depot/depot-test/src/testFunctional/tests/DepotWorkflow.testcase
@@ -588,12 +588,7 @@ definition {
 		property test.liferay.virtual.instance = "false";
 		property test.run.type = "single";
 
-		ApplicationsMenu.gotoPortlet(
-			category = "Workflow",
-			panel = "Applications",
-			portlet = "Process Builder");
-
-		Navigator.gotoNavItem(navItem = "Configuration");
+		Workflow.openWorkflowProcessBuilderConfiguration();
 
 		Workflow.configureWorkflow(
 			workflowDefinition = "Single Approver",

--- a/modules/apps/friendly-url/friendly-url-taglib/bnd.bnd
+++ b/modules/apps/friendly-url/friendly-url-taglib/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Friendly URL Taglib
 Bundle-SymbolicName: com.liferay.friendly.url.taglib
-Bundle-Version: 1.4.6
+Bundle-Version: 1.5.0
 Export-Package: com.liferay.friendly.url.taglib.servlet.taglib
 Provide-Capability:\
 	osgi.extender;\

--- a/modules/apps/friendly-url/friendly-url-taglib/package.json
+++ b/modules/apps/friendly-url/friendly-url-taglib/package.json
@@ -22,5 +22,5 @@
 		"format": "liferay-npm-scripts fix",
 		"test": "liferay-npm-scripts test"
 	},
-	"version": "1.4.6"
+	"version": "1.5.0"
 }

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/java/com/liferay/friendly/url/taglib/servlet/taglib/InputTag.java
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/java/com/liferay/friendly/url/taglib/servlet/taglib/InputTag.java
@@ -47,6 +47,10 @@ public class InputTag extends IncludeTag {
 		return _classPK;
 	}
 
+	public String getDefaultLanguageId() {
+		return _defaultLanguageId;
+	}
+
 	public String getHelpMessage() {
 		return _helpMessage;
 	}
@@ -81,6 +85,10 @@ public class InputTag extends IncludeTag {
 
 	public void setClassPK(long classPK) {
 		_classPK = classPK;
+	}
+
+	public void setDefaultLanguageId(String defaultLanguageId) {
+		_defaultLanguageId = defaultLanguageId;
 	}
 
 	public void setDisabled(boolean disabled) {
@@ -124,6 +132,7 @@ public class InputTag extends IncludeTag {
 
 		_className = null;
 		_classPK = 0;
+		_defaultLanguageId = null;
 		_disabled = false;
 		_helpMessage = null;
 		_inputAddon = null;
@@ -146,6 +155,9 @@ public class InputTag extends IncludeTag {
 			"liferay-friendly-url:input:className", getClassName());
 		httpServletRequest.setAttribute(
 			"liferay-friendly-url:input:classPK", getClassPK());
+		httpServletRequest.setAttribute(
+			"liferay-friendly-url:input:defaultLanguageId",
+			getDefaultLanguageId());
 		httpServletRequest.setAttribute(
 			"liferay-friendly-url:input:disabled", isDisabled());
 		httpServletRequest.setAttribute(
@@ -295,6 +307,7 @@ public class InputTag extends IncludeTag {
 
 	private String _className;
 	private long _classPK;
+	private String _defaultLanguageId;
 	private boolean _disabled;
 	private String _helpMessage;
 	private String _inputAddon;

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/liferay-friendly-url.tld
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/liferay-friendly-url.tld
@@ -55,6 +55,11 @@
 			<rtexprvalue>true</rtexprvalue>
 		</attribute>
 		<attribute>
+			<name>defaultLanguageId</name>
+			<required>false</required>
+			<rtexprvalue>true</rtexprvalue>
+		</attribute>
+		<attribute>
 			<name>disabled</name>
 			<required>false</required>
 			<rtexprvalue>true</rtexprvalue>

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/input/page.jsp
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/META-INF/resources/input/page.jsp
@@ -8,11 +8,16 @@
 <%@ include file="/input/init.jsp" %>
 
 <%
+String defaultLanguageId = (String)request.getAttribute("liferay-friendly-url:input:defaultLanguageId");
 boolean disabled = (boolean)request.getAttribute("liferay-friendly-url:input:disabled");
 int friendlyURLMaxLength = (int)request.getAttribute("liferay-friendly-url:input:friendlyURLMaxLength");
 boolean localizable = (boolean)request.getAttribute("liferay-friendly-url:input:localizable");
 String name = (String)request.getAttribute("liferay-friendly-url:input:name");
 String value = (String)request.getAttribute("liferay-friendly-url:input:value");
+
+if (defaultLanguageId == null) {
+	defaultLanguageId = LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale());
+}
 %>
 
 <c:if test='<%= (boolean)request.getAttribute("liferay-friendly-url:input:showHistory") %>'>
@@ -37,7 +42,7 @@ String value = (String)request.getAttribute("liferay-friendly-url:input:value");
 	<c:choose>
 		<c:when test="<%= localizable %>">
 			<liferay-ui:input-localized
-				defaultLanguageId="<%= LocaleUtil.toLanguageId(themeDisplay.getSiteDefaultLocale()) %>"
+				defaultLanguageId="<%= defaultLanguageId %>"
 				disabled="<%= disabled %>"
 				helpMessage='<%= (String)request.getAttribute("liferay-friendly-url:input:helpMessage") %>'
 				ignoreRequestValue="<%= SessionErrors.isEmpty(request) %>"

--- a/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/com/liferay/friendly/url/taglib/servlet/taglib/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-taglib/src/main/resources/com/liferay/friendly/url/taglib/servlet/taglib/packageinfo
@@ -1,1 +1,1 @@
-version 1.4.0
+version 1.5.0

--- a/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/src/main/resources/META-INF/resources/app/App.js
@@ -485,8 +485,8 @@ class App extends EventEmitter {
 					this.extractParams(route, path)
 				);
 			})
-			.then(() => nextScreen.evaluateStyles(this.surfaces))
 			.then(() => nextScreen.flip(this.surfaces))
+			.then(() => nextScreen.evaluateStyles(this.surfaces))
 			.then(() => nextScreen.evaluateScripts(this.surfaces))
 			.then(() => this.maybeUpdateScrollPositionState_())
 			.then(() => this.syncScrollPositionSyncThenAsync_())

--- a/modules/apps/frontend-js/frontend-js-spa-web/test/app/App.js
+++ b/modules/apps/frontend-js/frontend-js-spa-web/test/app/App.js
@@ -1748,15 +1748,15 @@ describe('App', function () {
 			this.app.navigate('/path2').then(() => {
 				const lifecycleOrder = [
 					StubScreen.prototype.load,
-					StubScreen.prototype.evaluateStyles,
 					StubScreen.prototype.flip,
+					StubScreen.prototype.evaluateStyles,
 					StubScreen.prototype.evaluateScripts,
 					StubScreen.prototype.activate,
 					StubScreen.prototype.beforeDeactivate,
 					StubScreen2.prototype.load,
 					StubScreen.prototype.deactivate,
-					StubScreen2.prototype.evaluateStyles,
 					StubScreen2.prototype.flip,
+					StubScreen2.prototype.evaluateStyles,
 					StubScreen2.prototype.evaluateScripts,
 					StubScreen2.prototype.activate,
 					StubScreen.prototype.disposeInternal,

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional/macros/ExportTask.macro
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional/macros/ExportTask.macro
@@ -12,6 +12,23 @@ definition {
 	}
 
 	@summary = "Default summary"
+	macro createExportTask(className = null, contentType = null) {
+		Variables.assertDefined(parameterList = "${className},${contentType}");
+
+		var portalURL = JSONCompany.getPortalURL();
+
+		var curl = '''
+			${portalURL}/o/headless-batch-engine/v1.0/export-task/${className}/${contentType}?flatten=true \
+				-u test@liferay.com:test \
+				-H Content-Type: application/json
+		''';
+
+		var curl = JSONCurlUtil.post(${curl});
+
+		return ${curl};
+	}
+
+	@summary = "Default summary"
 	macro getExportTaskById(exportTaskId = null) {
 		Variables.assertDefined(parameterList = ${exportTaskId});
 

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional/macros/OrganizationAPI.macro
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional/macros/OrganizationAPI.macro
@@ -1,0 +1,28 @@
+definition {
+
+	@summary = "Default summary"
+	macro deleteOrganizationByExternalReferenceCode(virtualHost = null, externalReferenceCode = null) {
+		Variables.assertDefined(parameterList = ${externalReferenceCode});
+
+		if (isSet(virtualHost)) {
+			if (!(isSet(port))) {
+				var port = 8080;
+			}
+
+			var portalURL = "http://${virtualHost}:${port}";
+		}
+		else {
+			var portalURL = JSONCompany.getPortalURL();
+		}
+
+		var curl = '''
+			${portalURL}/o/headless-admin-user/v1.0/organizations/by-external-reference-code/${externalReferenceCode} \
+				-H accept: application/json \
+				-H Content-Type: application/json \
+				-u test@liferay.com:test \
+		''';
+
+		JSONCurlUtil.delete(${curl});
+	}
+
+}

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional/tests/HeadlessBatchEngineExportOrganization.testcase
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testFunctional/tests/HeadlessBatchEngineExportOrganization.testcase
@@ -1,0 +1,85 @@
+@component-name = "portal-headless"
+definition {
+
+	property portal.release = "true";
+	property portal.upstream = "true";
+	property testray.main.component.name = "Headless Batch Engine API";
+
+	setUp {
+		TestCase.setUpPortalInstance();
+
+		User.firstLoginPG();
+	}
+
+	tearDown {
+		for (var externalReferenceCodeList : list "sub_organizationErc,organizationErc") {
+			OrganizationAPI.deleteOrganizationByExternalReferenceCode(externalReferenceCode = ${externalReferenceCodeList});
+		}
+
+		var testLiferayVirtualInstance = PropsUtil.get("test.liferay.virtual.instance");
+
+		if (${testLiferayVirtualInstance} == "true") {
+			PortalInstances.tearDownCP();
+		}
+	}
+
+	@priority = 4
+	test CanExportAllOrganizations {
+		property portal.acceptance = "true";
+
+		task ("Given a new organization") {
+			JSONOrganization.addOrganization(
+				externalReferenceCode = "organizationErc",
+				organizationName = "testOrganization");
+		}
+
+		task ("And Given a sub_tesOrganization in the created testOrganization") {
+			JSONOrganization.addOrganization(
+				externalReferenceCode = "sub_organizationErc",
+				organizationName = "sub_testOrganization",
+				parentOrganizationName = "testOrganization");
+		}
+
+		task ("And Given using POST export-task with className com.liferay.headless.admin.user.dto.v1_0.Organization and parameter flatten=true") {
+			var response = ExportTask.createExportTask(
+				className = "com.liferay.headless.admin.user.dto.v1_0.Organization",
+				contentType = "JSON");
+
+			var externalReferenceCode = JSONPathUtil.getErcValue(response = ${response});
+		}
+
+		task ("And Given using GET export-task/by-external-reference-code/${externalReferenceCode}/content with externalReferenceCode from POST") {
+			APIExplorer.navigateToOpenAPI(
+				api = "headless-batch-engine",
+				version = "v1.0");
+
+			APIExplorer.executeAPIMethod(
+				method = "getExportTaskByExternalReferenceCodeContent",
+				parameter = "externalReferenceCode",
+				service = "ExportTask",
+				value = ${externalReferenceCode});
+		}
+
+		task ("When click download file") {
+			WaitForElementPresent(
+				key_text = "Download file",
+				locator1 = "Link#ANY");
+
+			Click(
+				key_text = "Download file",
+				locator1 = "Link#ANY");
+		}
+
+		task ("Then the downloaded file includes the testOrganization and its sub_testOrganization") {
+			var fileName = selenium.getAttribute("//a[contains(.,'Download file')]@download");
+
+			AntCommands.runCommand("build-test.xml", "unzip-temp-file -DfileName=${fileName}");
+
+			BatchEngine.assertExportedFileContainsCorrectObject(
+				expectedValue = "testOrganization,sub_testOrganization",
+				fileName = "export.json",
+				jsonObject = "$..[0]name");
+		}
+	}
+
+}

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-test/src/testIntegration/java/com/liferay/headless/batch/engine/resource/v1_0/test/ExportTaskResourceTest.java
@@ -354,6 +354,8 @@ public class ExportTaskResourceTest {
 		"com.liferay.headless.commerce.admin.catalog.dto.v1_0.SkuUnitOfMeasure",
 		"com.liferay.headless.commerce.admin.catalog.dto.v1_0.Specification",
 		"com.liferay.headless.commerce.admin.channel.dto.v1_0." +
+			"AccountAddressChannel",
+		"com.liferay.headless.commerce.admin.channel.dto.v1_0." +
 			"PaymentMethodGroupRelOrderType",
 		"com.liferay.headless.commerce.admin.channel.dto.v1_0." +
 			"PaymentMethodGroupRelTerm",

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/macros/APIBuilderUI.macro
@@ -181,7 +181,7 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro createAPIEndpoint(path = null, name = null, applicationId = null, scope = null) {
+	macro createAPIEndpoint(path = null, method = null, scope = null, name = null, retrieveType = null, applicationId = null) {
 		Variables.assertDefined(parameterList = ${path});
 
 		Click(locator1 = "Button#PLUS");
@@ -190,6 +190,16 @@ definition {
 			Type(
 				locator1 = "TextInput#NAME",
 				value1 = ${name});
+		}
+
+		if (isSet(method)) {
+			Click(
+				key_value = "Select Method",
+				locator1 = "APIBuilder#DROPDOWN_TOGGLE");
+
+			Click(
+				key_optionName = ${method},
+				locator1 = "ObjectAdmin#LAYOUT_ADD_FIELD_OPTION");
 		}
 
 		if (isSet(retrieveType)) {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/CreateAnAPIApplicationEndpoint.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/CreateAnAPIApplicationEndpoint.testcase
@@ -39,9 +39,10 @@ definition {
 				title = "test1");
 
 			APIBuilderUI.createAPIEndpoint(
+				method = "GET",
 				path = "testendpoint1",
-				scope = "Company",
-				title = "test1");
+				retrieveType = "Collection",
+				scope = "Company");
 		}
 
 		task ("Then the endpoint with Company scope is created successfully and listed") {
@@ -74,9 +75,10 @@ definition {
 				title = "test2");
 
 			APIBuilderUI.createAPIEndpoint(
+				method = "GET",
 				path = "testendpoint2",
-				scope = "Site",
-				title = "test2");
+				retrieveType = "Collection",
+				scope = "Site");
 		}
 
 		task ("Then the endpoint with site scope is created successfully and listed") {

--- a/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/EditAPIApplicationEndpoint.testcase
+++ b/modules/apps/headless/headless-builder/headless-builder-test/src/testFunctional/tests/[UI]AllowUsersToDefineAPIApplicationEndpoints/EditAPIApplicationEndpoint.testcase
@@ -87,6 +87,7 @@ definition {
 				title = "My-app");
 
 			APIBuilderUI.createAPIEndpoint(
+				method = "GET",
 				path = "testendpoint2",
 				retrieveType = "Collection",
 				scope = "Company");
@@ -285,26 +286,6 @@ definition {
 				key_placeHolder = "Enter Path",
 				locator1 = "TextInput#ANY_PLACEHOLDER",
 				value1 = "updatedendpoint");
-		}
-	}
-
-	@priority = 3
-	test GetIsDefaultMethodValue {
-		task ("When creating endpoint with valid data") {
-			APIBuilderUI.switchToRelatedEntryInEditApplication(
-				entity = "Endpoints",
-				title = "My-app");
-
-			APIBuilderUI.createAPIEndpoint(
-				path = "testendpoint2",
-				retrieveType = "Collection",
-				scope = "Company");
-		}
-
-		task ("Then enpoint method is GET by default") {
-			AssertTextEquals(
-				locator1 = "Button#DISABLED_BUTTON",
-				value1 = "GET");
 		}
 	}
 

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
@@ -14,9 +14,25 @@ import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.util.JournalConverter;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.Portal;
+
+import org.w3c.dom.Document;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.StringReader;
+import java.io.StringWriter;
 
 /**
  * @author Preston Crary
@@ -64,6 +80,8 @@ public class JournalArticleDDMFieldsUpgradeProcess extends UpgradeProcess {
 						_portal.getSiteGroupId(groupId), classNameId,
 						ddmStructureKey, true);
 
+				content = _convertFieldNames(content);
+
 				DDMFormValues ddmFormValues =
 					_fieldsToDDMFormValuesConverter.convert(
 						ddmStructure,
@@ -73,6 +91,45 @@ public class JournalArticleDDMFieldsUpgradeProcess extends UpgradeProcess {
 					ddmStructure.getStructureId(), id, ddmFormValues);
 			},
 			null);
+	}
+	private String _convertFieldNames(String content)
+		throws Exception {
+		Document document = DocumentBuilderFactory.newInstance()
+			.newDocumentBuilder()
+			.parse(new InputSource(new StringReader(content)));
+
+		NodeList nodeList = document.getElementsByTagName("dynamic-element");
+
+		for(int i = 0 ; i < nodeList.getLength() ; i++) {
+			Node node = nodeList.item(i);
+
+			NamedNodeMap namedNodeMap = node.getAttributes();
+
+			Node nodeName = namedNodeMap.getNamedItem("name");
+
+			String oldNameValue = nodeName.getTextContent();
+
+			String newNameValue = oldNameValue.replaceAll(StringPool.MINUS, StringPool.BLANK);
+
+			nodeName.setTextContent(newNameValue);
+		}
+
+		return _convertDocumentToString(document);
+	}
+
+	private String _convertDocumentToString(Document document)
+		throws TransformerException {
+
+		TransformerFactory transformerFactory = TransformerFactory.newInstance();
+
+		Transformer transformer = transformerFactory.newTransformer();
+
+		StringWriter writer = new StringWriter();
+
+		transformer.transform(new DOMSource(document), new StreamResult(writer));
+
+		return writer.getBuffer().toString();
+
 	}
 
 	@Override

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
@@ -12,27 +12,28 @@ import com.liferay.dynamic.data.mapping.storage.DDMFormValues;
 import com.liferay.dynamic.data.mapping.util.FieldsToDDMFormValuesConverter;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.util.JournalConverter;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.security.xml.SecureXMLFactoryProviderUtil;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.upgrade.UpgradeProcessFactory;
 import com.liferay.portal.kernel.upgrade.UpgradeStep;
 import com.liferay.portal.kernel.util.Portal;
+
+import java.io.StringReader;
+import java.io.StringWriter;
+
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
 
 import org.w3c.dom.Document;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
-import org.xml.sax.InputSource;
 
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.dom.DOMSource;
-import javax.xml.transform.stream.StreamResult;
-import java.io.StringReader;
-import java.io.StringWriter;
+import org.xml.sax.InputSource;
 
 /**
  * @author Preston Crary
@@ -92,15 +93,42 @@ public class JournalArticleDDMFieldsUpgradeProcess extends UpgradeProcess {
 			},
 			null);
 	}
-	private String _convertFieldNames(String content)
+
+	@Override
+	protected UpgradeStep[] getPostUpgradeSteps() {
+		return new UpgradeStep[] {
+			UpgradeProcessFactory.dropColumns("JournalArticle", "content")
+		};
+	}
+
+	private String _convertDocumentToString(Document document)
 		throws Exception {
-		Document document = DocumentBuilderFactory.newInstance()
-			.newDocumentBuilder()
-			.parse(new InputSource(new StringReader(content)));
+
+		TransformerFactory transformerFactory =
+			TransformerFactory.newInstance();
+
+		Transformer transformer = transformerFactory.newTransformer();
+
+		StringWriter writer = new StringWriter();
+
+		transformer.transform(
+			new DOMSource(document), new StreamResult(writer));
+
+		return writer.getBuffer(
+		).toString();
+	}
+
+	private String _convertFieldNames(String content) throws Exception {
+		Document document =
+			SecureXMLFactoryProviderUtil.newDocumentBuilderFactory(
+			).newDocumentBuilder(
+			).parse(
+				new InputSource(new StringReader(content))
+			);
 
 		NodeList nodeList = document.getElementsByTagName("dynamic-element");
 
-		for(int i = 0 ; i < nodeList.getLength() ; i++) {
+		for (int i = 0; i < nodeList.getLength(); i++) {
 			Node node = nodeList.item(i);
 
 			NamedNodeMap namedNodeMap = node.getAttributes();
@@ -109,34 +137,13 @@ public class JournalArticleDDMFieldsUpgradeProcess extends UpgradeProcess {
 
 			String oldNameValue = nodeName.getTextContent();
 
-			String newNameValue = oldNameValue.replaceAll(StringPool.MINUS, StringPool.BLANK);
+			String newNameValue = oldNameValue.replaceAll(
+				StringPool.MINUS, StringPool.BLANK);
 
 			nodeName.setTextContent(newNameValue);
 		}
 
 		return _convertDocumentToString(document);
-	}
-
-	private String _convertDocumentToString(Document document)
-		throws TransformerException {
-
-		TransformerFactory transformerFactory = TransformerFactory.newInstance();
-
-		Transformer transformer = transformerFactory.newTransformer();
-
-		StringWriter writer = new StringWriter();
-
-		transformer.transform(new DOMSource(document), new StreamResult(writer));
-
-		return writer.getBuffer().toString();
-
-	}
-
-	@Override
-	protected UpgradeStep[] getPostUpgradeSteps() {
-		return new UpgradeStep[] {
-			UpgradeProcessFactory.dropColumns("JournalArticle", "content")
-		};
 	}
 
 	private final ClassNameLocalService _classNameLocalService;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/v4_0_0/JournalArticleDDMFieldsUpgradeProcess.java
@@ -101,24 +101,12 @@ public class JournalArticleDDMFieldsUpgradeProcess extends UpgradeProcess {
 		};
 	}
 
-	private String _convertDocumentToString(Document document)
-		throws Exception {
-
+	private String _convertFieldNames(String content) throws Exception {
 		TransformerFactory transformerFactory =
 			TransformerFactory.newInstance();
 
 		Transformer transformer = transformerFactory.newTransformer();
 
-		StringWriter writer = new StringWriter();
-
-		transformer.transform(
-			new DOMSource(document), new StreamResult(writer));
-
-		return writer.getBuffer(
-		).toString();
-	}
-
-	private String _convertFieldNames(String content) throws Exception {
 		Document document =
 			SecureXMLFactoryProviderUtil.newDocumentBuilderFactory(
 			).newDocumentBuilder(
@@ -133,17 +121,21 @@ public class JournalArticleDDMFieldsUpgradeProcess extends UpgradeProcess {
 
 			NamedNodeMap namedNodeMap = node.getAttributes();
 
-			Node nodeName = namedNodeMap.getNamedItem("name");
+			Node nameNode = namedNodeMap.getNamedItem("name");
 
-			String oldNameValue = nodeName.getTextContent();
+			String textContent = nameNode.getTextContent();
 
-			String newNameValue = oldNameValue.replaceAll(
-				StringPool.MINUS, StringPool.BLANK);
-
-			nodeName.setTextContent(newNameValue);
+			nameNode.setTextContent(
+				textContent.replaceAll(StringPool.MINUS, StringPool.BLANK));
 		}
 
-		return _convertDocumentToString(document);
+		StringWriter stringWriter = new StringWriter();
+
+		transformer.transform(
+			new DOMSource(document), new StreamResult(stringWriter));
+
+		return stringWriter.getBuffer(
+		).toString();
 	}
 
 	private final ClassNameLocalService _classNameLocalService;

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/friendly_url.jsp
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/article/friendly_url.jsp
@@ -28,6 +28,7 @@ JournalEditArticleDisplayContext journalEditArticleDisplayContext = new JournalE
 <liferay-friendly-url:input
 	className="<%= JournalArticle.class.getName() %>"
 	classPK="<%= (article == null) || (article.getPrimaryKey() == 0) ? 0 : article.getResourcePrimKey() %>"
+	defaultLanguageId="<%= journalEditArticleDisplayContext.getDefaultArticleLanguageId() %>"
 	inputAddon="<%= journalEditArticleDisplayContext.getFriendlyURLBase() %>"
 	name="friendlyURL"
 	showHistory="<%= false %>"

--- a/modules/apps/translation/translation-test/src/testFunctional/macros/Translations.macro
+++ b/modules/apps/translation/translation-test/src/testFunctional/macros/Translations.macro
@@ -547,7 +547,7 @@ definition {
 			var pageNameTranslation = "false";
 		}
 
-		AntCommands.runCommand("build-test-translation.xml", "update-translation-file -Dcontentpage.translation.file=${contentPageTranslation} -Dcontentpage.translation.fragment.target=<![CDATA[<p>${fragmentContentTranslation}</p> -Dcontentpage.translation.fragment.target.original=<![CDATA[<p>${fragmentContent}</p> -Dcontentpage.translation.title.target=<![CDATA[${pageNameTranslation}]]></target> -Dcontentpage.translation.title.target.original=<![CDATA[${pageName}]]></target> -Doperation=${operation} -Dtranslation.file.encoding=${encoding} -Dtranslation.file.name=${translationFileName} -Dtranslation.zip.file.name=${translationZipFileName}");
+		AntCommands.runCommand("build-test-translation.xml", "update-translation-file -Dcontentpage.translation.file=${contentPageTranslation} -Dcontentpage.translation.fragment.target=${fragmentContentTranslation} -Dcontentpage.translation.fragment.target.original=${fragmentContent} -Dcontentpage.translation.title.target=<![CDATA[${pageNameTranslation}]]></target> -Dcontentpage.translation.title.target.original=<![CDATA[${pageName}]]></target> -Doperation=${operation} -Dtranslation.file.encoding=${encoding} -Dtranslation.file.name=${translationFileName} -Dtranslation.zip.file.name=${translationZipFileName}");
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/DMDocument.macro
@@ -1451,7 +1451,7 @@ definition {
 				locator1 = "MenuItem#ANY_MENU_ITEM");
 		}
 
-		Click.mouseOverClick(
+		Click.javaScriptClick(
 			key_menuItem = "Copy Link",
 			locator1 = "MenuItem#MENU_ITEM_SPECIFIC");
 

--- a/portal-web/test/functional/com/liferay/portalweb/macros/OAuthClient.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/OAuthClient.macro
@@ -138,7 +138,9 @@ definition {
 
 		DoubleClick(locator1 = "FormFields#TEXT_MULTILINE_FIELD");
 
-		RobotType.robotTypeShortcut(locator1 = "Ctrl + a");
+		Type.sendKeys(
+			locator1 = "FormFields#TEXT_MULTILINE_FIELD",
+			value1 = "keys=CONTROL,a");
 
 		KeyPress(
 			locator1 = "FormFields#TEXT_MULTILINE_FIELD",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/DataSetAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/DataSetAdmin.macro
@@ -1,7 +1,7 @@
 definition {
 
 	@summary = "Default summary"
-	macro addActions(messageType = null, icon = null, headlessAction = null, type = null,method = null, url = null, actionName = null,key_actionNameList = null, confirmationMessage = null, actionTab = null, successMessage = null, errorMessage = null, inputText = null, variant = null) {
+	macro addActions(messageType = null, icon = null, headlessAction = null, type = null,method = null, url = null, actionName = null,key_actionNameList = null, confirmationMessage = null, actionTab = null, successMessage = null, errorMessage = null, title = null, variant = null) {
 		var key_actionNameList = ${actionName};
 
 		if (isSet(actionTab)) {
@@ -49,11 +49,19 @@ definition {
 					value1 = ${variant});
 			}
 
-			if (isSet(inputText)) {
-				Type(
-					key_fieldName = "add-here-the-title-of-the-modal",
-					locator1 = "DataSet#PRESELECT_VALUE_INPUT",
-					value1 = ${variant});
+			if (isSet(title)) {
+				if (IsElementPresent(key_fieldName = "add-here-the-title-of-the-modal", locator1 = "DataSet#PRESELECT_VALUE_INPUT")) {
+					Type(
+						key_fieldName = "add-here-the-title-of-the-modal",
+						locator1 = "DataSet#PRESELECT_VALUE_INPUT",
+						value1 = ${title});
+				}
+				else {
+					Type(
+						key_fieldName = "add-here-the-title-of-the-side-panel",
+						locator1 = "DataSet#PRESELECT_VALUE_INPUT",
+						value1 = ${title});
+				}
 			}
 
 			if (isSet(method)) {

--- a/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/DataSetAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/DataSetAdmin.macro
@@ -1,6 +1,6 @@
 definition {
 
-	@summary = "Default summary"
+	@summary = "Add a Item or Creation Action in Data Set"
 	macro addActions(messageType = null, icon = null, headlessAction = null, type = null,method = null, url = null, actionName = null,key_actionNameList = null, confirmationMessage = null, actionTab = null, successMessage = null, errorMessage = null, title = null, variant = null) {
 		var key_actionNameList = ${actionName};
 
@@ -557,7 +557,7 @@ definition {
 		Click(locator1 = "DataSet#MODAL_SAVE_BUTTON");
 	}
 
-	@summary = "Default summary"
+	@summary = "Delete a Item or Creation Action in Data Set"
 	macro deleteActionEntry(actionName = null, actionTab = null) {
 		if (isSet(actionTab)) {
 			Button.click(button = ${actionTab});
@@ -685,7 +685,7 @@ definition {
 		Alert.viewSuccessMessage();
 	}
 
-	@summary = "Default summary"
+	@summary = "Edit a Item or Creation Action in Data Set"
 	macro editActions(newMessageType = null, newIcon = null, newHeadlessAction = null, newType = null,newMethod = null, newURL = null, newActionName = null,oldActionName = null, newConfirmationMessage = null, actionTab = null, newSuccessMessage = null, newErrorMessage = null) {
 		if (isSet(actionTab)) {
 			Button.click(button = ${actionTab});

--- a/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/DataSetAdmin.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/frontendinfrastructure/DataSetAdmin.macro
@@ -726,6 +726,28 @@ definition {
 				value1 = ${newType});
 		}
 
+		if (isSet(newVariant)) {
+			Select(
+				key_fieldLabel = "Variant",
+				locator1 = "Select#GENERIC_SELECT_FIELD",
+				value1 = ${newVariant});
+		}
+
+		if (isSet(newTitle)) {
+			if (IsElementPresent(key_fieldName = "add-here-the-title-of-the-modal", locator1 = "DataSet#PRESELECT_VALUE_INPUT")) {
+				Type(
+					key_fieldName = "add-here-the-title-of-the-modal",
+					locator1 = "DataSet#PRESELECT_VALUE_INPUT",
+					value1 = ${newTitle});
+			}
+			else {
+				Type(
+					key_fieldName = "add-here-the-title-of-the-side-panel",
+					locator1 = "DataSet#PRESELECT_VALUE_INPUT",
+					value1 = ${newTitle});
+			}
+		}
+
 		if (isSet(newMethod)) {
 			Select(
 				key_fieldLabel = "Method",

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/organizations/JSONOrganization.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/organizations/JSONOrganization.macro
@@ -1,7 +1,7 @@
 definition {
 
 	@summary = "Default summary"
-	macro addOrganization(organizationType = null, organizationCountry = null, organizationName = null, organizationSite = null, organizationRegion = null, parentOrganizationName = null) {
+	macro addOrganization(externalReferenceCode = null, organizationType = null, organizationCountry = null, organizationName = null, organizationSite = null, organizationRegion = null, parentOrganizationName = null) {
 		Variables.assertDefined(parameterList = ${organizationName});
 
 		if (isSet(parentOrganizationName)) {
@@ -9,6 +9,7 @@ definition {
 		}
 
 		JSONOrganizationAPI._addOrganization(
+			externalReferenceCode = ${externalReferenceCode},
 			organizationCountry = ${organizationCountry},
 			organizationName = ${organizationName},
 			organizationRegion = ${organizationRegion},

--- a/portal-web/test/functional/com/liferay/portalweb/macros/json/organizations/JSONOrganizationAPI.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/json/organizations/JSONOrganizationAPI.macro
@@ -10,6 +10,10 @@ definition {
 			var organizationSite = "false";
 		}
 
+		if (!(isSet(externalReferenceCode))) {
+			var externalReferenceCode = "";
+		}
+
 		if (isSet(parentOrganizationId)) {
 			var parentOrganizationId = ${parentOrganizationId};
 		}
@@ -47,7 +51,7 @@ definition {
 		var curl = '''
 			${portalURL}/api/jsonws/organization/add-organization \
 				-u ${userLoginInfo} \
-				-d externalReferenceCode='' \
+				-d externalReferenceCode=${externalReferenceCode} \
 				-d parentOrganizationId=${parentOrganizationId} \
 				-d name=${organizationNameEncoded} \
 				-d type=${organizationType} \

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/security/usecase/SecurityUsecase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/security/security/usecase/SecurityUsecase.testcase
@@ -55,7 +55,7 @@ definition {
 
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "X-Liferay-Request-Group: ${groupId},5t,4x");
+				expected = "X-Liferay-Request-Group: ${groupId} 5t 4x");
 		}
 	}
 
@@ -81,7 +81,7 @@ definition {
 
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "X-Liferay-Request-Group: ${groupId},0t,1x,4x,s");
+				expected = "X-Liferay-Request-Group: ${groupId} 0t 1x 4x s");
 		}
 	}
 
@@ -123,7 +123,7 @@ definition {
 
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "X-Liferay-Request-Group: ${groupId},3t,9x,s");
+				expected = "X-Liferay-Request-Group: ${groupId} 3t 9x s");
 		}
 	}
 
@@ -167,7 +167,7 @@ definition {
 
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "X-Liferay-Request-Group: ${groupId},0t,8x");
+				expected = "X-Liferay-Request-Group: ${groupId} 0t 8x");
 		}
 	}
 
@@ -213,13 +213,13 @@ definition {
 
 			TestUtils.assertPartialEquals(
 				actual = ${profileResponse},
-				expected = "X-Liferay-Request-Group: ${groupId},0t,10x,6x");
+				expected = "X-Liferay-Request-Group: ${groupId} 0t 10x 6x");
 		}
 
 		task ("And: Verify that 0t and 5x show in the response header.") {
 			TestUtils.assertPartialEquals(
 				actual = ${dashboardResponse},
-				expected = "X-Liferay-Request-Group: ${groupId},0t,5x");
+				expected = "X-Liferay-Request-Group: ${groupId} 0t 5x");
 		}
 	}
 
@@ -260,7 +260,7 @@ definition {
 
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "X-Liferay-Request-Group: ${groupId},2t,2x,s");
+				expected = "X-Liferay-Request-Group: ${groupId} 2t 2x s");
 		}
 	}
 
@@ -292,7 +292,7 @@ definition {
 
 			TestUtils.assertPartialEquals(
 				actual = ${response},
-				expected = "X-Liferay-Request-Group: ${groupId},0t,7x");
+				expected = "X-Liferay-Request-Group: ${groupId} 0t 7x");
 		}
 	}
 
@@ -331,7 +331,7 @@ definition {
 
 			TestUtils.assertPartialEquals(
 				actual = ${stagingSiteResponse},
-				expected = "X-Liferay-Request-Group: ${groupId},1t,3x");
+				expected = "X-Liferay-Request-Group: ${groupId} 1t 3x");
 		}
 
 		task ("And: Verify that 1t, 3x, and s show in the response header of live site page") {
@@ -341,7 +341,7 @@ definition {
 
 			TestUtils.assertPartialEquals(
 				actual = ${liveSiteResponse},
-				expected = "X-Liferay-Request-Group: ${groupId},1t,3x,s");
+				expected = "X-Liferay-Request-Group: ${groupId} 1t 3x s");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -107,10 +107,8 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm that When the user selects the Modal option, the following fields are displayed in the modal:Variant,Title,URL,Headless Action Key,Confirmation Message,Message Type"
-	@priority = 5
+	@priority = 3
 	test AllFieldsAreInModalTypeOnItemAction {
-		property portal.acceptance = "true";
-
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
 
@@ -173,10 +171,8 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm that when the user selects the Side Panel option, the following fields are displayed in the modal"
-	@priority = 5
+	@priority = 3
 	test AllFieldsAreInSidePanelOptionOnItemAction {
-		property portal.acceptance = "true";
-
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
 
@@ -246,10 +242,8 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm that all the values set in the creation for all the fields are still present when the Edit modal is opened"
-	@priority = 5
+	@priority = 4
 	test AllFieldsArePresentWhenEditASidePanelAction {
-		property portal.acceptance = "true";
-
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
 
@@ -389,10 +383,8 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm that all the values set in the creation for all the fields are still present when the Edit modal is opened"
-	@priority = 5
+	@priority = 4
 	test AssertAllFieldsArePresentWhenEditAModalActionOnItemAction {
-		property portal.acceptance = "true";
-
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
 
@@ -469,7 +461,7 @@ definition {
 	}
 
 	@description = "LPS-191485. Verify if the options GET, POST, PATCH, LPS-199219DELETE are present in the Method dropdown in the Item Action"
-	@priority = 4
+	@priority = 3
 	test AssertAllMethodOptionsArePresentOnItemAction {
 		task ("When clicks on New Action button") {
 			Click(
@@ -937,7 +929,7 @@ definition {
 	}
 
 	@description = "LPS-191488. Confirm that it's possible to cancel changes in the Actions tab."
-	@priority = 4
+	@priority = 3
 	test CanCancelEditions {
 		task ("And creates a new item action") {
 			DataSetAdmin.addActions(
@@ -1194,7 +1186,7 @@ definition {
 		}
 	}
 
-	@description = "LPS-192149. Verify if the user can an Action"
+	@description = "LPS-192149. Verify if the user can create a Item Action Link type"
 	@priority = 5
 	test CanCreateActionEntry {
 		property portal.acceptance = "true";
@@ -1249,10 +1241,8 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm the Side Panel item action is created and it's present in the item action list"
-	@priority = 5
+	@priority = 4
 	test CanCreateASidePanelItemAction {
-		property portal.acceptance = "true";
-
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
 
@@ -1304,10 +1294,8 @@ definition {
 	}
 
 	@description = "LPS-191485. Verify if the use can create a Async item action"
-	@priority = 5
+	@priority = 4
 	test CanCreateAsyncItemActionOnItemAction {
-		property portal.acceptance = "true";
-
 		task ("When Create a New Action") {
 			LexiconEntry.gotoAdd();
 		}
@@ -1405,10 +1393,8 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm that is possible to create a Modal Action with Large variant on the Item Action"
-	@priority = 5
+	@priority = 4
 	test CanCreateLargeModalItemAction {
-		property portal.acceptance = "true";
-
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
 
@@ -1460,10 +1446,8 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm that is possible to create a Modal Actions on the Item Action"
-	@priority = 5
+	@priority = 4
 	test CanCreateModalItemAction {
-		property portal.acceptance = "true";
-
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
 
@@ -1514,10 +1498,8 @@ definition {
 	}
 
 	@description = "LPS-192956  Confirm that is possible to create a Modal Action with Small variant on the Item Action"
-	@priority = 5
+	@priority = 4
 	test CanCreateSmallModalItemAction {
-		property portal.acceptance = "true";
-
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
 
@@ -1565,41 +1547,6 @@ definition {
 			AssertElementPresent(
 				key_position = 1,
 				keyName = "Edit",
-				locator1 = "DataSet#FIELDS_TABLE");
-		}
-	}
-
-	@description = "LPS-191485. Verify if is possible to delete a Async Item Action created"
-	@priority = 5
-	test CanDeleteAAsyncItemAction {
-		property portal.acceptance = "true";
-
-		task ("When Create a New Action") {
-			DataSetAdmin.addActions(
-				actionName = "Async Item Action",
-				errorMessage = "Failed.",
-				icon = "asterisk",
-				method = "GET",
-				successMessage = "Passed.",
-				type = "Async",
-				url = "/group/control_panel/manage?p_p_id=com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet_34759&p_p_lifecycle=0&p_p_state=maximized&p_p_mode=view&_com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet_34759_objectDefinitionId=34759&_com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet_34759_mvcRenderCommandName=%2Fobject_entries%2Fedit_object_entry&_com_liferay_object_web_internal_object_definitions_portlet_ObjectDefinitionsPortlet_34759_externalReferenceCode={externalReferenceCode}");
-		}
-
-		task ("Then it appears on the Action tab") {
-			AssertElementPresent(
-				key_position = 1,
-				keyName = "Async Item Action",
-				locator1 = "DataSet#FIELDS_TABLE");
-		}
-
-		task ("When the user Delete Async Item Action item") {
-			DataSetAdmin.deleteActionEntry(actionName = "Async Item Action");
-		}
-
-		task ("Then the list of action items is empty") {
-			AssertElementNotPresent(
-				key_position = 1,
-				keyName = "Async Item Action",
 				locator1 = "DataSet#FIELDS_TABLE");
 		}
 	}
@@ -1741,10 +1688,8 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm that user can edit a Modal Item Action"
-	@priority = 5
+	@priority = 4
 	test CanEditAModalItemAction {
-		property portal.acceptance = "true";
-
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
 
@@ -1810,10 +1755,8 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm that when the user modify different fields (variant, label, etc.) the changes are saved"
-	@priority = 5
+	@priority = 4
 	test CanEditASidePanelItemAction {
-		property portal.acceptance = "true";
-
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
 
@@ -2398,7 +2341,7 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm that the Title field cannot be empty on the Modal Item Action"
-	@priority = 4
+	@priority = 3
 	test CannotLeaveTitleFieldEmptyInModalActionOnItemAction {
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
@@ -2460,7 +2403,7 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm that the Title field cannot be empty on the Side Panel Item Action"
-	@priority = 4
+	@priority = 3
 	test CannotLeaveTitleFieldEmptyInSidePanelItemAction {
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
@@ -2928,7 +2871,7 @@ definition {
 	}
 
 	@description = "LPS-191488. Verify if the user can edit a created Action and see the informations"
-	@priority = 3
+	@priority = 4
 	test CanSeeModalWhenClicksOnEditAction {
 		task ("And creates a new item action") {
 			DataSetAdmin.addActions(
@@ -3030,10 +2973,8 @@ definition {
 	}
 
 	@description = "LPS-192150. Verify if is possible to see the Action icon in the Data Set fragment."
-	@priority = 5
+	@priority = 3
 	test CanViewActionIconInFragment {
-		property portal.acceptance = "true";
-
 		task ("Given a new Object entity") {
 			ObjectAdmin.addObjectViaAPI(
 				labelName = "Data Set Object",
@@ -3379,10 +3320,8 @@ definition {
 	}
 
 	@description = "LPS-192149. Verify if the Label field is mandatory and localized in Action"
-	@priority = 5
+	@priority = 3
 	test MandatoryAndLocalizedLabelField {
-		property portal.acceptance = "true";
-
 		task ("And clicks on Create Item Action button") {
 			LexiconEntry.gotoAdd();
 		}
@@ -3419,10 +3358,8 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm that the mandatory fields cannot be empty after the edition"
-	@priority = 5
+	@priority = 3
 	test MandatoryFieldsCannotBeEmptyEditingSidePanelItemAction {
-		property portal.acceptance = "true";
-
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();
 
@@ -3480,7 +3417,7 @@ definition {
 	}
 
 	@description = "LPS-192956 Confirm that the mandatory fields cannot be empty after the edition"
-	@priority = 4
+	@priority = 3
 	test MandatoryFieldsCannotBeEmptyInModalActionOnItemAction {
 		task ("Given a new data set entry") {
 			DataSetAdmin.goToDataSetAdminPage();

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -245,6 +245,92 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm that all the values set in the creation for all the fields are still present when the Edit modal is opened"
+	@priority = 5
+	test AllFieldsArePresentWhenEditASidePanelAction {
+		property portal.acceptance = "true";
+
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And creates a modal item action and clicks on save button and clicks on Save button") {
+			DataSetAdmin.addActions(
+				actionName = "Edit",
+				confirmationMessage = "This is a confirmation message",
+				icon = "pencil",
+				messageType = "Info",
+				title = "Edit side panel",
+				type = "Modal",
+				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example");
+		}
+
+		task ("And clicks on the new side panel item action 3 dot menu button") {
+			Click(
+				key_tableEntry = "Edit",
+				locator1 = "LexiconTable#TABLE_ENTRY_ELLIPSIS");
+		}
+
+		task ("And clicks on Edit option") {
+			MenuItem.click(menuItem = "Edit");
+		}
+
+		task ("Then the values set in the creation are still present") {
+			AssertElementPresent(
+				key_unnamedTitle = "",
+				locator1 = "TextInput#DEPOT_UNNAMED_DEFAULT_TITLE",
+				value1 = "Edit");
+
+			AssertElementPresent(
+				key_fieldLabel = "Type",
+				locator1 = "Select#GENERIC_SELECT_FIELD",
+				value1 = "Side Panel");
+
+			AssertElementPresent(
+				key_fieldId = "URL",
+				locator1 = "TextArea#ANY_ID",
+				value1 = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example");
+
+			AssertElementPresent(
+				key_fieldName = "add-here-the-title-of-the-modal",
+				locator1 = "DataSet#PRESELECT_VALUE_INPUT",
+				value1 = "Edit side panel");
+
+			AssertElementPresent(
+				key_placeholder = "Add a message here.",
+				locator1 = "FrontendDataSet#PLACEHOLDER",
+				value1 = "This is a confirmation message");
+
+			AssertElementPresent(
+				key_fieldLabel = "Message Type",
+				locator1 = "Select#GENERIC_SELECT_FIELD",
+				value1 = "Info");
+		}
+	}
+
 
 	@description = "LPS-191485. Verify if the options GET, POST, PATCH, LPS-199219DELETE are present in the Method dropdown in the Item Action"
 	@priority = 4

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -172,6 +172,79 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm that when the user selects the Side Panel option, the following fields are displayed in the modal"
+	@priority = 5
+	test AllFieldsAreInSidePanelOptionOnItemAction {
+		property portal.acceptance = "true";
+
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And clicks on Type field and chooses the Side Panel option") {
+			LexiconEntry.gotoAdd();
+
+			Select(
+				key_fieldLabel = "Type",
+				locator1 = "Select#GENERIC_SELECT_FIELD",
+				value1 = "Side Panel");
+		}
+
+		task ("Then the Panel Title field is displayed") {
+			AssertElementPresent(
+				key_fieldName = "add-here-the-title-of-the-side-panel",
+				locator1 = "DataSet#PRESELECT_VALUE_INPUT",
+				value1 = "");
+		}
+
+		task ("And the URL field is displayed") {
+			AssertElementPresent(
+				key_fieldId = "URL",
+				locator1 = "TextArea#ANY_ID");
+		}
+
+		task ("And the Headless Action Key field is displayed") {
+			AssertElementPresent(
+				key_placeholder = "Add a value here.",
+				locator1 = "FrontendDataSet#PLACEHOLDER");
+		}
+
+		task ("And the Confirmation Message field is displayed") {
+			AssertElementPresent(
+				key_placeholder = "Add a message here.",
+				locator1 = "FrontendDataSet#PLACEHOLDER");
+		}
+
+		task ("And the Message Type field is displayed") {
+			AssertElementPresent(
+				key_fieldLabel = "Message Type",
+				locator1 = "Select#GENERIC_SELECT_FIELD");
+		}
+	}
+
 
 	@description = "LPS-191485. Verify if the options GET, POST, PATCH, LPS-199219DELETE are present in the Method dropdown in the Item Action"
 	@priority = 4

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -1459,6 +1459,61 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm that is possible to create a Modal Actions on the Item Action"
+	@priority = 5
+	test CanCreateModalItemAction {
+		property portal.acceptance = "true";
+
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And creates a modal item action and clicks on save button") {
+			DataSetAdmin.addActions(
+				actionName = "Edit",
+				icon = "pencil",
+				title = "Edit item Action",
+				type = "Modal",
+				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example",
+				variant = "Full Screen");
+		}
+
+		task ("Then the modal item action is created and a successful toast message is displayed") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#SUCCESS",
+				value1 = "Your request completed successfully.");
+
+			AssertElementPresent(
+				key_position = 1,
+				keyName = "Edit",
+				locator1 = "DataSet#FIELDS_TABLE");
+		}
+	}
+
+
 	@description = "LPS-191485. Verify if is possible to delete a Async Item Action created"
 	@priority = 5
 	test CanDeleteAAsyncItemAction {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -2764,7 +2764,7 @@ definition {
 				actionName = "Edit",
 				actionTab = "Creation Actions",
 				icon = "pencil",
-				inputText = "Products",
+				title = "Products",
 				type = "Modal",
 				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example",
 				variant = "Full Screen");

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -1248,6 +1248,61 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm the Side Panel item action is created and it's present in the item action list"
+	@priority = 5
+	test CanCreateASidePanelItemAction {
+		property portal.acceptance = "true";
+
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And creates a modal item action and clicks on save button and clicks on Save button") {
+			DataSetAdmin.addActions(
+				actionName = "Edit",
+				icon = "pencil",
+				title = "Edit side panel",
+				type = "Side Panel",
+				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example");
+		}
+
+		task ("Then a successful toast message is displayed") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#SUCCESS",
+				value1 = "Your request completed successfully.");
+		}
+
+		task ("And the side panel item action is created") {
+			AssertElementPresent(
+				key_position = 1,
+				keyName = "Edit",
+				locator1 = "DataSet#FIELDS_TABLE");
+		}
+	}
+
 	@description = "LPS-191485. Verify if the use can create a Async item action"
 	@priority = 5
 	test CanCreateAsyncItemActionOnItemAction {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -1513,6 +1513,61 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956  Confirm that is possible to create a Modal Action with Small variant on the Item Action"
+	@priority = 5
+	test CanCreateSmallModalItemAction {
+		property portal.acceptance = "true";
+
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And creates a modal item action and clicks on save button") {
+			DataSetAdmin.addActions(
+				actionName = "Edit",
+				confirmationMessage = "This is an info message",
+				icon = "pencil",
+				messageType = "Info",
+				title = "Edit item Action",
+				type = "Modal",
+				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example",
+				variant = "Small");
+		}
+
+		task ("Then the modal item action is created and a successful toast message is displayed") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#SUCCESS",
+				value1 = "Your request completed successfully.");
+
+			AssertElementPresent(
+				key_position = 1,
+				keyName = "Edit",
+				locator1 = "DataSet#FIELDS_TABLE");
+		}
+	}
 
 	@description = "LPS-191485. Verify if is possible to delete a Async Item Action created"
 	@priority = 5

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -331,6 +331,63 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 When the user clicks on the Variant field, a dropdown with the options “Full Screen”, “Large” and “Small” is displayed"
+	@priority = 5
+	test AllVariantOptionArePresentInItemAction {
+		property portal.acceptance = "true";
+
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And chooses the Modal option on Type field") {
+			LexiconEntry.gotoAdd();
+
+			Select(
+				key_fieldLabel = "Type",
+				locator1 = "Select#GENERIC_SELECT_FIELD",
+				value1 = "Modal");
+		}
+
+		task ("And clicks on Variant field") {
+			Click(
+				key_fieldLabel = "Variant",
+				locator1 = "Select#GENERIC_SELECT_FIELD");
+		}
+
+		task ("Then the options Full Screen, Large and Small are displayed in the dropdown") {
+			for (var assertFields : list "Full Screen,Large,Small") {
+				AssertElementPresent(
+					key_fieldLabel = "Variant",
+					locator1 = "Select#GENERIC_SELECT_FIELD",
+					value1 = ${assertFields});
+			}
+		}
+	}
+
 
 	@description = "LPS-191485. Verify if the options GET, POST, PATCH, LPS-199219DELETE are present in the Method dropdown in the Item Action"
 	@priority = 4

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -1404,6 +1404,61 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm that is possible to create a Modal Action with Large variant on the Item Action"
+	@priority = 5
+	test CanCreateLargeModalItemAction {
+		property portal.acceptance = "true";
+
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And creates a modal item action and clicks on save button") {
+			DataSetAdmin.addActions(
+				actionName = "Edit",
+				headlessAction = "update",
+				icon = "pencil",
+				title = "Edit item Action",
+				type = "Modal",
+				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example",
+				variant = "Large");
+		}
+
+		task ("Then the modal item action is created and a successful toast message is displayed") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#SUCCESS",
+				value1 = "Your request completed successfully.");
+
+			AssertElementPresent(
+				key_position = 1,
+				keyName = "Edit",
+				locator1 = "DataSet#FIELDS_TABLE");
+		}
+	}
+
 	@description = "LPS-191485. Verify if is possible to delete a Async Item Action created"
 	@priority = 5
 	test CanDeleteAAsyncItemAction {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -2459,6 +2459,67 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm that the Title field cannot be empty on the Side Panel Item Action"
+	@priority = 4
+	test CannotLeaveTitleFieldEmptyInSidePanelItemAction {
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And creates a modal item action and clicks on save button") {
+			DataSetAdmin.addActions(
+				actionName = "Edit",
+				icon = "pencil",
+				title = "",
+				type = "Side Panel",
+				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example");
+		}
+
+		task ("Then an error message is displayed") {
+			Type(
+				key_fieldName = "add-here-the-title-of-the-side-panel",
+				locator1 = "DataSet#PRESELECT_VALUE_INPUT",
+				value1 = "test");
+
+			Type(
+				key_fieldName = "add-here-the-title-of-the-side-panel",
+				locator1 = "DataSet#PRESELECT_VALUE_INPUT",
+				value1 = "");
+
+			AssertTextEquals(
+				locator1 = "Message#ERROR_FORM_FIELD_REQUIRED",
+				value1 = "This field is required.");
+		}
+
+		task ("And the changes cannot be saved") {
+			AssertVisible(
+				key_title = "New Item Action",
+				locator1 = "Header#H2_TITLE");
+		}
+	}
 
 	@description = "LPS-191488. Confirm that is possible to leave the label field empty in the Actions tab."
 	@priority = 4

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -1809,6 +1809,73 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm that when the user modify different fields (variant, label, etc.) the changes are saved"
+	@priority = 5
+	test CanEditASidePanelItemAction {
+		property portal.acceptance = "true";
+
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And creates a modal item action and clicks on save button and clicks on Save button") {
+			DataSetAdmin.addActions(
+				actionName = "Edit",
+				confirmationMessage = "This is a confirmation message",
+				icon = "pencil",
+				messageType = "Info",
+				title = "Edit side panel",
+				type = "Modal",
+				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example");
+		}
+
+		task ("When the user edits the Action created") {
+			DataSetAdmin.editActions(
+				newActionName = "update",
+				newConfirmationMessage = "This is a success message",
+				newHeadlessAction = "update",
+				newIcon = "pencil",
+				newMessageType = "Success",
+				newTitle = "Update Side Panel",
+				oldActionName = "Edit");
+		}
+
+		task ("Then a successful toast message is displayed") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#SUCCESS",
+				value1 = "Your request completed successfully.");
+		}
+
+		task ("And the side panel item action is created") {
+			AssertElementPresent(
+				key_position = 1,
+				keyName = "update",
+				locator1 = "DataSet#FIELDS_TABLE");
+		}
+	}
 
 	@description = "LPS-191485. Verify if is possible to edit a Async Item created"
 	@priority = 5

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -106,6 +106,73 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm that When the user selects the Modal option, the following fields are displayed in the modal:Variant,Title,URL,Headless Action Key,Confirmation Message,Message Type"
+	@priority = 5
+	test AllFieldsAreInModalTypeOnItemAction {
+		property portal.acceptance = "true";
+
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And clicks on Type field and chooses the Modal option") {
+			LexiconEntry.gotoAdd();
+
+			Select(
+				key_fieldLabel = "Type",
+				locator1 = "Select#GENERIC_SELECT_FIELD",
+				value1 = "Modal");
+		}
+
+		task ("Then the Variant field is displayed") {
+			AssertElementPresent(
+				key_fieldLabel = "Variant",
+				locator1 = "Select#GENERIC_SELECT_FIELD");
+		}
+
+		task ("And Title field is displayed") {
+			AssertElementPresent(
+				key_placeholder = "add-here-the-title-of-the-modal",
+				locator1 = "FrontendDataSet#PLACEHOLDER");
+		}
+
+		task ("And the URL field is displayed") {
+			AssertElementPresent(
+				key_fieldId = "URL",
+				locator1 = "TextArea#ANY_ID");
+		}
+
+		task ("And the Headless Action Key field is displayed") {
+			AssertElementPresent(
+				key_placeholder = "Add a value here.",
+				locator1 = "FrontendDataSet#PLACEHOLDER");
+		}
+	}
+
+
 	@description = "LPS-191485. Verify if the options GET, POST, PATCH, LPS-199219DELETE are present in the Method dropdown in the Item Action"
 	@priority = 4
 	test AssertAllMethodOptionsArePresentOnItemAction {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -3479,6 +3479,67 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm that the mandatory fields cannot be empty after the edition"
+	@priority = 4
+	test MandatoryFieldsCannotBeEmptyInModalActionOnItemAction {
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And creates a modal item action and clicks on save button") {
+			DataSetAdmin.addActions(
+				actionName = "Edit",
+				icon = "pencil",
+				title = "Edit item Action",
+				type = "Modal",
+				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example",
+				variant = "Small");
+		}
+
+		task ("When the user leaves mandatory fields empty") {
+			DataSetAdmin.editActions(
+				newActionName = "",
+				newIcon = "pencil",
+				newTitle = "",
+				newVariant = "Small",
+				oldActionName = "Edit");
+		}
+
+		task ("Then an error message is displayed") {
+			AssertTextEquals(
+				locator1 = "Message#ERROR_FORM_FIELD_REQUIRED",
+				value1 = "This field is required.");
+		}
+
+		task ("And the changes cannot be saved") {
+			AssertVisible(
+				key_title = "Edit",
+				locator1 = "Header#H2_TITLE");
+		}
+	}
 
 	@description = "LPS-192149. Verify if the URL field is mandatory"
 	@priority = 4

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -3418,6 +3418,68 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm that the mandatory fields cannot be empty after the edition"
+	@priority = 5
+	test MandatoryFieldsCannotBeEmptyEditingSidePanelItemAction {
+		property portal.acceptance = "true";
+
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And creates a modal item action and clicks on save button and clicks on Save button") {
+			DataSetAdmin.addActions(
+				actionName = "Edit",
+				icon = "pencil",
+				title = "Edit side panel",
+				type = "Side Panel",
+				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example");
+		}
+
+		task ("And clicks on the new side panel item action 3 dot menu button and clicks on Edit option") {
+			DataSetAdmin.editActions(
+				newTitle = "",
+				newURL = "",
+				oldActionName = "Edit");
+		}
+
+		task ("Then an error message is displayed") {
+			AssertTextEquals(
+				locator1 = "Message#ERROR_FORM_FIELD_REQUIRED",
+				value1 = "This field is required.");
+		}
+
+		task ("And the changes cannot be saved") {
+			AssertVisible(
+				key_title = "Edit",
+				locator1 = "Header#H2_TITLE");
+		}
+	}
+
+
 	@description = "LPS-192149. Verify if the URL field is mandatory"
 	@priority = 4
 	test MandatoryURLField {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -2397,6 +2397,69 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm that the Title field cannot be empty on the Modal Item Action"
+	@priority = 4
+	test CannotLeaveTitleFieldEmptyInModalActionOnItemAction {
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And creates a modal item action and clicks on save button") {
+			DataSetAdmin.addActions(
+				actionName = "Edit",
+				icon = "pencil",
+				title = "Edit item Action",
+				type = "Modal",
+				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example",
+				variant = "Small");
+		}
+
+		task ("When the user leaves mandatory fields empty") {
+			DataSetAdmin.editActions(
+				newActionName = "",
+				newIcon = "pencil",
+				newTitle = "",
+				newVariant = "Small",
+				oldActionName = "Edit");
+		}
+
+		task ("Then an error message is displayed") {
+			AssertTextEquals(
+				locator1 = "Message#ERROR_FORM_FIELD_REQUIRED",
+				value1 = "This field is required.");
+		}
+
+		task ("And the changes cannot be saved") {
+			AssertVisible(
+				key_title = "Edit",
+				locator1 = "Header#H2_TITLE");
+		}
+	}
+
+
 	@description = "LPS-191488. Confirm that is possible to leave the label field empty in the Actions tab."
 	@priority = 4
 	test CannotSaveLabelFieldEmpty {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -1740,6 +1740,76 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm that user can edit a Modal Item Action"
+	@priority = 5
+	test CanEditAModalItemAction {
+		property portal.acceptance = "true";
+
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And creates a modal item action and clicks on save button") {
+			DataSetAdmin.addActions(
+				actionName = "Edit",
+				icon = "pencil",
+				title = "Edit item Action",
+				type = "Modal",
+				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example",
+				variant = "Small");
+		}
+
+		task ("When the user changes the field values and clicks on Save button") {
+			DataSetAdmin.editActions(
+				newActionName = "update",
+				newHeadlessAction = "update",
+				newIcon = "pencil",
+				newVariant = "Small",
+				oldActionName = "Edit");
+		}
+
+		task ("Then a successful toast message is displayed") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#SUCCESS",
+				value1 = "Your request completed successfully.");
+		}
+
+		task ("And the changes are saved") {
+			AssertTextEquals.assertPartialText(
+				locator1 = "Message#SUCCESS",
+				value1 = "Your request completed successfully.");
+
+			AssertElementPresent(
+				key_position = 1,
+				keyName = "update",
+				locator1 = "DataSet#FIELDS_TABLE");
+		}
+	}
+
+
 	@description = "LPS-191485. Verify if is possible to edit a Async Item created"
 	@priority = 5
 	test CanEditAsyncItemAction {

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -388,6 +388,85 @@ definition {
 		}
 	}
 
+	@description = "LPS-192956 Confirm that all the values set in the creation for all the fields are still present when the Edit modal is opened"
+	@priority = 5
+	test AssertAllFieldsArePresentWhenEditAModalActionOnItemAction {
+		property portal.acceptance = "true";
+
+		task ("Given a new data set entry") {
+			DataSetAdmin.goToDataSetAdminPage();
+
+			DataSetAdmin.createDataSetEntryViaAPI(
+				dataSetName = "Country",
+				restApplication = "/headless-admin-address/v1.0",
+				restEndpoint = "/v1.0/countries",
+				restSchema = "Country");
+		}
+
+		task ("And a new view") {
+			DataSetAdmin.createFDSViewViaAPI(
+				dataSetName = "Country",
+				dataSetViewDescription = "FDSViewDescription",
+				key_dataSetViewNameList = "View Test");
+		}
+
+		task ("When the user goes to the view created") {
+			DataSetAdmin.goToSpecificViewPage(
+				dataSetName = "Country",
+				key_viewName = "View Test");
+		}
+
+		task ("When the user goes to the Action tab.") {
+			DataSetAdmin.goToTab(tabName = "Actions");
+		}
+
+		task ("And creates a modal item action and clicks on save button") {
+			DataSetAdmin.addActions(
+				actionName = "Edit",
+				icon = "pencil",
+				title = "Edit item Action",
+				type = "Modal",
+				url = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example",
+				variant = "Small");
+		}
+
+		task ("And clicks on the new modal item action 3 dot menu button") {
+			Click(
+				key_tableEntry = "pencil",
+				locator1 = "LexiconTable#TABLE_ENTRY_ELLIPSIS");
+		}
+
+		task ("And clicks on Edit option") {
+			MenuItem.click(menuItem = "Edit");
+		}
+
+		task ("Then the values set in the creation are still present") {
+			AssertElementPresent(
+				key_unnamedTitle = "",
+				locator1 = "TextInput#DEPOT_UNNAMED_DEFAULT_TITLE",
+				value1 = "Edit");
+
+			AssertElementPresent(
+				key_fieldLabel = "Type",
+				locator1 = "Select#GENERIC_SELECT_FIELD",
+				value1 = "Modal");
+
+			AssertElementPresent(
+				key_fieldId = "URL",
+				locator1 = "TextArea#ANY_ID",
+				value1 = "https://gist.github.com/deborasoliveira/40716d0b03d33ff7e636ca5d366c79c5#file-link-action-url-example");
+
+			AssertElementPresent(
+				key_fieldLabel = "Variant",
+				locator1 = "Select#GENERIC_SELECT_FIELD",
+				value1 = "Small");
+
+			AssertElementPresent(
+				key_fieldName = "add-here-the-title-of-the-modal",
+				locator1 = "DataSet#PRESELECT_VALUE_INPUT",
+				value1 = "Edit item Action");
+		}
+	}
 
 	@description = "LPS-191485. Verify if the options GET, POST, PATCH, LPS-199219DELETE are present in the Method dropdown in the Item Action"
 	@priority = 4

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/frontendinfrastructure/uiinfrastructure/dataset/DataSetViewActions.testcase
@@ -29,13 +29,11 @@ definition {
 				key_dataSetViewNameList = "View Test");
 		}
 
-		task ("When the user goes to the Action tab") {
+		task ("When the user goes to the Action tab.") {
 			DataSetAdmin.goToSpecificViewPage(
 				dataSetName = "Data Set Test",
 				key_viewName = "View Test");
-		}
 
-		task ("When the user goes to the Action tab.") {
 			DataSetAdmin.goToTab(tabName = "Actions");
 		}
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/accessiblity/FormFragmentsAccessibility.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/accessiblity/FormFragmentsAccessibility.testcase
@@ -282,7 +282,11 @@ definition {
 		}
 
 		task ("Then the rich text field should have correct accessibility") {
-			AssertElementAccessible(locator1 = "//div[contains(@class,'lfr-layout-structure-item-inputs-rich-text-input')]");
+			AssertElementAccessible(locator1 = "//label[contains(@class,'sr-only')][normalize-space()='Description']");
+
+			SelectFrame.selectFrameNoLoading(locator1 = "CKEditor#BODY_FIELD_IFRAME");
+
+			AssertElementAccessible(locator1 = "//body//p[normalize-space()='Create custom digital experiences without sacrificing speed, flexibility, or cost.']");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContentAdmin.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/journal/WebContentAdmin.testcase
@@ -192,7 +192,7 @@ definition {
 
 			AssertElementPresent(
 				key_title = "Email From",
-				locator1 = "Header#H1_TITLE");
+				locator1 = "Header#H2_TITLE");
 		}
 	}
 
@@ -220,7 +220,7 @@ definition {
 
 			AssertElementPresent(
 				key_title = "Email From",
-				locator1 = "Header#H1_TITLE");
+				locator1 = "Header#H2_TITLE");
 		}
 	}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/contentpagetemplate/ContentPageTemplateWithRemoteStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/contentpagetemplate/ContentPageTemplateWithRemoteStaging.testcase
@@ -65,7 +65,7 @@ definition {
 				text = 1);
 
 			SQL.assertTextInMySQLStatementResult(
-				mysqlStatement = "SELECT privateLayout FROM lportal_remote.Layout WHERE name LIKE '%Content Page Template Name%' LIMIT 1",
+				mysqlStatement = "SELECT privateLayout FROM lportal1_remote.Layout WHERE name LIKE '%Content Page Template Name%' LIMIT 1",
 				text = 1);
 		}
 	}

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/contentpagetemplate/ContentPageTemplateWithRemoteStaging.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/layout/pagetemplate/contentpagetemplate/ContentPageTemplateWithRemoteStaging.testcase
@@ -56,9 +56,7 @@ definition {
 		task ("When publish content page template to remote live") {
 			Staging.openStagingAdmin(siteURLKey = "test-site-name");
 
-			Staging.publishCustomPublication(
-				publicationTitle = "My Publish Title",
-				remoteStaging = "true");
+			Staging.publishCustomPublication(remoteStaging = "true");
 		}
 
 		task ("Then assert if privateLayout column is set to true in staging and live databases") {

--- a/readme/BREAKING_CHANGES_AMENDMENTS.markdown
+++ b/readme/BREAKING_CHANGES_AMENDMENTS.markdown
@@ -225,3 +225,17 @@ Class is removed.
 This class has been deprecated since 7.1.x, its only usage in rules_user_custom_attribute_content.drl is replaced by FacetImpl.
 ----
 ```
+----
+
+# f46f1e49076f31484ad6cceede099bb16c9ef911
+Incorrect format on breaking change
+
+Correct message should be:
+```
+# breaking
+## What portal-kernel/src/com/liferay/portal/kernel/dao/orm/IndexableActionableDynamicQuery.java
+setIndexWriterHelper() method is being removed.
+## Why
+This setter was added for the class UserIndexer (see 73427a8). UserIndexer has been deprecated and removed from the portal though.
+----
+```


### PR DESCRIPTION
Motivation
=======
Friendly url input's language is not loaded correctly when web content's language is different from site's language. Please check:https://liferay.atlassian.net/browse/LPS-203255

Proposed Solution
========
- Add a new optional field "defaultLanguageId" that can be set (similar to other localized inputs) to friendly-url input.
   - If this field is not present, old behavior is used (site's default language).
- Update Journal administration to use this new field.

Steps to Verify
========
Steps to reproduce:
1. Run Liferay and enable system settings “Web Content > Administration >Changeable Default Language“.
2. Check en_US is default site language.
3. Create a Basic Web content and modify default language to es_ES with some content, press save.
4. Reopen the web content for editing.

**Expected**: 
- All the fields are prepopulated with the default web content language, including friendly url.

**Current**: 
- The friendly url shows the site’s default language (en_US) and not the web content’s language (es_ES). 
- Switching the content’s languages makes the friendly url editable, but the default friendly-url language should be “es_ES” and is marked as non-default.

Alternative Solutions that were discarded
========
- Include "selectedLanguageId" but should not be necessary at this point.
