### PR TITLE
LPS-145606 Use numeric condition because some DBs don't have boolean type

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/persistence/impl/GroupFinderImpl.java
@@ -1188,9 +1188,15 @@ public class GroupFinderImpl
 					ResourceActionLocalServiceUtil.getResourceAction(
 						Group.class.getName(), (String)entry.getValue());
 
-				queryPos.add(
-					RoleLocalServiceUtil.hasUserRole(
-						userId, adminRole.getRoleId()));
+				int isAdmin = 0;
+
+				if (RoleLocalServiceUtil.hasUserRole(
+						userId, adminRole.getRoleId())) {
+
+					isAdmin = 1;
+				}
+
+				queryPos.add(isAdmin);
 				queryPos.add(userId);
 
 				queryPos.add(siteAdminRole.getRoleId());

--- a/portal-impl/src/custom-sql/portal.xml
+++ b/portal-impl/src/custom-sql/portal.xml
@@ -198,7 +198,7 @@
 				ResourcePermission ON
 					ResourcePermission.roleId = Roles.roleId
 			WHERE
-			(? = true) OR
+			(? = 1) OR
 			(
 				(Roles.userId = ?) AND
 				(


### PR DESCRIPTION
Motivation
=======
Test GroupFinderTest.testFindByC_C_N_DJoinByActionId fails with `Invalid column name 'true'.`
https://liferay.atlassian.net/browse/LPS-145606

Proposed Solution
========
By using a numeric condition, this query will work on DBs that don't have a boolean type

Steps to Verify
========
1. Setup Liferay with an Oracle or an MSSQL
2. Open a terminal
3. Navigate to `modules/apps/site/site-test`
4. Run `gw testIntegration --tests GroupFinderTest.testFindByC_C_N_DJoinByActionId`

**Expected behaviour:** The test passes successfully
**Actual behaviour:** The test fails with `Invalid column name 'true'.`

References to existing code
========
I do recall seeing similar WHERE clauses somewhere else, but couldn't find them anymore for a pattern to copy.