### PR TITLE
LPS-195861 - Avoiding UI Error regarding AssetListEntrySegmentsEntryRel 

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/exportimport/content/processor/AssetListEntryExportImportContentProcessor.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/exportimport/content/processor/AssetListEntryExportImportContentProcessor.java
@@ -144,6 +144,10 @@ public class AssetListEntryExportImportContentProcessor
 				String queryValues = unicodeProperties.getProperty(
 					"queryValues" + index);
 
+				if (Validator.isNull(queryValues)) {
+					continue;
+				}
+
 				long[] categoryIds = GetterUtil.getLongValues(
 					queryValues.split(","));
 

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/exportimport/content/processor/AssetListEntryExportImportContentProcessor.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/exportimport/content/processor/AssetListEntryExportImportContentProcessor.java
@@ -302,6 +302,10 @@ public class AssetListEntryExportImportContentProcessor
 				String queryValues = unicodeProperties.getProperty(
 					"queryValues" + index);
 
+				if (Validator.isNull(queryValues)) {
+					continue;
+				}
+
 				long[] categoryIds = GetterUtil.getLongValues(
 					queryValues.split(","));
 


### PR DESCRIPTION
Link: https://liferay.atlassian.net/browse/LPD-1773

Previous PR analysis: https://github.com/liferay-echo/liferay-portal/pull/13967#issuecomment-1757972704

Hi team, using the customer database, when exporting their portal and trying to import, I faced some null values. This fix has the intention of solving most part/more of the empty queries verification we have through the Content Processor, avoiding UI errors such as this one reported by the customer. Let me know your thoughts about this. Thanks!

```
Se produjo un error inesperado con el proceso de publicación. Consulte la configuración de publicación y del portal.
The model.resource.com.liferay.asset.list.model.AssetListEntrySegmentsEntryRel cb1e39d2-e79b-3df7-a848-742be9fa22f1 could not be imported because of the following error: null.
```

---

We also could have a SessionMessage addition after verifying the query values are empty here: https://github.com/liferay/liferay-portal/blob/master/modules/apps/asset/asset-list-web/src/main/java/com/liferay/asset/list/web/internal/display/context/EditAssetListDisplayContext.java#L369
The intention would be add an extra info to the customer in order to avoid any future error. Yet, I believe this should be treated as a feature to be analyzed with the design and product owner team. 

![image](https://github.com/liferay-echo/liferay-portal/assets/41641596/7e2edd01-1fa1-4c56-b8b8-6290a1000122)
