### PR TITLE
[TS] LPS-203973 Default style book is not maintained when creating a site from a template

### DIFF
--- a/modules/apps/style-book/style-book-api/bnd.bnd
+++ b/modules/apps/style-book/style-book-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Style Book API
 Bundle-SymbolicName: com.liferay.style.book.api
-Bundle-Version: 4.3.2
+Bundle-Version: 4.4.0
 Export-Package:\
 	com.liferay.style.book.constants,\
 	com.liferay.style.book.exception,\

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalService.java
@@ -66,6 +66,12 @@ public interface StyleBookEntryLocalService
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.style.book.service.impl.StyleBookEntryLocalServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the style book entry local service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link StyleBookEntryLocalServiceUtil} if injection and service tracking are not available.
 	 */
 	public StyleBookEntry addStyleBookEntry(
+			long userId, long groupId, boolean defaultStyleBookEntry,
+			String frontendTokensValues, String name, String styleBookEntryKey,
+			ServiceContext serviceContext)
+		throws PortalException;
+
+	public StyleBookEntry addStyleBookEntry(
 			long userId, long groupId, String name, String styleBookEntryKey,
 			ServiceContext serviceContext)
 		throws PortalException;

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceUtil.java
@@ -36,6 +36,17 @@ public class StyleBookEntryLocalServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.style.book.service.impl.StyleBookEntryLocalServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static StyleBookEntry addStyleBookEntry(
+			long userId, long groupId, boolean defaultStyleBookEntry,
+			String frontendTokensValues, String name, String styleBookEntryKey,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addStyleBookEntry(
+			userId, groupId, defaultStyleBookEntry, frontendTokensValues, name,
+			styleBookEntryKey, serviceContext);
+	}
+
+	public static StyleBookEntry addStyleBookEntry(
 			long userId, long groupId, String name, String styleBookEntryKey,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {

--- a/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
+++ b/modules/apps/style-book/style-book-api/src/main/java/com/liferay/style/book/service/StyleBookEntryLocalServiceWrapper.java
@@ -34,6 +34,18 @@ public class StyleBookEntryLocalServiceWrapper
 
 	@Override
 	public StyleBookEntry addStyleBookEntry(
+			long userId, long groupId, boolean defaultStyleBookEntry,
+			String frontendTokensValues, String name, String styleBookEntryKey,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _styleBookEntryLocalService.addStyleBookEntry(
+			userId, groupId, defaultStyleBookEntry, frontendTokensValues, name,
+			styleBookEntryKey, serviceContext);
+	}
+
+	@Override
+	public StyleBookEntry addStyleBookEntry(
 			long userId, long groupId, String name, String styleBookEntryKey,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {

--- a/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/packageinfo
+++ b/modules/apps/style-book/style-book-api/src/main/resources/com/liferay/style/book/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.6.0
+version 1.7.0

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/exportimport/staged/model/repository/StylebookEntryStagedModelRepository.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/internal/exportimport/staged/model/repository/StylebookEntryStagedModelRepository.java
@@ -47,6 +47,7 @@ public class StylebookEntryStagedModelRepository
 
 		return _styleBookEntryLocalService.addStyleBookEntry(
 			userId, styleBookEntry.getGroupId(),
+			styleBookEntry.isDefaultStyleBookEntry(),
 			styleBookEntry.getFrontendTokensValues(), styleBookEntry.getName(),
 			styleBookEntry.getStyleBookEntryKey(), serviceContext);
 	}

--- a/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
+++ b/modules/apps/style-book/style-book-service/src/main/java/com/liferay/style/book/service/impl/StyleBookEntryLocalServiceImpl.java
@@ -49,19 +49,9 @@ public class StyleBookEntryLocalServiceImpl
 
 	@Override
 	public StyleBookEntry addStyleBookEntry(
-			long userId, long groupId, String name, String styleBookEntryKey,
+			long userId, long groupId, boolean defaultStyleBookEntry,
+			String frontendTokensValues, String name, String styleBookEntryKey,
 			ServiceContext serviceContext)
-		throws PortalException {
-
-		return addStyleBookEntry(
-			userId, groupId, StringPool.BLANK, name, styleBookEntryKey,
-			serviceContext);
-	}
-
-	@Override
-	public StyleBookEntry addStyleBookEntry(
-			long userId, long groupId, String frontendTokensValues, String name,
-			String styleBookEntryKey, ServiceContext serviceContext)
 		throws PortalException {
 
 		User user = _userLocalService.getUser(userId);
@@ -99,12 +89,34 @@ public class StyleBookEntryLocalServiceImpl
 		styleBookEntry.setUserId(user.getUserId());
 		styleBookEntry.setUserName(user.getFullName());
 		styleBookEntry.setCreateDate(serviceContext.getCreateDate(new Date()));
-		styleBookEntry.setDefaultStyleBookEntry(false);
+		styleBookEntry.setDefaultStyleBookEntry(defaultStyleBookEntry);
 		styleBookEntry.setFrontendTokensValues(frontendTokensValues);
 		styleBookEntry.setName(name);
 		styleBookEntry.setStyleBookEntryKey(styleBookEntryKey);
 
 		return publishDraft(styleBookEntry);
+	}
+
+	@Override
+	public StyleBookEntry addStyleBookEntry(
+			long userId, long groupId, String name, String styleBookEntryKey,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		return addStyleBookEntry(
+			userId, groupId, StringPool.BLANK, name, styleBookEntryKey,
+			serviceContext);
+	}
+
+	@Override
+	public StyleBookEntry addStyleBookEntry(
+			long userId, long groupId, String frontendTokensValues, String name,
+			String styleBookEntryKey, ServiceContext serviceContext)
+		throws PortalException {
+
+		return addStyleBookEntry(
+			userId, groupId, false, frontendTokensValues, name,
+			styleBookEntryKey, serviceContext);
 	}
 
 	@Override


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-203973

Steps to Reproduce

1. Go to Control Panel - Site Templates and create a new Site Template
2. Click on the newly created template
3. Go to Design - Style Books and create a new Style Book
4. Mark the new style as default
5. Go to Control Panel - Sites and create a new site based on the template
6. Go to Design - Style Books

When adding a new Style Book it always passed through _false_ for whether or not it was the default Style Book. I added a new method to allow defining this through a parameter instead. The only updated call is the one in `StylebookEntryStagedModelRepository.java` so the impact is minimal.

I don't foresee any issues with this change but please let me know if there is something I've overlooking.