### PR TITLE
LPS-203911 When rendering a utility page ensure that the fragment's CSS is included

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_utility_page_entry/init.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_utility_page_entry/init.jsp
@@ -14,4 +14,5 @@ page import="com.liferay.layout.taglib.internal.display.context.RenderLayoutUtil
 page import="com.liferay.layout.taglib.internal.servlet.ServletContextUtil" %><%@
 page import="com.liferay.layout.util.structure.LayoutStructure" %><%@
 page import="com.liferay.layout.utility.page.model.LayoutUtilityPageEntry" %><%@
+page import="com.liferay.portal.kernel.servlet.taglib.util.OutputData" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %>

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_utility_page_entry/page.jsp
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/render_layout_utility_page_entry/page.jsp
@@ -20,6 +20,8 @@ RenderLayoutUtilityPageEntryDisplayContext renderLayoutUtilityPageEntryDisplayCo
 
 	<%
 	try {
+		request.setAttribute(WebKeys.OUTPUT_DATA, new OutputData());
+
 		request.setAttribute(WebKeys.SHOW_PORTLET_TOPPER, Boolean.FALSE);
 	%>
 


### PR DESCRIPTION
Resending due to https://github.com/brianchandotcom/liferay-portal/pull/145347#issuecomment-1859647080

Previously reviewed under https://github.com/liferay-echo/liferay-portal/pull/14729

I don't believe we need to clear it as Brian suggested. This is for caching information about already included CSS so that it is not included multiple times. When rendering the Utility Page this CSS is included so I believe we should maintain the information even after finishing here.

If there are any doubts please let me know and I can clear it in the finally block.