### PR TITLE
LPD-21554 Validate for all supported locales, not just available

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -56,6 +56,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.comparator.LayoutPriorityComparator;
 import com.liferay.portal.model.impl.LayoutImpl;
 import com.liferay.portal.util.LayoutTypeControllerTracker;
+import com.liferay.portal.util.PropsValues;
 
 import java.util.HashMap;
 import java.util.List;
@@ -523,13 +524,14 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 			}
 		}
 
-		for (Locale locale : LanguageUtil.getAvailableLocales()) {
-			String languageId = StringUtil.toLowerCase(
-				LocaleUtil.toLanguageId(locale));
+		for (String languageId : PropsValues.LOCALES) {
+			languageId = StringUtil.toLowerCase(languageId);
 
 			String i18nPathLanguageId =
 				StringPool.SLASH +
-					PortalUtil.getI18nPathLanguageId(locale, languageId);
+					PortalUtil.getI18nPathLanguageId(
+						LocaleUtil.fromLanguageId(languageId, false),
+						languageId);
 
 			String underlineI18nPathLanguageId = StringUtil.replace(
 				i18nPathLanguageId, CharPool.DASH, CharPool.UNDERLINE);


### PR DESCRIPTION
Motivation
=======
**Given** a page being created with a 2 letter locale code as its name
**When** that locale IS NOT available for the site
**Then** the locale code will be used as friendlyURL for the page

but,
**When** that locale IS available for the site
**Then** the `layoutId` will be used as friendlyURL for the page

Because URLs with locale codes are reserved for language changes and will not render pages. If the locale is not available, a 404 page will be displayed.

[LPD-21554](https://liferay.atlassian.net/browse/LPD-21554)

Proposed Solution
========
During page friendlyURL validation use all the supported locales to prevent the generation of a reserved friendlyURL

Steps to Verify
========
1. Create a Widget Page named `th`
2. Navigate to the home page
3. Click the `th` link in the navigation bar

**Expected behaviour:** The widget page opens
**Actual behaviour:** A 404 page opens