### PR TITLE
LPD-19450 use the full primary key

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v4_0_0/LayoutPageTemplateStructureRelUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v4_0_0/LayoutPageTemplateStructureRelUpgradeProcess.java
@@ -122,23 +122,28 @@ public class LayoutPageTemplateStructureRelUpgradeProcess
 	private void _upgradeLayoutPageTemplateStructureRel() throws Exception {
 		try (Statement s = connection.createStatement();
 			ResultSet resultSet = s.executeQuery(
-				"select lPageTemplateStructureRelId, data_ from " +
-					"LayoutPageTemplateStructureRel");
+				"select lPageTemplateStructureRelId, data_, ctCollectionId " +
+					"from  LayoutPageTemplateStructureRel");
 			PreparedStatement preparedStatement =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
 					"update LayoutPageTemplateStructureRel set data_ = ? " +
-						"where lPageTemplateStructureRelId = ?")) {
+						"where lPageTemplateStructureRelId = ? and " +
+							"ctCollectionId = ?")) {
 
 			while (resultSet.next()) {
 				long layoutPageTemplateStructureRelId = resultSet.getLong(
 					"lPageTemplateStructureRelId");
+
+				long ctCollectionId = resultSet.getLong("ctCollectionId");
 
 				String data = resultSet.getString("data_");
 
 				preparedStatement.setString(1, _upgradeLayoutData(data));
 
 				preparedStatement.setLong(2, layoutPageTemplateStructureRelId);
+
+				preparedStatement.setLong(3, ctCollectionId);
 
 				preparedStatement.addBatch();
 			}


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPD-19450 
best,
Attila

-------

The root cause of the issue is that the upgrade step does not use the full primary key, as a result records can be overwritten between publications. I fixed it by using the correct primary key to reference the records.