### PR TITLE
LPS-204954 Create upgrade process to mark Master Pages as private as per LPS-172534

### DIFF
--- a/modules/apps/layout/layout-service/bnd.bnd
+++ b/modules/apps/layout/layout-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Service
 Bundle-SymbolicName: com.liferay.layout.service
 Bundle-Version: 2.0.53
-Liferay-Require-SchemaVersion: 1.4.0
+Liferay-Require-SchemaVersion: 1.4.1
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/registry/LayoutServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/registry/LayoutServiceUpgradeStepRegistrator.java
@@ -82,6 +82,11 @@ public class LayoutServiceUpgradeStepRegistrator
 			UpgradeProcessFactory.addColumns(
 				"LayoutClassedModelUsage",
 				"cmExternalReferenceCode VARCHAR(75) null"));
+
+		registry.register(
+			"1.4.0", "1.4.1",
+			new com.liferay.layout.internal.upgrade.v1_4_1.
+				LayoutUpgradeProcess());
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_1/LayoutUpgradeProcess.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_1/LayoutUpgradeProcess.java
@@ -1,0 +1,58 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.internal.upgrade.v1_4_1;
+
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Jonathan McCann
+ */
+public class LayoutUpgradeProcess extends UpgradeProcess {
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		long classNameId = PortalUtil.getClassNameId(Layout.class.getName());
+
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			PreparedStatement preparedStatement1 = connection.prepareStatement(
+				StringBundler.concat(
+					"select plid from Layout where privateLayout = 0 and plid ",
+					"in (select plid from LayoutPageTemplateEntry where type_ ",
+					"= ", LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT,
+					")"));
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
+					connection,
+					StringBundler.concat(
+						"update Layout set privateLayout = 1 where plid = ? ",
+						"or (classPk = ? and classNameId = ", classNameId,
+						")"))) {
+
+			try (ResultSet resultSet = preparedStatement1.executeQuery()) {
+				while (resultSet.next()) {
+					long plid = resultSet.getLong("plid");
+
+					preparedStatement2.setLong(1, plid);
+					preparedStatement2.setLong(2, plid);
+
+					preparedStatement2.addBatch();
+				}
+
+				preparedStatement2.executeBatch();
+			}
+		}
+	}
+
+}


### PR DESCRIPTION
In https://liferay.atlassian.net/browse/LPS-172534 the logic was changed to propagate Master Pages as private. However, this was done without an upgrade process so some clients may still have data where the Master Page is marked as public.

This new upgrade process:

1. Fetches the affected entries in the `Layout` table by
    * Getting all of the Master Pages from the `LayoutPageTemplateEntry` table
    * Seeing if they are marked as `public` in the `Layout` table
2. Using these affected records updates two entries in the `Layout` table
    * The first is the entry with matching `plid`
    * The second is the draft layout for the first entry

With this the Master Page layouts are now marked as private and the propagation can happen successfully. I couldn't find a case where a Master Page was supposed to be public so let me know if such a case exists.

If there are any questions or concerns please let me know.