### PR TITLE
LPD-19799 Add endpoint to create a site with a site initializer zip file all in one go

### DIFF
--- a/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/rest-openapi.yaml
@@ -211,7 +211,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.change.tracking.rest.client', and version '2.3.0'."
+        'com.liferay.change.tracking.rest.client', and version '3.0.1'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/change-tracking/change-tracking-rest-impl/src/main/java/com/liferay/change/tracking/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.change.tracking.rest.client', and version '2.3.0'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.change.tracking.rest.client', and version '3.0.1'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/rest-openapi.yaml
@@ -2176,7 +2176,7 @@ info:
         name: Commerce Team
     description:
         "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay',
-        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.54'."
+        artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.55'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/commerce/headless/headless-commerce/headless-commerce-admin-catalog-impl/src/main/java/com/liferay/headless/commerce/admin/catalog/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.54'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
+	info = @Info(description = "Liferay Commerce Admin Catalog API. A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.commerce.admin.catalog.client', and version '4.0.55'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Liferay Commerce Admin Catalog API", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/digital-signature/digital-signature-rest-impl/rest-openapi.yaml
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/rest-openapi.yaml
@@ -85,7 +85,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.digital.signature.rest.client', and version '1.0.23'."
+        'com.liferay.digital.signature.rest.client', and version '1.0.24'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/digital-signature/digital-signature-rest-impl/src/main/java/com/liferay/digital/signature/rest/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.digital.signature.rest.client', and version '1.0.23'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.digital.signature.rest.client', and version '1.0.24'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/rest-openapi.yaml
@@ -367,7 +367,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.taxonomy.client', and version '4.0.30'."
+        'com.liferay.headless.admin.taxonomy.client', and version '4.0.31'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-taxonomy/headless-admin-taxonomy-impl/src/main/java/com/liferay/headless/admin/taxonomy/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.taxonomy.client', and version '4.0.30'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Taxonomy", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.taxonomy.client', and version '4.0.31'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin Taxonomy", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/rest-openapi.yaml
@@ -1264,7 +1264,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.admin.user.client', and version '4.0.57'."
+        'com.liferay.headless.admin.user.client', and version '4.0.58'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-admin-user/headless-admin-user-impl/src/main/java/com/liferay/headless/admin/user/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.57'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.admin.user.client', and version '4.0.58'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Admin User", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/BaseImportTaskResourceImpl.java
+++ b/modules/apps/headless/headless-batch-engine/headless-batch-engine-impl/src/main/java/com/liferay/headless/batch/engine/internal/resource/v1_0/BaseImportTaskResourceImpl.java
@@ -158,7 +158,8 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-batch-engine/v1.0/import-task/{className}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Uploads a new file for deleting items in batch."
+		description = "Uploads a new file for deleting items in batch.",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {@io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/x-ndjson", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/xml", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = DeleteImportTaskRequestBody.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "text/csv", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class))})
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -227,7 +228,7 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Uploads a new file for deleting items in batch.",
-		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = DeleteImportTaskRequestBody.class)))
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {@io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/x-ndjson", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/xml", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = DeleteImportTaskRequestBody.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "text/csv", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class))})
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -290,7 +291,8 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 	 * curl -X 'POST' 'http://localhost:8080/o/headless-batch-engine/v1.0/import-task/{className}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Uploads a new file for creating new items in batch."
+		description = "Uploads a new file for creating new items in batch.",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {@io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/x-ndjson", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/xml", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostImportTaskRequestBody.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "text/csv", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class))})
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -373,7 +375,7 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Uploads a new file for creating new items in batch.",
-		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostImportTaskRequestBody.class)))
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {@io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/x-ndjson", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/xml", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostImportTaskRequestBody.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "text/csv", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class))})
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -450,7 +452,8 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 	 * curl -X 'PUT' 'http://localhost:8080/o/headless-batch-engine/v1.0/import-task/{className}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
-		description = "Uploads a new file for updating items in batch."
+		description = "Uploads a new file for updating items in batch.",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {@io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/x-ndjson", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/xml", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PutImportTaskRequestBody.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "text/csv", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class))})
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {
@@ -526,7 +529,7 @@ public abstract class BaseImportTaskResourceImpl implements ImportTaskResource {
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Uploads a new file for updating items in batch.",
-		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PutImportTaskRequestBody.class)))
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {@io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/x-ndjson", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/xml", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PutImportTaskRequestBody.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "text/csv", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = ImportTask.class))})
 	)
 	@io.swagger.v3.oas.annotations.Parameters(
 		value = {

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/rest-openapi.yaml
@@ -5772,7 +5772,7 @@ components:
 info:
     description:
         "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID
-        'com.liferay.headless.delivery.client', and version '4.0.73'."
+        'com.liferay.headless.delivery.client', and version '4.0.74'."
     license:
         name: "Apache 2.0"
         url: "http://www.apache.org/licenses/LICENSE-2.0.html"

--- a/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-impl/src/main/java/com/liferay/headless/delivery/internal/resource/v1_0/OpenAPIResourceImpl.java
@@ -42,7 +42,7 @@ import org.osgi.service.component.annotations.Reference;
 )
 @Generated("")
 @OpenAPIDefinition(
-	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.73'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
+	info = @Info(description = "A Java client JAR is available for use with the group ID 'com.liferay', artifact ID 'com.liferay.headless.delivery.client', and version '4.0.74'.", license = @License(name = "Apache 2.0", url = "http://www.apache.org/licenses/LICENSE-2.0.html"), title = "Headless Delivery", version = "v1.0")
 )
 @Path("/v1.0")
 public class OpenAPIResourceImpl {

--- a/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/resource/v1_0/SiteResource.java
+++ b/modules/apps/headless/headless-site/headless-site-api/src/main/java/com/liferay/headless/site/resource/v1_0/SiteResource.java
@@ -49,6 +49,8 @@ public interface SiteResource {
 
 	public Site postSite(Site site) throws Exception;
 
+	public Site postSite(MultipartBody multipartBody) throws Exception;
+
 	public void deleteSiteByExternalReferenceCode(String externalReferenceCode)
 		throws Exception;
 

--- a/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/resource/v1_0/SiteResource.java
+++ b/modules/apps/headless/headless-site/headless-site-client/src/main/java/com/liferay/headless/site/client/resource/v1_0/SiteResource.java
@@ -44,6 +44,13 @@ public interface SiteResource {
 	public HttpInvoker.HttpResponse postSiteHttpResponse(Site site)
 		throws Exception;
 
+	public Site postFormDataSite(Site site, Map<String, File> multipartFiles)
+		throws Exception;
+
+	public HttpInvoker.HttpResponse postFormDataSiteHttpResponse(
+			Site site, Map<String, File> multipartFiles)
+		throws Exception;
+
 	public void deleteSiteByExternalReferenceCode(String externalReferenceCode)
 		throws Exception;
 
@@ -354,6 +361,116 @@ public interface SiteResource {
 			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
 
 			httpInvoker.body(site.toString(), "application/json");
+
+			if (_builder._locale != null) {
+				httpInvoker.header(
+					"Accept-Language", _builder._locale.toLanguageTag());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._headers.entrySet()) {
+
+				httpInvoker.header(entry.getKey(), entry.getValue());
+			}
+
+			for (Map.Entry<String, String> entry :
+					_builder._parameters.entrySet()) {
+
+				httpInvoker.parameter(entry.getKey(), entry.getValue());
+			}
+
+			httpInvoker.httpMethod(HttpInvoker.HttpMethod.POST);
+
+			httpInvoker.path(
+				_builder._scheme + "://" + _builder._host + ":" +
+					_builder._port + _builder._contextPath +
+						"/o/headless-site/v1.0/sites");
+
+			httpInvoker.userNameAndPassword(
+				_builder._login + ":" + _builder._password);
+
+			return httpInvoker.invoke();
+		}
+
+		public Site postFormDataSite(
+				Site site, Map<String, File> multipartFiles)
+			throws Exception {
+
+			HttpInvoker.HttpResponse httpResponse =
+				postFormDataSiteHttpResponse(site, multipartFiles);
+
+			String content = httpResponse.getContent();
+
+			if ((httpResponse.getStatusCode() / 100) != 2) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response content: " + content);
+				_logger.log(
+					Level.WARNING,
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.log(
+					Level.WARNING,
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+
+				Problem.ProblemException problemException = null;
+
+				if (Objects.equals(
+						httpResponse.getContentType(), "application/json")) {
+
+					problemException = new Problem.ProblemException(
+						Problem.toDTO(content));
+				}
+				else {
+					_logger.log(
+						Level.WARNING,
+						"Unable to process content type: " +
+							httpResponse.getContentType());
+
+					Problem problem = new Problem();
+
+					problem.setStatus(
+						String.valueOf(httpResponse.getStatusCode()));
+
+					problemException = new Problem.ProblemException(problem);
+				}
+
+				throw problemException;
+			}
+			else {
+				_logger.fine("HTTP response content: " + content);
+				_logger.fine(
+					"HTTP response message: " + httpResponse.getMessage());
+				_logger.fine(
+					"HTTP response status code: " +
+						httpResponse.getStatusCode());
+			}
+
+			try {
+				return SiteSerDes.toDTO(content);
+			}
+			catch (Exception e) {
+				_logger.log(
+					Level.WARNING,
+					"Unable to process HTTP response: " + content, e);
+
+				throw new Problem.ProblemException(Problem.toDTO(content));
+			}
+		}
+
+		public HttpInvoker.HttpResponse postFormDataSiteHttpResponse(
+				Site site, Map<String, File> multipartFiles)
+			throws Exception {
+
+			HttpInvoker httpInvoker = HttpInvoker.newHttpInvoker();
+
+			httpInvoker.multipart();
+
+			httpInvoker.part("site", SiteSerDes.toJSON(site));
+
+			for (Map.Entry<String, File> entry : multipartFiles.entrySet()) {
+				httpInvoker.part(entry.getKey(), entry.getValue());
+			}
 
 			if (_builder._locale != null) {
 				httpInvoker.header(

--- a/modules/apps/headless/headless-site/headless-site-impl/rest-openapi.yaml
+++ b/modules/apps/headless/headless-site/headless-site-impl/rest-openapi.yaml
@@ -88,6 +88,15 @@ paths:
                     application/xml:
                         schema:
                             $ref: "#/components/schemas/Site"
+                    multipart/form-data:
+                        schema:
+                            properties:
+                                file:
+                                    format: binary
+                                    type: string
+                                site:
+                                    $ref: "#/components/schemas/Site"
+                            type: object
             responses:
                 200:
                     content:

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -98,6 +98,27 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 	/**
 	 * Invoke this method with the command line:
 	 *
+	 * curl -X 'POST' 'http://localhost:8080/o/headless-site/v1.0/sites'  -u 'test@liferay.com:test'
+	 */
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Adds a new site",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostSiteRequestBody.class)))
+	)
+	@io.swagger.v3.oas.annotations.tags.Tags(
+		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Site")}
+	)
+	@javax.ws.rs.Consumes("multipart/form-data")
+	@javax.ws.rs.Path("/sites")
+	@javax.ws.rs.POST
+	@javax.ws.rs.Produces({"application/json", "application/xml"})
+	@Override
+	public Site postSite(MultipartBody multipartBody) throws Exception {
+		return new Site();
+	}
+
+	/**
+	 * Invoke this method with the command line:
+	 *
 	 * curl -X 'DELETE' 'http://localhost:8080/o/headless-site/v1.0/sites/by-external-reference-code/{externalReferenceCode}'  -u 'test@liferay.com:test'
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
@@ -432,6 +453,17 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 
 	private static final com.liferay.portal.kernel.log.Log _log =
 		LogFactoryUtil.getLog(BaseSiteResourceImpl.class);
+
+	private class PostSiteRequestBody {
+
+		@io.swagger.v3.oas.annotations.media.Schema(
+			description = "File", format = "binary", type = "string"
+		)
+		public String file;
+
+		public Site site;
+
+	}
 
 	private class PutSiteByExternalReferenceCodeRequestBody {
 

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/BaseSiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/BaseSiteResourceImpl.java
@@ -82,7 +82,10 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 	 *
 	 * curl -X 'POST' 'http://localhost:8080/o/headless-site/v1.0/sites' -d $'{"externalReferenceCode": ___, "membershipType": ___, "name": ___, "parentSiteKey": ___, "templateKey": ___, "templateType": ___}' --header 'Content-Type: application/json' -u 'test@liferay.com:test'
 	 */
-	@io.swagger.v3.oas.annotations.Operation(description = "Adds a new site")
+	@io.swagger.v3.oas.annotations.Operation(
+		description = "Adds a new site",
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {@io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Site.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/xml", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Site.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostSiteRequestBody.class))})
+	)
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Site")}
 	)
@@ -102,7 +105,7 @@ public abstract class BaseSiteResourceImpl implements SiteResource {
 	 */
 	@io.swagger.v3.oas.annotations.Operation(
 		description = "Adds a new site",
-		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostSiteRequestBody.class)))
+		requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(content = {@io.swagger.v3.oas.annotations.media.Content(mediaType = "application/json", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Site.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "application/xml", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = Site.class)), @io.swagger.v3.oas.annotations.media.Content(mediaType = "multipart/form-data", schema = @io.swagger.v3.oas.annotations.media.Schema(implementation = PostSiteRequestBody.class))})
 	)
 	@io.swagger.v3.oas.annotations.tags.Tags(
 		value = {@io.swagger.v3.oas.annotations.tags.Tag(name = "Site")}

--- a/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
+++ b/modules/apps/headless/headless-site/headless-site-impl/src/main/java/com/liferay/headless/site/internal/resource/v1_0/SiteResourceImpl.java
@@ -116,6 +116,15 @@ public class SiteResourceImpl extends BaseSiteResourceImpl {
 	}
 
 	@Override
+	public Site postSite(MultipartBody multipartBody) throws Exception {
+		Site site = postSite(
+			multipartBody.getValueAsInstance("site", Site.class));
+
+		return putSiteByExternalReferenceCode(
+			site.getExternalReferenceCode(), multipartBody);
+	}
+
+	@Override
 	public Site postSite(Site site) throws Exception {
 		try {
 			Group group = _addGroup(site.getExternalReferenceCode(), site);

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/BaseSiteResourceTestCase.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/BaseSiteResourceTestCase.java
@@ -208,13 +208,43 @@ public abstract class BaseSiteResourceTestCase {
 	public void testPostSite() throws Exception {
 		Site randomSite = randomSite();
 
-		Site postSite = testPostSite_addSite(randomSite);
+		Map<String, File> multipartFiles = getMultipartFiles();
+
+		Site postSite = testPostSite_addSite(randomSite, multipartFiles);
 
 		assertEquals(randomSite, postSite);
 		assertValid(postSite);
+
+		assertValid(postSite, multipartFiles);
 	}
 
-	protected Site testPostSite_addSite(Site site) throws Exception {
+	protected Site testPostSite_addSite(
+			Site site, Map<String, File> multipartFiles)
+		throws Exception {
+
+		throw new UnsupportedOperationException(
+			"This method needs to be implemented");
+	}
+
+	@Test
+	public void testPostFormDataSite() throws Exception {
+		Site randomSite = randomSite();
+
+		Map<String, File> multipartFiles = getMultipartFiles();
+
+		Site postSite = testPostFormDataSite_addSite(
+			randomSite, multipartFiles);
+
+		assertEquals(randomSite, postSite);
+		assertValid(postSite);
+
+		assertValid(postSite, multipartFiles);
+	}
+
+	protected Site testPostFormDataSite_addSite(
+			Site site, Map<String, File> multipartFiles)
+		throws Exception {
+
 		throw new UnsupportedOperationException(
 			"This method needs to be implemented");
 	}

--- a/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
+++ b/modules/apps/headless/headless-site/headless-site-test/src/testIntegration/java/com/liferay/headless/site/resource/v1_0/test/SiteResourceTest.java
@@ -203,12 +203,23 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 	}
 
 	@Override
-	protected Site testPostSite_addSite(Site site) throws Exception {
-		Site postSite = siteResource.postSite(site);
+	protected Site testPostFormDataSite_addSite(
+			Site site, Map<String, File> multipartFiles)
+		throws Exception {
+
+		Site postSite = siteResource.postFormDataSite(site, multipartFiles);
 
 		_sites.add(postSite);
 
 		return postSite;
+	}
+
+	@Override
+	protected Site testPostSite_addSite(
+			Site site, Map<String, File> multipartFiles)
+		throws Exception {
+
+		return testPostFormDataSite_addSite(site, multipartFiles);
 	}
 
 	@Override
@@ -219,6 +230,14 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			RandomTestUtil.randomString(), randomSite(), getMultipartFiles());
 	}
 
+	private Site _testPostSite_addSite(Site site) throws Exception {
+		Site postSite = siteResource.postSite(site);
+
+		_sites.add(postSite);
+
+		return postSite;
+	}
+
 	private void _testPostSiteFailureDuplicateName() throws Exception {
 		Site randomSite = new Site() {
 			{
@@ -226,13 +245,13 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			}
 		};
 
-		testPostSite_addSite(randomSite);
+		_testPostSite_addSite(randomSite);
 
 		try {
 			try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 					_CLASS_NAME_EXCEPTION_MAPPER, LoggerTestUtil.ERROR)) {
 
-				testPostSite_addSite(randomSite);
+				_testPostSite_addSite(randomSite);
 			}
 
 			Assert.fail();
@@ -252,7 +271,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		randomSite.setName("*");
 
 		try {
-			testPostSite_addSite(randomSite);
+			_testPostSite_addSite(randomSite);
 
 			Assert.fail();
 		}
@@ -270,7 +289,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		randomSite.setName((String)null);
 
 		try {
-			testPostSite_addSite(randomSite);
+			_testPostSite_addSite(randomSite);
 
 			Assert.fail();
 		}
@@ -288,7 +307,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			StringUtil.toLowerCase(RandomTestUtil.randomString()));
 
 		try {
-			testPostSite_addSite(randomSite);
+			_testPostSite_addSite(randomSite);
 
 			Assert.fail();
 		}
@@ -325,7 +344,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		randomSite.setTemplateType(Site.TemplateType.SITE_INITIALIZER);
 
 		try {
-			testPostSite_addSite(randomSite);
+			_testPostSite_addSite(randomSite);
 
 			Assert.fail();
 		}
@@ -353,7 +372,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		randomSite.setTemplateType(Site.TemplateType.SITE_INITIALIZER);
 
 		try {
-			testPostSite_addSite(randomSite);
+			_testPostSite_addSite(randomSite);
 
 			Assert.fail();
 		}
@@ -389,7 +408,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
 					_CLASS_NAME_EXCEPTION_MAPPER, LoggerTestUtil.ERROR)) {
 
-				testPostSite_addSite(randomSite);
+				_testPostSite_addSite(randomSite);
 			}
 
 			Assert.fail();
@@ -412,7 +431,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		randomSite.setTemplateType(Site.TemplateType.SITE_TEMPLATE);
 
 		try {
-			testPostSite_addSite(randomSite);
+			_testPostSite_addSite(randomSite);
 
 			Assert.fail();
 		}
@@ -436,7 +455,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 			StringUtil.toLowerCase(RandomTestUtil.randomString()));
 
 		try {
-			testPostSite_addSite(randomSite);
+			_testPostSite_addSite(randomSite);
 
 			Assert.fail();
 		}
@@ -458,7 +477,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 		randomSite.setTemplateType(Site.TemplateType.SITE_INITIALIZER);
 
 		try {
-			testPostSite_addSite(randomSite);
+			_testPostSite_addSite(randomSite);
 
 			Assert.fail();
 		}
@@ -473,7 +492,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 	}
 
 	private Site _testPostSiteSuccess(Site site) throws Exception {
-		Site postSite = testPostSite_addSite(site);
+		Site postSite = _testPostSite_addSite(site);
 
 		assertEquals(site, postSite);
 		assertValid(postSite);
@@ -482,7 +501,7 @@ public class SiteResourceTest extends BaseSiteResourceTestCase {
 	}
 
 	private void _testPostSiteSuccessChild() throws Exception {
-		Site parentSite = testPostSite_addSite(randomSite());
+		Site parentSite = _testPostSite_addSite(randomSite());
 
 		Site randomSite = randomSite();
 

--- a/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
+++ b/modules/util/portal-tools-rest-builder/src/main/java/com/liferay/portal/tools/rest/builder/internal/freemarker/tool/java/parser/ResourceOpenAPIParser.java
@@ -147,22 +147,14 @@ public class ResourceOpenAPIParser {
 				sb.append(operation.getDescription());
 				sb.append("\"");
 
-				if (javaMethodSignature.getRequestBodyMediaTypes(
-					).contains(
-						"multipart/form-data"
-					)) {
-
+				if (getMultipartBodySchemas(javaMethodSignature) != null) {
 					sb.append(", requestBody = ");
 					sb.append("@io.swagger.v3.oas.annotations.parameters.");
-					sb.append("RequestBody(content = @io.swagger.v3.oas.");
-					sb.append("annotations.media.Content( mediaType = ");
-					sb.append("\"multipart/form-data\", schema = @io.swagger.");
-					sb.append("v3.oas.annotations.media.Schema( ");
-					sb.append("implementation = ");
-					sb.append(
-						StringUtil.upperCaseFirstLetter(
-							operation.getOperationId()));
-					sb.append("RequestBody.class)))");
+					sb.append("RequestBody(content = ");
+
+					sb.append(_getRequestBodyContent(javaMethodSignature));
+
+					sb.append(")");
 				}
 			}
 
@@ -176,13 +168,11 @@ public class ResourceOpenAPIParser {
 
 			sb.append("requestBody = ");
 			sb.append("@io.swagger.v3.oas.annotations.parameters.");
-			sb.append("RequestBody(content = @io.swagger.v3.oas.annotations.");
-			sb.append("media.Content( mediaType = \"multipart/form-data\", ");
-			sb.append("schema = @io.swagger.v3.oas.annotations.media.Schema( ");
-			sb.append("implementation = ");
-			sb.append(
-				StringUtil.upperCaseFirstLetter(operation.getOperationId()));
-			sb.append("RequestBody.class))))");
+			sb.append("RequestBody(content = ");
+
+			sb.append(_getRequestBodyContent(javaMethodSignature));
+
+			sb.append("))");
 
 			methodAnnotations.add(sb.toString());
 		}
@@ -1204,6 +1194,59 @@ public class ResourceOpenAPIParser {
 		parameter.setSchema(schema);
 
 		return parameter;
+	}
+
+	private static String _getRequestBodyContent(
+		JavaMethodSignature javaMethodSignature) {
+
+		Operation operation = javaMethodSignature.getOperation();
+
+		RequestBody requestBody = operation.getRequestBody();
+
+		Map<String, Content> contents = requestBody.getContent();
+
+		List<Map.Entry<String, Content>> entries = new ArrayList<>(
+			contents.entrySet());
+
+		StringBundler sb = new StringBundler();
+
+		if (entries.size() > 1) {
+			sb.append("{");
+		}
+
+		for (Map.Entry<String, Content> entry : entries) {
+			if (Objects.equals(entry.getKey(), "multipart/form-data")) {
+				sb.append("@io.swagger.v3.oas.annotations.media.Content( ");
+				sb.append("mediaType = \"multipart/form-data\", schema = ");
+				sb.append("@io.swagger.v3.oas.annotations.media.Schema( ");
+				sb.append("implementation = ");
+				sb.append(
+					StringUtil.upperCaseFirstLetter(
+						operation.getOperationId()));
+				sb.append("RequestBody.class))");
+			}
+			else {
+				sb.append("@io.swagger.v3.oas.annotations.media.Content( ");
+				sb.append("mediaType = \"");
+				sb.append(entry.getKey());
+				sb.append("\", schema = @io.swagger.v3.oas.annotations.media.");
+				sb.append("Schema( implementation = ");
+
+				sb.append(javaMethodSignature.getReturnType());
+
+				sb.append(".class))");
+			}
+
+			if (entry != entries.get(entries.size() - 1)) {
+				sb.append(",");
+			}
+		}
+
+		if (entries.size() > 1) {
+			sb.append("}");
+		}
+
+		return sb.toString();
 	}
 
 	private static String _getReturnType(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-19799.

As requested by Brian, this PR adds the option to create the site and initialize it with a site initializer in the same POST request like this:

```bash
curl -X POST \
      http://localhost:8080/o/headless-site/v1.0/sites \
      -H 'accept: application/json' \
      -H 'Content-Type: multipart/form-data' \
      -u test@liferay.com:test \
      -F 'site={
            "externalReferenceCode": "my-site",
            "membershipType": "open",
            "name": "string",
            "templateKey": "blank-site-initializer",
            "templateType": "site-initializer"
          }' \
      -F 'file=@site-initializer.zip'
```

![image](https://github.com/liferay-echo/liferay-portal/assets/1937354/56ca6326-0402-403f-ad62-989f09ba80d2)
