### PR TITLE
LPS-203550 - Removed search options portlet from the Site Template is not propagated to the Site

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -280,7 +280,7 @@ public class FragmentEntryLinkLocalServiceImpl
 					String instanceId = jsonObject.getString("instanceId");
 					String portletId = jsonObject.getString("portletId");
 
-					if (!instanceId.isEmpty()) {
+					if (Validator.isNotNull(instanceId)) {
 						portletId = portletId + "_INSTANCE_" + instanceId;
 					}
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -42,6 +42,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -269,6 +270,29 @@ public class FragmentEntryLinkLocalServiceImpl
 				fragmentEntryLink);
 
 			deletedFragmentEntryLinks.add(fragmentEntryLink);
+
+			if (fragmentEntryLink.isTypePortlet()) {
+
+				try {
+					JSONObject jsonObject = _jsonFactory.createJSONObject(
+						fragmentEntryLink.getEditableValues());
+					String portletId = jsonObject.getString("portletId");
+					String instanceId = jsonObject.getString("instanceId");
+
+					if (!instanceId.isEmpty()) {
+						portletId = portletId + "_INSTANCE_" + instanceId;
+					}
+
+					PortletPreferencesLocalServiceUtil.deletePortletPreferences(
+						0, 3, fragmentEntryLink.getPlid(), portletId);
+
+				}
+				catch (PortalException portalException) {
+					if (_log.isDebugEnabled()) {
+						_log.debug(portalException);
+					}
+				}
+			}
 		}
 
 		return deletedFragmentEntryLinks;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -277,8 +277,8 @@ public class FragmentEntryLinkLocalServiceImpl
 					JSONObject jsonObject = _jsonFactory.createJSONObject(
 						fragmentEntryLink.getEditableValues());
 
-					String portletId = jsonObject.getString("portletId");
 					String instanceId = jsonObject.getString("instanceId");
+					String portletId = jsonObject.getString("portletId");
 
 					if (!instanceId.isEmpty()) {
 						portletId = portletId + "_INSTANCE_" + instanceId;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
@@ -284,7 +285,9 @@ public class FragmentEntryLinkLocalServiceImpl
 					}
 
 					PortletPreferencesLocalServiceUtil.deletePortletPreferences(
-						0, 3, fragmentEntryLink.getPlid(), portletId);
+						PortletKeys.PREFS_OWNER_ID_DEFAULT,
+						PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+						fragmentEntryLink.getPlid(), portletId);
 				}
 				catch (PortalException portalException) {
 					if (_log.isDebugEnabled()) {

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -272,10 +272,10 @@ public class FragmentEntryLinkLocalServiceImpl
 			deletedFragmentEntryLinks.add(fragmentEntryLink);
 
 			if (fragmentEntryLink.isTypePortlet()) {
-
 				try {
 					JSONObject jsonObject = _jsonFactory.createJSONObject(
 						fragmentEntryLink.getEditableValues());
+
 					String portletId = jsonObject.getString("portletId");
 					String instanceId = jsonObject.getString("instanceId");
 
@@ -285,7 +285,6 @@ public class FragmentEntryLinkLocalServiceImpl
 
 					PortletPreferencesLocalServiceUtil.deletePortletPreferences(
 						0, 3, fragmentEntryLink.getPlid(), portletId);
-
 				}
 				catch (PortalException portalException) {
 					if (_log.isDebugEnabled()) {

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryLinkLocalServiceImpl.java
@@ -42,7 +42,7 @@ import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.security.auth.GuestOrUserUtil;
 import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.LayoutLocalService;
-import com.liferay.portal.kernel.service.PortletPreferencesLocalServiceUtil;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
@@ -284,7 +284,7 @@ public class FragmentEntryLinkLocalServiceImpl
 						portletId = portletId + "_INSTANCE_" + instanceId;
 					}
 
-					PortletPreferencesLocalServiceUtil.deletePortletPreferences(
+					_portletPreferencesLocalService.deletePortletPreferences(
 						PortletKeys.PREFS_OWNER_ID_DEFAULT,
 						PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
 						fragmentEntryLink.getPlid(), portletId);
@@ -1067,6 +1067,9 @@ public class FragmentEntryLinkLocalServiceImpl
 
 	@Reference
 	private Portal _portal;
+
+	@Reference
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
 	@Reference
 	private UserLocalService _userLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-203550 - Removed search options portlet from the Site Template is not propagated to the Site

// @matyaswollner 

Original PR comment:

Hi Team,

This PR is a proposed solution to [LPS-199595](https://liferay.atlassian.net/browse/LPS-203550)

**Motivation**:  Removing a portlet from the master template while propagations is active does not remove the portlet properties from the sites propagated by the master template, even though those portlets are no longer visible in the layout. This can cause bugs, like the one described in the reproduction steps.

**Proposed Solution**: After deleting a Portlet from the master template page, during the propagation process, add an additional if statement to deleteLayoutPageTemplateEntryFragmentEntryLinks in FragmentEntryLinkLocalServiceImpl. If the deleted fragmentEntaryLink points to a Portlet, then delete the preferences of that Portlet. 

**Steps to verify:**

Reproduction Steps:

1. Set up DXP 7.3 with u27 + hotfix-8173-7310
2. Open the main menu on the top right and go to Control Panel --> Sites --> Site Templates and create a blank site template.
3. In the Site Template go to Site Builder --> Pages and add a site template page as a content (blank) page and add to it Search Results and Search Options widgets.
4. Configure the Search Options widget to Allow Empty Searches and publish the page.
Checkpoint: When viewing the Site Template Page, you can see search results displayed.
5. Open the main menu and go to Control Panel --> Sites --> Sites and create a Site from the Site Template.
Checkpoint: The Page on the Site displays the search results (expected).
6. Go to the Site Template, edit the Page, remove the Search Options widget, then publish the page
7. Go back to the Site and open the Page.

Actual Result: The removed Search Options portlet preferences are not propagated to the Site Page because the search results are still displayed on the Site Page.

Expected Result: The removed Search Options portlet preferences should be propagated and the search results should not display any contents.

Please, review my solution and share with me any additional remarks, ideals, or suggestions. 
Best regards, Mátyás