### PR TITLE
LPD-15582 Increase z-index when focusing the button.

### DIFF
--- a/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
+++ b/modules/apps/journal/journal-web/src/main/resources/META-INF/resources/css/main.scss
@@ -209,7 +209,7 @@ $productMenuWidth: 320px;
 			padding-top: 0;
 			position: fixed;
 			width: $productMenuWidth;
-			z-index: 2;
+			z-index: 5;
 
 			@include media-breakpoint-down(xs) {
 				height: auto;


### PR DESCRIPTION
We need to increase z-index to 5 as when the button is in focus it has a maximum z-index of 4, this should not affect structures as the button is disabled.
![image (16)](https://github.com/liferay-echo/liferay-portal/assets/59687465/4fe57b8f-ace8-4703-81f6-37fbfb91775e)
