### PR TITLE
LPS-200303 Cannot see previous published content after submit for workflow on content page as guest

### DIFF
--- a/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/helper/DispatchTriggerHelper.java
+++ b/modules/apps/dispatch/dispatch-service/src/main/java/com/liferay/dispatch/internal/helper/DispatchTriggerHelper.java
@@ -126,7 +126,8 @@ public class DispatchTriggerHelper {
 
 	private String _getGroupName(DispatchTrigger dispatchTrigger) {
 		return String.format(
-			"DISPATCH_GROUP_%07d@%d", dispatchTrigger.getDispatchTriggerId());
+			"DISPATCH_GROUP_%07d@%d", dispatchTrigger.getDispatchTriggerId(),
+			dispatchTrigger.getCompanyId());
 	}
 
 	private String _getJobName(DispatchTrigger dispatchTrigger) {

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutPermissionTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutPermissionTest.java
@@ -85,7 +85,7 @@ public class LayoutPermissionTest {
 	public void testContainsWithoutViewPermissionOnApprovedLayout()
 		throws Exception {
 
-		Layout layout = _addTypeContentLayout();
+		Layout layout = _addTypeContentLayout(true);
 
 		_removeGuestViewPermission(layout);
 
@@ -99,7 +99,7 @@ public class LayoutPermissionTest {
 		throws Exception {
 
 		try {
-			Layout layout = _addTypeContentLayout();
+			Layout layout = _addTypeContentLayout(true);
 
 			_removeGuestViewPermission(layout);
 
@@ -223,7 +223,7 @@ public class LayoutPermissionTest {
 
 		Assert.assertTrue(
 			_layoutPermission.contains(
-				_getGuestPermissionChecker(), _addTypeContentLayout(),
+				_getGuestPermissionChecker(), _addTypeContentLayout(true),
 				ActionKeys.VIEW));
 	}
 
@@ -232,7 +232,7 @@ public class LayoutPermissionTest {
 		throws Exception {
 
 		try {
-			Layout layout = _addTypeContentLayout();
+			Layout layout = _addTypeContentLayout(true);
 
 			_setUpLayoutWorkflow();
 
@@ -250,7 +250,30 @@ public class LayoutPermissionTest {
 		}
 	}
 
-	private Layout _addTypeContentLayout() throws Exception {
+	@Test
+	public void testContainsWithViewPermissionOnUnpublishedPendingLayout()
+		throws Exception {
+
+		try {
+			Layout layout = _addTypeContentLayout(false);
+
+			_setUpLayoutWorkflow();
+
+			layout = _updateLayout(layout);
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_PENDING, layout.getStatus());
+
+			Assert.assertFalse(
+				_layoutPermission.contains(
+					_getGuestPermissionChecker(), layout, ActionKeys.VIEW));
+		}
+		finally {
+			_tearDownLayoutWorkflow();
+		}
+	}
+
+	private Layout _addTypeContentLayout(boolean publish) throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
 				_group, TestPropsValues.getUserId());
@@ -262,15 +285,20 @@ public class LayoutPermissionTest {
 			LayoutConstants.TYPE_CONTENT, false, StringPool.BLANK,
 			serviceContext);
 
-		Layout draftLayout = layout.fetchDraftLayout();
+		if (publish) {
+			Layout draftLayout = layout.fetchDraftLayout();
 
-		Assert.assertNotNull(draftLayout);
+			Assert.assertNotNull(draftLayout);
 
-		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+			ContentLayoutTestUtil.publishLayout(draftLayout, layout);
 
-		layout = _layoutLocalService.getLayout(layout.getPlid());
+			layout = _layoutLocalService.getLayout(layout.getPlid());
 
-		Assert.assertTrue(layout.isPublished());
+			Assert.assertTrue(layout.isPublished());
+		}
+		else {
+			Assert.assertFalse(layout.isPublished());
+		}
 
 		return layout;
 	}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutPermissionTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutPermissionTest.java
@@ -6,9 +6,12 @@
 package com.liferay.layout.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.User;
@@ -16,12 +19,20 @@ import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.security.permission.PermissionChecker;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
+import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.service.permission.LayoutPermission;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -50,6 +61,19 @@ public class LayoutPermissionTest {
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
+	}
+
+	@Test
+	public void testContainsWithoutViewPermissionOnApprovedLayout()
+		throws Exception {
+
+		Layout layout = _addTypeContentLayout();
+
+		_removeGuestViewPermission(layout);
+
+		Assert.assertFalse(
+			_layoutPermission.contains(
+				_getGuestPermissionChecker(), layout, ActionKeys.VIEW));
 	}
 
 	@Test
@@ -150,6 +174,46 @@ public class LayoutPermissionTest {
 				permissionChecker, layout));
 	}
 
+	@Test
+	public void testContainsWithViewPermissionOnApprovedLayout()
+		throws Exception {
+
+		Assert.assertTrue(
+			_layoutPermission.contains(
+				_getGuestPermissionChecker(), _addTypeContentLayout(),
+				ActionKeys.VIEW));
+	}
+
+	private Layout _addTypeContentLayout() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId());
+
+		Layout layout = _layoutLocalService.addLayout(
+			TestPropsValues.getUserId(), _group.getGroupId(), false,
+			LayoutConstants.DEFAULT_PARENT_LAYOUT_ID,
+			RandomTestUtil.randomString(), StringPool.BLANK, StringPool.BLANK,
+			LayoutConstants.TYPE_CONTENT, false, StringPool.BLANK,
+			serviceContext);
+
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		Assert.assertNotNull(draftLayout);
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		layout = _layoutLocalService.getLayout(layout.getPlid());
+
+		Assert.assertTrue(layout.isPublished());
+
+		return layout;
+	}
+
+	private PermissionChecker _getGuestPermissionChecker() throws Exception {
+		return PermissionCheckerFactoryUtil.create(
+			_userLocalService.getGuestUser(TestPropsValues.getCompanyId()));
+	}
+
 	private PermissionChecker _getPermissionChecker(String actionId)
 		throws Exception {
 
@@ -168,13 +232,36 @@ public class LayoutPermissionTest {
 		return PermissionCheckerFactoryUtil.create(user);
 	}
 
+	private void _removeGuestViewPermission(Layout layout) throws Exception {
+		Role guestRole = _roleLocalService.getRole(
+			layout.getCompanyId(), RoleConstants.GUEST);
+
+		_resourcePermissionLocalService.removeResourcePermission(
+			layout.getCompanyId(), Layout.class.getName(),
+			ResourceConstants.SCOPE_INDIVIDUAL,
+			String.valueOf(layout.getPlid()), guestRole.getRoleId(),
+			ActionKeys.VIEW);
+	}
+
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
 
 	@Inject
 	private LayoutPermission _layoutPermission;
 
 	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
 	private RoleLocalService _roleLocalService;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutPermissionTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutPermissionTest.java
@@ -6,9 +6,12 @@
 package com.liferay.layout.service.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.asset.publisher.constants.AssetPublisherPortletKeys;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
@@ -24,8 +27,11 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.service.RoleLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.UserLocalService;
+import com.liferay.portal.kernel.service.WorkflowDefinitionLinkLocalService;
 import com.liferay.portal.kernel.service.permission.LayoutPermission;
+import com.liferay.portal.kernel.test.portlet.MockLiferayPortletRenderResponse;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -34,9 +40,19 @@ import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.JavaConstants;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.kernel.workflow.WorkflowInstance;
+import com.liferay.portal.kernel.workflow.WorkflowInstanceManagerUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+
+import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -44,6 +60,8 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
  * @author Lourdes Fernández Besada
@@ -74,6 +92,31 @@ public class LayoutPermissionTest {
 		Assert.assertFalse(
 			_layoutPermission.contains(
 				_getGuestPermissionChecker(), layout, ActionKeys.VIEW));
+	}
+
+	@Test
+	public void testContainsWithoutViewPermissionOnPendingLayout()
+		throws Exception {
+
+		try {
+			Layout layout = _addTypeContentLayout();
+
+			_removeGuestViewPermission(layout);
+
+			_setUpLayoutWorkflow();
+
+			layout = _updateLayout(layout);
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_PENDING, layout.getStatus());
+
+			Assert.assertFalse(
+				_layoutPermission.contains(
+					_getGuestPermissionChecker(), layout, ActionKeys.VIEW));
+		}
+		finally {
+			_tearDownLayoutWorkflow();
+		}
 	}
 
 	@Test
@@ -184,6 +227,29 @@ public class LayoutPermissionTest {
 				ActionKeys.VIEW));
 	}
 
+	@Test
+	public void testContainsWithViewPermissionOnPendingLayout()
+		throws Exception {
+
+		try {
+			Layout layout = _addTypeContentLayout();
+
+			_setUpLayoutWorkflow();
+
+			layout = _updateLayout(layout);
+
+			Assert.assertEquals(
+				WorkflowConstants.STATUS_PENDING, layout.getStatus());
+
+			Assert.assertTrue(
+				_layoutPermission.contains(
+					_getGuestPermissionChecker(), layout, ActionKeys.VIEW));
+		}
+		finally {
+			_tearDownLayoutWorkflow();
+		}
+	}
+
 	private Layout _addTypeContentLayout() throws Exception {
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext(
@@ -212,6 +278,29 @@ public class LayoutPermissionTest {
 	private PermissionChecker _getGuestPermissionChecker() throws Exception {
 		return PermissionCheckerFactoryUtil.create(
 			_userLocalService.getGuestUser(TestPropsValues.getCompanyId()));
+	}
+
+	private HttpServletRequest _getHttpServletRequest() throws Exception {
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockHttpServletRequest.setAttribute(
+			JavaConstants.JAVAX_PORTLET_RESPONSE,
+			new MockLiferayPortletRenderResponse());
+
+		Company company = _companyLocalService.getCompany(
+			_group.getCompanyId());
+		Layout layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		ThemeDisplay themeDisplay = ContentLayoutTestUtil.getThemeDisplay(
+			company, _group, layout);
+
+		themeDisplay.setRequest(mockHttpServletRequest);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		return mockHttpServletRequest;
 	}
 
 	private PermissionChecker _getPermissionChecker(String actionId)
@@ -243,6 +332,50 @@ public class LayoutPermissionTest {
 			ActionKeys.VIEW);
 	}
 
+	private void _setUpLayoutWorkflow() throws Exception {
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId());
+
+		serviceContext.setRequest(_getHttpServletRequest());
+
+		ServiceContextThreadLocal.pushServiceContext(serviceContext);
+
+		_workflowDefinitionLinkLocalService.updateWorkflowDefinitionLink(
+			TestPropsValues.getUserId(), TestPropsValues.getCompanyId(),
+			_group.getGroupId(), Layout.class.getName(), 0, 0,
+			"Single Approver@1");
+	}
+
+	private void _tearDownLayoutWorkflow() throws Exception {
+		List<WorkflowInstance> workflowInstances =
+			WorkflowInstanceManagerUtil.getWorkflowInstances(
+				TestPropsValues.getCompanyId(), TestPropsValues.getUserId(),
+				new String[] {Layout.class.getName()}, false, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS, null);
+
+		for (WorkflowInstance workflowInstance : workflowInstances) {
+			WorkflowInstanceManagerUtil.deleteWorkflowInstance(
+				TestPropsValues.getCompanyId(),
+				workflowInstance.getWorkflowInstanceId());
+		}
+
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	private Layout _updateLayout(Layout layout) throws Exception {
+		Layout draftLayout = layout.fetchDraftLayout();
+
+		Assert.assertNotNull(draftLayout);
+
+		ContentLayoutTestUtil.addPortletToLayout(
+			layout, AssetPublisherPortletKeys.ASSET_PUBLISHER);
+
+		ContentLayoutTestUtil.publishLayout(draftLayout, layout);
+
+		return _layoutLocalService.getLayout(layout.getPlid());
+	}
+
 	@Inject
 	private CompanyLocalService _companyLocalService;
 
@@ -263,5 +396,9 @@ public class LayoutPermissionTest {
 
 	@Inject
 	private UserLocalService _userLocalService;
+
+	@Inject
+	private WorkflowDefinitionLinkLocalService
+		_workflowDefinitionLinkLocalService;
 
 }

--- a/portal-impl/src/com/liferay/portal/service/permission/LayoutPermissionImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/permission/LayoutPermissionImpl.java
@@ -304,7 +304,9 @@ public class LayoutPermissionImpl implements LayoutPermission {
 			return false;
 		}
 
-		if (layout.isPending()) {
+		if (layout.isPending() &&
+			(!actionId.equals(ActionKeys.VIEW) || !layout.isPublished())) {
+
 			Boolean hasPermission = WorkflowPermissionUtil.hasPermission(
 				permissionChecker, layout.getGroupId(), Layout.class.getName(),
 				layout.getPlid(), actionId);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-200303

@ealonso 

I am convinced that what you proposed as a solution to this ticket at https://github.com/liferay-echo/liferay-portal/pull/14248 is something we should implement but, from my point of view:

1. We should implement an UpgradeProcess that changes the in-curse workflow instances to reference the draft layout instead of the published one, to eliminate from the code the possibility that a published layout is in workflow.
2. We should review a series of associated behaviors to assess how they should behave. For example, some of the behaviors discussed in https://github.com/liferay-echo/liferay-portal/pull/14248 and https://github.com/liferay-echo/liferay-portal/pull/14299

For these reasons, I am proposing to approach the layout workflow changes as a story and apply the changes that this PR incorporates as a solution for LPS-200303

Could you please analyze it?

Thanks in advance!