### PR TITLE
[TS] LPS-204740 | Remove HTML escape to avoid JSON parse issues

### DIFF
--- a/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/select_structure_field_item.jsp
+++ b/modules/apps/asset/asset-list-web/src/main/resources/META-INF/resources/asset_list/select_structure_field_item.jsp
@@ -49,7 +49,7 @@ if (name.equals(ddmStructureFieldName)) {
 				'<%= HtmlUtil.escape((String)ddmStructureFieldName) %>'
 			) {
 				field.setValue(
-					'<%= HtmlUtil.escape((String)ddmStructureFieldValue) %>'
+					'<%= HtmlUtil.escapeJS((String)ddmStructureFieldValue) %>'
 				);
 			}
 		});

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/select_structure_field_item.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/select_structure_field_item.jsp
@@ -49,7 +49,7 @@ if (name.equals(ddmStructureFieldName)) {
 				'<%= HtmlUtil.escape((String)ddmStructureFieldName) %>'
 			) {
 				field.setValue(
-					'<%= HtmlUtil.escape((String)ddmStructureFieldValue) %>'
+					'<%= HtmlUtil.escapeJS((String)ddmStructureFieldValue) %>'
 				);
 			}
 		});


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPS-204740
best,
Attila

------
The root cause of the issue is that the JSON characters are escaped and because of this, the JSON parse in the ddm_form.js can't parse the forwarded values.

**Steps to reproduce:**
1. Create a Structure and add a type Select from list with options: "2023, 2022, 2021" for example
2. Create a page
3. Add an asset publisher and filter by the structure and the field "select from list", click on the filter and select 2023
4. Click on save
5. Click on select for the filter by field

**Expected:** The popup shows the previously made selection
**Result:** Error in javascript the selection is not displayed. 