### PR TITLE
LPD-20690 Replace lock icons of pages when a page is restricted

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumnsItem.js
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/js/miller_columns/MillerColumnsItem.js
@@ -489,7 +489,7 @@ const MillerColumnsItem = ({
 								data-title={Liferay.Language.get(
 									'restricted-page'
 								)}
-								symbol="lock"
+								symbol="password-policies"
 							/>
 						)}
 

--- a/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/select_layout/SelectLayoutTree.js
+++ b/modules/apps/layout/layout-taglib/src/main/resources/META-INF/resources/js/select_layout/SelectLayoutTree.js
@@ -317,7 +317,7 @@ export function SelectLayoutTree({
 										>
 											<ClayIcon
 												className="c-mt-0 text-4"
-												symbol="lock"
+												symbol="password-policies"
 											/>
 										</span>
 									) : null}
@@ -404,7 +404,7 @@ export function SelectLayoutTree({
 													>
 														<ClayIcon
 															className="c-mt-0 text-4"
-															symbol="lock"
+															symbol="password-policies"
 														/>
 													</span>
 												)}

--- a/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutHeaderProductNavigationControlMenuEntry.java
+++ b/modules/apps/product-navigation/product-navigation-control-menu-web/src/main/java/com/liferay/product/navigation/control/menu/web/internal/LayoutHeaderProductNavigationControlMenuEntry.java
@@ -154,7 +154,7 @@ public class LayoutHeaderProductNavigationControlMenuEntry
 				IconTag iconTag = new IconTag();
 
 				iconTag.setCssClass("c-mt-0");
-				iconTag.setSymbol("lock");
+				iconTag.setSymbol("password-policies");
 
 				try {
 					sb.append(

--- a/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTree.js
+++ b/modules/apps/product-navigation/product-navigation-product-menu-web/src/main/resources/META-INF/resources/js/PagesTree.js
@@ -269,7 +269,7 @@ function TreeItem({
 									data-title={Liferay.Language.get(
 										'restricted-page'
 									)}
-									symbol="lock"
+									symbol="password-policies"
 								/>
 							) : null}
 
@@ -371,7 +371,7 @@ function TreeItem({
 											data-title={Liferay.Language.get(
 												'restricted-page'
 											)}
-											symbol="lock"
+											symbol="password-policies"
 										/>
 									) : null}
 

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/js/index.js
@@ -187,7 +187,7 @@ function TreeItem({
 						>
 							<ClayIcon
 								className="c-mt-0 lfr-portal-tooltip text-4"
-								symbol="lock"
+								symbol="password-policies"
 							/>
 						</span>
 					) : null}
@@ -243,7 +243,7 @@ function TreeItem({
 								>
 									<ClayIcon
 										className="c-mt-0 lfr-portal-tooltip text-4"
-										symbol="lock"
+										symbol="password-policies"
 									/>
 								</span>
 							) : null}

--- a/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/PreviewSelector.js
+++ b/modules/apps/style-book/style-book-web/src/main/resources/META-INF/resources/js/style-book-editor/PreviewSelector.js
@@ -226,7 +226,7 @@ export function LayoutSelector({layoutType}) {
 									>
 										<ClayIcon
 											className="c-mt-0 text-4 text-dark"
-											symbol="lock"
+											symbol="password-policies"
 										/>
 									</span>
 								)}


### PR DESCRIPTION
subtask: https://liferay.atlassian.net/browse/LPD-20690

Description
-----------
Replace icon from lock to password-policies as you can see in the [story](https://liferay.atlassian.net/browse/LPD-15807) :

> We should replace the lock icon of pages (LPD-6798: Identify the public pages from the restricted ones when seeing or editing them) for the permissions icon