### PR TITLE
[TS] LPS-205417

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java
@@ -6335,7 +6335,7 @@ public class UserLocalServiceImpl extends UserLocalServiceBaseImpl {
 			passwordResetURL = StringBundler.concat(
 				serviceContext.getPortalURL(), serviceContext.getPathMain(),
 				updatePasswordURL, "ticketId=", ticket.getTicketId(),
-				"&ticketKey=", ticket.getKey());
+				"&ticketKey=", ticket.getKey(), "&languageId=", user.getLanguageId());
 
 			ticket.setKey(PasswordEncryptorUtil.encrypt(ticket.getKey()));
 


### PR DESCRIPTION
@dacousalr 
Ticket: https://liferay.atlassian.net/browse/LPS-205417

<h1>Motivation</h1>
Previously, without my solution, the language of the generated email was not matching that of the password reset link, causing confusion.
<h1>Proposed Solution</h1>
I introduced the addition of &languageId=user.getLanguageId() to the URL of the password reset link. This ensures that the language selected by the administrator for a new user is now consistently incorporated into both the email content and the password reset link.
<h1>Steps to Verify</h1>

1.Go to Instance Settings -> Email and ability Account Created Notification.

2.Set a different language for the email than the Instance.

3.As an administrator go to Control Panel -> Users and Organizations

4.Click to Plus button to create a new User

5.Fill in the form

6.Set the same language selected in point 2 for the user

7.Save new user

8.Login with new user

9.Check the email and click in the link to set up your password