### PR TITLE
LPD-15563

### DIFF
--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/internal/model/listener/FragmentEntryLinkModelListener.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet/src/main/java/com/liferay/fragment/entry/processor/portlet/internal/model/listener/FragmentEntryLinkModelListener.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -85,7 +86,9 @@ public class FragmentEntryLinkModelListener
 					for (PortletPreferences curPortletPreferences :
 							portletPreferences) {
 
-						if (masterLayoutPlids.contains(
+						if ((curPortletPreferences.getPlid() ==
+								PortletKeys.PREFS_PLID_SHARED) ||
+							masterLayoutPlids.contains(
 								curPortletPreferences.getPlid())) {
 
 							continue;


### PR DESCRIPTION
Motivation
=======
Fixing https://liferay.atlassian.net/browse/LPD-15563

Proposed Solution
========
When Portlet Preferences are created for a widget that is included in a master layout and there are other layouts created with this master layout, the Portlet Preferences are created with the shared plid (plid = 0). As this Portlet Preference with plid=0 was being deleted by changes made in https://liferay.atlassian.net/browse/LPD-1681 the configuration was being lost.
That is why I added an exception to not delete the shared Portlet Preferences.

Steps to Verify
========
1. In default site create a master page “myMasterPage”, add search bar widget to top of the page and publish
1. Create a content page “myContentPage” based on “myMasterPage” and publish
1. Visit “myContentPage” to force the render of the page. The search bar should be seen
1. Edit “myMasterPage” and configure the search bar widget. In field “Destination page” enter value “/search”. Save and publish
1. Edit “myMasterPage” again and access search bar widget configuration

**Expected behavior:**
- In Search Bar widget configuration the “Destination page” field has value equals to “/search”

**Actual behavior:**
- In Search Bar widget configuration the “Destination page” field is empty