### PR TITLE
LPP-51929 Add min-height to resolve CKEditor Firefox Issue

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/editor/configuration/JournalArticleContentEditorConfigContributor.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/editor/configuration/JournalArticleContentEditorConfigContributor.java
@@ -43,7 +43,7 @@ public class JournalArticleContentEditorConfigContributor
 		RequestBackedPortletURLFactory requestBackedPortletURLFactory) {
 
 		jsonObject.put(
-			"bodyClass", jsonObject.getString("bodyClass") + " h-100");
+			"bodyClass", jsonObject.getString("bodyClass") + " min-vh-100");
 
 		JSONArray contentsCSSJSONArray = jsonObject.getJSONArray("contentsCss");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-203446

Adding min-height resolves the Firefox specific issue that the CKEditor scrolls to top after text is modified, making it hard to see what was modified.
Please let me know if there are any questions or comments about this.

Thank you!