### PR TITLE
LPS-203837 Duplicated web content urlTItle is wrong

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalUtil.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalUtil.java
@@ -195,8 +195,7 @@ public class JournalUtil {
 			title = String.valueOf(id);
 		}
 		else {
-			title = FriendlyURLNormalizerUtil.normalizeWithPeriodsAndSlashes(
-				title);
+			title = FriendlyURLNormalizerUtil.normalizeWithEncoding(title);
 		}
 
 		return ModelHintsUtil.trimString(


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPS-203837 
best,
Attila

--------

The root cause of the issue is that the FriendlyURLNormalizerUtil NormalizeWithPeriodsAndSlashes method removes all the language special characters like Japanese symbols. As we allow acented characters in friendlyURLs it is better to use the normalaziewithEncoding method here.