### PR TITLE
LPS-205943

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/model/impl/JournalArticleImpl.java
@@ -248,7 +248,11 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 
 	@Override
 	public DDMFormValues getDDMFormValues() {
-		return getDDMFormValues(true);
+		if (_ddmFormValues == null) {
+			_ddmFormValues = getDDMFormValues(true);
+		}
+
+		return _ddmFormValues;
 	}
 
 	@Override
@@ -829,6 +833,7 @@ public class JournalArticleImpl extends JournalArticleBaseImpl {
 		_ddmFormValuesToFieldsConverter;
 	private static volatile JournalConverter _journalConverter;
 
+	private DDMFormValues _ddmFormValues;
 	private Map<Locale, String> _descriptionMap;
 	private Document _document;
 	private Map<String, Document> _documentMap;


### PR DESCRIPTION
From https://liferay.atlassian.net/browse/LPS-205265
Calling multiple times to `JournalArticleImpl#getDDMFormValues()` can produce performance degradation for complex structures with multiple fields, nested fields, translations, … So, we should avoid as much as possible call it multiple times if it is not necessary.

**Steps to reproduce:**

- Go to Web Content
- Creates a new Basic web content
- Edit the web content

**Actual Result**

- We are calling four times to `JournalArticleImpl#getDDMFormValues() `

**Expected Result**

- We call only once `JournalArticleImpl#getDDMFormValues()`