### PR TITLE
LPD-6870 Interactive utility pages may need to be public layouts

### DIFF
--- a/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
+++ b/modules/apps/layout/layout-utility-page-service/src/main/java/com/liferay/layout/utility/page/service/impl/LayoutUtilityPageEntryLocalServiceImpl.java
@@ -96,7 +96,7 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 
 		if (plid == 0) {
 			Layout layout = _addLayout(
-				userId, groupId, name, masterLayoutPlid, serviceContext);
+				userId, groupId, name, masterLayoutPlid, type, serviceContext);
 
 			if (layout != null) {
 				plid = layout.getPlid();
@@ -403,7 +403,7 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 
 	private Layout _addLayout(
 			long userId, long groupId, String name, long masterLayoutPlid,
-			ServiceContext serviceContext)
+			String type, ServiceContext serviceContext)
 		throws PortalException {
 
 		Map<Locale, String> titleMap = Collections.singletonMap(
@@ -431,9 +431,10 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 			"layout.instanceable.allowed", Boolean.TRUE);
 
 		Layout layout = _layoutLocalService.addLayout(
-			userId, groupId, true, 0, 0, 0, titleMap, titleMap, null, null,
-			null, LayoutConstants.TYPE_CONTENT, typeSettings, true, true,
-			new HashMap<>(), masterLayoutPlid, serviceContext);
+			userId, groupId, !_isPublicLayoutNeeded(type), 0, 0, 0, titleMap,
+			titleMap, null, null, null, LayoutConstants.TYPE_CONTENT,
+			typeSettings, true, true, new HashMap<>(), masterLayoutPlid,
+			serviceContext);
 
 		Layout draftLayout = layout.fetchDraftLayout();
 
@@ -538,6 +539,16 @@ public class LayoutUtilityPageEntryLocalServiceImpl
 		}
 
 		return name;
+	}
+
+	private boolean _isPublicLayoutNeeded(String type) {
+		if (type.equals("LOGIN") || type.equals("FORGOT_PASSWORD") ||
+			type.equals("CREATE_ACCOUNT")) {
+
+			return true;
+		}
+
+		return false;
 	}
 
 	private void _validateName(


### PR DESCRIPTION
Hi @lfbesada . As we discussed on Slack, this is needed for the Login functionality because of the portlet interactions.

Motivation
=======
The Login functionality utility pages require interactions with portlets unlike simpler 404/500 utility pages that only display content.

Proposed Solution
========
Set the privateLayout parameter according to the utility page type. In the future maybe you can refactor this into a SPI.

Steps to Verify
========
N/A

References to existing code (if applies)
========
N/A

Screenshots (if applies)
========
N/A

Alternative Solutions that were discarded (if applies)
========
We attempted to use the same approach as with `TermsOfUseStrutsAction` but this falls short when interacting with the LoginPortlet. Because the `PortletURLFactory` will not generate portlet URLs that use the `StrutsAction` path.