### PR TITLE
LPS-203650 Change query for structures not available when restriction is applied

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalFolderServiceImpl.java
@@ -6,6 +6,7 @@
 package com.liferay.journal.service.impl;
 
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLinkLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMStructureService;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
@@ -417,22 +418,18 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 				JournalFolderConstants.
 					RESTRICTION_TYPE_DDM_STRUCTURES_AND_WORKFLOW) {
 
-			return _ddmStructureService.search(
-				companyId, groupIds,
+			return _ddmStructureLinkLocalService.getStructureLinkStructures(
 				_classNameLocalService.getClassNameId(JournalFolder.class),
-				folderId, keywords, WorkflowConstants.STATUS_ANY, start, end,
-				orderByComparator);
+				folderId, keywords, start, end);
 		}
 
 		folderId = journalFolderLocalService.getOverridedDDMStructuresFolderId(
 			folderId);
 
 		if (folderId != JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
-			return _ddmStructureService.search(
-				companyId, groupIds,
+			return _ddmStructureLinkLocalService.getStructureLinkStructures(
 				_classNameLocalService.getClassNameId(JournalFolder.class),
-				folderId, keywords, WorkflowConstants.STATUS_ANY, start, end,
-				orderByComparator);
+				folderId, keywords, start, end);
 		}
 
 		return _ddmStructureService.search(
@@ -552,6 +549,9 @@ public class JournalFolderServiceImpl extends JournalFolderServiceBaseImpl {
 
 	@Reference
 	private ClassNameLocalService _classNameLocalService;
+
+	@Reference
+	private DDMStructureLinkLocalService _ddmStructureLinkLocalService;
 
 	@Reference(
 		target = "(model.class.name=com.liferay.dynamic.data.mapping.model.DDMStructure)"


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPS-203650)

**Steps to reproduce:**  

1. Go to site administrator
2. Create 10 structures (with a text field) and different names. 
3. Create a folder and click on edit. 
4. Assign a restriction to this folder: 

- Select 9 structures to this folder, without workflow assigned

5. Go to this folder and click on (+) in options availables and click on “More“ 


**Expected behaviour:** 

See all available structures for this folder

**Current behaviour:** 

No results are shown


My proposal is to change this method: 
```
_ddmStructureService.search(companyId, groupIds,
    _classNameLocalService.getClassNameId(JournalFolder.class),
    folderId, keywords, WorkflowConstants.STATUS_ANY, start, end,
    orderByComparator)
```

By this one: `getStructureLinkStructures` because Index doesn't contain classNameId injected in DDMStructure object (Check LPS response details)