### PR TITLE
[TS]LPD-17673 use distinct, based on the columns being used, the versioning of the file entry is not needed

### DIFF
--- a/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/upgrade/v3_0_0/UpgradeAssetDisplayPageEntry.java
+++ b/modules/apps/asset/asset-display-page-service/src/main/java/com/liferay/asset/display/page/internal/upgrade/v3_0_0/UpgradeAssetDisplayPageEntry.java
@@ -45,10 +45,11 @@ public class UpgradeAssetDisplayPageEntry
 
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
 				StringBundler.concat(
-					"select groupId, companyId, userId, userName, fileEntryId ",
-					"from DLFileEntry where fileEntryId not in (select ",
-					"classPK from AssetDisplayPageEntry where classNameId in (",
-					dlFileEntryClassNameId, ", ", fileEntryClassNameId, "))"));
+					"select distinct groupId, companyId, userId, userName, ",
+					"fileEntryId from DLFileEntry where fileEntryId not in ",
+					"(select classPK from AssetDisplayPageEntry where ",
+					"classNameId in (", dlFileEntryClassNameId, ", ",
+					fileEntryClassNameId, "))"));
 			PreparedStatement preparedStatement2 =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,


### PR DESCRIPTION
Issue:
When there are multiple versions of the same file,  the select query pulls multiple version of the file entry.  
Since multiple versions are being inserted a constraint violation is being thrown.
Based on the columns being used,  it doesn't seem like the versioning of the file entry is relevent unless each version would need it's own entry in AssetDisplayPageEntry.

If this is not the proper solution,  can LPD-17673 be assigned and worked on,  an LPP is dependent on the ticket.
