### PR TITLE
LPD-21140 - Site initializer adding same globalJS client extension entry in master page template configuration every time we run site initializer

### DIFF
--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -377,7 +377,8 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 			if (cetExternalReferenceCode.equals(
 					clientExtensionEntryRel.getCETExternalReferenceCode())) {
 
-				return;
+				_clientExtensionEntryRelLocalService.
+					deleteClientExtensionEntryRel(clientExtensionEntryRel);
 			}
 		}
 

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/importer/LayoutsImporterImpl.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.liferay.asset.kernel.NoSuchClassTypeException;
 import com.liferay.asset.list.service.AssetListEntryLocalService;
 import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntryRel;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.client.extension.type.CET;
 import com.liferay.client.extension.type.manager.CETManager;
@@ -364,6 +365,20 @@ public class LayoutsImporterImpl implements LayoutsImporter {
 
 		if ((cet == null) || !Objects.equals(type, cet.getType())) {
 			return;
+		}
+
+		List<ClientExtensionEntryRel> clientExtensionEntryRels =
+			_clientExtensionEntryRelLocalService.getClientExtensionEntryRels(
+				_portal.getClassNameId(Layout.class), layout.getPlid());
+
+		for (ClientExtensionEntryRel clientExtensionEntryRel :
+				clientExtensionEntryRels) {
+
+			if (cetExternalReferenceCode.equals(
+					clientExtensionEntryRel.getCETExternalReferenceCode())) {
+
+				return;
+			}
 		}
 
 		UnicodeProperties unicodeProperties = new UnicodeProperties(true);


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-21140 - Site initializer adding same globalJS client extension entry in master page template configuration every time we run site initializer

Original PR description: https://github.com/liferay-echo/liferay-portal/pull/15399#issue-2201117690

**Additional Scenarios Reproduction Steps:**

The issue can be reproduced as well outside of Site Initializer.

**Steps Scenario 1:**

1. Deploy Liferay Sample Global JS CX
2. Go to Design > Page Templates > Master > and create a Master Page
3. Go to Page design options(Left side menu 3rd option) and click on setting gear icon
4. Now go to Customization section and click on Javascript tab
5. Add Liferay Sample Global JS 
6. Publish master page
7. Export master page
8. Import master page selecting “Overwrite Existing Items”

**Expected result:**
There is one entry for Liferay Sample Global JS and no additional CX entries will be added every time we run site import with “Overwrite Existing Items”

**Actual result:**
There are two entries for Liferay Sample Global JS and it will add same CX entry every time we run site import with “Overwrite Existing Items”

We should also account for the fact that the configuration of the CX relationship may have been changed on a subsequent import.

**Steps Scenario 2:**

1. Deploy Liferay Sample Global JS CX
2. Go to Design > Page Templates > Master > and create a Master Page
3. Go to Page design options(Left side menu 3rd option) and click on setting gear icon
4. Now go to Customization section and click on Javascript tab
5. Add Liferay Sample Global JS 
6. Change Load to async 
7. Publish master page
8. Export master page
9. Go to Page design options(Left side menu 3rd option) and click on setting gear icon
10. Now go to Customization section and click on Javascript tab
11. Change Load  to defer
12. Save
13. Publish master page
14. Import master page selecting “Overwrite Existing Items”

**Expected result:**
There is one entry for Liferay Sample Global JS with load "async" and no additional CX entries will be added every time we run site import with “Overwrite Existing Items”

**Actual result:**
There are two entries for Liferay Sample Global JS (one with load "defer" and one with load "async") and it will add same CX entry every time we run site import with “Overwrite Existing Items”