### PR TITLE
LPD-17496 Filter the tags by the site the user is currently on

### DIFF
--- a/modules/apps/fragment/fragment-collection-filter-tags/build.gradle
+++ b/modules/apps/fragment/fragment-collection-filter-tags/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.1"
 	compileOnly group: "org.apache.felix", name: "org.apache.felix.http.servlet-api", version: "1.1.2"
 	compileOnly group: "org.osgi", name: "org.osgi.service.component.annotations", version: "1.4.0"
+	compileOnly project(":apps:depot:depot-api")
 	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:fragment:fragment-collection-filter-api")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/java/com/liferay/fragment/collection/filter/tags/FragmentCollectionFilterTags.java
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/java/com/liferay/fragment/collection/filter/tags/FragmentCollectionFilterTags.java
@@ -94,7 +94,8 @@ public class FragmentCollectionFilterTags implements FragmentCollectionFilter {
 			httpServletRequest.setAttribute(
 				FragmentCollectionFilterTagsDisplayContext.class.getName(),
 				new FragmentCollectionFilterTagsDisplayContext(
-					getConfiguration(), _fragmentEntryConfigurationParser,
+					httpServletRequest, getConfiguration(),
+					_fragmentEntryConfigurationParser,
 					fragmentRendererContext));
 
 			RequestDispatcher requestDispatcher =

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/java/com/liferay/fragment/collection/filter/tags/display/context/FragmentCollectionFilterTagsDisplayContext.java
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/java/com/liferay/fragment/collection/filter/tags/display/context/FragmentCollectionFilterTagsDisplayContext.java
@@ -5,17 +5,24 @@
 
 package com.liferay.fragment.collection.filter.tags.display.context;
 
+import com.liferay.depot.util.SiteConnectedGroupGroupProviderUtil;
 import com.liferay.fragment.constants.FragmentConfigurationFieldDataType;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.renderer.FragmentRendererContext;
 import com.liferay.fragment.util.configuration.FragmentEntryConfigurationParser;
 import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 
 import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * @author Pablo Molina
@@ -23,7 +30,7 @@ import java.util.Map;
 public class FragmentCollectionFilterTagsDisplayContext {
 
 	public FragmentCollectionFilterTagsDisplayContext(
-		String configuration,
+		HttpServletRequest httpServletRequest, String configuration,
 		FragmentEntryConfigurationParser fragmentEntryConfigurationParser,
 		FragmentRendererContext fragmentRendererContext) {
 
@@ -32,6 +39,9 @@ public class FragmentCollectionFilterTagsDisplayContext {
 		_fragmentRendererContext = fragmentRendererContext;
 
 		_fragmentEntryLink = fragmentRendererContext.getFragmentEntryLink();
+
+		_themeDisplay = (ThemeDisplay)httpServletRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
 	}
 
 	public String getHelpText() {
@@ -58,7 +68,7 @@ public class FragmentCollectionFilterTagsDisplayContext {
 		return StringPool.BLANK;
 	}
 
-	public Map<String, Object> getProps() {
+	public Map<String, Object> getProps() throws PortalException {
 		if (_props != null) {
 			return _props;
 		}
@@ -68,6 +78,12 @@ public class FragmentCollectionFilterTagsDisplayContext {
 		).put(
 			"fragmentEntryLinkId",
 			String.valueOf(_fragmentEntryLink.getFragmentEntryLinkId())
+		).put(
+			"groupIds",
+			ArrayUtil.toStringArray(
+				SiteConnectedGroupGroupProviderUtil.
+					getCurrentAndAncestorSiteAndDepotGroupIds(
+						_themeDisplay.getScopeGroupId()))
 		).put(
 			"helpText",
 			() -> {
@@ -115,5 +131,6 @@ public class FragmentCollectionFilterTagsDisplayContext {
 	private final FragmentEntryLink _fragmentEntryLink;
 	private final FragmentRendererContext _fragmentRendererContext;
 	private Map<String, Object> _props;
+	private final ThemeDisplay _themeDisplay;
 
 }

--- a/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/js/index.tsx
+++ b/modules/apps/fragment/fragment-collection-filter-tags/src/main/resources/META-INF/resources/js/index.tsx
@@ -13,6 +13,7 @@ import React, {useCallback, useState} from 'react';
 interface IProps {
 	disabled: boolean;
 	fragmentEntryLinkId: string;
+	groupIds: Array<string>;
 	helpText: string;
 	label: string;
 	showLabel: boolean;
@@ -22,6 +23,7 @@ interface IProps {
 export function SelectTags({
 	disabled,
 	fragmentEntryLinkId,
+	groupIds,
 	helpText,
 	label,
 	showLabel,
@@ -59,6 +61,7 @@ export function SelectTags({
 	return (
 		<AssetTagsSelector
 			formGroupClassName="mb-0"
+			groupIds={groupIds}
 			helpText={helpText}
 			inputValue={inputValue}
 			label={label}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-17496

Currently, the tags are not filtered by the group so all tags from all groups are displayed in the fragment.

If there is a reason why this behavior is preferable please let me know so I can inform the client.