### PR TITLE
LPD-17379 | Global Information Template not showing on Display Page Template

### DIFF
--- a/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/item/provider/TemplateInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/item/provider/TemplateInfoItemFieldSetProviderImpl.java
@@ -5,7 +5,9 @@
 
 package com.liferay.template.internal.info.item.provider;
 
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.dynamic.data.mapping.service.DDMTemplateLocalService;
 import com.liferay.info.field.InfoField;
 import com.liferay.info.field.InfoFieldSet;
@@ -22,6 +24,8 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portlet.display.template.PortletDisplayTemplate;
 import com.liferay.staging.StagingGroupHelper;
@@ -123,13 +127,27 @@ public class TemplateInfoItemFieldSetProviderImpl
 			return Collections.emptyList();
 		}
 
+		long ddmStructureKey = GetterUtil.getLong(infoItemFormVariationKey);
+
+		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
+			ddmStructureKey);
+
+		List<Long> groupIds = new ArrayList<>();
+
+		if (ddmStructure != null) {
+			groupIds.add(ddmStructure.getGroupId());
+		}
+
+		groupIds.add(
+			_stagingGroupHelper.getStagedPortletGroupId(
+				serviceContext.getScopeGroupId(),
+				TemplatePortletKeys.TEMPLATE));
+
 		try {
 			return _templateEntryLocalService.getTemplateEntries(
-				_stagingGroupHelper.getStagedPortletGroupId(
-					serviceContext.getScopeGroupId(),
-					TemplatePortletKeys.TEMPLATE),
-				infoItemClassName, infoItemFormVariationKey, QueryUtil.ALL_POS,
-				QueryUtil.ALL_POS, null);
+				ArrayUtil.toLongArray(groupIds), infoItemClassName,
+				infoItemFormVariationKey, QueryUtil.ALL_POS, QueryUtil.ALL_POS,
+				null);
 		}
 		catch (Exception exception) {
 			if (_log.isDebugEnabled()) {
@@ -202,6 +220,9 @@ public class TemplateInfoItemFieldSetProviderImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		TemplateInfoItemFieldSetProviderImpl.class);
+
+	@Reference
+	private DDMStructureLocalService _ddmStructureLocalService;
 
 	@Reference
 	private DDMTemplateLocalService _ddmTemplateLocalService;


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPD-17379
best,
Attila

-----

**Steps to reproduce**

1. Create a Web Content Structure on the global site
2. Create an Information Template for the newly created Web Content Structure on the global site
3. Go to the Default Site
4. Create a Display Page Template for the global Web Content Structure
5. Place a "paragraph" Element on the site and try to map the content with the global Information Template

**Expected Result:** I can select the global Information Template
**Actual Results:** The global Information Template does not show up in the list

The root cause of the issue is that the scope of the structure is not considered at all when the infoItemProviders provides the [templates](https://github.com/liferay/liferay-portal-ee/blob/master/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/item/provider/TemplateInfoItemFieldSetProviderImpl.java#L127-L132). My solution is simply to retrieve the structure and search for tempalteEntires in the structure original group as well. 