### PR TITLE
LPS-203611 and LPS-203689

### DIFF
--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/DeleteLayoutPageTemplateEntryMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/DeleteLayoutPageTemplateEntryMVCActionCommand.java
@@ -97,6 +97,8 @@ public class DeleteLayoutPageTemplateEntryMVCActionCommand
 				SessionErrors.add(actionRequest, clazz);
 			}
 
+			hideDefaultErrorMessage(actionRequest);
+
 			sendRedirect(actionRequest, actionResponse);
 
 			return;

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/DeleteLayoutPageTemplateEntryMVCActionCommand.java
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/DeleteLayoutPageTemplateEntryMVCActionCommand.java
@@ -7,6 +7,7 @@ package com.liferay.layout.page.template.admin.web.internal.portlet.action;
 
 import com.liferay.layout.page.template.admin.constants.LayoutPageTemplateAdminPortletKeys;
 import com.liferay.layout.page.template.service.LayoutPageTemplateEntryService;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
@@ -92,6 +93,8 @@ public class DeleteLayoutPageTemplateEntryMVCActionCommand
 
 		if (deleteLayoutPageTemplateEntryIds.length ==
 				deleteLayoutPageTemplateEntryIdsList.size()) {
+
+			SessionErrors.add(actionRequest, PortalException.class);
 
 			for (Class<?> clazz : exceptionClasses) {
 				SessionErrors.add(actionRequest, clazz);

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_display_pages.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_display_pages.jsp
@@ -49,7 +49,7 @@ DisplayPageManagementToolbarDisplayContext displayPageManagementToolbarDisplayCo
 	</portlet:actionURL>
 
 	<aui:form action="<%= deleteDisplayPageURL %>" cssClass="container-fluid container-fluid-max-xl" name="fm">
-		<liferay-ui:error key="<%= RequiredLayoutPageTemplateEntryException.class.getName() %>" message="you-cannot-delete-display-page-templates-that-are-used-by-one-or-more-items.-please-view-the-usages-and-try-to-unassign-them" />
+		<liferay-ui:error exception="<%= RequiredLayoutPageTemplateEntryException.class %>" message="you-cannot-delete-display-page-templates-that-are-used-by-one-or-more-items.-please-view-the-usages-and-try-to-unassign-them" />
 
 		<liferay-ui:success key="displayPageContentTypeChanged" message='<%= GetterUtil.getString(SessionMessages.get(renderRequest, "displayPageContentTypeChanged")) %>' />
 		<liferay-ui:success key="displayPageTemplateDeleted" message='<%= GetterUtil.getString(MultiSessionMessages.get(renderRequest, "displayPageTemplateDeleted")) %>' />

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_display_pages.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_display_pages.jsp
@@ -49,6 +49,7 @@ DisplayPageManagementToolbarDisplayContext displayPageManagementToolbarDisplayCo
 	</portlet:actionURL>
 
 	<aui:form action="<%= deleteDisplayPageURL %>" cssClass="container-fluid container-fluid-max-xl" name="fm">
+		<liferay-ui:error exception="<%= PortalException.class %>" message="one-or-more-entries-could-not-be-deleted" />
 		<liferay-ui:error exception="<%= RequiredLayoutPageTemplateEntryException.class %>" message="you-cannot-delete-display-page-templates-that-are-used-by-one-or-more-items.-please-view-the-usages-and-try-to-unassign-them" />
 
 		<liferay-ui:success key="displayPageContentTypeChanged" message='<%= GetterUtil.getString(SessionMessages.get(renderRequest, "displayPageContentTypeChanged")) %>' />

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_entries.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_entries.jsp
@@ -23,7 +23,7 @@ LayoutPageTemplateManagementToolbarDisplayContext layoutPageTemplateManagementTo
 </portlet:actionURL>
 
 <aui:form action="<%= deleteLayoutPageTemplateEntryURL %>" name="fm">
-	<liferay-ui:error key="<%= PortalException.class.getName() %>" message="you-cannot-delete-page-templates-that-are-used-by-a-page" />
+	<liferay-ui:error key="<%= RequiredLayoutPrototypeException.class.getName() %>" message="you-cannot-delete-page-templates-that-are-used-by-a-page" />
 
 	<liferay-ui:search-container
 		id="layoutPageTemplateEntries"

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_entries.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_entries.jsp
@@ -23,6 +23,7 @@ LayoutPageTemplateManagementToolbarDisplayContext layoutPageTemplateManagementTo
 </portlet:actionURL>
 
 <aui:form action="<%= deleteLayoutPageTemplateEntryURL %>" name="fm">
+	<liferay-ui:error exception="<%= PortalException.class %>" message="one-or-more-entries-could-not-be-deleted" />
 	<liferay-ui:error exception="<%= RequiredLayoutPrototypeException.class %>" message="you-cannot-delete-page-templates-that-are-used-by-a-page" />
 
 	<liferay-ui:search-container

--- a/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_entries.jsp
+++ b/modules/apps/layout/layout-page-template-admin-web/src/main/resources/META-INF/resources/view_layout_page_template_entries.jsp
@@ -23,7 +23,7 @@ LayoutPageTemplateManagementToolbarDisplayContext layoutPageTemplateManagementTo
 </portlet:actionURL>
 
 <aui:form action="<%= deleteLayoutPageTemplateEntryURL %>" name="fm">
-	<liferay-ui:error key="<%= RequiredLayoutPrototypeException.class.getName() %>" message="you-cannot-delete-page-templates-that-are-used-by-a-page" />
+	<liferay-ui:error exception="<%= RequiredLayoutPrototypeException.class %>" message="you-cannot-delete-page-templates-that-are-used-by-a-page" />
 
 	<liferay-ui:search-container
 		id="layoutPageTemplateEntries"


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-203689
https://liferay.atlassian.net/browse/LPS-203611

The idea is to follow the same pattern that we use in master pages, that is, show a specific error of what is happening, but also show a generic error stating that one or more items could not be removed. This is for page templates and display pages. 

This has to be done following moving logic from checking if there are usages to model listeners. Attached some screenshots:

![Screenshot 2023-12-13 at 08 48 53](https://github.com/liferay-echo/liferay-portal/assets/4267448/c0ec1bf3-6cb9-404d-bba1-4348e114518e)


![Screenshot 2023-12-13 at 08 49 08](https://github.com/liferay-echo/liferay-portal/assets/4267448/9a4b02c0-8cc0-4411-ac0f-6c7fe029bb11)

