### PR TITLE
LPS-202551 Revert change as this should affect only paragraph fragment

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/editor/configuration/FragmentEntryLinkEditorConfigContributor.java
@@ -61,6 +61,8 @@ public class FragmentEntryLinkEditorConfigContributor
 		).put(
 			"documentBrowseLinkUrl", itemSelectorURL.toString()
 		).put(
+			"enterMode", 2
+		).put(
 			"extraPlugins", getExtraPluginsLists()
 		).put(
 			"filebrowserImageBrowseLinkUrl", imageSelectorURL.toString()


### PR DESCRIPTION
If you click on the paragraph is still adding an update in the history, as is adding a paragraph element in the default text.

Not sure if we can add this paragraph element in the default text for paragraph fragment.

![image](https://github.com/liferay-echo/liferay-portal/assets/59687465/b24ddb8a-38a0-4af0-a1fc-c3096257fe4d)

![image](https://github.com/liferay-echo/liferay-portal/assets/59687465/1e5263cd-f40c-4195-972e-102a2b92d1bf)
