### PR TITLE
LPD-7239 Screen reader does not read icon in Pages tree

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumnsItem.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumnsItem.js
@@ -452,16 +452,25 @@ const MillerColumnsItem = ({
 				>
 					{viewUrl ? (
 						<ClayLink
-							aria-label={
-								Liferay.FeatureFlags['LPS-174417'] &&
-								hasDuplicatedFriendlyURL
-									? `${title}. ${Liferay.Language.get(
-											'restricted-page'
-									  )} ${warningMessage}`
-									: `${title}. ${Liferay.Language.get(
-											'restricted-page'
-									  )}`
-							}
+							aria-label={(() => {
+								if (
+									Liferay.FeatureFlags['LPS-196847'] &&
+									!hasGuestViewPermission
+								) {
+									return `${title}. ${Liferay.Language.get(
+										'restricted-page'
+									)}`;
+								}
+
+								if (
+									Liferay.FeatureFlags['LPS-174417'] &&
+									hasDuplicatedFriendlyURL
+								) {
+									return `${title}. ${warningMessage}`;
+								}
+
+								return title;
+							})()}
 							className="text-truncate"
 							href={viewUrl}
 							target={target}

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTree.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTree.js
@@ -265,7 +265,7 @@ function TreeItem({
 							{Liferay.FeatureFlags['LPS-196847'] &&
 							!item.hasGuestViewPermission ? (
 								<ClayIcon
-									className="c-ml-2 c-mt-0 flex-shrink-0 icon-tooltip lfr-portal-tooltip text-4"
+									className="c-ml-2 c-mt-0 flex-shrink-0 icon-tooltip text-4"
 									data-title={Liferay.Language.get(
 										'restricted-page'
 									)}
@@ -367,7 +367,7 @@ function TreeItem({
 									{Liferay.FeatureFlags['LPS-196847'] &&
 									!item.hasGuestViewPermission ? (
 										<ClayIcon
-											className="c-ml-2 c-mt-0 flex-shrink-0 icon-tooltip lfr-portal-tooltip text-4"
+											className="c-ml-2 c-mt-0 flex-shrink-0 icon-tooltip text-4"
 											data-title={Liferay.Language.get(
 												'restricted-page'
 											)}

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTree.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTree.js
@@ -228,6 +228,27 @@ function TreeItem({
 				<div className="align-items-center d-flex pl-2">
 					{item.regularURL ? (
 						<a
+							aria-label={(() => {
+								if (
+									Liferay.FeatureFlags['LPS-196847'] &&
+									!item.hasGuestViewPermission
+								) {
+									return `${
+										item.name
+									}. ${Liferay.Language.get(
+										'restricted-page'
+									)}`;
+								}
+
+								if (
+									Liferay.FeatureFlags['LPS-174417'] &&
+									item.hasDuplicatedFriendlyURL
+								) {
+									return `${item.name}. ${warningMessage}`;
+								}
+
+								return item.name;
+							})()}
 							className="align-items-center d-flex flex-grow-1 text-decoration-none text-truncate w-100"
 							data-tooltip-floating="true"
 							href={item.regularURL}

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTree.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTree.js
@@ -243,20 +243,13 @@ function TreeItem({
 
 							{Liferay.FeatureFlags['LPS-196847'] &&
 							!item.hasGuestViewPermission ? (
-								<span
-									aria-label={Liferay.Language.get(
+								<ClayIcon
+									className="c-ml-2 c-mt-0 flex-shrink-0 icon-tooltip lfr-portal-tooltip text-4"
+									data-title={Liferay.Language.get(
 										'restricted-page'
 									)}
-									className="c-ml-2 icon-tooltip lfr-portal-tooltip"
-									title={Liferay.Language.get(
-										'restricted-page'
-									)}
-								>
-									<ClayIcon
-										className="c-mt-0 flex-shrink-0 icon-tooltip text-4"
-										symbol="lock"
-									/>
-								</span>
+									symbol="lock"
+								/>
 							) : null}
 
 							{Liferay.FeatureFlags['LPS-174417'] &&
@@ -313,12 +306,31 @@ function TreeItem({
 						<div className="align-items-center d-flex pl-2">
 							{item.regularURL ? (
 								<a
-									aria-label={
-										Liferay.FeatureFlags['LPS-174417'] &&
-										item.hasDuplicatedFriendlyURL
-											? `${item.name}. ${warningMessage}`
-											: item.name
-									}
+									aria-label={(() => {
+										if (
+											Liferay.FeatureFlags[
+												'LPS-196847'
+											] &&
+											!item.hasGuestViewPermission
+										) {
+											return `${
+												item.name
+											}. ${Liferay.Language.get(
+												'restricted-page'
+											)}`;
+										}
+
+										if (
+											Liferay.FeatureFlags[
+												'LPS-174417'
+											] &&
+											item.hasDuplicatedFriendlyURL
+										) {
+											return `${item.name}. ${warningMessage}`;
+										}
+
+										return item.name;
+									})()}
 									className="align-items-center d-flex flex-grow-1 text-decoration-none text-truncate-inline"
 									href={item.regularURL}
 									tabIndex="-1"
@@ -333,20 +345,13 @@ function TreeItem({
 
 									{Liferay.FeatureFlags['LPS-196847'] &&
 									!item.hasGuestViewPermission ? (
-										<span
-											aria-label={Liferay.Language.get(
+										<ClayIcon
+											className="c-ml-2 c-mt-0 flex-shrink-0 icon-tooltip lfr-portal-tooltip text-4"
+											data-title={Liferay.Language.get(
 												'restricted-page'
 											)}
-											className="c-ml-2 icon-tooltip lfr-portal-tooltip"
-											title={Liferay.Language.get(
-												'restricted-page'
-											)}
-										>
-											<ClayIcon
-												className="c-mt-0 flex-shrink-0 text-4"
-												symbol="lock"
-											/>
-										</span>
+											symbol="lock"
+										/>
 									) : null}
 
 									{Liferay.FeatureFlags['LPS-174417'] &&


### PR DESCRIPTION
[Link to ticket](https://liferay.atlassian.net/browse/LPD-7239)

## Steps 

Create a Content Page and set it Guest View permission to false 

**Case 1**

- Go to Product Menu Page tree and use the screen reader

**Case 2**

- Go to Miller Columns and use the screen reader