### PR TITLE
LPS-204755 The sidebar when editing a staging widget page overlaps the 'publish to live' button

### DIFF
--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/css/main.scss
@@ -1,6 +1,10 @@
 @import 'cadmin-variables';
 
 html#{$cadmin-selector} {
+	body.open-admin-panel .cadmin .staging-bar {
+		margin-right: 320px;
+	}
+
 	.cadmin {
 		.staging-top {
 			background-color: $cadmin-white;


### PR DESCRIPTION
Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPS-204755)

## Test scenario 1

1. Go to Publishing > Staging.
2. Select and save a local live staging configuration.
3. Go to Site Builder > Edit the Search Widget Page.
4. Click on the “+” button to ads the widgets.
5. Check the sidebar behaviour.

## Results

https://github.com/liferay-echo/liferay-portal/assets/93203423/f3df9fcb-1d29-4f5c-82e4-0796ad370e3c
