### PR TITLE
LPS-204596 check latest non-expired article, to make assetentry visible

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5566,10 +5566,9 @@ public class JournalArticleLocalServiceImpl
 				article.getModifiedDate(), JournalArticle.class.getName(),
 				article.getPrimaryKey(), article.getUuid(),
 				article.getDDMStructureId(), assetCategoryIds, assetTagNames,
-				isListable(article), false, null, null, null,
-				expirationDate, ContentTypes.TEXT_HTML, title,
-				description, description, null, article.getLayoutUuid(), 0, 0,
-				priority);
+				isListable(article), false, null, null, null, expirationDate,
+				ContentTypes.TEXT_HTML, title, description, description, null,
+				article.getLayoutUuid(), 0, 0, priority);
 		}
 		else {
 			JournalArticleResource journalArticleResource =
@@ -5588,9 +5587,9 @@ public class JournalArticleLocalServiceImpl
 				journalArticleResource.getResourcePrimKey(),
 				journalArticleResource.getUuid(), article.getDDMStructureId(),
 				assetCategoryIds, assetTagNames, isListable(article), visible,
-				null, null, publishDate, expirationDate,
-				ContentTypes.TEXT_HTML, title, description, description, null,
-				article.getLayoutUuid(), 0, 0, priority);
+				null, null, publishDate, expirationDate, ContentTypes.TEXT_HTML,
+				title, description, description, null, article.getLayoutUuid(),
+				0, 0, priority);
 		}
 
 		_assetLinkLocalService.updateLinks(

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5582,14 +5582,6 @@ public class JournalArticleLocalServiceImpl
 				article.getLayoutUuid(), 0, 0, priority);
 		}
 
-		if ((journalArticleLocalService.fetchLatestArticle(
-				article.getResourcePrimKey(),
-				WorkflowConstants.STATUS_APPROVED) != null) &&
-			(assetEntry != null)) {
-
-			_assetEntryLocalService.updateVisible(assetEntry, true);
-		}
-
 		_assetLinkLocalService.updateLinks(
 			userId, assetEntry.getEntryId(), assetLinkEntryIds,
 			AssetLinkConstants.TYPE_RELATED);

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5535,6 +5535,17 @@ public class JournalArticleLocalServiceImpl
 		throws PortalException {
 
 		boolean visible = article.isApproved();
+		Date expirationDate = article.getExpirationDate();
+
+		JournalArticle latestApprovedArticle =
+			journalArticleLocalService.fetchLatestArticle(
+				article.getResourcePrimKey(),
+				WorkflowConstants.STATUS_APPROVED);
+
+		if (latestApprovedArticle != null) {
+			visible = true;
+			expirationDate = latestApprovedArticle.getExpirationDate();
+		}
 
 		if (article.getClassNameId() !=
 				JournalArticleConstants.CLASS_NAME_ID_DEFAULT) {
@@ -5556,7 +5567,7 @@ public class JournalArticleLocalServiceImpl
 				article.getPrimaryKey(), article.getUuid(),
 				article.getDDMStructureId(), assetCategoryIds, assetTagNames,
 				isListable(article), false, null, null, null,
-				article.getExpirationDate(), ContentTypes.TEXT_HTML, title,
+				expirationDate, ContentTypes.TEXT_HTML, title,
 				description, description, null, article.getLayoutUuid(), 0, 0,
 				priority);
 		}
@@ -5577,7 +5588,7 @@ public class JournalArticleLocalServiceImpl
 				journalArticleResource.getResourcePrimKey(),
 				journalArticleResource.getUuid(), article.getDDMStructureId(),
 				assetCategoryIds, assetTagNames, isListable(article), visible,
-				null, null, publishDate, article.getExpirationDate(),
+				null, null, publishDate, expirationDate,
 				ContentTypes.TEXT_HTML, title, description, description, null,
 				article.getLayoutUuid(), 0, 0, priority);
 		}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/service/impl/JournalArticleLocalServiceImpl.java
@@ -5582,6 +5582,14 @@ public class JournalArticleLocalServiceImpl
 				article.getLayoutUuid(), 0, 0, priority);
 		}
 
+		if ((journalArticleLocalService.fetchLatestArticle(
+				article.getResourcePrimKey(),
+				WorkflowConstants.STATUS_APPROVED) != null) &&
+			(assetEntry != null)) {
+
+			_assetEntryLocalService.updateVisible(assetEntry, true);
+		}
+
 		_assetLinkLocalService.updateLinks(
 			userId, assetEntry.getEntryId(), assetLinkEntryIds,
 			AssetLinkConstants.TYPE_RELATED);


### PR DESCRIPTION
Hi Team,

Could you please review this pull request?
https://liferay.atlassian.net/browse/LPS-204596
Thank you!

------

**Reproduction Steps:**

1. Add an Asset Publish to the Home page and configure Asset Selection to Dynamic
2. Create a Web Content: MyWC
3. Enable Local Staging
4. Assert that MyWC is visible in both Staging and Live
5. Edit MyWC again in order to to create a newer version of it
6. Go to Version history and expire version 1.0. Version 1.1 is still approved.
7. Go to Publishing > Staging and perform a new Publish Process

**Expected**
MyWC is still visible in the Home page in both Staging and Live

**Actual**
MyWC is not visible anymore in Live site

**Solution:**
As AssetEntry was updated on every version's iteration, I checked if there is any non-expired version, and updated the visible status.
