### PR TITLE
LPD-16444

### DIFF
--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -1092,20 +1092,20 @@ public class JournalEditArticleDisplayContext {
 	}
 
 	public String getSelectedLanguageId() {
-		if (Validator.isNotNull(_defaultLanguageId)) {
-			return _defaultLanguageId;
+		if (Validator.isNotNull(_selectedLanguageId)) {
+			return _selectedLanguageId;
 		}
 
-		String defaultLanguageId = ParamUtil.getString(
+		String selectedLanguageId = ParamUtil.getString(
 			_httpServletRequest, "languageId");
 
-		if (Validator.isNull(defaultLanguageId)) {
-			defaultLanguageId = getDefaultArticleLanguageId();
+		if (Validator.isNull(selectedLanguageId)) {
+			selectedLanguageId = getDefaultArticleLanguageId();
 		}
 
-		_defaultLanguageId = defaultLanguageId;
+		_selectedLanguageId = selectedLanguageId;
 
-		return _defaultLanguageId;
+		return _selectedLanguageId;
 	}
 
 	public List<TabsItem> getTabsItems() {
@@ -1682,7 +1682,7 @@ public class JournalEditArticleDisplayContext {
 	private DDMTemplate _ddmTemplate;
 	private String _ddmTemplateKey;
 	private String _defaultArticleLanguageId;
-	private String _defaultLanguageId;
+	private String _selectedLanguageId;
 	private LayoutPageTemplateEntry _defaultLayoutPageTemplateEntry;
 	private Integer _displayPageType;
 	private Long _folderId;

--- a/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
+++ b/modules/apps/journal/journal-web/src/main/java/com/liferay/journal/web/internal/display/context/JournalEditArticleDisplayContext.java
@@ -556,7 +556,8 @@ public class JournalEditArticleDisplayContext {
 			return _defaultArticleLanguageId;
 		}
 
-		String defaultArticleLanguageId = null;
+		String defaultArticleLanguageId = ParamUtil.getString(
+			_httpServletRequest, "defaultLanguageId", null);
 
 		if (Validator.isNotNull(getArticleId())) {
 			DDMFormValues ddmFormValues = _article.getDDMFormValues();
@@ -564,8 +565,9 @@ public class JournalEditArticleDisplayContext {
 			defaultArticleLanguageId = LocaleUtil.toLanguageId(
 				ddmFormValues.getDefaultLocale());
 		}
-		else if (getClassNameId() ==
-					JournalArticleConstants.CLASS_NAME_ID_DEFAULT) {
+		else if ((defaultArticleLanguageId == null) &&
+				 (getClassNameId() ==
+					 JournalArticleConstants.CLASS_NAME_ID_DEFAULT)) {
 
 			defaultArticleLanguageId = _getDDMStructureDefaultLanguageId();
 		}
@@ -1682,7 +1684,6 @@ public class JournalEditArticleDisplayContext {
 	private DDMTemplate _ddmTemplate;
 	private String _ddmTemplateKey;
 	private String _defaultArticleLanguageId;
-	private String _selectedLanguageId;
 	private LayoutPageTemplateEntry _defaultLayoutPageTemplateEntry;
 	private Integer _displayPageType;
 	private Long _folderId;
@@ -1699,6 +1700,7 @@ public class JournalEditArticleDisplayContext {
 	private String _redirect;
 	private Long _refererPlid;
 	private String _referringPortletResource;
+	private String _selectedLanguageId;
 	private Boolean _showHeader;
 	private Boolean _showSelectFolder;
 	private final ThemeDisplay _themeDisplay;


### PR DESCRIPTION
Motivation
=======
Solving https://liferay.atlassian.net/browse/LPD-16444

Steps to Verify
========
1. Access to System Settings → Section CONTENT AND DATA -> ‘Web Content' ->System Scope → Administration and check 'Changeable Default Language’:
If checked, the default language of web content articles will be changeable. The default language of web content articles is inherited from the site settings.

1. Create one site named 'cvx' and configure Localization in Site Setting with next languages:
Default language: Catalan (Spain)
Current languages: Catalan (Spain) and Spanish (Spain)

1. Create one vocabulary inside ‘cvx' call 'Content’ and select associated asset type to Basic Web Content. Mark it as required.

1. Create one category inside 'Content' vocabulary.

1. Access site 'cvx' → Content & Data → Web Content

1. Access to create Basic Web Content and first change de default language to 'español (ES)'

1. Fill the basic fields in language 'español (ES)' → title and content.

1. In Properties panel (Right section of content creation.) fill the description, featured images for instance and not select the required category of vocabulary 'Content' (Prerrequisites step 3)

1. Publish web content.

**Current behavior:**

 - The publication is not successful because the category was not selected. This is correct → It display one correct error → 'Please select at least one category for Content'

However, the default language of the web content is reset to 'Catalan (Spain)' (this is the default language of the site but not what was set in step 6)

**Expected behavior**

 - Although the publication is not successful as the category was not selected, the default language of the web content is the same as the default language set in step 6 (es_ES, not Catalan)

Additional verifications
========
I tested that these other related use cases still work after these changes:
- [LPS-176371](https://liferay.atlassian.net/browse/LPS-176371) - Default language specified in a structure is not used when creating a new web content
- [LPS-93619](https://liferay.atlassian.net/browse/LPS-93619) - Saving a web content as draft while translating it takes user to the default translation