### PR TITLE
LPS-203952 Validation error when creating structured contents containing fieldSets through REST API

### DIFF
--- a/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-api/src/main/java/com/liferay/headless/delivery/dto/v1_0/util/DDMFormValuesUtil.java
@@ -235,7 +235,9 @@ public class DDMFormValuesUtil {
 		DDMFormField ddmFormField, Locale locale) {
 
 		if (Objects.equals(
-				DDMFormFieldTypeConstants.SEPARATOR, ddmFormField.getType())) {
+				DDMFormFieldTypeConstants.SEPARATOR, ddmFormField.getType()) ||
+			Objects.equals(
+				DDMFormFieldTypeConstants.FIELDSET, ddmFormField.getType())) {
 
 			return null;
 		}

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-complex-ddm-structure.json
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/resources/com/liferay/headless/delivery/resource/v1_0/test/dependencies/test-complex-ddm-structure.json
@@ -284,6 +284,143 @@
 			"visibilityExpression": ""
 		},
 		{
+			"collapsible": false,
+			"ddmStructureId": "",
+			"ddmStructureLayoutId": "",
+			"fieldReference": "Fieldset39810423",
+			"label": {
+				"en_US": "Fields Group"
+			},
+			"labelAtStructureLevel": true,
+			"localizable": false,
+			"name": "Fieldset39810423",
+			"nestedFields": [
+				{
+					"confirmationErrorMessage": {
+						"en_US": ""
+					},
+					"confirmationLabel": {
+						"en_US": ""
+					},
+					"dataType": "string",
+					"direction": [
+						"vertical"
+					],
+					"displayStyle": "singleline",
+					"fieldNamespace": "",
+					"fieldReference": "Text97681688",
+					"hideField": false,
+					"indexType": "keyword",
+					"label": {
+						"en_US": "Text"
+					},
+					"labelAtStructureLevel": true,
+					"localizable": true,
+					"name": "Text97681688",
+					"nativeField": false,
+					"objectFieldName": "",
+					"placeholder": {
+						"en_US": ""
+					},
+					"predefinedValue": {
+						"en_US": ""
+					},
+					"readOnly": false,
+					"repeatable": false,
+					"requireConfirmation": false,
+					"required": false,
+					"requiredErrorMessage": {
+						"en_US": ""
+					},
+					"showLabel": true,
+					"tip": {
+						"en_US": ""
+					},
+					"tooltip": {
+						"en_US": ""
+					},
+					"type": "text",
+					"visibilityExpression": ""
+				},
+				{
+					"confirmationErrorMessage": {
+						"en_US": ""
+					},
+					"confirmationLabel": {
+						"en_US": ""
+					},
+					"dataType": "string",
+					"direction": [
+						"vertical"
+					],
+					"displayStyle": "singleline",
+					"fieldNamespace": "",
+					"fieldReference": "Text60420360",
+					"hideField": false,
+					"indexType": "keyword",
+					"label": {
+						"en_US": "Text"
+					},
+					"labelAtStructureLevel": true,
+					"localizable": true,
+					"name": "Text60420360",
+					"nativeField": false,
+					"objectFieldName": "",
+					"placeholder": {
+						"en_US": ""
+					},
+					"predefinedValue": {
+						"en_US": ""
+					},
+					"readOnly": false,
+					"repeatable": false,
+					"requireConfirmation": false,
+					"required": false,
+					"requiredErrorMessage": {
+						"en_US": ""
+					},
+					"showLabel": true,
+					"tip": {
+						"en_US": ""
+					},
+					"tooltip": {
+						"en_US": ""
+					},
+					"type": "text",
+					"visibilityExpression": ""
+				}
+			],
+			"normalizedStructure": false,
+			"readOnly": false,
+			"repeatable": false,
+			"required": false,
+			"rows": [
+				{
+					"columns": [
+						{
+							"fields": [
+								"Text97681688"
+							],
+							"size": 12
+						}
+					]
+				},
+				{
+					"columns": [
+						{
+							"fields": [
+								"Text60420360"
+							],
+							"size": 12
+						}
+					]
+				}
+			],
+			"showLabel": true,
+			"type": "fieldset",
+			"upgradedStructure": false
+		},
+		{
 			"dataType": "integer",
 			"fieldNamespace": "",
 			"fieldReference": "Numeric",


### PR DESCRIPTION
Motivation
=======
This PR solves https://liferay.atlassian.net/browse/LPS-203952

Proposed Solution
========
In class com.liferay.headless.delivery.dto.v1_0.util.DDMFormValuesUtil._toPredefinedValue default values of DDMFields are set. In this case, fields of type fieldSet are assigned an empty string value when they are transient fields that should have a null value.

Steps to Verify
========
1. Start a 7.4 bundle with the latest update (Q3)
1. Create a web content structure with a text field
1. Go to http://localhost:8080/o/api, use the POST
/v1.0/sites/{siteId}/structured-contents
postSiteStructuredContent request

1. Put the site ID into the siteID field
1. Put the below code into the request body:

```
{
  "contentFields": [],
  "contentStructureId": $DDMSTRUCTURE_ID,
  "title": "support test",
   "viewableBy": "Anyone"
}
```
1. Execute -> web content gets created
1. Add another text field into the existing text field in the structure so it forms a Field Group
1. Run the request (change the title) again

- **Expected behavior:** Web content should be created

- **Current behavior:** It fails with Error: response status is 400

```
{
"status": "BAD_REQUEST",
"title": "Value should not be set for transient field name Fieldset62067391",
"type": "DDMFormValuesValidationException.MustNotSetValue"
}
```