### PR TITLE
[TS] LPS-203911 When rendering a utility page ensure that the fragment's CSS is included

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_utility_page_entry/init.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_utility_page_entry/init.jsp
@@ -14,4 +14,5 @@ page import="com.liferay.layout.taglib.internal.display.context.RenderLayoutUtil
 page import="com.liferay.layout.taglib.internal.servlet.ServletContextUtil" %><%@
 page import="com.liferay.layout.util.structure.LayoutStructure" %><%@
 page import="com.liferay.layout.utility.page.model.LayoutUtilityPageEntry" %><%@
+page import="com.liferay.portal.kernel.servlet.taglib.util.OutputData" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_utility_page_entry/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_utility_page_entry/page.jsp
@@ -20,6 +20,8 @@ RenderLayoutUtilityPageEntryDisplayContext renderLayoutUtilityPageEntryDisplayCo
 
 	<%
 	try {
+		request.setAttribute(WebKeys.OUTPUT_DATA, new OutputData());
+
 		request.setAttribute(WebKeys.SHOW_PORTLET_TOPPER, Boolean.FALSE);
 	%>
 


### PR DESCRIPTION
Motivation
=======
https://liferay.atlassian.net/browse/LPS-203911

When a user is shown a Utility Page they actually land on the default page for the site but are shown the content of the Utility Page. If the same fragment exists on the default page as well as the Utility Page then that fragment's CSS will not be included. This caching functionality was added as part of https://liferay.atlassian.net/browse/LPS-104119. The issue is that since we are not actually rendering the landing page this CSS is never included (although the caching mechanism thinks it was).

Proposed Solution
========
For the solution I decided to clear the `OutputData` in the request so that when the Utility Page is rendered it will always include the CSS for the fragment. As far as I could tell we only use this `OutputData` for determining whether or not CSS has already been included on the page:

https://github.com/liferay/liferay-portal/blob/master/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/renderer/FragmentEntryFragmentRenderer.java#L257-L294

https://github.com/liferay/liferay-portal/blob/master/modules/apps/fragment/fragment-renderer-react-impl/src/main/java/com/liferay/fragment/renderer/react/internal/renderer/FragmentEntryFragmentRendererReact.java#L199-L238

Please let me know if you see any issues with this approach or any alternative solutions.

Steps to Verify
========
1. Go to Design --> Fragments, add a Fragment Set, and create a basic fragment with the following configuration:

```
HTML:
<div class="fragment_1">
Local fragment
</div>

CSS:
.fragment_1 {
color: red;
}

Javascript:
console.log("Local fragment");
```

2. Go to Design --> Page Templates and under Masters add a master page and add the above fragment to it, then publish it.
3. Go to Site Builder --> Pages --> Utility Pages and add a Utility Page based on the new master page and add to it a Paragraph fragment with the text "404", and make sure that the Page is configured to use the new Master Page by going to the left panel --> Click the Page Design Options icon and select the new master page, then publish it
4. Click on the kebab menu of the utility page and mark it as default.Checkpoint: Type any non-existent URL, for example, http://localhost:8080/nonexistent, and see that the fragment from the master page appears (in red color).
5. Go to Site Builder --> Pages, click the kebab menu beside the Home Page, and configure it to use the new master page (from the left panel --> Page Design Options), then publish it.
6. Hit the non-existent URL: http://localhost:8080/nonexist

Actual Result: The fragment appears but without the style color of the master fragment.
Expected Result: The fragment appears with the style configured on the master page.