### PR TITLE
LPD-17892 Do not use pagination in layouts tree if property layout.ma…

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/GetLayoutsTreeStrutsAction.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/struts/GetLayoutsTreeStrutsAction.java
@@ -55,6 +55,13 @@ public class GetLayoutsTreeStrutsAction implements StrutsAction {
 			JSONUtil.put(
 				"hasMoreElements",
 				() -> {
+					int pageSize = GetterUtil.getInteger(
+						PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN);
+
+					if (pageSize == -1) {
+						return false;
+					}
+
 					int childLayoutsCount = _layoutService.getLayoutsCount(
 						groupId, privateLayout, parentLayoutId);
 
@@ -62,9 +69,6 @@ public class GetLayoutsTreeStrutsAction implements StrutsAction {
 						httpServletRequest, "start");
 
 					start = Math.max(0, start);
-
-					int pageSize = GetterUtil.getInteger(
-						PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN);
 
 					int end = ParamUtil.getInteger(
 						httpServletRequest, "end", start + pageSize);

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/struts/GetLayoutsStrutsAction.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/struts/GetLayoutsStrutsAction.java
@@ -6,6 +6,7 @@
 package com.liferay.layout.taglib.internal.struts;
 
 import com.liferay.layout.taglib.internal.util.LayoutUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.service.LayoutService;
@@ -61,11 +62,20 @@ public class GetLayoutsStrutsAction implements StrutsAction {
 
 		int startEndMax = Math.max(start, end);
 
+		if (pageSize == -1) {
+			start = QueryUtil.ALL_POS;
+			end = QueryUtil.ALL_POS;
+		}
+
 		ServletResponseUtil.write(
 			httpServletResponse,
 			JSONUtil.put(
 				"hasMoreElements",
 				() -> {
+					if (pageSize == -1) {
+						return false;
+					}
+
 					int childLayoutsCount = _layoutService.getLayoutsCount(
 						groupId, privateLayout, parentLayoutId);
 

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/servlet/taglib/react/SelectLayoutTag.java
@@ -7,6 +7,7 @@ package com.liferay.layout.taglib.servlet.taglib.react;
 
 import com.liferay.layout.taglib.internal.servlet.ServletContextUtil;
 import com.liferay.layout.taglib.internal.util.LayoutUtil;
+import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONUtil;
@@ -202,7 +203,7 @@ public class SelectLayoutTag extends IncludeTag {
 					_checkDisplayPage, _enableCurrentPage,
 					themeDisplay.getScopeGroupId(), getRequest(),
 					_itemSelectorReturnType, _privateLayout, 0,
-					selectedLayoutIds, selPlid, 0,
+					selectedLayoutIds, selPlid, QueryUtil.ALL_POS,
 					GetterUtil.getInteger(
 						PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN))
 			).put(
@@ -220,6 +221,10 @@ public class SelectLayoutTag extends IncludeTag {
 			).put(
 				"paginated",
 				() -> {
+					if (PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN == -1) {
+						return false;
+					}
+
 					int layoutsCount = LayoutServiceUtil.getLayoutsCount(
 						themeDisplay.getScopeGroupId(), _privateLayout,
 						LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/portlet/action/GetLayoutsMVCResourceCommand.java
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/java/com/liferay/product/navigation/product/menu/web/internal/portlet/action/GetLayoutsMVCResourceCommand.java
@@ -68,6 +68,13 @@ public class GetLayoutsMVCResourceCommand extends BaseMVCResourceCommand {
 			JSONUtil.put(
 				"hasMoreElements",
 				() -> {
+					int pageSize = GetterUtil.getInteger(
+						PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN);
+
+					if (pageSize == -1) {
+						return false;
+					}
+
 					int childLayoutsCount = _layoutService.getLayoutsCount(
 						themeDisplay.getScopeGroupId(), privateLayout,
 						parentLayoutId);
@@ -76,9 +83,6 @@ public class GetLayoutsMVCResourceCommand extends BaseMVCResourceCommand {
 						httpServletRequest, "start");
 
 					start = Math.max(0, start);
-
-					int pageSize = GetterUtil.getInteger(
-						PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN);
 
 					int end = ParamUtil.getInteger(
 						httpServletRequest, "end", start + pageSize);

--- a/modules/apps/staging/staging-taglib/src/main/java/com/liferay/staging/taglib/internal/display/context/LayoutsTreeDisplayContext.java
+++ b/modules/apps/staging/staging-taglib/src/main/java/com/liferay/staging/taglib/internal/display/context/LayoutsTreeDisplayContext.java
@@ -376,6 +376,10 @@ public class LayoutsTreeDisplayContext {
 			).put(
 				"paginated",
 				() -> {
+					if (PropsValues.LAYOUT_MANAGE_PAGES_INITIAL_CHILDREN == -1) {
+						return false;
+					}
+
 					int layoutsCount = LayoutServiceUtil.getLayoutsCount(
 						_getSelectPagesGroupId(), isSelectPagesPrivateLayout(),
 						LayoutConstants.DEFAULT_PARENT_LAYOUT_ID);


### PR DESCRIPTION
Motivation
=======
Solve https://liferay.atlassian.net/browse/LPD-17892
When using property layout.manage.pages.initial.children=-1, the layout trees should not use pagination and show all the children of a given node. See property description:
```html
# Set the initial number of child pages to display in the Manage Pages tree.
# Set this to -1 to show all.
layout.manage.pages.initial.children=20
```
This was not properly managed in our code in several uses of the layouts tree.

Steps to Verify
========
1. Add this to portal-ext.properties: layout.manage.pages.initial.children=-1
1. Start up Liferay, log in as Admin
1. Go to Site > Site Builder > Pages
1. Create a few static pages (they can be empty)
1. Create some child pages as well
1. Enable Local Live staging
1. Create a new publication process
1. Scroll down to the Pages section and behold the page tree under the "Pages to Publish" heading
1. All the top level pages are visible in the page tree correctly, however, at the bottom there is a link to "Load More Results"
1. "Load More Results" link is visible under Child pages as well
1. Click Load More Results

Results of Testing

**Expected Result:** This link should not be there at all because all the top level pages are also listed in the page tree because the portal ext entry mentioned in the first point is used. If the value is set to -1, the link to "Load More Results" should not be shown at all because all the pages of the page tree have already been shown and no pages are remaining to be loaded in the page tree.

**Actual Results:** Clicking on "Load More Results" the complete page hierarchy is duplicated and all the pages are now shown twice. The "Load More Results" page is still available after each click on it, resulting into an infinite duplication of the page tree/hierarchy if user keeps on clicking the link. Same behavior is seen with child pages too.

**Another uses of this layouts tree can be tested using the layouts created in these reproduction steps such as:**
1. Clicking in "Page tree" in the product menu will render the layouts tree
2. Creating a page using the "Link to a page of this site" template and selecting the page to link to
3. Creating a structure with a "Link to page" field. Creating a content using this structure will show a button that will render this layout tree