### PR TITLE
LPD-17364 Collection Displays can reference Exporting site's content

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/exportimport/content/processor/DataValuesMappingExportImportContentProcessor.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/exportimport/content/processor/DataValuesMappingExportImportContentProcessor.java
@@ -16,6 +16,7 @@ import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
 import com.liferay.exportimport.content.processor.ExportImportContentProcessor;
+import com.liferay.exportimport.kernel.exception.ExportImportContentProcessorException;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.PortletDataException;
@@ -88,7 +89,8 @@ public class DataValuesMappingExportImportContentProcessor
 
 		JSONObject jsonObject = _jsonFactory.createJSONObject(data);
 
-		_replaceImportContentReferences(jsonObject, portletDataContext);
+		_replaceImportContentReferences(
+			jsonObject, portletDataContext, stagedModel);
 
 		return jsonObject.toString();
 	}
@@ -402,7 +404,8 @@ public class DataValuesMappingExportImportContentProcessor
 	}
 
 	private void _replaceCollectionImportContentReferences(
-		JSONObject itemJSONObject, PortletDataContext portletDataContext) {
+		JSONObject itemJSONObject, PortletDataContext portletDataContext,
+		StagedModel stagedModel) {
 
 		if (!itemJSONObject.has("config")) {
 			return;
@@ -432,6 +435,41 @@ public class DataValuesMappingExportImportContentProcessor
 				AssetListEntry.class.getName());
 
 		long newClassPK = MapUtil.getLong(
+			assetListEntryNewPrimaryKeys, classPK, -1);
+
+		if (newClassPK == -1) {
+			try {
+				StagedModelDataHandlerUtil.importReferenceStagedModel(
+					portletDataContext, stagedModel, AssetListEntry.class,
+					classPK);
+			}
+			catch (Exception exception) {
+				StringBundler exceptionSB = new StringBundler(6);
+
+				exceptionSB.append("Unable to process asset list entry ");
+				exceptionSB.append(classPK);
+				exceptionSB.append(" for ");
+				exceptionSB.append(stagedModel.getModelClassName());
+				exceptionSB.append(" with primary key ");
+				exceptionSB.append(stagedModel.getPrimaryKeyObj());
+
+				ExportImportContentProcessorException
+					exportImportContentProcessorException =
+						new ExportImportContentProcessorException(
+							exceptionSB.toString(), exception);
+
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						exceptionSB.toString(),
+						exportImportContentProcessorException);
+				}
+				else if (_log.isWarnEnabled()) {
+					_log.warn(exceptionSB.toString());
+				}
+			}
+		}
+
+		newClassPK = MapUtil.getLong(
 			assetListEntryNewPrimaryKeys, classPK, classPK);
 
 		AssetListEntry assetListEntry =
@@ -510,7 +548,8 @@ public class DataValuesMappingExportImportContentProcessor
 	}
 
 	private void _replaceImportContentReferences(
-		JSONObject jsonObject, PortletDataContext portletDataContext) {
+		JSONObject jsonObject, PortletDataContext portletDataContext,
+		StagedModel stagedModel) {
 
 		if (!jsonObject.has("items")) {
 			return;
@@ -537,7 +576,7 @@ public class DataValuesMappingExportImportContentProcessor
 						LayoutDataItemTypeConstants.TYPE_COLLECTION)) {
 
 				_replaceCollectionImportContentReferences(
-					itemJSONObject, portletDataContext);
+					itemJSONObject, portletDataContext, stagedModel);
 			}
 			else if (Objects.equals(
 						itemJSONObject.get("type"),

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/exportimport/content/processor/DataValuesMappingExportImportContentProcessor.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/exportimport/content/processor/DataValuesMappingExportImportContentProcessor.java
@@ -130,7 +130,7 @@ public class DataValuesMappingExportImportContentProcessor
 		if (assetListEntry != null) {
 			try {
 				StagedModelDataHandlerUtil.exportReferenceStagedModel(
-					portletDataContext, assetListEntry, stagedModel,
+					portletDataContext, stagedModel, assetListEntry,
 					PortletDataContext.REFERENCE_TYPE_DEPENDENCY);
 			}
 			catch (PortletDataException portletDataException) {


### PR DESCRIPTION
Motivation
=======
Collection Displays can reference Exporting site's content when there is a navigation menu referencing the page the Collection Display is on.
https://liferay.atlassian.net/browse/LPD-17364

Proposed Solution
========
Make the ContentProcessor to import the referred AssetListEntry if it hasn't already been imported so that it can replace its classPK

Steps to Verify
========
1. Create a site “Source”
2. Create dynamic collection “Test Collection” displaying “Web Content Article” and sub type “Basic Web Content”
3. Create Basic Web Content with title and content -> “TEST-1”
4. Create a Navigation Menu “Test menu”
5. Create a new Collection Page ”Home”:
6. When creating the page, check Add ‘Home” to the menu 'Test menu’
7. Select the "Test Collection" collection
8. Add a heading fragment and map the heading to the Title field
9. Publish and view the page, you should see “TEST-1”
10. Export the site through Publishing -> Export
11. Create a new Blank site “Target” and import the lar from previous step (Publishing -> Import)
12. Access to the home page and check the “TEST-1” content
13. Modify the “TEST-1” content’s title in the original site (“Source”) to “TEST-2”
14. Reload “Target” homepage

**Expected behaviour:** TEST-1 is displayed as the content in this site was not changed.
**Actual behaviour:** The page displays “TEST-2” from the “Source” site.

Cheers,
Balázs