### PR TITLE
LPD-15505 Take into account the rest of the localizable fields in the translation status label

### DIFF
--- a/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/Field/Field.es.js
+++ b/modules/apps/data-engine/data-engine-js-components-web/src/main/resources/META-INF/resources/js/core/components/Field/Field.es.js
@@ -237,7 +237,15 @@ export function Field({field, itemPath, loc, ...otherProps}) {
 	return (
 		<ErrorBoundary onError={setHasError}>
 			<AutoFocus>
-				<div className="ddm-field" data-field-name={field.fieldName}>
+				<div
+					className="ddm-field"
+					data-ddm-localizable-field={
+						(Liferay.FeatureFlags['LPS-114700'] &&
+							field.localizable) ||
+						null
+					}
+					data-field-name={field.fieldName}
+				>
 					<Suspense fallback={<ClayLoadingIndicator />}>
 						<ParentFieldContext.Provider
 							value={getRootParentField(field, loc, parentField)}

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -211,7 +211,10 @@ export function FieldBase({
 		}
 
 		return Object.entries(localizedValue).map(([locale, value]) => {
-			if (locale === editingLanguageId) {
+			if (
+				!Liferay.FeatureFlags['LPS-114700'] &&
+				locale === editingLanguageId
+			) {
 				return null;
 			}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -217,6 +217,8 @@ export function FieldBase({
 
 			return (
 				<input
+					data-field-name={fieldName}
+					data-languageid={locale}
 					key={locale}
 					name={name.replace(editingLanguageId, locale)}
 					type="hidden"
@@ -224,7 +226,7 @@ export function FieldBase({
 				/>
 			);
 		});
-	}, [localizedValue, editingLanguageId, name, type]);
+	}, [localizedValue, editingLanguageId, fieldName, name, type]);
 
 	const renderLabel =
 		(label && showLabel) || hideField || repeatable || required || tooltip;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/src/main/resources/META-INF/resources/FieldBase/ReactFieldBase.es.js
@@ -19,7 +19,7 @@ import {
 } from 'data-engine-js-components-web';
 import {sub} from 'frontend-js-web';
 import moment from 'moment/min/moment-with-locales';
-import React, {useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useState} from 'react';
 
 import './FieldBase.scss';
 
@@ -230,6 +230,12 @@ export function FieldBase({
 			);
 		});
 	}, [localizedValue, editingLanguageId, fieldName, name, type]);
+
+	useEffect(() => {
+		if (Liferay.FeatureFlags['LPS-114700']) {
+			Liferay.fire('inputLocalized:updateTranslationStatus');
+		}
+	}, [hiddenTranslations.length]);
 
 	const renderLabel =
 		(label && showLabel) || hideField || repeatable || required || tooltip;

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/ReactFieldBase.es.js
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-form-field-type/test/js/FieldBase/ReactFieldBase.es.js
@@ -218,6 +218,44 @@ describe('ReactFieldBase', () => {
 		expect(getByText('Tooltip Description')).toBeInTheDocument();
 	});
 
+	it('fires inputLocalized:updateTranslationStatus event when component is mounted', () => {
+		Liferay.FeatureFlags['LPS-114700'] = true;
+
+		render(<FieldBaseWithProvider />);
+
+		expect(global.Liferay.fire).toHaveBeenCalledWith(
+			'inputLocalized:updateTranslationStatus'
+		);
+
+		Liferay.FeatureFlags['LPS-114700'] = false;
+	});
+
+	it('renders the hidden inputs with data-languageid and data-field-name', () => {
+		Liferay.FeatureFlags['LPS-114700'] = true;
+
+		const localizedValue = {ca_ES: 'test_ca_ES', en_US: 'test_en_US'};
+
+		render(
+			<FieldBaseWithProvider
+				fieldName="field_name"
+				localizedValue={localizedValue}
+				name="test_name"
+			/>
+		);
+
+		const inputs = document.querySelectorAll('[name="test_name"]');
+
+		inputs.forEach((input, i) => {
+			expect(input).toHaveAttribute('data-field-name', 'field_name');
+			expect(input).toHaveAttribute(
+				'data-languageid',
+				Object.keys(localizedValue)[i]
+			);
+		});
+
+		Liferay.FeatureFlags['LPS-114700'] = false;
+	});
+
 	describe('Hide Field', () => {
 		it('renders the FieldBase with hideField markup', () => {
 			const {getAllByText, getByText} = render(

--- a/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
+++ b/modules/apps/frontend-js/frontend-js-aui-web/src/main/resources/META-INF/resources/liferay/input_localized.js
@@ -703,7 +703,7 @@ AUI.add(
 				},
 
 				INPUT_HIDDEN_TEMPLATE:
-					'<input data-field-name={name} data-language-id={languageId} id="{namespace}{id}_{languageId}" name="{namespace}{fieldNamePrefix}{name}_{languageId}{fieldNameSuffix}" type="hidden" value="" />',
+					'<input data-field-name={name} data-languageid={languageId} id="{namespace}{id}_{languageId}" name="{namespace}{fieldNamePrefix}{name}_{languageId}{fieldNameSuffix}" type="hidden" value="" />',
 
 				TRANSLATION_STATUS_TEMPLATE:
 					'<span aria-label="{translationAriaLabel}" role="button" tabindex="0"> {languageId} <span class="dropdown-item-indicator-end w-auto"><span class="label label-{translationStatusCssClass}">{translationStatus}</span></span></span>',

--- a/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
+++ b/modules/apps/frontend-js/frontend-js-components-web/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.tsx
@@ -9,7 +9,14 @@ import ClayDropDown from '@clayui/drop-down';
 import ClayIcon from '@clayui/icon';
 import ClayLayout from '@clayui/layout';
 import {sub} from 'frontend-js-web';
-import React, {Ref, useEffect, useMemo, useRef, useState} from 'react';
+import React, {
+	MutableRefObject,
+	Ref,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from 'react';
 
 import useId from '../hooks/useId';
 import {Locale, Translations} from './TranslationAdminContent';
@@ -34,6 +41,7 @@ interface IProps extends Translations {
 	showOnlyFlags?: boolean;
 	small?: boolean;
 	translationProgress?: TranslationProgress | null;
+	triggerRef?: MutableRefObject<HTMLButtonElement | null>;
 }
 
 export interface TranslationProgress {
@@ -45,6 +53,7 @@ interface TriggerButtonProps {
 	displayType: DisplayType;
 	selectedItem: Locale;
 	small: boolean;
+	triggerRef?: MutableRefObject<HTMLButtonElement | null>;
 }
 
 // These variables are defined here, out of the component, to avoid
@@ -54,13 +63,28 @@ const noop = () => {};
 
 const TriggerButton = React.forwardRef(
 	(
-		{displayType, selectedItem, small, ...props}: TriggerButtonProps,
+		{
+			displayType,
+			selectedItem,
+			small,
+			triggerRef,
+			...props
+		}: TriggerButtonProps,
 		ref: Ref<HTMLButtonElement>
 	) => {
 		const ariaLabelButton = sub(
 			Liferay.Language.get('select-a-language.-current-language-x'),
 			selectedItem.displayName
 		);
+
+		useEffect(() => {
+			if (ref && triggerRef) {
+
+				// @ts-ignore
+
+				triggerRef.current = ref.current;
+			}
+		}, [ref, triggerRef]);
 
 		return Liferay.FeatureFlags['LPS-114700'] &&
 			displayType === DISPLAY_TYPE.HORIZONTAL ? (
@@ -114,8 +138,9 @@ export default function TranslationAdminSelector({
 	selectedLanguageId: initialSelectedLanguageId,
 	showOnlyFlags,
 	small = false,
-	translations = null,
 	translationProgress = null,
+	translations = null,
+	triggerRef,
 }: IProps) {
 	const [activeLanguageIds, setActiveLanguageIds] = useState<
 		Liferay.Language.Locale[]
@@ -128,7 +153,11 @@ export default function TranslationAdminSelector({
 	const [translationModalVisible, setTranslationModalVisible] = useState(
 		false
 	);
-	const triggerRef = useRef<HTMLButtonElement | null>(null);
+	const buttonRef = useRef<HTMLButtonElement | null>(null);
+
+	if (!triggerRef) {
+		triggerRef = buttonRef;
+	}
 
 	const handleCloseTranslationModal = (
 		activeLanguageIds: Liferay.Language.Locale[]
@@ -188,6 +217,7 @@ export default function TranslationAdminSelector({
 					(locale) => locale.id === selectedLanguageId
 				)}
 				selectedKey={selectedLanguageId}
+				triggerRef={triggerRef}
 			>
 				{(item) => (
 					<Option key={item.id} textValue={item.label}>
@@ -227,7 +257,9 @@ export default function TranslationAdminSelector({
 					<TriggerButton
 						displayType={displayType}
 						ref={(node) => {
-							triggerRef.current = node;
+							if (triggerRef) {
+								triggerRef.current = node;
+							}
 						}}
 						selectedItem={selectedLocale}
 						small={small}
@@ -246,7 +278,7 @@ export default function TranslationAdminSelector({
 									setSelectedLanguageId(activeLocale.id);
 									setSelectorDropdownActive(false);
 
-									triggerRef.current?.focus();
+									triggerRef?.current?.focus();
 								}}
 								symbolLeft={active ? 'check-small' : undefined}
 							>

--- a/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/TranslationAdminSelector.js
+++ b/modules/apps/frontend-js/frontend-js-components-web/test/translation_manager/TranslationAdminSelector.js
@@ -375,4 +375,22 @@ describe('TranslationAdminSelector', () => {
 
 		Liferay.FeatureFlags['LPS-114700'] = false;
 	});
+
+	it('allows passing a trigger reference from outside', () => {
+		Liferay.FeatureFlags['LPS-114700'] = true;
+
+		const triggerRef = React.createRef();
+
+		render(
+			<TranslationAdminSelector
+				{...props}
+				selectedLanguageId="en_US"
+				triggerRef={triggerRef}
+			/>
+		);
+
+		expect(triggerRef.current).toBeInTheDocument();
+
+		Liferay.FeatureFlags['LPS-114700'] = false;
+	});
 });

--- a/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.d.ts
+++ b/modules/apps/frontend-js/frontend-js-components-web/types/src/main/resources/META-INF/resources/translation_manager/TranslationAdminSelector.d.ts
@@ -3,8 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-/// <reference types="react" />
-
+import {MutableRefObject} from 'react';
 import {Translations} from './TranslationAdminContent';
 declare const DISPLAY_TYPE: {
 	readonly DEFAULT: 'DEFAULT';
@@ -22,6 +21,7 @@ interface IProps extends Translations {
 	showOnlyFlags?: boolean;
 	small?: boolean;
 	translationProgress?: TranslationProgress | null;
+	triggerRef?: MutableRefObject<HTMLButtonElement | null>;
 }
 export interface TranslationProgress {
 	totalItems: number;
@@ -39,7 +39,8 @@ export default function TranslationAdminSelector({
 	selectedLanguageId: initialSelectedLanguageId,
 	showOnlyFlags,
 	small,
-	translations,
 	translationProgress,
+	translations,
+	triggerRef,
 }: IProps): JSX.Element;
 export {};

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.tsx
@@ -4,9 +4,11 @@
  */
 
 import {Locale, TranslationAdminSelector} from 'frontend-js-components-web';
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {useEffect, useMemo, useRef, useState} from 'react';
 
 type Field = Record<Liferay.Language.Locale, string>;
+
+type Fields = Record<string, Field> | null;
 
 interface Props {
 	defaultLanguageId: Liferay.Language.Locale;
@@ -17,19 +19,25 @@ interface Props {
 
 export default function TranslationManager({
 	defaultLanguageId,
-	fields,
+	fields: initialFields,
 	locales,
 	selectedLanguageId: initialSelectedLanguageId,
 }: Props) {
+	const [fields, setFields] = useState<Fields>(null);
 	const [selectedLanguageId, setSelectedLanguageId] = useState<
 		Liferay.Language.Locale
 	>(initialSelectedLanguageId);
 	const [translations, setTranslations] = useState(
-		fieldToTranslations(fields)
+		fieldToTranslations(initialFields)
 	);
+	const triggerRef = useRef<HTMLButtonElement | null>(null);
 
 	useEffect(() => {
 		const updateTranslations = () => {
+			if (!fields) {
+				return;
+			}
+
 			const newTranslations = Object.keys(fields).map((fieldName) => {
 				const languages = Array.from(
 					document.querySelectorAll<HTMLInputElement>(
@@ -51,10 +59,34 @@ export default function TranslationManager({
 			setTranslations(newTranslations);
 		};
 
-		Liferay.on(
-			'inputLocalized:updateTranslationStatus',
-			updateTranslations
-		);
+		const getLocalizableFields = () => {
+			const ddmFields = Array.from(
+				document.querySelectorAll<HTMLInputElement>(
+					`[data-ddm-localizable-field]`
+				)
+			)
+				.map((field) => field.dataset.fieldName!)
+				.reduce((acc, name) => ({...acc, [name]: {}}), {});
+
+			const fields = {...initialFields, ...ddmFields};
+
+			setFields(fields);
+
+			triggerRef.current?.removeEventListener(
+				'click',
+				getLocalizableFields
+			);
+		};
+
+		if (fields) {
+			Liferay.on(
+				'inputLocalized:updateTranslationStatus',
+				updateTranslations
+			);
+		}
+		else {
+			triggerRef.current?.addEventListener('click', getLocalizableFields);
+		}
 
 		return () => {
 			Liferay.detach(
@@ -62,7 +94,7 @@ export default function TranslationManager({
 				updateTranslations
 			);
 		};
-	}, [fields]);
+	}, [fields, initialFields]);
 
 	useEffect(() => {
 		Liferay.fire('inputLocalized:localeChanged', {
@@ -98,11 +130,13 @@ export default function TranslationManager({
 			translationProgress={
 				Object.keys(translatedItems).length
 					? {
-							totalItems: Object.keys(fields).length,
+							totalItems: Object.keys(fields || initialFields)
+								.length,
 							translatedItems,
 					  }
 					: null
 			}
+			triggerRef={triggerRef}
 		/>
 	);
 }

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.tsx
@@ -33,7 +33,7 @@ export default function TranslationManager({
 	const triggerRef = useRef<HTMLButtonElement | null>(null);
 
 	useEffect(() => {
-		const updateTranslations = () => {
+		const updateTranslations = (fields: Fields) => {
 			if (!fields) {
 				return;
 			}
@@ -72,16 +72,20 @@ export default function TranslationManager({
 
 			setFields(fields);
 
+			updateTranslations(fields);
+
 			triggerRef.current?.removeEventListener(
 				'click',
 				getLocalizableFields
 			);
 		};
 
+		const updateTranslationStatus = () => updateTranslations(fields);
+
 		if (fields) {
 			Liferay.on(
 				'inputLocalized:updateTranslationStatus',
-				updateTranslations
+				updateTranslationStatus
 			);
 		}
 		else {
@@ -91,7 +95,7 @@ export default function TranslationManager({
 		return () => {
 			Liferay.detach(
 				'inputLocalized:updateTranslationStatus',
-				updateTranslations
+				updateTranslationStatus
 			);
 		};
 	}, [fields, initialFields]);

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.tsx
@@ -47,7 +47,7 @@ export default function TranslationManager({
 					.filter((input) => input.value)
 					.map(
 						(input) =>
-							input.dataset.languageId as Liferay.Language.Locale
+							input.dataset.languageid as Liferay.Language.Locale
 					);
 
 				return {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.tsx
@@ -4,7 +4,7 @@
  */
 
 import {Locale, TranslationAdminSelector} from 'frontend-js-components-web';
-import React, {useEffect, useMemo, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 type Field = Record<Liferay.Language.Locale, string>;
 
@@ -32,56 +32,56 @@ export default function TranslationManager({
 	);
 	const triggerRef = useRef<HTMLButtonElement | null>(null);
 
-	useEffect(() => {
-		const updateTranslations = (fields: Fields) => {
-			if (!fields) {
-				return;
-			}
+	const updateTranslations = (fields: Fields) => {
+		if (!fields) {
+			return;
+		}
 
-			const newTranslations = Object.keys(fields).map((fieldName) => {
-				const languages = Array.from(
-					document.querySelectorAll<HTMLInputElement>(
-						`[type="hidden"][data-field-name="${fieldName}"]`
-					)
-				)
-					.filter((input) => input.value)
-					.map(
-						(input) =>
-							input.dataset.languageid as Liferay.Language.Locale
-					);
-
-				return {
-					fieldName,
-					languages,
-				};
-			});
-
-			setTranslations(newTranslations);
-		};
-
-		const getLocalizableFields = () => {
-			const ddmFields = Array.from(
+		const newTranslations = Object.keys(fields).map((fieldName) => {
+			const languages = Array.from(
 				document.querySelectorAll<HTMLInputElement>(
-					`[data-ddm-localizable-field]`
+					`[type="hidden"][data-field-name="${fieldName}"]`
 				)
 			)
-				.map((field) => field.dataset.fieldName!)
-				.reduce((acc, name) => ({...acc, [name]: {}}), {});
+				.filter((input) => input.value)
+				.map(
+					(input) =>
+						input.dataset.languageid as Liferay.Language.Locale
+				);
 
-			const fields = {...initialFields, ...ddmFields};
+			return {
+				fieldName,
+				languages,
+			};
+		});
 
-			setFields(fields);
+		setTranslations(newTranslations);
+	};
 
-			updateTranslations(fields);
+	const updateTranslationStatus = useCallback(
+		() => updateTranslations(fields),
+		[fields]
+	);
 
-			triggerRef.current?.removeEventListener(
-				'click',
-				getLocalizableFields
-			);
-		};
+	const getLocalizableFields = useCallback(() => {
+		const ddmFields = Array.from(
+			document.querySelectorAll<HTMLInputElement>(
+				`[data-ddm-localizable-field]`
+			)
+		)
+			.map((field) => field.dataset.fieldName!)
+			.reduce((acc, name) => ({...acc, [name]: {}}), {});
 
-		const updateTranslationStatus = () => updateTranslations(fields);
+		const fields = {...initialFields, ...ddmFields};
 
+		setFields(fields);
+
+		updateTranslations(fields);
+
+		triggerRef.current?.removeEventListener('click', getLocalizableFields);
+	}, [initialFields]);
+
+	useEffect(() => {
 		if (fields) {
 			Liferay.on(
 				'inputLocalized:updateTranslationStatus',
@@ -98,7 +98,7 @@ export default function TranslationManager({
 				updateTranslationStatus
 			);
 		};
-	}, [fields, initialFields]);
+	}, [fields, initialFields, getLocalizableFields, updateTranslationStatus]);
 
 	useEffect(() => {
 		Liferay.fire('inputLocalized:localeChanged', {

--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.tsx
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.tsx
@@ -63,23 +63,42 @@ export default function TranslationManager({
 		[fields]
 	);
 
-	const getLocalizableFields = useCallback(() => {
-		const ddmFields = Array.from(
-			document.querySelectorAll<HTMLInputElement>(
-				`[data-ddm-localizable-field]`
+	const getLocalizableFields = useCallback(
+		(event) => {
+			if (
+				event.type === 'keydown' &&
+				event.key !== 'Enter' &&
+				event.key !== 'Scape'
+			) {
+				return;
+			}
+
+			const ddmFields = Array.from(
+				document.querySelectorAll<HTMLInputElement>(
+					`[data-ddm-localizable-field]`
+				)
 			)
-		)
-			.map((field) => field.dataset.fieldName!)
-			.reduce((acc, name) => ({...acc, [name]: {}}), {});
+				.map((field) => field.dataset.fieldName!)
+				.reduce((acc, name) => ({...acc, [name]: {}}), {});
 
-		const fields = {...initialFields, ...ddmFields};
+			const fields = {...initialFields, ...ddmFields};
 
-		setFields(fields);
+			setFields(fields);
 
-		updateTranslations(fields);
+			updateTranslations(fields);
 
-		triggerRef.current?.removeEventListener('click', getLocalizableFields);
-	}, [initialFields]);
+			triggerRef.current?.removeEventListener(
+				'click',
+				getLocalizableFields
+			);
+
+			triggerRef.current?.removeEventListener(
+				'keydown',
+				getLocalizableFields
+			);
+		},
+		[initialFields]
+	);
 
 	useEffect(() => {
 		if (fields) {
@@ -90,6 +109,10 @@ export default function TranslationManager({
 		}
 		else {
 			triggerRef.current?.addEventListener('click', getLocalizableFields);
+			triggerRef.current?.addEventListener(
+				'keydown',
+				getLocalizableFields
+			);
 		}
 
 		return () => {

--- a/modules/apps/journal/journal-web/test/js/translation_manager/TranslationManager.test.tsx
+++ b/modules/apps/journal/journal-web/test/js/translation_manager/TranslationManager.test.tsx
@@ -5,6 +5,7 @@
 
 import '@testing-library/jest-dom/extend-expect';
 import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 
 import TranslationManager, {
@@ -72,8 +73,10 @@ describe('TranslationManager', () => {
 		]);
 	});
 
-	it('attaches inputLocalized:updateTranslationStatus event on mount', () => {
+	it('attaches inputLocalized:updateTranslationStatus event when the button is clicked', () => {
 		renderComponent();
+
+		userEvent.click(screen.getByRole('button'));
 
 		expect(global.Liferay.on).toHaveBeenCalledWith(
 			'inputLocalized:updateTranslationStatus',

--- a/modules/apps/journal/journal-web/types/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.d.ts
+++ b/modules/apps/journal/journal-web/types/src/main/resources/META-INF/resources/js/translation_manager/TranslationManager.d.ts
@@ -15,7 +15,7 @@ interface Props {
 }
 export default function TranslationManager({
 	defaultLanguageId,
-	fields,
+	fields: initialFields,
 	locales,
 	selectedLanguageId: initialSelectedLanguageId,
 }: Props): JSX.Element;

--- a/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
+++ b/portal-web/docroot/html/taglib/ui/input_localized/page.jsp
@@ -116,7 +116,7 @@ Map<String, Map<String, String>> languagesTranslationsAriaLabelsMap = new HashMa
 			}
 		%>
 
-			<aui:input data-languageid="<%= curLanguageId %>" dir="<%= curLanguageDir %>" disabled="<%= disabled %>" id="<%= HtmlUtil.escapeAttribute(id + StringPool.UNDERLINE + curLanguageId) %>" name="<%= HtmlUtil.escapeAttribute(fieldNamePrefix + name + StringPool.UNDERLINE + curLanguageId + fieldNameSuffix) %>" type="hidden" value="<%= languageValue %>" />
+			<aui:input data-field-name="<%= HtmlUtil.escapeAttribute(id + fieldSuffix) %>" data-languageid="<%= curLanguageId %>" dir="<%= curLanguageDir %>" disabled="<%= disabled %>" id="<%= HtmlUtil.escapeAttribute(id + StringPool.UNDERLINE + curLanguageId) %>" name="<%= HtmlUtil.escapeAttribute(fieldNamePrefix + name + StringPool.UNDERLINE + curLanguageId + fieldNameSuffix) %>" type="hidden" value="<%= languageValue %>" />
 
 		<%
 		}


### PR DESCRIPTION
The label that shows the status of the translation has to take into account all **localizable fields**, both the Name and Metadata, as well as the Fields (ddm fields)

<img width="600" alt="Screen Shot 2024-01-26 at 4 04 56 PM" src="https://github.com/liferay-echo/liferay-portal/assets/9701095/ad0cd85a-8f85-4a34-be9c-3a3051178e48">
<img width="600" alt="Screen Shot 2024-01-26 at 4 10 51 PM" src="https://github.com/liferay-echo/liferay-portal/assets/9701095/e848e39a-5d31-4f22-ae39-fd641540a4ad">


