### PR TITLE
LPS-206141 In Display Page Template changing display style of a Related Items Collection Provider in Collection Display fragment does not work

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/Collection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/Collection.js
@@ -432,12 +432,14 @@ const Collection = React.memo(
 			selectedViewportSize
 		);
 
-		const showEmptyMessage =
-			collectionConfig.listStyle !== '' && collection.fakeCollection;
-
 		const flexEnabled =
 			collectionConfig.listStyle === CONTENT_DISPLAY_OPTIONS.flexColumn ||
 			collectionConfig.listStyle === CONTENT_DISPLAY_OPTIONS.flexRow;
+
+		const showEmptyMessage =
+			collection.fakeCollection &&
+			collectionConfig.listStyle !== '' &&
+			!flexEnabled;
 
 		let CollectionContent = null;
 


### PR DESCRIPTION
Hey,

[LPS-206141](https://liferay.atlassian.net/browse/LPS-206141)

Based on `showEmptyMessage` we either display an empty message warning inside `CollectionContent` or we use `<FlexContainer /> `or `<Grid />` to display the children. I modified the code so we display the `fakeCollection` in flex mode as well and use the same <EmptyCollectionGridMessage /> component on the top. This way the users can drag and drop fragments into the sample collection in every display style expect when they use an already defined template.

Please review my change.

Thanks,