### PR TITLE
LPD-17238 The language selection widget may not work when setting categories to users.

### DIFF
--- a/portal-impl/src/com/liferay/portlet/admin/util/AdminUtil.java
+++ b/portal-impl/src/com/liferay/portlet/admin/util/AdminUtil.java
@@ -106,7 +106,7 @@ public class AdminUtil {
 			contact.getSuffixListTypeId(), contact.isMale(), birthdayMonth,
 			birthdayDay, birthdayYear, smsSn, facebookSn, jabberSn, skypeSn,
 			twitterSn, contact.getJobTitle(), groupIds, organizationIds,
-			roleIds, userGroupRoles, userGroupIds, new ServiceContext());
+			roleIds, userGroupRoles, userGroupIds, null);
 	}
 
 	public static User updateUser(


### PR DESCRIPTION
[LPD-17238](https://liferay.atlassian.net/browse/LPD-17238)

Passing a new ServiceContext ensures an asset update [here](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/impl/UserLocalServiceImpl.java#L5523-L5529) However it will fail during validation due to a missing required category, as the new serviceContext won't hold that information.
I believe we do not need to pass a serviceContext to update the user and passing null resolves the issue reported on the LPD. I made this PR to get some help figuring out wether it breakes anything else, I did not find any issue.

Please review my changes.

/cc @Mikellorza 