### PR TITLE
LPS-206127

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/internal/model/listener/FragmentEntryLinkModelListener.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/internal/model/listener/FragmentEntryLinkModelListener.java
@@ -8,18 +8,29 @@ package com.liferay.fragment.entry.processor.portlet.internal.model.listener;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.PortletRegistry;
+import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
+import com.liferay.layout.page.template.model.LayoutPageTemplateEntry;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.service.LayoutClassedModelUsageLocalService;
 import com.liferay.portal.kernel.exception.ModelListenerException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.BaseModelListener;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ModelListener;
 import com.liferay.portal.kernel.model.Portlet;
+import com.liferay.portal.kernel.model.PortletPreferences;
+import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.util.Portal;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Eudaldo Alonso
@@ -45,6 +56,47 @@ public class FragmentEntryLinkModelListener
 					fragmentEntryLink.getCompanyId(), portletId,
 					fragmentEntryLink.getPlid());
 
+				LayoutPageTemplateEntry layoutPageTemplateEntry =
+					_layoutPageTemplateEntryLocalService.
+						fetchLayoutPageTemplateEntryByPlid(
+							fragmentEntryLink.getPlid());
+
+				if ((layoutPageTemplateEntry != null) &&
+					Objects.equals(
+						layoutPageTemplateEntry.getType(),
+						LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT)) {
+
+					List<Long> masterLayoutPlids = new ArrayList<>();
+
+					masterLayoutPlids.add(fragmentEntryLink.getPlid());
+
+					Layout masterDraftLayout =
+						_layoutLocalService.fetchLayout(
+							_portal.getClassNameId(Layout.class),
+							fragmentEntryLink.getPlid());
+
+					if (masterDraftLayout != null) {
+						masterLayoutPlids.add(masterDraftLayout.getPlid());
+					}
+
+					List<PortletPreferences> portletPreferences =
+						_portletPreferencesLocalService.getPortletPreferences(
+							portletId);
+
+					for (PortletPreferences curPortletPreferences :
+						portletPreferences) {
+
+						if (!masterLayoutPlids.contains(
+							curPortletPreferences.getPlid())) {
+
+							_portletPreferencesLocalService.
+								deletePortletPreferences(
+									curPortletPreferences.
+										getPortletPreferencesId());
+						}
+					}
+				}
+
 				_layoutClassedModelUsageLocalService.
 					deleteLayoutClassedModelUsages(
 						portletId, _portal.getClassNameId(Portlet.class),
@@ -66,10 +118,20 @@ public class FragmentEntryLinkModelListener
 		_layoutClassedModelUsageLocalService;
 
 	@Reference
+	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
+
+	@Reference
 	private Portal _portal;
 
 	@Reference
 	private PortletLocalService _portletLocalService;
+
+	@Reference
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
 
 	@Reference
 	private PortletRegistry _portletRegistry;

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/internal/model/listener/FragmentEntryLinkModelListener.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/internal/model/listener/FragmentEntryLinkModelListener.java
@@ -25,12 +25,12 @@ import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.util.Portal;
 
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
 
 /**
  * @author Eudaldo Alonso
@@ -70,10 +70,9 @@ public class FragmentEntryLinkModelListener
 
 					masterLayoutPlids.add(fragmentEntryLink.getPlid());
 
-					Layout masterDraftLayout =
-						_layoutLocalService.fetchLayout(
-							_portal.getClassNameId(Layout.class),
-							fragmentEntryLink.getPlid());
+					Layout masterDraftLayout = _layoutLocalService.fetchLayout(
+						_portal.getClassNameId(Layout.class),
+						fragmentEntryLink.getPlid());
 
 					if (masterDraftLayout != null) {
 						masterLayoutPlids.add(masterDraftLayout.getPlid());
@@ -84,10 +83,10 @@ public class FragmentEntryLinkModelListener
 							portletId);
 
 					for (PortletPreferences curPortletPreferences :
-						portletPreferences) {
+							portletPreferences) {
 
 						if (!masterLayoutPlids.contains(
-							curPortletPreferences.getPlid())) {
+								curPortletPreferences.getPlid())) {
 
 							_portletPreferencesLocalService.
 								deletePortletPreferences(

--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -436,6 +436,11 @@ public class PortletPreferencesLocalServiceImpl
 	}
 
 	@Override
+	public List<PortletPreferences> getPortletPreferences(String portletId) {
+		return portletPreferencesFinder.findByPortletId(portletId);
+	}
+
+	@Override
 	public List<PortletPreferences> getPortletPreferencesByOwnerId(
 		long ownerId) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PortletPreferencesLocalService.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PortletPreferencesLocalService.java
@@ -314,6 +314,9 @@ public interface PortletPreferencesLocalService
 		long plid, String portletId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public List<PortletPreferences> getPortletPreferences(String portletId);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<PortletPreferences> getPortletPreferencesByOwnerId(
 		long ownerId);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PortletPreferencesLocalServiceUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PortletPreferencesLocalServiceUtil.java
@@ -373,6 +373,12 @@ public class PortletPreferencesLocalServiceUtil {
 		return getService().getPortletPreferences(plid, portletId);
 	}
 
+	public static List<PortletPreferences> getPortletPreferences(
+		String portletId) {
+
+		return getService().getPortletPreferences(portletId);
+	}
+
 	public static List<PortletPreferences> getPortletPreferencesByOwnerId(
 		long ownerId) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/PortletPreferencesLocalServiceWrapper.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/PortletPreferencesLocalServiceWrapper.java
@@ -431,6 +431,13 @@ public class PortletPreferencesLocalServiceWrapper
 	}
 
 	@Override
+	public java.util.List<PortletPreferences> getPortletPreferences(
+		String portletId) {
+
+		return _portletPreferencesLocalService.getPortletPreferences(portletId);
+	}
+
+	@Override
 	public java.util.List<PortletPreferences> getPortletPreferencesByOwnerId(
 		long ownerId) {
 

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 29.1.0
+version 29.2.0


### PR DESCRIPTION
Resend of #15001 with the changes requested by Brian in https://github.com/brianchandotcom/liferay-portal/pull/146396

Motivation
=======
Fix https://liferay.atlassian.net/browse/LPS-206127
When removing a fragment that has an embedded widget from a master page, orphaned portletPreferences are left in the database.

Proposed Solution
========
First I considered that the cause of the problem was the creation of these portletPreferences that are orphaned when removing the fragment but they are necessary when rendering the layouts.
After discarding that, I focused on deleting these preferences when removing the fragment from the master page.

Steps to Verify
========
1. Create a fragment MyFragment with the following HTML code. It has an embedded SearchBar widget

```
<div class="fragment_1">
	<lfr-widget-search-bar id="MySB"></lfr-widget-search-bar>
</div>
```
1. Create a Master Page: MyMasterPage
1. Add MyFragment
1. Create a page from MyMasterPage: MyPage
1. Click Publish
1. Find de plid. For instance, open the JS Console and execute themeDisplay.getPlid()

**Checkpoint:** 
`select * from portletpreferences p where plid = XX and p.portletid like '%com_liferay_portal_search_web_search_bar_portlet_SearchBarPortlet%' `
returns 1 row

1. Go to MyMasterPage
1. Remove MyFragment
1. Add MyFragment again
1. Publish Master
1. Go to MyPage
1. Check your database again:
` select * from portletpreferences p where plid = XX and p.portletid like '%com_liferay_portal_search_web_search_bar_portlet_SearchBarPortlet%'`

:+1: **Expected**
Only 1 row is returned. The orphan portletpreference record has been removed

:-1:  **Current**
2 rows are returned. The orphan portletpreference hasn’t been removed