### PR TITLE
LPS-203646 Fix back button title when configuring Widget Page Templates in Global SIte

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/ContentManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/ContentManager.java
@@ -720,6 +720,17 @@ public class ContentManager {
 				redirect
 			).setParameter(
 				"assetListEntryId", assetListEntry.getAssetListEntryId()
+			).setParameter(
+				"backURLTitle",
+				() -> {
+					ThemeDisplay themeDisplay =
+						(ThemeDisplay)httpServletRequest.getAttribute(
+							WebKeys.THEME_DISPLAY);
+
+					Layout layout = themeDisplay.getLayout();
+
+					return layout.getName(themeDisplay.getLocale());
+				}
 			).buildString();
 		}
 		catch (PortalException portalException) {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/LayoutPrototypeVerticalCard.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/LayoutPrototypeVerticalCard.java
@@ -85,8 +85,11 @@ public class LayoutPrototypeVerticalCard
 			String layoutFullURL = layoutPrototypeGroup.getDisplayURL(
 				_themeDisplay, true);
 
-			return HttpComponentsUtil.setParameter(
-				layoutFullURL, "p_l_back_url", _themeDisplay.getURLCurrent());
+			return HttpComponentsUtil.addParameters(
+				layoutFullURL, "p_l_back_url_title",
+				LanguageUtil.get(
+					_themeDisplay.getLocale(), "widget-page-templates"),
+				"p_l_back_url", _themeDisplay.getURLCurrent());
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateEntryActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateEntryActionDropdownItemsProvider.java
@@ -193,15 +193,17 @@ public class LayoutPageTemplateEntryActionDropdownItemsProvider {
 			PortletRequest.RENDER_PHASE);
 
 		return dropdownItem -> {
+			PortletDisplay portletDisplay = _themeDisplay.getPortletDisplay();
+
 			dropdownItem.setHref(
 				editPageURL, "mvcRenderCommandName",
 				"/layout_admin/edit_layout", "redirect",
 				_themeDisplay.getURLCurrent(), "backURL",
 				_themeDisplay.getURLCurrent(), "backURLTitle",
-				LanguageUtil.get(_httpServletRequest, "page-templates"),
-				"portletResource",
+				portletDisplay.getPortletDisplayName(), "portletResource",
 				LayoutPageTemplateAdminPortletKeys.LAYOUT_PAGE_TEMPLATES,
 				"selPlid", _layoutPageTemplateEntry.getPlid());
+
 			dropdownItem.setIcon("cog");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "configure"));

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateEntryActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPageTemplateEntryActionDropdownItemsProvider.java
@@ -219,6 +219,14 @@ public class LayoutPageTemplateEntryActionDropdownItemsProvider {
 			).setRedirect(
 				_themeDisplay.getURLCurrent()
 			).setParameter(
+				"backURLTitle",
+				() -> {
+					PortletDisplay portletDisplay =
+						_themeDisplay.getPortletDisplay();
+
+					return portletDisplay.getPortletDisplayName();
+				}
+			).setParameter(
 				"layoutPrototypeId",
 				_layoutPageTemplateEntry.getLayoutPrototypeId()
 			).buildPortletURL();

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPrototypeActionDropdownItemsProvider.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/servlet/taglib/util/LayoutPrototypeActionDropdownItemsProvider.java
@@ -118,8 +118,10 @@ public class LayoutPrototypeActionDropdownItemsProvider {
 		return dropdownItem -> {
 			dropdownItem.setHref(
 				_renderResponse.createRenderURL(), "mvcPath",
-				"/edit_layout_prototype.jsp", "layoutPrototypeId",
-				_layoutPrototype.getLayoutPrototypeId());
+				"/edit_layout_prototype.jsp", "backURLTitle",
+				LanguageUtil.get(
+					_themeDisplay.getLocale(), "widget-page-templates"),
+				"layoutPrototypeId", _layoutPrototype.getLayoutPrototypeId());
 			dropdownItem.setIcon("cog");
 			dropdownItem.setLabel(
 				LanguageUtil.get(_httpServletRequest, "configure"));

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/edit_layout_prototype.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/edit_layout_prototype.jsp
@@ -32,7 +32,7 @@ request.setAttribute("edit_layout_prototype.jsp-redirect", redirect);
 
 portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(redirect);
-portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
+portletDisplay.setURLBackTitle(ParamUtil.getString(request, "backURLTitle"));
 
 renderResponse.setTitle(layoutPrototype.isNew() ? LanguageUtil.get(request, "new-page-template") : layoutPrototype.getName(locale));
 %>


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-203646)

## Steps 

**Case 1: edit_asset_list_entry.jsp : Configuring Widget Page Templates**

**- 2 ways:**
**Case 1.1: LayoutPageTemplateEntryActionDropdownItemsProvider.java**

- Go to Design > Page Templates > Create a Widget Page Template
- Click on the Page Template ellipsis > Configuration > See back button title 

![Screenshot 2023-12-11 at 16 11 49](https://github.com/liferay-echo/liferay-portal/assets/91208451/f25462f0-5fb6-4745-96d7-3c7d221f1f12)


**Case 1.2: LayoutPageTemplateEntryActionDropdownItemsProvider.java**

- Go to Control Menu > Sites > Global Site 
- Go to Design > Widget Page Templates > Create one 
- In the Page created > click on ellipsis > Configure

![Screenshot 2023-12-11 at 16 12 48](https://github.com/liferay-echo/liferay-portal/assets/91208451/c336d69f-7c3d-4743-9b02-a0625f2e5fde)

**Case 2: LayoutPrototypeVerticalCard.java: Editing WPT by clicking on the name**

- Go to Control Menu > Sites > Global Site 
- Go to Design > Widget Page Templates > Create one 
- In the Page created > click on the name > see back button title

![Uploading Screenshot 2023-12-13 at 11.24.44.png…]()


**Case 3: ContentManager.java: Creating Web Content from Collection Display fragment**

- Go to Content & Data > Web Content > Create one
- Go to Site Builder > Collections > Create a Manual Collection with Web Content Article > Basic Web Content
- Add the Web Content created
- Go to Site Builder > Pages > Create a Collection Page > select the Collection created
- Edit the Collection Page
- Click on the Collection Display 
- Go to Collection Display Options in the right navbar
- Click on ellipsis > Edit Collection

![Screenshot 2023-12-11 at 16 14 37](https://github.com/liferay-echo/liferay-portal/assets/91208451/ae9994fa-af9e-4b3b-b7b1-5d65e03dcd3c)
