### PR TITLE
LPD-19864 Take ctCollectionId into account for v5_1_1/LayoutPageTemplateStructureUpgradeProcess

### DIFF
--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/LayoutPageTemplateStructureUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/LayoutPageTemplateStructureUpgradeProcess.java
@@ -5,6 +5,7 @@
 
 package com.liferay.layout.page.template.internal.upgrade.v5_1_1;
 
+import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
@@ -71,35 +72,50 @@ public class LayoutPageTemplateStructureUpgradeProcess extends UpgradeProcess {
 		List<Long> plids = new ArrayList<>();
 
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				"select layoutPageTemplateStructureId, classPK from " +
-					"LayoutPageTemplateStructure where classPK in " +
-						"(select plid from Layout where type_ = ?)");
+				StringBundler.concat(
+					"select LayoutPageTemplateStructure.",
+					"layoutPageTemplateStructureId, ",
+					"LayoutPageTemplateStructure.ctCollectionId, ",
+					"LayoutPageTemplateStructure.classPK from ",
+					"LayoutPageTemplateStructure inner join Layout on ",
+					"LayoutPageTemplateStructure.classPK = Layout.plid and ",
+					"LayoutPageTemplateStructure.ctCollectionId = ",
+					"Layout.ctCollectionId and Layout.type_ = ?"));
 			PreparedStatement preparedStatement2 =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
 					"delete from LayoutPageTemplateStructure where classPK = " +
-						"?");
+						"? and ctCollectionId = ?");
 			PreparedStatement preparedStatement3 =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,
 					"delete from LayoutPageTemplateStructureRel where " +
-						"layoutPageTemplateStructureId = ?")) {
+						"layoutPageTemplateStructureId = ? and " +
+							"ctCollectionId = ?")) {
 
 			preparedStatement1.setString(1, LayoutConstants.TYPE_PORTLET);
 
 			ResultSet resultSet = preparedStatement1.executeQuery();
 
 			while (resultSet.next()) {
-				long classPK = resultSet.getLong("classPK");
+				long classPK = resultSet.getLong(
+					"LayoutPageTemplateStructure.classPK");
+				long ctCollectionId = resultSet.getLong(
+					"LayoutPageTemplateStructure.ctCollectionId");
 
 				plids.add(classPK);
 
 				preparedStatement2.setLong(1, classPK);
+				preparedStatement2.setLong(2, ctCollectionId);
 
 				preparedStatement2.addBatch();
 
 				preparedStatement3.setLong(
-					1, resultSet.getLong("layoutPageTemplateStructureId"));
+					1,
+					resultSet.getLong(
+						"LayoutPageTemplateStructure." +
+							"layoutPageTemplateStructureId"));
+				preparedStatement3.setLong(2, ctCollectionId);
 
 				preparedStatement3.addBatch();
 			}

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/LayoutPageTemplateStructureUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/LayoutPageTemplateStructureUpgradeProcess.java
@@ -84,8 +84,9 @@ public class LayoutPageTemplateStructureUpgradeProcess extends UpgradeProcess {
 			PreparedStatement preparedStatement2 =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
-					"delete from LayoutPageTemplateStructure where classPK = " +
-						"? and ctCollectionId = ?");
+					"delete from LayoutPageTemplateStructure where " +
+						"layoutPageTemplateStructureId = ? and " +
+							"ctCollectionId = ?");
 			PreparedStatement preparedStatement3 =
 				AutoBatchPreparedStatementUtil.concurrentAutoBatch(
 					connection,
@@ -102,19 +103,18 @@ public class LayoutPageTemplateStructureUpgradeProcess extends UpgradeProcess {
 					"LayoutPageTemplateStructure.classPK");
 				long ctCollectionId = resultSet.getLong(
 					"LayoutPageTemplateStructure.ctCollectionId");
+				long layoutPageTemplateStructureId = resultSet.getLong(
+					"LayoutPageTemplateStructure." +
+						"layoutPageTemplateStructureId");
 
 				plids.add(classPK);
 
-				preparedStatement2.setLong(1, classPK);
+				preparedStatement2.setLong(1, layoutPageTemplateStructureId);
 				preparedStatement2.setLong(2, ctCollectionId);
 
 				preparedStatement2.addBatch();
 
-				preparedStatement3.setLong(
-					1,
-					resultSet.getLong(
-						"LayoutPageTemplateStructure." +
-							"layoutPageTemplateStructureId"));
+				preparedStatement3.setLong(1, layoutPageTemplateStructureId);
 				preparedStatement3.setLong(2, ctCollectionId);
 
 				preparedStatement3.addBatch();

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/LayoutPageTemplateStructureUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/LayoutPageTemplateStructureUpgradeProcess.java
@@ -5,7 +5,6 @@
 
 package com.liferay.layout.page.template.internal.upgrade.v5_1_1;
 
-import com.liferay.portal.dao.orm.common.SQLTransformer;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
@@ -72,10 +71,9 @@ public class LayoutPageTemplateStructureUpgradeProcess extends UpgradeProcess {
 		List<Long> plids = new ArrayList<>();
 
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				SQLTransformer.transform(
-					"select layoutPageTemplateStructureId, classPK from " +
-						"LayoutPageTemplateStructure where classPK in " +
-							"(select plid from Layout where type_ = ?)"));
+				"select layoutPageTemplateStructureId, classPK from " +
+					"LayoutPageTemplateStructure where classPK in " +
+						"(select plid from Layout where type_ = ?)");
 			PreparedStatement preparedStatement2 =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,

--- a/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/LayoutPageTemplateStructureUpgradeProcess.java
+++ b/modules/apps/layout/layout-page-template-service/src/main/java/com/liferay/layout/page/template/internal/upgrade/v5_1_1/LayoutPageTemplateStructureUpgradeProcess.java
@@ -99,15 +99,14 @@ public class LayoutPageTemplateStructureUpgradeProcess extends UpgradeProcess {
 			ResultSet resultSet = preparedStatement1.executeQuery();
 
 			while (resultSet.next()) {
-				long classPK = resultSet.getLong(
-					"LayoutPageTemplateStructure.classPK");
 				long ctCollectionId = resultSet.getLong(
 					"LayoutPageTemplateStructure.ctCollectionId");
 				long layoutPageTemplateStructureId = resultSet.getLong(
 					"LayoutPageTemplateStructure." +
 						"layoutPageTemplateStructureId");
 
-				plids.add(classPK);
+				plids.add(
+					resultSet.getLong("LayoutPageTemplateStructure.classPK"));
 
 				preparedStatement2.setLong(1, layoutPageTemplateStructureId);
 				preparedStatement2.setLong(2, ctCollectionId);


### PR DESCRIPTION
Motivation
=======
If a widget page was converted to a content page while the page is also present in a Publication the content page will lose its LayoutPageTemplateStructure when v5_1_1/LayoutPageTemplateStructureUpgradeProcess is executed.
[LPD-19864](https://liferay.atlassian.net/browse/LPD-19864)

Proposed Solution
========
Add ctCollectionId to the upgradeProcess' sqls

Steps to Verify
========
1. Launch 7.3 U17
2. Enable Publications
3. On Production, create a widget page
4. Create a new publications and visit the widget page that was created
5. Add an asset publisher widget
6. Do not merge the publication to production
7. Navigate to Production and view the widget page in Page Builder
8. Convert the Widget Page to a Content Page
9. Add a Heading to the Page and Publish
10. Check the page as a guest and view the heading added
11. Upgrade to master
12. Visit the page

**Expected behaviour:** Page shows the heading
**Actual behaviour:** The heading is not present and there is an NPE in the logs

Cheers,
Balázs