### PR TITLE
LPS-99212 Only count DDMTemplates of JournalArticles when populating last publish date counts in the Journal context

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalPortletDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalPortletDataHandler.java
@@ -6,6 +6,7 @@
 package com.liferay.journal.internal.exportimport.data.handler;
 
 import com.liferay.changeset.model.ChangesetCollection;
+import com.liferay.changeset.model.ChangesetEntry;
 import com.liferay.changeset.service.ChangesetCollectionLocalService;
 import com.liferay.changeset.service.ChangesetEntryLocalService;
 import com.liferay.data.engine.model.DEDataDefinitionFieldLink;
@@ -33,6 +34,8 @@ import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelType;
 import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.exportimport.kernel.staging.constants.StagingConstants;
+import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.exportimport.staged.model.repository.StagedModelRepositoryRegistryUtil;
 import com.liferay.journal.configuration.JournalServiceConfiguration;
 import com.liferay.journal.constants.JournalConstants;
 import com.liferay.journal.constants.JournalPortletKeys;
@@ -63,6 +66,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Element;
 
 import java.util.List;
+import java.util.Objects;
 
 import javax.portlet.PortletPreferences;
 
@@ -475,13 +479,11 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 					new StagedModelType(
 						DDMStructure.class.getName(),
 						JournalArticle.class.getName()),
-					new StagedModelType(
-						DDMTemplate.class.getName(),
-						DDMStructure.class.getName()),
 					new StagedModelType(JournalFeed.class.getName()),
 					new StagedModelType(JournalFolder.class.getName())
 				});
 
+			_populateDDMTemplateLastPublishDateCounts(portletDataContext);
 			_populateJournalArticleLastPublishDateCounts(portletDataContext);
 
 			return;
@@ -689,6 +691,68 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 		}
 
 		return true;
+	}
+
+	private void _populateDDMTemplateLastPublishDateCounts(
+			PortletDataContext portletDataContext)
+		throws Exception {
+
+		ManifestSummary manifestSummary =
+			portletDataContext.getManifestSummary();
+
+		StagedModelType stagedModelType = new StagedModelType(
+			DDMTemplate.class.getName(), DDMStructure.class.getName());
+
+		long modelAdditionCount = manifestSummary.getModelAdditionCount(
+			stagedModelType);
+
+		if (modelAdditionCount > -1) {
+			return;
+		}
+
+		ChangesetCollection changesetCollection =
+			_changesetCollectionLocalService.fetchChangesetCollection(
+				portletDataContext.getScopeGroupId(),
+				StagingConstants.RANGE_FROM_LAST_PUBLISH_DATE_CHANGESET_NAME);
+
+		if (changesetCollection != null) {
+			StagedModelRepository<?> stagedModelRepository =
+				StagedModelRepositoryRegistryUtil.getStagedModelRepository(
+					stagedModelType.getClassName());
+
+			if (stagedModelRepository != null) {
+				modelAdditionCount = 0;
+
+				for (ChangesetEntry changesetEntry :
+						_changesetEntryLocalService.getChangesetEntries(
+							changesetCollection.getChangesetCollectionId(),
+							stagedModelType.getClassNameId())) {
+
+					DDMTemplate ddmTemplate =
+						(DDMTemplate)stagedModelRepository.getStagedModel(
+							changesetEntry.getClassPK());
+
+					if (Objects.equals(
+							ddmTemplate.getClassName(),
+							stagedModelType.getReferrerClassName()) &&
+						Objects.equals(
+							ddmTemplate.getResourceClassName(),
+							JournalArticle.class.getName())) {
+
+						modelAdditionCount++;
+					}
+				}
+			}
+
+			manifestSummary.addModelAdditionCount(
+				stagedModelType, modelAdditionCount);
+		}
+
+		long modelDeletionCount = _exportImportHelper.getModelDeletionCount(
+			portletDataContext, stagedModelType);
+
+		manifestSummary.addModelDeletionCount(
+			stagedModelType, modelDeletionCount);
 	}
 
 	private void _populateJournalArticleLastPublishDateCounts(


### PR DESCRIPTION
## Motivation
Fix the bug reported in [LPS-99212](https://liferay.atlassian.net/browse/LPS-99212) where DDMTemplates of Dynamic Data Lists are counted under Web Content in the staging summary.

## Proposed Solution
Creates a new method for populating DDMTemplate "last publish date" counts that considers just the DDMTemplates that are related to JournalArticle.

## Steps to Verify

#### Enabling Dynamic Data Lists
- Open applications menu
- Go to Control panel > Configuration > Instance settings > Feature flags > Deprecation
- Enable feature flag for Dynamic Data Lists

#### Configuring staging
- Add the following lines to `portal-ext.properties`:

```
tunnel.servlet.hosts.allowed=127.0.0.1,SERVER_IP
axis.servlet.hosts.allowed=127.0.0.1,SERVER_IP
tunneling.servlet.shared.secret=6162636465666768696a6b6c6d6e6f70
tunneling.servlet.shared.secret.hex=true
```

- Go to Control Panel > Sites 
- Create a new blank site
- On the created site, go to Product Menu > Publishing > Staging
- Choose 'Remote Live'
- Use 127.0.0.1 for 'Remote Host/IP'
- Use 8080 for 'Remote Port'
- Fill in the other site's ID on 'Remote Site ID'
- Check 'Dynamic Data Lists' under 'Staged Content'
- Save it

#### Reproducing the bug
- On the created staging site, go to Product Menu > Content & Data > Dynamic Data Lists
- Click on the kebab menu at the top right corner and then click on 'Manage Data Definitions'
- Create a Data Definition
- On the created Data Definition, click on the kebab icon and then on 'Manage Templates'
- Add a new Form Template
- Go to Product Menu > Staging 
- Click on 'New' to add a new publish process
- Under 'Content', select 'From Last Publish Date' and click on 'Refresh Counts'

**Expected behavior:** Template for DDL is not show in any counts
**Actual behavior:** Template for DDL is shown under Web Content

## References to existing code
I believe the created method follows a somewhat similar approach to what is being done [here](https://github.com/liferay/liferay-portal/blob/8d7a2491ee556c16f336c3f8cfcf4e3d212d1a2d/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalPortletDataHandler.java#L758)