### PR TITLE
[TS] LPS-203605 Allow the user to re-click the same category to clear the filter

### DIFF
--- a/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
+++ b/modules/apps/asset/asset-taglib/src/main/resources/META-INF/resources/asset_categories_navigation/js/AssetCategoriesNavigationTreeView.js
@@ -3,9 +3,10 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
+import ClayButton from '@clayui/button';
 import {TreeView as ClayTreeView} from '@clayui/core';
 import ClayIcon from '@clayui/icon';
-import {navigate} from 'frontend-js-web';
+import {navigate, sub} from 'frontend-js-web';
 import React from 'react';
 
 const AssetCategoriesNavigationTreeView = ({
@@ -67,6 +68,22 @@ const AssetCategoriesNavigationTreeView = ({
 					<ClayTreeView.Group items={item.children}>
 						{(item) => (
 							<ClayTreeView.Item
+								actions={
+									selectedCategoryId === item.id ? (
+										<ClayButton
+											aria-label={sub(
+												Liferay.Language.get(
+													'remove-x-filter'
+												),
+												item.name
+											)}
+											monospaced
+											onClick={() => navigate(item.url)}
+										>
+											<ClayIcon symbol="times" />
+										</ClayButton>
+									) : null
+								}
 								onClick={(event) => onClick(event, item)}
 								onKeyUp={(event) => onKeyUp(event, item)}
 							>


### PR DESCRIPTION
Steps to reproduce

1. Go to Categorization > Categories, and make 1 Vocabulary (Test Vocabulary) and 1 category (Name: Test Category)
2. Go to Content & Data > Documents and Media
3. Upload two picture files, and add “Test Category” on Test Vocabulary to 1 of the documents. 
4. Go to HOME, and add Categories Filter widget and Documents and Media widget to page.
5. Select “+” button on left side of Test Vocabulary and, click “Test Category”.(Button will turn blue to show that it is selected. And  1 picture is shown which has Test Category)
6. Click “Test Category” again for cancel category filter.

Expected results
It is possible to clear the filter.

Actual results
It is not possible to clear the filter

If for some reason we do not want to have this functionality please let me know and we can inform the client. Additionally, if there is a cleaner way to achieve the same goal please let me know.