### PR TITLE
LPS-205266

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalDisplayContext.java
@@ -1195,6 +1195,16 @@ public class JournalDisplayContext {
 		).build();
 	}
 
+	public boolean hasAssetFilter() {
+		if (ArrayUtil.isEmpty(_getAssetCategoryIds()) &&
+			ArrayUtil.isEmpty(_getAssetTagNames())) {
+
+			return false;
+		}
+
+		return true;
+	}
+
 	public boolean hasCommentsResults() throws PortalException {
 		if (getCommentsTotal() > 0) {
 			return true;
@@ -1348,9 +1358,8 @@ public class JournalDisplayContext {
 	}
 
 	public boolean isShowInfoButton() throws PortalException {
-		if (isNavigationMine() || isNavigationRecent() || isSearch() ||
-			isTypeVersions() || ArrayUtil.isNotEmpty(_getAssetCategoryIds()) ||
-			ArrayUtil.isNotEmpty(_getAssetTagNames())) {
+		if (hasAssetFilter() || isNavigationMine() || isNavigationRecent() ||
+			isSearch() || isTypeVersions()) {
 
 			return false;
 		}
@@ -1511,8 +1520,8 @@ public class JournalDisplayContext {
 		}
 
 		if (!FeatureFlagManagerUtil.isEnabled("LPS-196768")) {
-			if (!isHighlightedDDMStructure() && !isSearch() &&
-				!isNavigationMine() && !isNavigationRecent() &&
+			if (!hasAssetFilter() && !isHighlightedDDMStructure() &&
+				!isSearch() && !isNavigationMine() && !isNavigationRecent() &&
 				(getDDMStructureId() <= 0)) {
 
 				SearchContainer<Object> articleAndFolderSearchContainer =
@@ -1534,7 +1543,9 @@ public class JournalDisplayContext {
 				return _articleSearchContainer;
 			}
 
-			if (!isSearch() && (isNavigationMine() || isNavigationRecent())) {
+			if (!hasAssetFilter() && !isSearch() &&
+				(isNavigationMine() || isNavigationRecent())) {
+
 				SearchContainer<JournalArticle> articleSearchContainer =
 					_getArticleSearchContainer();
 
@@ -1555,7 +1566,7 @@ public class JournalDisplayContext {
 				return _articleSearchContainer;
 			}
 
-			if (!isSearch() && (getDDMStructureId() > 0)) {
+			if (!hasAssetFilter() && !isSearch() && (getDDMStructureId() > 0)) {
 				SearchContainer<JournalArticle> articleSearchContainer =
 					_getArticleSearchContainer();
 
@@ -1577,7 +1588,9 @@ public class JournalDisplayContext {
 				return _articleSearchContainer;
 			}
 
-			if (isHighlightedDDMStructure() && !isSearch()) {
+			if (!hasAssetFilter() && isHighlightedDDMStructure() &&
+				!isSearch()) {
+
 				SearchContainer<JournalArticle> articleSearchContainer =
 					_getArticleSearchContainer();
 
@@ -1601,12 +1614,10 @@ public class JournalDisplayContext {
 		}
 
 		if (FeatureFlagManagerUtil.isEnabled("LPS-196768") &&
-			!isHighlightedDDMStructure() && !isNavigationMine() &&
-			!isNavigationRecent() && !isSearch() && !isTypeVersions() &&
-			(getDDMStructureId() <= 0) &&
-			(getStatus() == WorkflowConstants.STATUS_ANY) &&
-			ArrayUtil.isEmpty(_getAssetCategoryIds()) &&
-			ArrayUtil.isEmpty(_getAssetTagNames())) {
+			!hasAssetFilter() && !isHighlightedDDMStructure() &&
+			!isNavigationMine() && !isNavigationRecent() && !isSearch() &&
+			!isTypeVersions() && (getDDMStructureId() <= 0) &&
+			(getStatus() == WorkflowConstants.STATUS_ANY)) {
 
 			SearchContainer<Object> articleAndFolderSearchContainer =
 				_getArticleAndFolderSearchContainer();
@@ -1628,6 +1639,7 @@ public class JournalDisplayContext {
 		}
 
 		if (FeatureFlagManagerUtil.isEnabled("LPS-196768") &&
+			!hasAssetFilter() &&
 			(isHighlightedDDMStructure() || isNavigationStructure())) {
 
 			SearchContainer<JournalArticle> articleSearchContainer =

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalManagementToolbarDisplayContext.java
@@ -607,7 +607,8 @@ public class JournalManagementToolbarDisplayContext
 
 	@Override
 	public Boolean isDisabled() {
-		if ((getItemsTotal() > 0) || _journalDisplayContext.isSearch() ||
+		if ((getItemsTotal() > 0) || _journalDisplayContext.hasAssetFilter() ||
+			_journalDisplayContext.isSearch() ||
 			!_journalDisplayContext.isNavigationHome() ||
 			(_journalDisplayContext.getStatus() !=
 				WorkflowConstants.STATUS_ANY)) {
@@ -668,6 +669,7 @@ public class JournalManagementToolbarDisplayContext
 		if (FeatureFlagManagerUtil.isEnabled("LPS-196768")) {
 			filterNavigationDropdownItems.add(
 				DropdownItemBuilder.setActive(
+					!_journalDisplayContext.hasAssetFilter() &&
 					_journalDisplayContext.isNavigationHome()
 				).setHref(
 					PortletURLBuilder.create(
@@ -724,6 +726,7 @@ public class JournalManagementToolbarDisplayContext
 		else {
 			filterNavigationDropdownItems.add(
 				DropdownItemBuilder.setActive(
+					!_journalDisplayContext.hasAssetFilter() &&
 					_journalDisplayContext.isNavigationHome()
 				).setHref(
 					PortletURLBuilder.create(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPS-205266

After https://github.com/liferay/liferay-portal/commit/1961eeec57900e81fd58f6644b926ad2d48b4665 filtering based on Category or Tag became broken since `JournalDisplayContext._getArticlesSearchContainer` would no longer reach the point where the filters are added to the search query.

These changes add a new method to check whether or not a Category or Tag has been selected. If so, then it will filter the results based on these choices. I wasn't sure the best name for the method (`hasAssetFilter`) so please let me know if there is a better alternative. `JournalDisplayContext.isFilterApplied` exists but has more checks than needed for this use case thus the new method being created.

If there are any questions or concerns please let me know.