### PR TITLE
LPD-21854 Title translated in collection display mapped field

### DIFF
--- a/modules/apps/info/info-api/bnd.bnd
+++ b/modules/apps/info/info-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Info API
 Bundle-SymbolicName: com.liferay.info.api
-Bundle-Version: 36.3.2
+Bundle-Version: 36.4.0
 Export-Package:\
 	com.liferay.info.collection.provider,\
 	com.liferay.info.constants,\

--- a/modules/apps/info/info-api/src/main/java/com/liferay/info/localized/InfoLocalizedValue.java
+++ b/modules/apps/info/info-api/src/main/java/com/liferay/info/localized/InfoLocalizedValue.java
@@ -74,6 +74,12 @@ public interface InfoLocalizedValue<T> {
 			return this;
 		}
 
+		public Builder<T> translate(boolean translate) {
+			_translate = translate;
+
+			return this;
+		}
+
 		public Builder<T> value(Locale locale, T value) {
 			_values.put(locale, value);
 
@@ -99,6 +105,7 @@ public interface InfoLocalizedValue<T> {
 		}
 
 		private Locale _defaultLocale;
+		private boolean _translate = true;
 		private final Map<Locale, T> _values = new HashMap<>();
 
 	}
@@ -159,7 +166,7 @@ public interface InfoLocalizedValue<T> {
 				value = _builder._values.get(getDefaultLocale());
 			}
 
-			if (value instanceof String) {
+			if ((value instanceof String) && _builder._translate) {
 				value = (T)LanguageUtil.get(locale, (String)value);
 			}
 

--- a/modules/apps/info/info-api/src/main/resources/com/liferay/info/localized/packageinfo
+++ b/modules/apps/info/info-api/src/main/resources/com/liferay/info/localized/packageinfo
@@ -1,1 +1,1 @@
-version 2.0.0
+version 2.1.0


### PR DESCRIPTION
bug: https://liferay.atlassian.net/browse/LPD-21854

Description
-------------
We are translating values of the InfoLocalizedValue and this does not make sense for some fields like journal article title or description. So, I added a translate method to the builder in order to decide if we want to translate the value or not. I selected default translated value as true because I think that we can not assume that we can not stop translate the value for all use cases, let me know if I am wrong.