### PR TITLE
LPS-203708 Instead of 'This filed is required', 'Please fill out this field' displays in modal when saving the field with blank in page templates

### DIFF
--- a/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
+++ b/modules/apps/frontend-js/frontend-js-web/src/main/resources/META-INF/resources/liferay/modal/components/SimpleInputModal.es.js
@@ -5,7 +5,7 @@
 
 import ClayAlert from '@clayui/alert';
 import ClayButton from '@clayui/button';
-import {ClayCheckbox, ClayInput} from '@clayui/form';
+import ClayForm, {ClayCheckbox, ClayInput} from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayModal, {useModal} from '@clayui/modal';
 import {useIsMounted} from '@liferay/frontend-js-react-web';
@@ -60,12 +60,32 @@ const SimpleInputModal = ({
 		}
 	};
 
+	const validateInput = () => {
+		let error = '';
+
+		if (!inputValue) {
+			error = Liferay.Language.get('this-field-is-required');
+		}
+
+		return error;
+	};
+
 	const _handleSubmit = (event) => {
 		event.preventDefault();
 
 		const formData = new FormData(
 			document.querySelector(`#${namespace}form`)
 		);
+
+		const error = validateInput(formData);
+
+		if (error) {
+			setErrorMessage(error);
+
+			return;
+		}
+
+		setLoadingResponse(true);
 
 		fetch(formSubmitURL, {
 			body: formData,
@@ -102,8 +122,6 @@ const SimpleInputModal = ({
 			.catch((response) => {
 				handleFormError(response);
 			});
-
-		setLoadingResponse(true);
 	};
 
 	const {observer, onClose} = useModal({
@@ -119,7 +137,11 @@ const SimpleInputModal = ({
 			<ClayModal center={center} observer={observer} size={size}>
 				<ClayModal.Header>{dialogTitle}</ClayModal.Header>
 
-				<form id={`${namespace}form`} onSubmit={_handleSubmit}>
+				<ClayForm
+					id={`${namespace}form`}
+					noValidate
+					onSubmit={_handleSubmit}
+				>
 					<ClayModal.Body>
 						{alert && alert.message && alert.title && (
 							<ClayAlert
@@ -228,7 +250,7 @@ const SimpleInputModal = ({
 							</ClayButton.Group>
 						}
 					/>
-				</form>
+				</ClayForm>
 			</ClayModal>
 		)
 	);


### PR DESCRIPTION
## Motivation

[Link to ticket\](https://liferay.atlassian.net/browse/LPS-203708)

## Test Scenario 1

> [!NOTE]
>Add feature.flag.LPS-189856=true into portal-ext.properties

1. Go to Design > Page Template > Display page templates
2. Add a folder with blank name
3. Save in the modal

## Test Scenario 2

1. Go to Design > Page Template > Masters
2. Add a master page template with blank name
3. Save in the modal

## Test Scenario 3

1. Go to Design > Page Template > Page templates
2. Add a page template set
3. Add a content/widget page template with blank name
4. Save in the modal

### Notes

This solution creates a generic fix for all the places where we are using the OpneSimpleInputModal. 
![image](https://github.com/liferay-echo/liferay-portal/assets/93203423/7624c83e-73ef-47cc-bbe3-01bd943b9b1e)
