### PR TITLE
LPS-205566 Increase z-index of properties panel to 2 in order to not …

### DIFF
--- a/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/MultiPanelSidebar.scss
+++ b/modules/apps/data-engine/data-engine-taglib/src/main/resources/META-INF/resources/data_layout_builder/js/components/sidebar/MultiPanelSidebar.scss
@@ -7,6 +7,7 @@ $toolbarHeight: 110px;
 
 // z-indexes for children of page-editor-sidebar (which is a stacking context).
 
+$zIndexPanel: 1;
 $zIndexButtons: 1;
 $zIndexContent: 0;
 
@@ -18,6 +19,7 @@ $zIndexContent: 0;
 	position: fixed;
 	right: 0;
 	top: calc(var(--control-menu-container-height) + #{$toolbarHeight});
+	z-index: $zIndexPanel;
 
 	&-content {
 		height: calc(

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -206,7 +206,7 @@ $productMenuWidth: 320px;
 			padding-top: 0;
 			position: fixed;
 			width: $productMenuWidth;
-			z-index: 1;
+			z-index: 2;
 
 			.schedule {
 				.form-group-autofit {


### PR DESCRIPTION
…overlap with image select button

Before:
![image](https://github.com/liferay-echo/liferay-portal/assets/59687465/dc4cd804-92e9-4551-a64c-08a7b8cc3d41)

After:
![image](https://github.com/liferay-echo/liferay-portal/assets/59687465/48eb0036-9d20-4621-ac24-7f90ce9ff4d8)
