### PR TITLE
LPS-206284 Apply master page plid when creating an utility page

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_utility_page_entry_master_layout.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/select_layout_utility_page_entry_master_layout.jsp
@@ -47,7 +47,7 @@ renderResponse.setTitle(LanguageUtil.get(request, "select-master-page"));
 								).setRedirect(
 									themeDisplay.getURLCurrent()
 								).setParameter(
-									"masterLayoutPlid", selectLayoutPageTemplateEntryDisplayContext.getMasterLayoutPlid()
+									"masterLayoutPlid", masterLayoutPageTemplateEntry.getPlid()
 								).setParameter(
 									"type", selectLayoutPageTemplateEntryDisplayContext.getType()
 								).buildString()


### PR DESCRIPTION
Same as [SelectLayoutMasterLayoutVerticalCard.java#L73](https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/frontend/taglib/clay/servlet/taglib/SelectLayoutMasterLayoutVerticalCard.java#L73) 
or
[SelectDisplayPageMasterLayoutVerticalCard.java#L54
](https://github.com/liferay/liferay-portal/blob/a9c43c6469feeabf4b34ced92493c3cc337f64b1/modules/apps/layout/layout-page-template-admin-web/src/main/java/com/liferay/layout/page/template/admin/web/internal/frontend/taglib/clay/servlet/taglib/SelectDisplayPageMasterLayoutVerticalCard.java#L54)
[selectLayoutPageTemplateEntryDisplayContext.getMasterLayoutPlid()](https://github.com/liferay/liferay-portal/blob/3f610aea9cea2c660cc3aee4b2f0d836dcb66b2e/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/SelectLayoutPageTemplateEntryDisplayContext.java#L225) is expecting to have the param masterLayoutPlid in the request 