### PR TITLE
LPD-21566 Issues with Master Page Template after default language change

### DIFF
--- a/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/service/LayoutLocalServiceStagingAdvice.java
+++ b/modules/apps/staging/staging-impl/src/main/java/com/liferay/staging/internal/service/LayoutLocalServiceStagingAdvice.java
@@ -36,6 +36,7 @@ import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Localization;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
@@ -133,6 +134,10 @@ public class LayoutLocalServiceStagingAdvice {
 
 		Layout layout = _layoutPersistence.findByG_P_L(
 			groupId, privateLayout, layoutId);
+
+		if (nameMap.isEmpty()) {
+			nameMap = _localization.getLocalizationMap(layout.getName(), true);
+		}
 
 		String name = nameMap.get(LocaleUtil.getSiteDefault());
 
@@ -669,6 +674,9 @@ public class LayoutLocalServiceStagingAdvice {
 
 	@Reference
 	private LayoutRevisionPersistence _layoutRevisionPersistence;
+
+	@Reference
+	private Localization _localization;
 
 	@Reference
 	private Portal _portal;


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPD-21566
best,
Attila

------

The root cause of the issue is that the NameMap will be a field based on the available languages. Based on this if we change the original default language and remove it from the available languages the layout will not be able to access its name through the name map. In most cases, it is avoided/fixed by required fields preventing the saving of the changes, but the designed tab does not depend on the title. To avoid the bug I made it so that when an update layout is called if we can't access the name through the name map it will be retrieved from the original name xml.