### PR TITLE
LPD-19215 Wrap containerKey value in quote

### DIFF
--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_1/LayoutClassedModelUsageUpgradeProcess.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_1/LayoutClassedModelUsageUpgradeProcess.java
@@ -234,8 +234,8 @@ public class LayoutClassedModelUsageUpgradeProcess extends UpgradeProcess {
 				StringBundler.concat(
 					"select 1 from LayoutClassedModelUsage where classNameId ",
 					"= ", classNameId, " and classPK = ", classPK,
-					" and containerKey = ", fragmentEntryLinkId,
-					" and containerType = ", _fragmentEntryLinkClassNameId,
+					" and containerKey = '", fragmentEntryLinkId,
+					"' and containerType = ", _fragmentEntryLinkClassNameId,
 					" and plid = ", plid));
 			ResultSet resultSet = preparedStatement.executeQuery()) {
 


### PR DESCRIPTION
Motivation
=======
During upgrade, a LayoutClassedModelUsage can't be identified if the db is PostgreSQL.
[LPD-19215](https://liferay.atlassian.net/browse/LPD-19215)

Proposed Solution
========
Wrap containerKey value in quote to signal its type is String (varchar) to the DB

Steps to Verify
========
1. Start up a 7.4 u92 bundle
2. Create a web content
3. Create a page
4. Add a Heading fragment to the page
5. In the Heading fragment's element-text component map the created web content's title
6. Publish the page
7. Stop DXP and upgrade it to 2023.q4.4

**Expected behaviour:** The update finishes with no issues

**Actual behaviour:**
The upgrade fails with the attached error:
```org.postgresql.util.PSQLException: ERROR: operator does not exist: character varying = integer_  Hint: No operator matches the given name and argument types. You might need to add explicit type casts._```

Cheers,
Balázs