### PR TITLE
LPS-204954 - Cannot propagate changes from Site Template to Site when using Master Page

### DIFF
--- a/modules/apps/layout/layout-service/bnd.bnd
+++ b/modules/apps/layout/layout-service/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Layout Service
 Bundle-SymbolicName: com.liferay.layout.service
 Bundle-Version: 2.0.54
-Liferay-Require-SchemaVersion: 1.4.1
+Liferay-Require-SchemaVersion: 1.4.2
 Liferay-Service: true
 -dsannotations-options: inherit

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/registry/LayoutServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/registry/LayoutServiceUpgradeStepRegistrator.java
@@ -90,6 +90,11 @@ public class LayoutServiceUpgradeStepRegistrator
 			new com.liferay.layout.internal.upgrade.v1_4_1.
 				LayoutClassedModelUsageUpgradeProcess(
 					_classNameLocalService, _jsonFactory));
+
+		registry.register(
+			"1.4.1", "1.4.2",
+			new com.liferay.layout.internal.upgrade.v1_4_2.LayoutUpgradeProcess(
+				_layoutLocalService));
 	}
 
 	@Reference

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_2/LayoutUpgradeProcess.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_2/LayoutUpgradeProcess.java
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.internal.upgrade.v1_4_2;
+
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.petra.string.StringBundler;
+import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.PortalUtil;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+/**
+ * @author Jonathan McCann
+ */
+public class LayoutUpgradeProcess extends UpgradeProcess {
+
+	public LayoutUpgradeProcess(LayoutLocalService layoutLocalService) {
+		_layoutLocalService = layoutLocalService;
+	}
+
+	@Override
+	protected void doUpgrade() throws Exception {
+		try (LoggingTimer loggingTimer = new LoggingTimer();
+			PreparedStatement preparedStatement1 = connection.prepareStatement(
+				StringBundler.concat(
+					"SELECT groupId, plid FROM Layout WHERE privateLayout = ? ",
+					"AND (plid IN (SELECT plid FROM LayoutPageTemplateEntry ",
+					"WHERE type_ = ?) OR (classPk IN (SELECT plid FROM ",
+					"LayoutPageTemplateEntry WHERE type_ = ?) AND classNameId ",
+					"= ?))"));
+			PreparedStatement preparedStatement2 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update Layout set privateLayout = ?, layoutId = ? where " +
+						"plid = ?");
+			PreparedStatement preparedStatement3 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update LayoutFriendlyURL set privateLayout = ? where " +
+						"plid = ?")) {
+
+			preparedStatement1.setBoolean(1, false);
+			preparedStatement1.setLong(
+				2, LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT);
+			preparedStatement1.setLong(
+				3, LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT);
+			preparedStatement1.setLong(
+				4, PortalUtil.getClassNameId(Layout.class.getName()));
+
+			try (ResultSet resultSet = preparedStatement1.executeQuery()) {
+				while (resultSet.next()) {
+					long groupId = resultSet.getLong("groupId");
+					long plid = resultSet.getLong("plid");
+
+					preparedStatement2.setBoolean(1, true);
+					preparedStatement2.setLong(
+						2, _layoutLocalService.getNextLayoutId(groupId, true));
+					preparedStatement2.setLong(3, plid);
+
+					preparedStatement2.addBatch();
+
+					preparedStatement3.setBoolean(1, true);
+					preparedStatement3.setLong(2, plid);
+
+					preparedStatement3.addBatch();
+				}
+			}
+
+			preparedStatement2.executeBatch();
+
+			preparedStatement3.executeBatch();
+		}
+	}
+
+	private final LayoutLocalService _layoutLocalService;
+
+}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/upgrade/v1_4_2/test/LayoutUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/upgrade/v1_4_2/test/LayoutUpgradeProcessTest.java
@@ -1,0 +1,187 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.internal.upgrade.v1_4_2.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutFriendlyURL;
+import com.liferay.portal.kernel.portlet.bridges.mvc.MVCActionCommand;
+import com.liferay.portal.kernel.service.ClassNameLocalService;
+import com.liferay.portal.kernel.service.LayoutFriendlyURLLocalService;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Rubén Pulido
+ */
+@RunWith(Arquillian.class)
+public class LayoutUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_serviceContext = ServiceContextTestUtil.getServiceContext(
+			_group.getGroupId());
+
+		ServiceContextThreadLocal.pushServiceContext(_serviceContext);
+	}
+
+	@After
+	public void tearDown() {
+		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testUpgradeProcess() throws Exception {
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+				TestPropsValues.getUserId(), _group.getGroupId(), 0,
+				RandomTestUtil.randomString(),
+				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT, 0,
+				WorkflowConstants.STATUS_DRAFT, _serviceContext);
+
+		Layout draftLayout = _layoutLocalService.fetchLayout(
+			_classNameLocalService.getClassNameId(Layout.class),
+			layoutPageTemplateEntry.getPlid());
+
+		Layout layout = _layoutLocalService.getLayout(draftLayout.getClassPK());
+
+		draftLayout.setPrivateLayout(false);
+
+		draftLayout = _layoutLocalService.updateLayout(draftLayout);
+
+		layout.setPrivateLayout(false);
+
+		layout = _layoutLocalService.updateLayout(layout);
+
+		ReflectionTestUtil.invoke(
+			_mvcActionCommand, "_publishLayoutPageTemplateEntry",
+			new Class<?>[] {Layout.class, Layout.class}, draftLayout, layout);
+
+		LayoutFriendlyURL draftLayoutFriendlyURL =
+			_layoutFriendlyURLLocalService.fetchLayoutFriendlyURL(
+				draftLayout.getPlid(), draftLayout.getDefaultLanguageId());
+
+		draftLayoutFriendlyURL.setPrivateLayout(false);
+
+		_layoutFriendlyURLLocalService.updateLayoutFriendlyURL(
+			draftLayoutFriendlyURL);
+
+		LayoutFriendlyURL layoutFriendlyURL =
+			_layoutFriendlyURLLocalService.fetchLayoutFriendlyURL(
+				layout.getPlid(), layout.getDefaultLanguageId());
+
+		layoutFriendlyURL.setPrivateLayout(false);
+
+		_layoutFriendlyURLLocalService.updateLayoutFriendlyURL(
+			layoutFriendlyURL);
+
+		_runUpgrade();
+
+		Layout updatedDraftLayout = _layoutLocalService.fetchLayout(
+			draftLayout.getPlid());
+
+		Assert.assertTrue(updatedDraftLayout.isPrivateLayout());
+
+		Layout updatedLayout = _layoutLocalService.fetchLayout(
+			layout.getPlid());
+
+		Assert.assertTrue(updatedLayout.isPrivateLayout());
+
+		LayoutFriendlyURL updatedDraftLayoutFriendlyURL =
+			_layoutFriendlyURLLocalService.fetchLayoutFriendlyURL(
+				updatedDraftLayout.getPlid(),
+				updatedDraftLayout.getDefaultLanguageId());
+
+		Assert.assertTrue(updatedDraftLayoutFriendlyURL.isPrivateLayout());
+
+		LayoutFriendlyURL updatedLayoutFriendlyURL =
+			_layoutFriendlyURLLocalService.fetchLayoutFriendlyURL(
+				updatedLayout.getPlid(), updatedLayout.getDefaultLanguageId());
+
+		Assert.assertTrue(updatedLayoutFriendlyURL.isPrivateLayout());
+	}
+
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+			_upgradeStepRegistrator, _CLASS_NAME);
+
+		upgradeProcess.upgrade();
+
+		_multiVMPool.clear();
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.layout.internal.upgrade.v1_4_2.LayoutUpgradeProcess";
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.layout.internal.upgrade.registry.LayoutServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@Inject
+	private ClassNameLocalService _classNameLocalService;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	@Inject
+	private LayoutFriendlyURLLocalService _layoutFriendlyURLLocalService;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@Inject
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject(
+		filter = "mvc.command.name=/layout_content_page_editor/publish_layout_page_template_entry"
+	)
+	private MVCActionCommand _mvcActionCommand;
+
+	private ServiceContext _serviceContext;
+
+}


### PR DESCRIPTION
This PR adds an integration test to the original PR: https://github.com/liferay-echo/liferay-portal/pull/14925

Original PR comment:

https://liferay.atlassian.net/browse/LPS-204954

Previously submitted under https://github.com/liferay-echo/liferay-portal/pull/14902 @ruben-pulido. Resending due to a few issues caught by @jorgediaz-lr.

The changes from the previous pull are:

1. Using a parameter to set the boolean for `privateLayout` instead of hard coded `0` and `1` due to differences in databases
2. Updating the layout's `layoutId` to avoid a potential conflict in the case of private pages existing in the site
3. Additionally updating the `LayoutFriendlyURL` table to reflect the change from public to private

If there are any questions or concerns please let me know.