### PR TITLE
LPD-17762 Allow freemarker variables to use - symbol for layoutpagetemplateentrykey

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/info/item/provider/DisplayPageInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/info/item/provider/DisplayPageInfoItemFieldSetProviderImpl.java
@@ -127,7 +127,7 @@ public class DisplayPageInfoItemFieldSetProviderImpl
 					).uniqueId(
 						_getUniqueId(
 							layoutPageTemplateEntry.
-								getLayoutPageTemplateEntryKey())
+								getLayoutPageTemplateEntryId())
 					).name(
 						layoutPageTemplateEntry.getName()
 					).attribute(
@@ -249,7 +249,7 @@ public class DisplayPageInfoItemFieldSetProviderImpl
 					_getDisplayPageInfoFieldType()
 				).uniqueId(
 					_getUniqueId(
-						layoutPageTemplateEntry.getLayoutPageTemplateEntryKey())
+						layoutPageTemplateEntry.getLayoutPageTemplateEntryId())
 				).name(
 					layoutPageTemplateEntry.getName()
 				).labelInfoLocalizedValue(
@@ -282,9 +282,9 @@ public class DisplayPageInfoItemFieldSetProviderImpl
 		return StringPool.BLANK;
 	}
 
-	private String _getUniqueId(String layoutPageTemplateEntryKey) {
+	private String _getUniqueId(long layoutPageTemplateEntryId) {
 		return LayoutPageTemplateEntry.class.getSimpleName() +
-			StringPool.UNDERLINE + layoutPageTemplateEntryKey;
+			StringPool.UNDERLINE + layoutPageTemplateEntryId;
 	}
 
 	private String _getURLSeparator() {


### PR DESCRIPTION
Same as https://github.com/liferay/liferay-portal/commit/4140e7c386f40547f0d0ef9e3c97f4f58811849d

The unique key is being created here: https://github.com/liferay/liferay-portal/blob/5af8b3db3d61285e86371cdd942fcbbfc3b9d105/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/info/item/provider/DisplayPageInfoItemFieldSetProviderImpl.java#L128

When a client is using space in Display page template name, this is being replaced with - symbol, this creates problems as is being used as operator minus.

I added others symbols to be blacklisted as they could create the same issues.