### PR TITLE
LPD-19643 SignedIn segment expression not working for headless call

### DIFF
--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SegmentResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/SegmentResourceImpl.java
@@ -10,24 +10,16 @@ import com.liferay.headless.admin.user.resource.v1_0.SegmentResource;
 import com.liferay.portal.kernel.model.User;
 import com.liferay.portal.kernel.service.UserService;
 import com.liferay.portal.kernel.util.ArrayUtil;
-import com.liferay.portal.kernel.util.CamelCaseUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
-import com.liferay.segments.context.Context;
+import com.liferay.segments.context.RequestContextMapper;
 import com.liferay.segments.model.SegmentsEntry;
 import com.liferay.segments.provider.SegmentsEntryProviderRegistry;
 import com.liferay.segments.service.SegmentsEntryService;
 
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
-
-import java.util.List;
-import java.util.Map;
-
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
-import javax.ws.rs.core.MultivaluedMap;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -67,61 +59,21 @@ public class SegmentResourceImpl extends BaseSegmentResourceImpl {
 				ArrayUtil.toArray(
 					_segmentsEntryProviderRegistry.getSegmentsEntryIds(
 						siteId, user.getModelClassName(), user.getPrimaryKey(),
-						_createSegmentsContext(), new long[0])),
+						_requestContextMapper.map(contextHttpServletRequest),
+						new long[0])),
 				segmentsEntryId -> _toSegment(
 					_segmentsEntryService.getSegmentsEntry(segmentsEntryId))));
-	}
-
-	private Context _createSegmentsContext() {
-		Context context = new Context();
-
-		MultivaluedMap<String, String> multivaluedMap =
-			_httpHeaders.getRequestHeaders();
-
-		for (Map.Entry<String, List<String>> entry :
-				multivaluedMap.entrySet()) {
-
-			String key = StringUtil.toLowerCase(entry.getKey());
-
-			List<String> values = entry.getValue();
-
-			String value = values.get(0);
-
-			if (key.startsWith("x-")) {
-				context.put(
-					CamelCaseUtil.toCamelCase(
-						StringUtil.removeSubstring(key, "x-")),
-					value);
-			}
-			else if (key.equals("accept-language")) {
-				context.put(
-					Context.LANGUAGE_ID, StringUtil.replace(value, '-', '_'));
-			}
-			else if (key.equals("host")) {
-				context.put(Context.URL, value);
-			}
-			else if (key.equals("referer")) {
-				context.put(Context.REFERRER_URL, value);
-			}
-			else if (key.equals("user-agent")) {
-				context.put(Context.USER_AGENT, value);
-			}
-			else {
-				context.put(key, value);
-			}
-		}
-
-		context.put(Context.LOCAL_DATE, LocalDate.from(ZonedDateTime.now()));
-
-		return context;
 	}
 
 	private Segment _toSegment(SegmentsEntry segmentsEntry) throws Exception {
 		return _segmentDTOConverter.toDTO(segmentsEntry);
 	}
 
-	@javax.ws.rs.core.Context
+	@Context
 	private HttpHeaders _httpHeaders;
+
+	@Reference
+	private RequestContextMapper _requestContextMapper;
 
 	@Reference(
 		target = "(component.name=com.liferay.headless.admin.user.internal.dto.v1_0.converter.SegmentDTOConverter)"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentSetElementResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/ContentSetElementResourceImpl.java
@@ -13,21 +13,15 @@ import com.liferay.headless.delivery.dto.v1_0.ContentSetElement;
 import com.liferay.headless.delivery.resource.v1_0.ContentSetElementResource;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.change.tracking.CTAware;
-import com.liferay.portal.kernel.util.CamelCaseUtil;
-import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.vulcan.dto.converter.DTOConverter;
 import com.liferay.portal.vulcan.dto.converter.DTOConverterRegistry;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 import com.liferay.portal.vulcan.pagination.Page;
 import com.liferay.portal.vulcan.pagination.Pagination;
 import com.liferay.portal.vulcan.util.LocalizedMapUtil;
-import com.liferay.segments.context.Context;
+import com.liferay.segments.context.RequestContextMapper;
 import com.liferay.segments.provider.SegmentsEntryProviderRegistry;
 
-import java.time.LocalDate;
-import java.time.ZonedDateTime;
-
-import java.util.Enumeration;
 import java.util.HashMap;
 
 import org.osgi.service.component.annotations.Component;
@@ -96,46 +90,6 @@ public class ContentSetElementResourceImpl
 		return _getContentSetContentSetElementsPage(assetListEntry, pagination);
 	}
 
-	private Context _createSegmentsContext() {
-		Context context = new Context();
-
-		Enumeration<String> enumeration =
-			contextHttpServletRequest.getHeaderNames();
-
-		while (enumeration.hasMoreElements()) {
-			String key = enumeration.nextElement();
-
-			String value = contextHttpServletRequest.getHeader(key);
-
-			if (key.equals("accept-language")) {
-				context.put(
-					Context.LANGUAGE_ID, StringUtil.replace(value, '-', '_'));
-			}
-			else if (key.equals("host")) {
-				context.put(Context.URL, value);
-			}
-			else if (key.equals("referer")) {
-				context.put(Context.REFERRER_URL, value);
-			}
-			else if (key.equals("user-agent")) {
-				context.put(Context.USER_AGENT, value);
-			}
-			else if (key.startsWith("x-")) {
-				context.put(
-					CamelCaseUtil.toCamelCase(
-						StringUtil.removeSubstring(key, "x-")),
-					value);
-			}
-			else {
-				context.put(key, value);
-			}
-		}
-
-		context.put(Context.LOCAL_DATE, LocalDate.from(ZonedDateTime.now()));
-
-		return context;
-	}
-
 	private Page<ContentSetElement> _getContentSetContentSetElementsPage(
 			AssetListEntry assetListEntry, Pagination pagination)
 		throws Exception {
@@ -143,7 +97,8 @@ public class ContentSetElementResourceImpl
 		long[] segmentsEntryIds =
 			_segmentsEntryProviderRegistry.getSegmentsEntryIds(
 				assetListEntry.getGroupId(), contextUser.getModelClassName(),
-				contextUser.getPrimaryKey(), _createSegmentsContext(),
+				contextUser.getPrimaryKey(),
+				_requestContextMapper.map(contextHttpServletRequest),
 				new long[0]);
 
 		return Page.of(
@@ -208,6 +163,9 @@ public class ContentSetElementResourceImpl
 
 	@Reference
 	private DTOConverterRegistry _dtoConverterRegistry;
+
+	@Reference
+	private RequestContextMapper _requestContextMapper;
 
 	@Reference
 	private SegmentsEntryProviderRegistry _segmentsEntryProviderRegistry;


### PR DESCRIPTION
Motivation
=======
Session based segments aren't always evaluated correctly in Collection headless calls
[LPD-19643](https://liferay.atlassian.net/browse/LPD-19643)

Proposed Solution
========
Collections has its own code to map an httpRequest to a segmentsContext. This method could be replaced by the centralised requestContextMapper.map call, which has the more advanced logic to map far more information.
Based on this pattern, I've updated SegmentResource as well

Steps to Verify
========
Please check [LPD-19643](https://liferay.atlassian.net/browse/LPD-19643), sadly this is a very long scenario.

Cheers,
Balázs