### PR TITLE
LPD-16327 Define a value so that it is not taken from the label

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/text_styles.jsp
+++ b/modules/apps/portlet-configuration/portlet-configuration-css-web/src/main/resources/META-INF/resources/text_styles.jsp
@@ -53,7 +53,7 @@ DecimalFormat decimalFormat = portletConfigurationCSSPortletDisplayContext.getDe
 			<aui:option label="justify" selected='<%= Objects.equals(portletConfigurationCSSPortletDisplayContext.getTextDataProperty("textAlign"), "justify") %>' />
 			<aui:option label="left" selected='<%= Objects.equals(portletConfigurationCSSPortletDisplayContext.getTextDataProperty("textAlign"), "left") %>' />
 			<aui:option label="right" selected='<%= Objects.equals(portletConfigurationCSSPortletDisplayContext.getTextDataProperty("textAlign"), "right") %>' />
-			<aui:option label="center[alignment]" selected='<%= Objects.equals(portletConfigurationCSSPortletDisplayContext.getTextDataProperty("textAlign"), "center") %>' />
+			<aui:option label="center[alignment]" selected='<%= Objects.equals(portletConfigurationCSSPortletDisplayContext.getTextDataProperty("textAlign"), "center") %>' value="center" />
 		</aui:select>
 
 		<aui:select label="text-decoration" name="textDecoration" showEmptyOption="<%= true %>">


### PR DESCRIPTION
Motivation
Portlet Look and Feel configuration can't save Text Styles -> Alignment = center
https://liferay.atlassian.net/browse/LPD-16327

Proposed Solution
the label value of this aui:option was changed to better reflect a localisation requirement. But if a value attribute is not defined this new label center[alignment] is used as the value. So, let's add a value attribute.
In regards of upgrade steps, I can create one, but I feel that anyone still using widget pages and meeting this issue would have immediately reported it. What do you think, should we add an upgrade step?

Steps to Verify
In Site Builder > Pages > Create a new Widget Page
Add an Asset Publisher to the new page
Click on the widget's three dot menu > Select Look and Feel Configuration
Click on "Text Styles" tab > Click down menu for “Alignment”
Click on "Center"
Click Save
Expected behaviour: The Center value stays in the modal
Actual Results: The Center value disappears in the modal

Cheers,
Balázs