### PR TITLE
LPD-15111 Migrate ViewUndoInteractionStatesClearedAfterRefreshPage to Playwright

### DIFF
--- a/modules/test/playwright/tests/layout-content-page-editor-web/undoRedo.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/undoRedo.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {applicationsMenuPageTest} from '../../fixtures/applicationsMenuPageTest';
+import {pageEditorPagesTest} from '../../fixtures/pageEditorPages';
+import getRandomId from '../../utils/getRandomId';
+import getFragmentDefinition from './utils/getFragmentDefinition';
+import getPageDefinition from './utils/getPageDefinition';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	applicationsMenuPageTest,
+	pageEditorPagesTest
+);
+
+test('View Undo interaction state is cleared after refreshing the page', async ({
+	apiHelpers,
+	page,
+	pageEditorPage,
+}) => {
+	await page.goto('/');
+
+	// Create a site
+
+	const site = await apiHelpers.headlessSite.createSite(getRandomId());
+
+	// Create a page with a Heading fragment
+
+	const headingId = getRandomId();
+
+	const headingFragment = getFragmentDefinition(
+		headingId,
+		'BASIC_COMPONENT-heading'
+	);
+
+	const layout = await apiHelpers.headlessDelivery.createSitePage(
+		site.id,
+		getRandomId(),
+		getPageDefinition([headingFragment])
+	);
+
+	// Go to edit mode of page
+
+	await pageEditorPage.goToEditMode(site, layout);
+
+	// assert undo button is visible
+
+	expect(page.getByTitle('Undo')).toBeVisible();
+
+	// select the fragment
+
+	await pageEditorPage.selectFragment(headingId);
+
+	// Go to Styles panel and set text to Align Center
+
+	await pageEditorPage.goToConfigurationTab('Styles');
+	await page.getByLabel('Align Center').click();
+
+	// assert undo button is enabled
+
+	await expect(page.getByTitle('Undo')).toBeEnabled();
+
+	// refresh the page
+
+	await page.reload({waitUntil: 'domcontentloaded'});
+
+	// assert Undo button is disabled
+
+	await expect(page.getByTitle('Undo')).toBeDisabled();
+
+	// Delete the site
+
+	await apiHelpers.headlessSite.deleteSite(site.id);
+});


### PR DESCRIPTION
[LPD-15111](https://liferay.atlassian.net/browse/LPD-15111)

I had to await on most of the steps due to the page.reload() inside the test.

Please review my change