### PR TITLE
LPD-15726 - Blank page is displayed after filtering for category in collection page

### DIFF
--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -459,10 +459,10 @@ public class AssetListAssetEntryProviderImpl
 		};
 	}
 
-	private BooleanClause[] _getAssetEntryQueryBooleanClauses(
-		String field, long[] longArray) {
+	private BooleanClause[] _getClassTypeIdsBooleanClauses(
+		long[] classTypeIds) {
 
-		if (ArrayUtil.isEmpty(longArray)) {
+		if (ArrayUtil.isEmpty(classTypeIds)) {
 			return new BooleanClause[0];
 		}
 
@@ -470,9 +470,9 @@ public class AssetListAssetEntryProviderImpl
 
 		BooleanFilter booleanFilter = new BooleanFilter();
 
-		TermsFilter termsFilter = new TermsFilter(field);
+		TermsFilter termsFilter = new TermsFilter(Field.CLASS_TYPE_ID);
 
-		termsFilter.addValues(ArrayUtil.toStringArray(longArray));
+		termsFilter.addValues(ArrayUtil.toStringArray(classTypeIds));
 
 		booleanFilter.add(termsFilter, BooleanClauseOccur.MUST);
 
@@ -776,8 +776,8 @@ public class AssetListAssetEntryProviderImpl
 			ArrayUtil.append(
 				_getAssetCategoryIdsBooleanClauses(assetCategoryIds),
 				_getAssetTagNamesBooleanClauses(assetTagNames),
-				_getAssetEntryQueryBooleanClauses(
-					Field.CLASS_TYPE_ID, assetEntryQuery.getClassTypeIds())));
+				_getClassTypeIdsBooleanClauses(
+					assetEntryQuery.getClassTypeIds())));
 		searchContext.setCompanyId(companyId);
 		searchContext.setEnd(assetEntryQuery.getEnd());
 		searchContext.setKeywords(keywords);

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -468,15 +468,15 @@ public class AssetListAssetEntryProviderImpl
 
 		BooleanQueryImpl booleanQueryImpl = new BooleanQueryImpl();
 
-		BooleanFilter assetTagNamesBooleanFilter = new BooleanFilter();
+		BooleanFilter booleanFilter = new BooleanFilter();
 
 		TermsFilter termsFilter = new TermsFilter(field);
 
 		termsFilter.addValues(ArrayUtil.toStringArray(longArray));
 
-		assetTagNamesBooleanFilter.add(termsFilter, BooleanClauseOccur.MUST);
+		booleanFilter.add(termsFilter, BooleanClauseOccur.MUST);
 
-		booleanQueryImpl.setPreBooleanFilter(assetTagNamesBooleanFilter);
+		booleanQueryImpl.setPreBooleanFilter(booleanFilter);
 
 		return new BooleanClause[] {
 			BooleanClauseFactoryUtil.create(

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -459,6 +459,31 @@ public class AssetListAssetEntryProviderImpl
 		};
 	}
 
+	private BooleanClause[] _getAssetEntryQueryBooleanClauses(
+		String field, long[] longArray) {
+
+		if (ArrayUtil.isEmpty(longArray)) {
+			return new BooleanClause[0];
+		}
+
+		BooleanQueryImpl booleanQueryImpl = new BooleanQueryImpl();
+
+		BooleanFilter assetTagNamesBooleanFilter = new BooleanFilter();
+
+		TermsFilter termsFilter = new TermsFilter(field);
+
+		termsFilter.addValues(ArrayUtil.toStringArray(longArray));
+
+		assetTagNamesBooleanFilter.add(termsFilter, BooleanClauseOccur.MUST);
+
+		booleanQueryImpl.setPreBooleanFilter(assetTagNamesBooleanFilter);
+
+		return new BooleanClause[] {
+			BooleanClauseFactoryUtil.create(
+				booleanQueryImpl, BooleanClauseOccur.MUST.getName())
+		};
+	}
+
 	private List<AssetListEntryAssetEntryRel> _getAssetListEntryAssetEntryRels(
 		AssetListEntry assetListEntry, long[] segmentsEntryIds) {
 
@@ -750,7 +775,9 @@ public class AssetListAssetEntryProviderImpl
 		searchContext.setBooleanClauses(
 			ArrayUtil.append(
 				_getAssetCategoryIdsBooleanClauses(assetCategoryIds),
-				_getAssetTagNamesBooleanClauses(assetTagNames)));
+				_getAssetTagNamesBooleanClauses(assetTagNames),
+				_getAssetEntryQueryBooleanClauses(
+					Field.CLASS_TYPE_ID, assetEntryQuery.getClassTypeIds())));
 		searchContext.setCompanyId(companyId);
 		searchContext.setEnd(assetEntryQuery.getEnd());
 		searchContext.setKeywords(keywords);

--- a/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
+++ b/modules/apps/asset/asset-list-service/src/main/java/com/liferay/asset/list/internal/asset/entry/provider/AssetListAssetEntryProviderImpl.java
@@ -459,31 +459,6 @@ public class AssetListAssetEntryProviderImpl
 		};
 	}
 
-	private BooleanClause[] _getClassTypeIdsBooleanClauses(
-		long[] classTypeIds) {
-
-		if (ArrayUtil.isEmpty(classTypeIds)) {
-			return new BooleanClause[0];
-		}
-
-		BooleanQueryImpl booleanQueryImpl = new BooleanQueryImpl();
-
-		BooleanFilter booleanFilter = new BooleanFilter();
-
-		TermsFilter termsFilter = new TermsFilter(Field.CLASS_TYPE_ID);
-
-		termsFilter.addValues(ArrayUtil.toStringArray(classTypeIds));
-
-		booleanFilter.add(termsFilter, BooleanClauseOccur.MUST);
-
-		booleanQueryImpl.setPreBooleanFilter(booleanFilter);
-
-		return new BooleanClause[] {
-			BooleanClauseFactoryUtil.create(
-				booleanQueryImpl, BooleanClauseOccur.MUST.getName())
-		};
-	}
-
 	private List<AssetListEntryAssetEntryRel> _getAssetListEntryAssetEntryRels(
 		AssetListEntry assetListEntry, long[] segmentsEntryIds) {
 
@@ -675,6 +650,31 @@ public class AssetListAssetEntryProviderImpl
 		}
 
 		return availableClassTypeIds;
+	}
+
+	private BooleanClause[] _getClassTypeIdsBooleanClauses(
+		long[] classTypeIds) {
+
+		if (ArrayUtil.isEmpty(classTypeIds)) {
+			return new BooleanClause[0];
+		}
+
+		BooleanQueryImpl booleanQueryImpl = new BooleanQueryImpl();
+
+		BooleanFilter booleanFilter = new BooleanFilter();
+
+		TermsFilter termsFilter = new TermsFilter(Field.CLASS_TYPE_ID);
+
+		termsFilter.addValues(ArrayUtil.toStringArray(classTypeIds));
+
+		booleanFilter.add(termsFilter, BooleanClauseOccur.MUST);
+
+		booleanQueryImpl.setPreBooleanFilter(booleanFilter);
+
+		return new BooleanClause[] {
+			BooleanClauseFactoryUtil.create(
+				booleanQueryImpl, BooleanClauseOccur.MUST.getName())
+		};
 	}
 
 	private long[] _getCombinedSegmentsEntryIds(

--- a/modules/apps/asset/asset-list-test/build.gradle
+++ b/modules/apps/asset/asset-list-test/build.gradle
@@ -5,6 +5,7 @@ dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-publisher-api")
 	testIntegrationImplementation project(":apps:asset:asset-test-util")
 	testIntegrationImplementation project(":apps:change-tracking:change-tracking-test-util")
+	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:journal:journal-api")
 	testIntegrationImplementation project(":apps:journal:journal-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-test-util")

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -118,11 +118,6 @@ public class AssetListAssetEntryProviderTest {
 		_addJournalArticle(new long[0], TestPropsValues.getUserId());
 		_addJournalArticle(new long[0], user.getUserId());
 
-		long[] segmentsEntryIds = {
-			segmentsEntry1.getSegmentsEntryId(),
-			segmentsEntry2.getSegmentsEntryId()
-		};
-
 		AssetListTestUtil.addAssetListEntrySegmentsEntryRel(
 			_group.getGroupId(), assetListEntry,
 			segmentsEntry1.getSegmentsEntryId(),
@@ -131,6 +126,11 @@ public class AssetListAssetEntryProviderTest {
 		AssetListTestUtil.addAssetListEntrySegmentsEntryRel(
 			_group.getGroupId(), assetListEntry,
 			segmentsEntry2.getSegmentsEntryId(), _getTypeSettings(userName));
+
+		long[] segmentsEntryIds = {
+			segmentsEntry1.getSegmentsEntryId(),
+			segmentsEntry2.getSegmentsEntryId()
+		};
 
 		List<AssetEntry> assetEntries =
 			_assetListAssetEntryProvider.getAssetEntries(
@@ -204,11 +204,6 @@ public class AssetListAssetEntryProviderTest {
 
 		_addJournalArticle(new long[0], TestPropsValues.getUserId());
 
-		long[] segmentsEntryIds = {
-			segmentsEntry1.getSegmentsEntryId(),
-			segmentsEntry2.getSegmentsEntryId()
-		};
-
 		AssetListTestUtil.addAssetListEntrySegmentsEntryRel(
 			_group.getGroupId(), assetListEntry,
 			segmentsEntry1.getSegmentsEntryId(),
@@ -218,6 +213,11 @@ public class AssetListAssetEntryProviderTest {
 			_group.getGroupId(), assetListEntry,
 			segmentsEntry2.getSegmentsEntryId(),
 			_getTypeSettings(user.getFirstName()));
+
+		long[] segmentsEntryIds = {
+			segmentsEntry1.getSegmentsEntryId(),
+			segmentsEntry2.getSegmentsEntryId()
+		};
 
 		List<AssetEntry> assetEntries =
 			_assetListAssetEntryProvider.getAssetEntries(
@@ -260,11 +260,6 @@ public class AssetListAssetEntryProviderTest {
 		_addJournalArticle(new long[0], TestPropsValues.getUserId());
 		_addJournalArticle(new long[0], TestPropsValues.getUserId());
 
-		long[] segmentsEntryIds = {
-			segmentsEntry1.getSegmentsEntryId(),
-			segmentsEntry2.getSegmentsEntryId()
-		};
-
 		AssetListTestUtil.addAssetListEntrySegmentsEntryRel(
 			_group.getGroupId(), assetListEntry,
 			segmentsEntry1.getSegmentsEntryId(),
@@ -274,6 +269,11 @@ public class AssetListAssetEntryProviderTest {
 			_group.getGroupId(), assetListEntry,
 			segmentsEntry2.getSegmentsEntryId(),
 			_getTypeSettings(user.getFirstName()));
+
+		long[] segmentsEntryIds = {
+			segmentsEntry1.getSegmentsEntryId(),
+			segmentsEntry2.getSegmentsEntryId()
+		};
 
 		List<AssetEntry> assetEntries =
 			_assetListAssetEntryProvider.getAssetEntries(

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -103,9 +103,9 @@ public class AssetListAssetEntryProviderTest {
 			null, ServiceContextTestUtil.getServiceContext());
 
 		SegmentsEntry segmentsEntry1 = _addSegmentsEntryByFirstName(
-			_group.getGroupId(), userTest);
+			_group.getGroupId(), userTest.getFirstName());
 		SegmentsEntry segmentsEntry2 = _addSegmentsEntryByFirstName(
-			_group.getGroupId(), user);
+			_group.getGroupId(), user.getFirstName());
 
 		JournalArticle journalArticle = _addJournalArticle(
 			new long[0], TestPropsValues.getUserId());
@@ -156,9 +156,9 @@ public class AssetListAssetEntryProviderTest {
 		User userTest = TestPropsValues.getUser();
 
 		SegmentsEntry segmentsEntry1 = _addSegmentsEntryByFirstName(
-			_group.getGroupId(), userTest);
+			_group.getGroupId(), userTest.getFirstName());
 		SegmentsEntry segmentsEntry2 = _addSegmentsEntryByFirstName(
-			_group.getGroupId(), userTest);
+			_group.getGroupId(), userTest.getFirstName());
 
 		JournalArticle journalArticle = _addJournalArticle(
 			new long[0], TestPropsValues.getUserId());
@@ -798,9 +798,9 @@ public class AssetListAssetEntryProviderTest {
 			null, ServiceContextTestUtil.getServiceContext());
 
 		SegmentsEntry segmentsEntry1 = _addSegmentsEntryByFirstName(
-			_group.getGroupId(), userTest);
+			_group.getGroupId(), userTest.getFirstName());
 		SegmentsEntry segmentsEntry2 = _addSegmentsEntryByFirstName(
-			_group.getGroupId(), user);
+			_group.getGroupId(), user.getFirstName());
 
 		JournalArticle journalArticle = _addJournalArticle(
 			new long[0], TestPropsValues.getUserId());
@@ -854,13 +854,14 @@ public class AssetListAssetEntryProviderTest {
 				_group.getGroupId(), userId, assetCategoryIds));
 	}
 
-	private SegmentsEntry _addSegmentsEntryByFirstName(long groupId, User user)
+	private SegmentsEntry _addSegmentsEntryByFirstName(
+			long groupId, String firstName)
 		throws Exception {
 
 		Criteria criteria = new Criteria();
 
 		_segmentsCriteriaContributor.contribute(
-			criteria, String.format("(firstName eq '%s')", user.getFirstName()),
+			criteria, String.format("(firstName eq '%s')", firstName),
 			Criteria.Conjunction.AND);
 
 		return SegmentsTestUtil.addSegmentsEntry(

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -16,15 +16,20 @@ import com.liferay.asset.list.model.AssetListEntry;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.asset.list.test.util.AssetListTestUtil;
 import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.dynamic.data.mapping.model.DDMStructure;
+import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
 import com.liferay.journal.constants.JournalFolderConstants;
 import com.liferay.journal.model.JournalArticle;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.test.util.ConfigurationTestUtil;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
+import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.rule.SynchronousDestinationTestRule;
@@ -133,6 +138,95 @@ public class AssetListAssetEntryProviderTest {
 				StringPool.BLANK, QueryUtil.ALL_POS, QueryUtil.ALL_POS);
 
 		Assert.assertEquals(assetEntries.toString(), 3, assetEntries.size());
+
+		AssetEntry firstAssetEntry = assetEntries.get(0);
+
+		Assert.assertEquals(
+			firstAssetEntry.getTitle(LocaleUtil.US),
+			journalArticle.getTitle(LocaleUtil.US));
+	}
+
+	@Test
+	public void testCombineSegmentsOfDynamicCollectionWithCategoryFilter()
+		throws Exception {
+
+		_setCombinedAssetForDynamicCollections(true);
+
+		Company company = _companyLocalService.getCompany(
+			TestPropsValues.getCompanyId());
+
+		Group globalGroup = company.getGroup();
+
+		DDMStructure structure = _ddmStructureLocalService.fetchStructure(
+			globalGroup.getGroupId(),
+			_portal.getClassNameId(JournalArticle.class), "BASIC-WEB-CONTENT");
+
+		AssetListEntry assetListEntry =
+			_assetListEntryLocalService.addAssetListEntry(
+				TestPropsValues.getUserId(), _group.getGroupId(),
+				"Dynamic title", AssetListEntryTypeConstants.TYPE_DYNAMIC,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"anyAssetType",
+					String.valueOf(_portal.getClassNameId(JournalArticle.class))
+				).put(
+					"anyClassTypeJournalArticleAssetRendererFactory",
+					structure.getStructureId()
+				).buildString(),
+				_serviceContext);
+
+		AssetVocabulary globalVocabulary = AssetTestUtil.addVocabulary(
+			globalGroup.getGroupId());
+
+		AssetCategory globalCategory = AssetTestUtil.addCategory(
+			globalGroup.getGroupId(), globalVocabulary.getVocabularyId());
+
+		long[] assetCategoryIds = {globalCategory.getCategoryId()};
+
+		User userTest = TestPropsValues.getUser();
+
+		_userLocalService.updateAsset(
+			userTest.getUserId(), userTest, assetCategoryIds, null);
+
+		ServiceContext serviceContext =
+			ServiceContextTestUtil.getServiceContext();
+
+		serviceContext.setAssetCategoryIds(assetCategoryIds);
+
+		SegmentsEntry segmentsEntry1 = _addSegmentsEntryByFirstName(
+			_group.getGroupId(), userTest.getFirstName());
+		SegmentsEntry segmentsEntry2 = _addSegmentsEntryByCategoryId(
+			_group.getGroupId(), globalCategory.getCategoryId());
+
+		JournalArticle journalArticle = _addJournalArticle(
+			assetCategoryIds, TestPropsValues.getUserId());
+
+		_addJournalArticle(new long[0], TestPropsValues.getUserId());
+
+		long[] segmentsEntryIds = {
+			segmentsEntry1.getSegmentsEntryId(),
+			segmentsEntry2.getSegmentsEntryId()
+		};
+
+		AssetListTestUtil.addAssetListEntrySegmentsEntryRel(
+			_group.getGroupId(), assetListEntry,
+			segmentsEntry1.getSegmentsEntryId(),
+			_getTypeSettings(userTest.getFirstName()));
+
+		AssetListTestUtil.addAssetListEntrySegmentsEntryRel(
+			_group.getGroupId(), assetListEntry,
+			segmentsEntry2.getSegmentsEntryId(),
+			_getTypeSettings(userTest.getFirstName()));
+
+		List<AssetEntry> assetEntries =
+			_assetListAssetEntryProvider.getAssetEntries(
+				assetListEntry, segmentsEntryIds,
+				new long[][] {{globalCategory.getCategoryId()}}, null,
+				StringPool.BLANK, StringPool.BLANK, QueryUtil.ALL_POS,
+				QueryUtil.ALL_POS);
+
+		Assert.assertEquals(assetEntries.toString(), 1, assetEntries.size());
 
 		AssetEntry firstAssetEntry = assetEntries.get(0);
 
@@ -854,6 +948,14 @@ public class AssetListAssetEntryProviderTest {
 				_group.getGroupId(), userId, assetCategoryIds));
 	}
 
+	private SegmentsEntry _addSegmentsEntryByCategoryId(
+			long groupId, long categoryId)
+		throws Exception {
+
+		return _getSegmentsEntry(
+			groupId, "(assetCategoryIds eq '%s')", String.valueOf(categoryId));
+	}
+
 	private SegmentsEntry _addSegmentsEntryByFirstName(
 			long groupId, String firstName)
 		throws Exception {
@@ -862,13 +964,13 @@ public class AssetListAssetEntryProviderTest {
 	}
 
 	private SegmentsEntry _getSegmentsEntry(
-			long groupId, String criteriaString, String param)
+			long groupId, String criteriaString, String firstName)
 		throws Exception {
 
 		Criteria criteria = new Criteria();
 
 		_segmentsCriteriaContributor.contribute(
-			criteria, String.format(criteriaString, param),
+			criteria, String.format(criteriaString, firstName),
 			Criteria.Conjunction.AND);
 
 		return SegmentsTestUtil.addSegmentsEntry(
@@ -932,6 +1034,12 @@ public class AssetListAssetEntryProviderTest {
 	@Inject
 	private AssetListEntryLocalService _assetListEntryLocalService;
 
+	@Inject
+	private CompanyLocalService _companyLocalService;
+
+	@Inject
+	private DDMStructureLocalService _ddmStructureLocalService;
+
 	@DeleteAfterTestRun
 	private Group _group;
 
@@ -945,5 +1053,8 @@ public class AssetListAssetEntryProviderTest {
 	private SegmentsCriteriaContributor _segmentsCriteriaContributor;
 
 	private ServiceContext _serviceContext;
+
+	@Inject
+	private UserLocalService _userLocalService;
 
 }

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -836,21 +836,22 @@ public class AssetListAssetEntryProviderTest {
 			journalArticle.getTitle(LocaleUtil.US));
 	}
 
-	private JournalArticle _addJournalArticle(long[] assetCategories)
+	private JournalArticle _addJournalArticle(long[] assetCategoryIds)
 		throws Exception {
 
-		return _addJournalArticle(assetCategories, TestPropsValues.getUserId());
+		return _addJournalArticle(
+			assetCategoryIds, TestPropsValues.getUserId());
 	}
 
 	private JournalArticle _addJournalArticle(
-			long[] assetCategories, long userId)
+			long[] assetCategoryIds, long userId)
 		throws Exception {
 
 		return JournalTestUtil.addArticle(
 			_group.getGroupId(),
 			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
 			ServiceContextTestUtil.getServiceContext(
-				_group.getGroupId(), userId, assetCategories));
+				_group.getGroupId(), userId, assetCategoryIds));
 	}
 
 	private SegmentsEntry _addSegmentsEntryByFirstName(long groupId, User user)

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -858,10 +858,17 @@ public class AssetListAssetEntryProviderTest {
 			long groupId, String firstName)
 		throws Exception {
 
+		return _getSegmentsEntry(groupId, "(firstName eq '%s')", firstName);
+	}
+
+	private SegmentsEntry _getSegmentsEntry(
+			long groupId, String criteriaString, String param)
+		throws Exception {
+
 		Criteria criteria = new Criteria();
 
 		_segmentsCriteriaContributor.contribute(
-			criteria, String.format("(firstName eq '%s')", firstName),
+			criteria, String.format(criteriaString, param),
 			Criteria.Conjunction.AND);
 
 		return SegmentsTestUtil.addSegmentsEntry(

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -139,10 +139,10 @@ public class AssetListAssetEntryProviderTest {
 
 		Assert.assertEquals(assetEntries.toString(), 3, assetEntries.size());
 
-		AssetEntry firstAssetEntry = assetEntries.get(0);
+		AssetEntry assetEntry = assetEntries.get(0);
 
 		Assert.assertEquals(
-			firstAssetEntry.getTitle(LocaleUtil.US),
+			assetEntry.getTitle(LocaleUtil.US),
 			journalArticle.getTitle(LocaleUtil.US));
 	}
 
@@ -228,10 +228,10 @@ public class AssetListAssetEntryProviderTest {
 
 		Assert.assertEquals(assetEntries.toString(), 1, assetEntries.size());
 
-		AssetEntry firstAssetEntry = assetEntries.get(0);
+		AssetEntry assetEntry = assetEntries.get(0);
 
 		Assert.assertEquals(
-			firstAssetEntry.getTitle(LocaleUtil.US),
+			assetEntry.getTitle(LocaleUtil.US),
 			journalArticle.getTitle(LocaleUtil.US));
 	}
 
@@ -282,10 +282,10 @@ public class AssetListAssetEntryProviderTest {
 
 		Assert.assertEquals(assetEntries.toString(), 3, assetEntries.size());
 
-		AssetEntry firstAssetEntry = assetEntries.get(0);
+		AssetEntry assetEntry = assetEntries.get(0);
 
 		Assert.assertEquals(
-			firstAssetEntry.getTitle(LocaleUtil.US),
+			assetEntry.getTitle(LocaleUtil.US),
 			journalArticle.getTitle(LocaleUtil.US));
 	}
 
@@ -923,10 +923,10 @@ public class AssetListAssetEntryProviderTest {
 
 		Assert.assertEquals(assetEntries.toString(), 2, assetEntries.size());
 
-		AssetEntry firstAssetEntry = assetEntries.get(0);
+		AssetEntry assetEntry = assetEntries.get(0);
 
 		Assert.assertEquals(
-			firstAssetEntry.getTitle(LocaleUtil.US),
+			assetEntry.getTitle(LocaleUtil.US),
 			journalArticle.getTitle(LocaleUtil.US));
 	}
 

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -952,7 +952,7 @@ public class AssetListAssetEntryProviderTest {
 			long groupId, long categoryId)
 		throws Exception {
 
-		return _getSegmentsEntry(
+		return _addSegmentsEntry(
 			groupId, "(assetCategoryIds eq '%s')", String.valueOf(categoryId));
 	}
 
@@ -960,10 +960,10 @@ public class AssetListAssetEntryProviderTest {
 			long groupId, String firstName)
 		throws Exception {
 
-		return _getSegmentsEntry(groupId, "(firstName eq '%s')", firstName);
+		return _addSegmentsEntry(groupId, "(firstName eq '%s')", firstName);
 	}
 
-	private SegmentsEntry _getSegmentsEntry(
+	private SegmentsEntry _addSegmentsEntry(
 			long groupId, String criteriaString, String firstName)
 		throws Exception {
 

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -157,7 +157,7 @@ public class AssetListAssetEntryProviderTest {
 
 		Group globalGroup = company.getGroup();
 
-		DDMStructure structure = _ddmStructureLocalService.fetchStructure(
+		DDMStructure ddmStructure = _ddmStructureLocalService.fetchStructure(
 			globalGroup.getGroupId(),
 			_portal.getClassNameId(JournalArticle.class), "BASIC-WEB-CONTENT");
 
@@ -172,22 +172,22 @@ public class AssetListAssetEntryProviderTest {
 					String.valueOf(_portal.getClassNameId(JournalArticle.class))
 				).put(
 					"anyClassTypeJournalArticleAssetRendererFactory",
-					structure.getStructureId()
+					ddmStructure.getStructureId()
 				).buildString(),
 				_serviceContext);
 
-		AssetVocabulary globalVocabulary = AssetTestUtil.addVocabulary(
+		AssetVocabulary globalAssetVocabulary = AssetTestUtil.addVocabulary(
 			globalGroup.getGroupId());
 
-		AssetCategory globalCategory = AssetTestUtil.addCategory(
-			globalGroup.getGroupId(), globalVocabulary.getVocabularyId());
+		AssetCategory globalAssetCategory = AssetTestUtil.addCategory(
+			globalGroup.getGroupId(), globalAssetVocabulary.getVocabularyId());
 
-		long[] assetCategoryIds = {globalCategory.getCategoryId()};
+		long[] assetCategoryIds = {globalAssetCategory.getCategoryId()};
 
-		User userTest = TestPropsValues.getUser();
+		User user = TestPropsValues.getUser();
 
 		_userLocalService.updateAsset(
-			userTest.getUserId(), userTest, assetCategoryIds, null);
+			user.getUserId(), user, assetCategoryIds, null);
 
 		ServiceContext serviceContext =
 			ServiceContextTestUtil.getServiceContext();
@@ -195,9 +195,9 @@ public class AssetListAssetEntryProviderTest {
 		serviceContext.setAssetCategoryIds(assetCategoryIds);
 
 		SegmentsEntry segmentsEntry1 = _addSegmentsEntryByFirstName(
-			_group.getGroupId(), userTest.getFirstName());
+			_group.getGroupId(), user.getFirstName());
 		SegmentsEntry segmentsEntry2 = _addSegmentsEntryByCategoryId(
-			_group.getGroupId(), globalCategory.getCategoryId());
+			_group.getGroupId(), globalAssetCategory.getCategoryId());
 
 		JournalArticle journalArticle = _addJournalArticle(
 			assetCategoryIds, TestPropsValues.getUserId());
@@ -212,17 +212,17 @@ public class AssetListAssetEntryProviderTest {
 		AssetListTestUtil.addAssetListEntrySegmentsEntryRel(
 			_group.getGroupId(), assetListEntry,
 			segmentsEntry1.getSegmentsEntryId(),
-			_getTypeSettings(userTest.getFirstName()));
+			_getTypeSettings(user.getFirstName()));
 
 		AssetListTestUtil.addAssetListEntrySegmentsEntryRel(
 			_group.getGroupId(), assetListEntry,
 			segmentsEntry2.getSegmentsEntryId(),
-			_getTypeSettings(userTest.getFirstName()));
+			_getTypeSettings(user.getFirstName()));
 
 		List<AssetEntry> assetEntries =
 			_assetListAssetEntryProvider.getAssetEntries(
 				assetListEntry, segmentsEntryIds,
-				new long[][] {{globalCategory.getCategoryId()}}, null,
+				new long[][] {{globalAssetCategory.getCategoryId()}}, null,
 				StringPool.BLANK, StringPool.BLANK, QueryUtil.ALL_POS,
 				QueryUtil.ALL_POS);
 
@@ -247,12 +247,12 @@ public class AssetListAssetEntryProviderTest {
 				"Dynamic title", AssetListEntryTypeConstants.TYPE_DYNAMIC, null,
 				_serviceContext);
 
-		User userTest = TestPropsValues.getUser();
+		User user = TestPropsValues.getUser();
 
 		SegmentsEntry segmentsEntry1 = _addSegmentsEntryByFirstName(
-			_group.getGroupId(), userTest.getFirstName());
+			_group.getGroupId(), user.getFirstName());
 		SegmentsEntry segmentsEntry2 = _addSegmentsEntryByFirstName(
-			_group.getGroupId(), userTest.getFirstName());
+			_group.getGroupId(), user.getFirstName());
 
 		JournalArticle journalArticle = _addJournalArticle(
 			new long[0], TestPropsValues.getUserId());
@@ -268,12 +268,12 @@ public class AssetListAssetEntryProviderTest {
 		AssetListTestUtil.addAssetListEntrySegmentsEntryRel(
 			_group.getGroupId(), assetListEntry,
 			segmentsEntry1.getSegmentsEntryId(),
-			_getTypeSettings(userTest.getFirstName()));
+			_getTypeSettings(user.getFirstName()));
 
 		AssetListTestUtil.addAssetListEntrySegmentsEntryRel(
 			_group.getGroupId(), assetListEntry,
 			segmentsEntry2.getSegmentsEntryId(),
-			_getTypeSettings(userTest.getFirstName()));
+			_getTypeSettings(user.getFirstName()));
 
 		List<AssetEntry> assetEntries =
 			_assetListAssetEntryProvider.getAssetEntries(

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -948,15 +948,13 @@ public class AssetListAssetEntryProviderTest {
 				_group.getGroupId(), userId, assetCategoryIds));
 	}
 
-	private SegmentsEntry _addSegmentsEntry(
-			long groupId, String criteriaString, String firstName)
+	private SegmentsEntry _addSegmentsEntry(long groupId, String filterString)
 		throws Exception {
 
 		Criteria criteria = new Criteria();
 
 		_segmentsCriteriaContributor.contribute(
-			criteria, String.format(criteriaString, firstName),
-			Criteria.Conjunction.AND);
+			criteria, filterString, Criteria.Conjunction.AND);
 
 		return SegmentsTestUtil.addSegmentsEntry(
 			groupId, CriteriaSerializer.serialize(criteria));
@@ -967,14 +965,15 @@ public class AssetListAssetEntryProviderTest {
 		throws Exception {
 
 		return _addSegmentsEntry(
-			groupId, "(assetCategoryIds eq '%s')", String.valueOf(categoryId));
+			groupId, String.format("(assetCategoryIds eq '%s')", categoryId));
 	}
 
 	private SegmentsEntry _addSegmentsEntryByFirstName(
 			long groupId, String firstName)
 		throws Exception {
 
-		return _addSegmentsEntry(groupId, "(firstName eq '%s')", firstName);
+		return _addSegmentsEntry(
+			groupId, String.format("(firstName eq '%s')", firstName));
 	}
 
 	private String _getTypeSettings(String queryValue) {

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -176,6 +176,8 @@ public class AssetListAssetEntryProviderTest {
 				).buildString(),
 				_serviceContext);
 
+		User user = TestPropsValues.getUser();
+
 		AssetVocabulary globalAssetVocabulary = AssetTestUtil.addVocabulary(
 			globalGroup.getGroupId());
 
@@ -183,8 +185,6 @@ public class AssetListAssetEntryProviderTest {
 			globalGroup.getGroupId(), globalAssetVocabulary.getVocabularyId());
 
 		long[] assetCategoryIds = {globalAssetCategory.getCategoryId()};
-
-		User user = TestPropsValues.getUser();
 
 		_userLocalService.updateAsset(
 			user.getUserId(), user, assetCategoryIds, null);

--- a/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
+++ b/modules/apps/asset/asset-list-test/src/testIntegration/java/com/liferay/asset/list/asset/entry/provider/test/AssetListAssetEntryProviderTest.java
@@ -948,6 +948,20 @@ public class AssetListAssetEntryProviderTest {
 				_group.getGroupId(), userId, assetCategoryIds));
 	}
 
+	private SegmentsEntry _addSegmentsEntry(
+			long groupId, String criteriaString, String firstName)
+		throws Exception {
+
+		Criteria criteria = new Criteria();
+
+		_segmentsCriteriaContributor.contribute(
+			criteria, String.format(criteriaString, firstName),
+			Criteria.Conjunction.AND);
+
+		return SegmentsTestUtil.addSegmentsEntry(
+			groupId, CriteriaSerializer.serialize(criteria));
+	}
+
 	private SegmentsEntry _addSegmentsEntryByCategoryId(
 			long groupId, long categoryId)
 		throws Exception {
@@ -961,20 +975,6 @@ public class AssetListAssetEntryProviderTest {
 		throws Exception {
 
 		return _addSegmentsEntry(groupId, "(firstName eq '%s')", firstName);
-	}
-
-	private SegmentsEntry _addSegmentsEntry(
-			long groupId, String criteriaString, String firstName)
-		throws Exception {
-
-		Criteria criteria = new Criteria();
-
-		_segmentsCriteriaContributor.contribute(
-			criteria, String.format(criteriaString, firstName),
-			Criteria.Conjunction.AND);
-
-		return SegmentsTestUtil.addSegmentsEntry(
-			groupId, CriteriaSerializer.serialize(criteria));
 	}
 
 	private String _getTypeSettings(String queryValue) {


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-15726 - Blank page is displayed after filtering for category in collection page

//cc @balazssk

Original PR comment:

Motivation
=======
Blank page is displayed after filtering for category in collection page because in some cases a categorised User can make its way to the search results. Which can't be converted to the AssetList's type.
https://liferay.atlassian.net/browse/LPD-15726

Proposed Solution
========
By adding a classTypeId filter to the searchContext of the dynamicSearch triggered, we can rule out User typed results.

Cheers,
Balázs