### PR TITLE
Lpd 18024 | The "Add This Page to navigation menu" checkbox does not work when a page gets copied

### DIFF
--- a/modules/apps/layout/layout-admin-web-test/build.gradle
+++ b/modules/apps/layout/layout-admin-web-test/build.gradle
@@ -13,6 +13,8 @@ dependencies {
 	testIntegrationImplementation project(":apps:layout:layout-test-util")
 	testIntegrationImplementation project(":apps:layout:layout-utility-page-api")
 	testIntegrationImplementation project(":apps:segments:segments-api")
+	testIntegrationImplementation project(":apps:site-navigation:site-navigation-api")
+	testIntegrationImplementation project(":apps:site-navigation:site-navigation-menu-item-api")
 	testIntegrationImplementation project(":apps:translation:translation-api")
 	testIntegrationImplementation project(":test:arquillian-extension-junit-bridge")
 }

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/CopyLayoutMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/CopyLayoutMVCActionCommandTest.java
@@ -51,6 +51,10 @@ import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.segments.service.SegmentsExperienceLocalService;
+import com.liferay.site.navigation.constants.SiteNavigationConstants;
+import com.liferay.site.navigation.model.SiteNavigationMenu;
+import com.liferay.site.navigation.service.SiteNavigationMenuItemLocalService;
+import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
 
 import java.util.Collections;
 import java.util.List;
@@ -150,6 +154,83 @@ public class CopyLayoutMVCActionCommandTest {
 			expectedResourcePermissions.toString(),
 			expectedResourcePermissions.size(),
 			actualResourcePermissions.size());
+	}
+
+	@Test
+	public void testDoProcessActionCopyLayoutWithNavigationMenu()
+		throws Exception {
+
+		Layout expectedLayout = LayoutTestUtil.addTypeContentPublishedLayout(
+			_group, "Test layout", WorkflowConstants.STATUS_APPROVED);
+
+		expectedLayout.setFriendlyURL("/test-layout");
+
+		expectedLayout = _layoutLocalService.updateLayout(expectedLayout);
+
+		SiteNavigationMenu siteNavigationMenu =
+			_siteNavigationMenuLocalService.addSiteNavigationMenu(
+				TestPropsValues.getUserId(), _group.getGroupId(), "Menu",
+				SiteNavigationConstants.TYPE_DEFAULT, true, _serviceContext);
+
+		MockLiferayPortletActionRequest mockLiferayPortletActionRequest =
+			_getMockLiferayPortletActionRequest();
+
+		mockLiferayPortletActionRequest.addParameter(
+			"groupId", String.valueOf(_group.getGroupId()));
+		mockLiferayPortletActionRequest.addParameter(
+			"privateLayout", String.valueOf(expectedLayout.isPrivateLayout()));
+		mockLiferayPortletActionRequest.addParameter(
+			"name", "Copy test layout");
+		mockLiferayPortletActionRequest.addParameter(
+			"sourcePlid", String.valueOf(expectedLayout.getPlid()));
+		mockLiferayPortletActionRequest.addParameter(
+			"TypeSettingsProperties--siteNavigationMenuId--",
+			String.valueOf(siteNavigationMenu.getSiteNavigationMenuId()));
+
+		_addFragmentEntryLinkToLayout(
+			expectedLayout,
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				expectedLayout.getPlid()));
+
+		Role role = _roleLocalService.addRole(
+			_serviceContext.getUserId(), null, 0, StringUtil.randomString(),
+			Collections.emptyMap(), Collections.emptyMap(),
+			RoleConstants.TYPE_REGULAR, StringPool.BLANK, _serviceContext);
+
+		_addModelResources(role, expectedLayout);
+
+		_mvcActionCommand.processAction(
+			mockLiferayPortletActionRequest,
+			new MockLiferayPortletActionResponse());
+
+		Layout actualLayout = _layoutLocalService.fetchLayoutByFriendlyURL(
+			expectedLayout.getGroupId(), expectedLayout.isPrivateLayout(),
+			"/copy-test-layout");
+
+		_validateCopiedLayout(expectedLayout, actualLayout);
+
+		List<ResourcePermission> expectedResourcePermissions =
+			_resourcePermissionLocalService.getResourcePermissions(
+				expectedLayout.getCompanyId(), Layout.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(expectedLayout.getPlid()));
+
+		List<ResourcePermission> actualResourcePermissions =
+			_resourcePermissionLocalService.getResourcePermissions(
+				expectedLayout.getCompanyId(), Layout.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(actualLayout.getPlid()));
+
+		Assert.assertNotEquals(
+			expectedResourcePermissions.toString(),
+			expectedResourcePermissions.size(),
+			actualResourcePermissions.size());
+
+		long navigationItemCount =
+			_siteNavigationMenuItemLocalService.getSiteNavigationMenuItemsCount(
+				siteNavigationMenu.getSiteNavigationMenuId());
+
+		Assert.assertEquals(1, navigationItemCount);
 	}
 
 	@Test
@@ -405,5 +486,12 @@ public class CopyLayoutMVCActionCommandTest {
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;
 
 	private ServiceContext _serviceContext;
+
+	@Inject
+	private SiteNavigationMenuItemLocalService
+		_siteNavigationMenuItemLocalService;
+
+	@Inject
+	private SiteNavigationMenuLocalService _siteNavigationMenuLocalService;
 
 }

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceImpl.java
@@ -105,6 +105,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
+import com.liferay.portal.kernel.util.PropertiesParamUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
 import com.liferay.portal.kernel.util.Validator;
@@ -132,6 +133,8 @@ import java.util.Objects;
 import java.util.Queue;
 import java.util.Set;
 import java.util.UUID;
+
+import javax.servlet.http.HttpServletRequest;
 
 /**
  * Provides the local service for accessing, adding, deleting, exporting,
@@ -708,10 +711,18 @@ public class LayoutLocalServiceImpl extends LayoutLocalServiceBaseImpl {
 			ServiceContext serviceContext)
 		throws PortalException {
 
+		HttpServletRequest httpServletRequest = serviceContext.getRequest();
+
+		UnicodeProperties typeSettingsUnicodeProperties =
+			PropertiesParamUtil.getProperties(
+				httpServletRequest, "TypeSettingsProperties--");
+
 		Layout sourceLayout = layoutLocalService.getLayout(sourcePlid);
 
 		UnicodeProperties sourceUnicodeProperties =
 			sourceLayout.getTypeSettingsProperties();
+
+		sourceUnicodeProperties.putAll(typeSettingsUnicodeProperties);
 
 		Layout targetLayout = layoutLocalService.addLayout(
 			userId, groupId, privateLayout, sourceLayout.getParentLayoutId(),


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPD-18024
best,
Attila

-----

The root cause of the issue was [LPS-179883](https://github.com/brianchandotcom/liferay-portal/pull/132924/commits/d790f9a73452663c4ba8b46f9f0f743fd2e697e1). The logic migration was not perfect and there was some feature loss. I added the lost functionality in the updated CopyLayout method to restore the lost functionality. I also added an integration test to avoid possible loss in the future.