### PR TITLE
LPD-18557 Add default value for tablet and portrait mobile view as well

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddItemMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddItemMVCActionCommand.java
@@ -65,6 +65,12 @@ public class AddItemMVCActionCommand
 		collectionStyledLayoutStructureItem.setViewportConfiguration(
 			ViewportSize.MOBILE_LANDSCAPE.getViewportSizeId(),
 			JSONUtil.put("numberOfColumns", 1));
+		collectionStyledLayoutStructureItem.setViewportConfiguration(
+			ViewportSize.PORTRAIT_MOBILE.getViewportSizeId(),
+			JSONUtil.put("numberOfColumns", 1));
+		collectionStyledLayoutStructureItem.setViewportConfiguration(
+			ViewportSize.TABLET.getViewportSizeId(),
+			JSONUtil.put("numberOfColumns", 1));
 
 		return collectionStyledLayoutStructureItem;
 	}


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPD-18557
best,
Attila

------

The root cause of the issue is [LPS-186892](https://liferay.atlassian.net/browse/LPS-186892). The introduced logic at [ResponsiveLayoutStructureUtil.java#L50-L57](https://github.com/liferay/liferay-portal/blob/master/modules/apps/layout/layout-api/src/main/java/com/liferay/layout/responsive/ResponsiveLayoutStructureUtil.java#L50-L57) defaults to the 12 column separation if there is no default value set for the viewport numberOfColumns variable. I fixed the issue by adding the same default value already added for the mobile view "numberOfColumns:1".