### PR TITLE
[CLDR] LPD-18589 Make LocalizationUseCase#DisplayTemplatesViaLanguageSelect work with both CLDR and JRE locale provider

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/MenuItem.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/MenuItem.macro
@@ -50,6 +50,13 @@ definition {
 	}
 
 	@summary = "Default summary"
+	macro viewNotPresentPartialMatch(menuItem = null) {
+		AssertElementNotPresent(
+			key_menuItem = ${menuItem},
+			locator1 = "MenuItem#ANY_MENU_ITEM_PARTIAL_MATCH");
+	}
+
+	@summary = "Default summary"
 	macro viewNotVisible(menuItem = null) {
 		AssertNotVisible(
 			key_menuItem = ${menuItem},
@@ -75,6 +82,13 @@ definition {
 		AssertElementPresent(
 			key_menuItem = ${menuItem},
 			locator1 = "MenuItem#ANY_MENU_ITEM");
+	}
+
+	@summary = "Default summary"
+	macro viewPresentPartialMatch(menuItem = null) {
+		AssertElementPresent(
+			key_menuItem = ${menuItem},
+			locator1 = "MenuItem#ANY_MENU_ITEM_PARTIAL_MATCH");
 	}
 
 	@summary = "Default summary"

--- a/portal-web/test/functional/com/liferay/portalweb/macros/sitenavigation/languageportlet/LanguagePortlet.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/sitenavigation/languageportlet/LanguagePortlet.macro
@@ -122,6 +122,19 @@ definition {
 				MenuItem.viewNotPresent(menuItem = ${unavailableLanguage});
 			}
 		}
+		else if (${displayTemplate} == "Icon Menu Partial Match") {
+			Click(
+				key_portletName = "LanguagePortlet",
+				locator1 = "Language#DROPDOWN");
+
+			for (var availableLanguage : list ${availableLanguageList}) {
+				MenuItem.viewPresentPartialMatch(menuItem = ${availableLanguage});
+			}
+
+			for (var unavailableLanguage : list ${unavailableLanguageList}) {
+				MenuItem.viewNotPresentPartialMatch(menuItem = ${unavailableLanguage});
+			}
+		}
 		else if (${displayTemplate} == "Long Text") {
 			for (var availableLanguage : list ${availableLanguageList}) {
 				AssertTextEquals(

--- a/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/MenuItem.path
+++ b/portal-web/test/functional/com/liferay/portalweb/paths/pathlib/uielements/MenuItem.path
@@ -26,6 +26,11 @@
 	<td></td>
 </tr>
 <tr>
+	<td>ANY_MENU_ITEM_PARTIAL_MATCH</td>
+	<td>xpath=(//div | //li)[contains(@class,'open') or contains(@class,'show')][contains(@class,'menu')][not(contains(@class,'product-menu'))]//*[contains(normalize-space(text()), '${key_menuItem}')] | //ul[contains(@class,'dropdown-menu') and contains(@class,'show')]//li//*[contains(normalize-space(text()), '${key_menuItem}')]</td>
+	<td></td>
+</tr>
+<tr>
 	<td>ANY_MENU_ITEM_SELECTED</td>
 	<td>xpath=(//div | //li)[contains(@class,'open') or contains(@class,'show')][contains(@class,'menu')][not(contains(@class,'product-menu'))]//*[normalize-space(text())="${key_menuItem}"] | //ul[contains(@class,'dropdown-menu') and contains(@class,'show')]//li//*[normalize-space(text())="${key_menuItem}"]//*[name()='svg'][contains(@class,'icon-check')]//*[name()='svg'][contains(@class,'icon-check')]</td>
 	<td></td>

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/sitenavigation/languageselector/LocalizationUseCase.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/sitenavigation/languageselector/LocalizationUseCase.testcase
@@ -85,8 +85,8 @@ definition {
 			LanguagePortlet.viewCurrentLanguage(locale = "en-US");
 
 			LanguagePortlet.viewLanguages(
-				availableLanguageList = "العربية-السعودية,català-Espanya,中文-中国,nederlands-Nederland,suomi-Suomi,français-France,deutsch-Deutschland,magyar-Magyarország,日本語-日本,português-Brasil,español-España,svenska-Sverige",
-				displayTemplate = "Icon Menu");
+				availableLanguageList = "السعودية,català-Espanya,中文-中国,nederlands-Nederland,suomi-Suomi,français-France,deutsch-Deutschland,magyar-Magyarország,日本語-日本,português-Brasil,español-España,svenska-Sverige",
+				displayTemplate = "Icon Menu Partial Match");
 		}
 
 		task ("Define Icon as display template in Language Selector") {


### PR DESCRIPTION
Hello Echo team,
This pull is for [LPD-18589](https://liferay.atlassian.net/browse/LPD-18589)

### Motivation
We are in preparation to change locale provider from JRE/COMPAT to CLDR. This made some slight differences in some display name of timezone, country, and formats. This made many functional tests fail as a result.

### Proposed Solution
In this pull, I made the test check for partial text in the MenuItem instead of exact matched text.

### Steps to Reproduce
- Change java.locale.provider in tomcat setenv.sh from `JRE,COMPAT,CLDR` to `CLDR`
- Start portal and add Language Selector
- Inspect the display name for Saudi Arabia
JRE/COMPAT: العربية-السعودية
CLDR: العربية-المملكة العربية السعودية

### Steps to Verify that the test works now
- Run the functional test locally both using JRE and CLDR provider setting.
- Test should pass both cases.

I am testing it 2 ways here:
1. [With JRE](https://github.com/julschong/liferay-portal/pull/1160)
2. [With CLDR](https://github.com/julschong/liferay-portal/pull/1161)


