### PR TITLE
LPS-204936 - In 7.3, in the Global site, the urlTitle field of the webcontent is set to null

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/registry/JournalServiceUpgradeStepRegistrator.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/upgrade/registry/JournalServiceUpgradeStepRegistrator.java
@@ -283,8 +283,10 @@ public class JournalServiceUpgradeStepRegistrator
 
 		registry.register("3.4.2", "3.4.3", new DummyUpgradeStep());
 
+		registry.register("3.4.3", "3.4.4", new DummyUpgradeStep());
+
 		registry.register(
-			"3.4.3", "3.5.0",
+			"3.4.4", "3.5.0",
 			new JournalArticleContentUpgradeProcess(
 				_journalContentCompatibilityConverter));
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-204936 - In 7.3, in the Global site, the urlTitle field of the webcontent is set to null

This is needed for: https://github.com/liferay-echo/liferay-portal-ee/pull/1