### PR TITLE
[TS] LPS-204468 Refactor dynamicContentElement to handle multiple values.

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java
@@ -621,7 +621,17 @@ public class JournalConverterImpl implements JournalConverter {
 				}
 			}
 			else {
-				dynamicContentElement.addCDATA(jsonArray.getString(0));
+				String concatenatedValuesString = jsonArray.getString(0);
+
+				if (jsonArray.length() > 0) {
+					for (int i = 1; i < jsonArray.length(); i++) {
+						concatenatedValuesString = StringBundler.concat(
+							concatenatedValuesString, StringPool.COMMA,
+							jsonArray.getString(i));
+					}
+
+					dynamicContentElement.addCDATA(concatenatedValuesString);
+				}
 			}
 		}
 		else {


### PR DESCRIPTION
Hi,

May I ask if you could review my PR?

Issue is: https://liferay.atlassian.net/browse/LPS-204468.
When creating a structure with a 'Select from List' field and the option values(The edit option will be added) contain commas, the 'Select from List' value is not saved during the creation of web content

Root cause is that the value represents also the multiselection value, so the coma used for separation in it. In the https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/util/JournalConverterImpl.java#L624 if its not a multi select field, only using the first element of the JSONArray.

Solution: check if the array has more than 1 element, and if yes, concat it to the string value.

Tested it locally, and it solved the issue.

Thank you in advance!
BR,
Gege