### PR TITLE
LPD-21140 prevent duplicated ClientExtensionEntryRel when import a Layout

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liferay.asset.kernel.NoSuchClassTypeException;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntryRel;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.manager.CETManager;
@@ -364,6 +365,20 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 
 		if ((cet == null) || !Objects.equals(type, cet.getType())) {
 			return;
+		}
+
+		List<ClientExtensionEntryRel> clientExtensionEntryRels =
+			_clientExtensionEntryRelLocalService.getClientExtensionEntryRels(
+				_portal.getClassNameId(Layout.class), layout.getPlid());
+
+		for (ClientExtensionEntryRel clientExtensionEntryRel :
+				clientExtensionEntryRels) {
+
+			if (cetExternalReferenceCode.equals(
+					clientExtensionEntryRel.getCETExternalReferenceCode())) {
+
+				return;
+			}
 		}
 
 		UnicodeProperties unicodeProperties = new UnicodeProperties(true);


### PR DESCRIPTION
Motivation
=======
A new global JS entry was being added when a site initializer client extension was was deployed.

Ticket https://liferay.atlassian.net/browse/LPD-21140

Proposed Solution
========
Do not add a new `ClientExtensionEntryRel` entry when the master page layout is imported

Steps to Verify
========
1. Deploy Liferay Sample Global JS CX;
2. Deploy Sample Site initializer CX;
3. Go to Sample site created by the Site Initializer (click Application Menu, on Sites section, click "Sample");
4. Go to Design > Page Templates > Master > Sample Master Page and then go to Page design options (Left side menu 3rd option) and click on setting gear icon;
5. Now go to Customization section and click on the Javascript tab, here you will see that Liferay Sample Global JS is already configured;
6. Deploy Sample Site initializer CX again and once it deploy successfully refresh STEP 5 page , we will see that there are two entries for Liferay Sample Global JS and it will add same CX entry every time we run site initializer.

Screenshots (if applies)
========
![image](https://github.com/liferay-platform-experience/liferay-portal/assets/57292581/92638045-2f30-4f9e-b92c-238348144789)