### PR TITLE
LPS-205105 Unable to select a display page if it's not in the 1st level of page structure

### DIFF
--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/LayoutUtil.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/util/LayoutUtil.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.service.RoleLocalServiceUtil;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.Constants;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HttpComponentsUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.WebKeys;
@@ -104,15 +105,31 @@ public class LayoutUtil {
 				continue;
 			}
 
+			Boolean disabled =
+				(checkDisplayPage && !layout.isContentDisplayPage()) ||
+				(!enableCurrentPage && (layout.getPlid() == selPlid));
+
 			jsonArray.put(
 				JSONUtil.put(
+					"children",
+					() -> {
+						if (disabled && layout.hasChildren()) {
+							return getLayoutsJSONArray(
+								checkDisplayPage, enableCurrentPage, groupId,
+								httpServletRequest, itemSelectorReturnType,
+								privateLayout, layout.getLayoutId(),
+								selectedLayoutUuid, layout.getPlid(), 0,
+								GetterUtil.getInteger(
+									PropsValues.
+										LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN));
+						}
+
+						return null;
+					}
+				).put(
 					"disabled",
 					() -> {
-						if ((checkDisplayPage &&
-							 !layout.isContentDisplayPage()) ||
-							(!enableCurrentPage &&
-							 (layout.getPlid() == selPlid))) {
-
+						if (disabled) {
 							return true;
 						}
 


### PR DESCRIPTION
[Link to LPS](https://liferay.atlassian.net/browse/LPS-205105)

**Description**
The issue was caused by [LPS-181477](https://liferay.atlassian.net/browse/LPS-181477), more specifically this commit:
https://github.com/liferay-echo/liferay-portal/pull/13844/commits/60affd8884632ef05ea0c265cd712fe6f8cf8815

While it improved the performance of layout-tree, by not loading all the children prematurely, however if the parentLayout is set to disabled while having children, the user won't be able to expand the layout-tree item, loading the hidden children.

**Solution**
I did not want to revert the optimalization of not loading the children prematurely, so I decided to do it conditionally, if the layout has children and we would also set it to disabled, we load it's children.
In case there is a children of the layout-tree item, it will be expandable even if it is disabled.

Please review my changes.