### PR TITLE
LPS-203762 Themes whose portal_normal.ftl doesn't have an element with id 'content' can produce a noninformative NPE

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/GetPagePreviewStrutsAction.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/GetPagePreviewStrutsAction.java
@@ -176,7 +176,7 @@ public class GetPagePreviewStrutsAction implements StrutsAction {
 					servletContext, httpServletRequest, httpServletResponse,
 					"portal_normal.ftl", layoutSet.getTheme(), false));
 
-			Element contentElement = document.getElementById("content");
+			Element contentElement = document.getElementById("main-content");
 
 			StringBundler sb = (StringBundler)httpServletRequest.getAttribute(
 				WebKeys.LAYOUT_CONTENT);

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-status/src/main/java/com/liferay/layout/utility/page/status/internal/struts/StatusStrutsAction.java
@@ -76,7 +76,7 @@ public class StatusStrutsAction implements StrutsAction {
 		PortalMessages.clear(httpServletRequest);
 		SessionMessages.clear(httpServletRequest);
 
-		Element contentElement = document.getElementById("content");
+		Element contentElement = document.getElementById("main-content");
 
 		contentElement.html(unsyncStringWriter.toString());
 

--- a/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/java/com/liferay/layout/utility/page/terms/of/use/internal/struts/TermsOfUseStrutsAction.java
+++ b/modules/apps/layout/layout-utility-page/layout-utility-page-terms-of-use/src/main/java/com/liferay/layout/utility/page/terms/of/use/internal/struts/TermsOfUseStrutsAction.java
@@ -73,7 +73,7 @@ public class TermsOfUseStrutsAction implements StrutsAction {
 				httpServletResponse, "portal_normal.ftl", layoutSet.getTheme(),
 				false));
 
-		Element contentElement = document.getElementById("content");
+		Element contentElement = document.getElementById("main-content");
 
 		contentElement.html(unsyncStringWriter.toString());
 


### PR DESCRIPTION
## Reproducing Steps

1. Create a theme (using yo liferay-theme, for example)
2. Edit the file portal_normal.ftl to change the line `<section id="content">` to `<section id="content1">`.
3. Deploy the theme to a Liferay (with gulp deploy, for example).
4. Set the theme for the public pages in the default site.
5. Go to the URL http://localhost:8080/c/portal/status to force the execution of the class StatusStrutsAction.java.

> [!NOTE]
>This bug is also reproducible doing the changes in the classic theme instead of creating a new one.