### PR TITLE
ISSD-1982 - Make parent vocabulary and parent category localized named maps available when returning a category via REST API

### DIFF
--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/bnd.bnd
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Headless Admin Taxonomy API
 Bundle-SymbolicName: com.liferay.headless.admin.taxonomy.api
-Bundle-Version: 14.2.1
+Bundle-Version: 14.3.0
 Export-Package:\
 	com.liferay.headless.admin.taxonomy.dto.v1_0,\
 	com.liferay.headless.admin.taxonomy.resource.v1_0

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/ParentTaxonomyCategory.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/ParentTaxonomyCategory.java
@@ -27,6 +27,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.validation.Valid;
+
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -103,6 +105,36 @@ public class ParentTaxonomyCategory implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String name;
 
+	@Schema
+	@Valid
+	public Map<String, String> getName_i18n() {
+		return name_i18n;
+	}
+
+	public void setName_i18n(Map<String, String> name_i18n) {
+		this.name_i18n = name_i18n;
+	}
+
+	@JsonIgnore
+	public void setName_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			name_i18nUnsafeSupplier) {
+
+		try {
+			name_i18n = name_i18nUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Map<String, String> name_i18n;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -153,6 +185,16 @@ public class ParentTaxonomyCategory implements Serializable {
 			sb.append(_escape(name));
 
 			sb.append("\"");
+		}
+
+		if (name_i18n != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name_i18n\": ");
+
+			sb.append(_toJSON(name_i18n));
 		}
 
 		sb.append("}");

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/ParentTaxonomyVocabulary.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/java/com/liferay/headless/admin/taxonomy/dto/v1_0/ParentTaxonomyVocabulary.java
@@ -27,6 +27,8 @@ import java.util.Set;
 
 import javax.annotation.Generated;
 
+import javax.validation.Valid;
+
 import javax.xml.bind.annotation.XmlRootElement;
 
 /**
@@ -103,6 +105,36 @@ public class ParentTaxonomyVocabulary implements Serializable {
 	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
 	protected String name;
 
+	@Schema
+	@Valid
+	public Map<String, String> getName_i18n() {
+		return name_i18n;
+	}
+
+	public void setName_i18n(Map<String, String> name_i18n) {
+		this.name_i18n = name_i18n;
+	}
+
+	@JsonIgnore
+	public void setName_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			name_i18nUnsafeSupplier) {
+
+		try {
+			name_i18n = name_i18nUnsafeSupplier.get();
+		}
+		catch (RuntimeException re) {
+			throw re;
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@GraphQLField
+	@JsonProperty(access = JsonProperty.Access.READ_WRITE)
+	protected Map<String, String> name_i18n;
+
 	@Override
 	public boolean equals(Object object) {
 		if (this == object) {
@@ -153,6 +185,16 @@ public class ParentTaxonomyVocabulary implements Serializable {
 			sb.append(_escape(name));
 
 			sb.append("\"");
+		}
+
+		if (name_i18n != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name_i18n\": ");
+
+			sb.append(_toJSON(name_i18n));
 		}
 
 		sb.append("}");

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/dto/v1_0/packageinfo
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-api/src/main/resources/com/liferay/headless/admin/taxonomy/dto/v1_0/packageinfo
@@ -1,1 +1,1 @@
-version 4.1.1
+version 4.2.0

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/ParentTaxonomyCategory.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/ParentTaxonomyCategory.java
@@ -10,6 +10,7 @@ import com.liferay.headless.admin.taxonomy.client.serdes.v1_0.ParentTaxonomyCate
 
 import java.io.Serializable;
 
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -62,6 +63,28 @@ public class ParentTaxonomyCategory implements Cloneable, Serializable {
 	}
 
 	protected String name;
+
+	public Map<String, String> getName_i18n() {
+		return name_i18n;
+	}
+
+	public void setName_i18n(Map<String, String> name_i18n) {
+		this.name_i18n = name_i18n;
+	}
+
+	public void setName_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			name_i18nUnsafeSupplier) {
+
+		try {
+			name_i18n = name_i18nUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, String> name_i18n;
 
 	@Override
 	public ParentTaxonomyCategory clone() throws CloneNotSupportedException {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/ParentTaxonomyVocabulary.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/dto/v1_0/ParentTaxonomyVocabulary.java
@@ -10,6 +10,7 @@ import com.liferay.headless.admin.taxonomy.client.serdes.v1_0.ParentTaxonomyVoca
 
 import java.io.Serializable;
 
+import java.util.Map;
 import java.util.Objects;
 
 import javax.annotation.Generated;
@@ -62,6 +63,28 @@ public class ParentTaxonomyVocabulary implements Cloneable, Serializable {
 	}
 
 	protected String name;
+
+	public Map<String, String> getName_i18n() {
+		return name_i18n;
+	}
+
+	public void setName_i18n(Map<String, String> name_i18n) {
+		this.name_i18n = name_i18n;
+	}
+
+	public void setName_i18n(
+		UnsafeSupplier<Map<String, String>, Exception>
+			name_i18nUnsafeSupplier) {
+
+		try {
+			name_i18n = name_i18nUnsafeSupplier.get();
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	protected Map<String, String> name_i18n;
 
 	@Override
 	public ParentTaxonomyVocabulary clone() throws CloneNotSupportedException {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/ParentTaxonomyCategorySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/ParentTaxonomyCategorySerDes.java
@@ -70,6 +70,16 @@ public class ParentTaxonomyCategorySerDes {
 			sb.append("\"");
 		}
 
+		if (parentTaxonomyCategory.getName_i18n() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name_i18n\": ");
+
+			sb.append(_toJSON(parentTaxonomyCategory.getName_i18n()));
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -105,6 +115,15 @@ public class ParentTaxonomyCategorySerDes {
 			map.put("name", String.valueOf(parentTaxonomyCategory.getName()));
 		}
 
+		if (parentTaxonomyCategory.getName_i18n() == null) {
+			map.put("name_i18n", null);
+		}
+		else {
+			map.put(
+				"name_i18n",
+				String.valueOf(parentTaxonomyCategory.getName_i18n()));
+		}
+
 		return map;
 	}
 
@@ -136,6 +155,13 @@ public class ParentTaxonomyCategorySerDes {
 				if (jsonParserFieldValue != null) {
 					parentTaxonomyCategory.setName(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name_i18n")) {
+				if (jsonParserFieldValue != null) {
+					parentTaxonomyCategory.setName_i18n(
+						(Map)ParentTaxonomyCategorySerDes.toMap(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/ParentTaxonomyVocabularySerDes.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-client/src/main/java/com/liferay/headless/admin/taxonomy/client/serdes/v1_0/ParentTaxonomyVocabularySerDes.java
@@ -72,6 +72,16 @@ public class ParentTaxonomyVocabularySerDes {
 			sb.append("\"");
 		}
 
+		if (parentTaxonomyVocabulary.getName_i18n() != null) {
+			if (sb.length() > 1) {
+				sb.append(", ");
+			}
+
+			sb.append("\"name_i18n\": ");
+
+			sb.append(_toJSON(parentTaxonomyVocabulary.getName_i18n()));
+		}
+
 		sb.append("}");
 
 		return sb.toString();
@@ -107,6 +117,15 @@ public class ParentTaxonomyVocabularySerDes {
 			map.put("name", String.valueOf(parentTaxonomyVocabulary.getName()));
 		}
 
+		if (parentTaxonomyVocabulary.getName_i18n() == null) {
+			map.put("name_i18n", null);
+		}
+		else {
+			map.put(
+				"name_i18n",
+				String.valueOf(parentTaxonomyVocabulary.getName_i18n()));
+		}
+
 		return map;
 	}
 
@@ -138,6 +157,13 @@ public class ParentTaxonomyVocabularySerDes {
 				if (jsonParserFieldValue != null) {
 					parentTaxonomyVocabulary.setName(
 						(String)jsonParserFieldValue);
+				}
+			}
+			else if (Objects.equals(jsonParserFieldName, "name_i18n")) {
+				if (jsonParserFieldValue != null) {
+					parentTaxonomyVocabulary.setName_i18n(
+						(Map)ParentTaxonomyVocabularySerDes.toMap(
+							(String)jsonParserFieldValue));
 				}
 			}
 		}

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -205,6 +205,10 @@ components:
                             type: integer
                         name:
                             type: string
+                        name_i18n:
+                            additionalProperties:
+                                type: string
+                            type: object
                     type: object
                 parentTaxonomyVocabulary:
                     description:
@@ -215,6 +219,10 @@ components:
                             type: integer
                         name:
                             type: string
+                        name_i18n:
+                            additionalProperties:
+                                type: string
+                            type: object
                     readOnly: true
                     type: object
                 siteId:

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/dto/v1_0/converter/TaxonomyCategoryDTOConverter.java
@@ -85,6 +85,9 @@ public class TaxonomyCategoryDTOConverter
 				id = parentAssetCategory.getCategoryId();
 				name = parentAssetCategory.getTitle(
 					dtoConverterContext.getLocale());
+				name_i18n = LocalizedMapUtil.getI18nMap(
+					dtoConverterContext.isAcceptAllLanguages(),
+					parentAssetCategory.getTitleMap());
 			}
 		};
 	}
@@ -192,6 +195,9 @@ public class TaxonomyCategoryDTOConverter
 								id = assetCategory.getVocabularyId();
 								name = assetVocabulary.getTitle(
 									dtoConverterContext.getLocale());
+								name_i18n = LocalizedMapUtil.getI18nMap(
+									dtoConverterContext.isAcceptAllLanguages(),
+									assetVocabulary.getTitleMap());
 							}
 						};
 					});


### PR DESCRIPTION
https://liferay.atlassian.net/browse/ISSD-1982 

`vocabularyId` and `vocabularyName` could already be retrieved by requesting `embeddedTaxonomyCategory` through the `nestedFields` parameter.

Example:
 `curl -s -X GET 'http://localhost:8080/o/headless-delivery/v1.0/sites/<site-id>/structured-contents?nestedFields=embeddedTaxonomyCategory' -H 'X-Liferay-Accept-All-Languages: true' -u test@liferay.com:test` 

In this PR we are adding the localized named map of the category's parent vocabulary (or parent category, if the parent is a category) available, so no additional requests are required to get the localized named map of the parent vocabulary when getting structured content via REST API.

@joseabelenda