### PR TITLE
LPD-21554 - Some page names result in 404 friendly URLs

### DIFF
--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesGroupApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesGroupApiHelper.ts
@@ -31,4 +31,18 @@ export class JSONWebServicesGroupApiHelper {
 			await this.apiHelpers.getJSONWebServicesHeaders()
 		);
 	}
+
+	async getGroup(companyId: string, groupKey: string): Promise<Group> {
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append('companyId', companyId);
+		urlSearchParams.append('groupKey', groupKey);
+
+		return this.apiHelpers.post(
+			`${liferayConfig.environment.baseUrl}${this.basePath}/get-group`,
+			urlSearchParams.toString(),
+			true,
+			await this.apiHelpers.getJSONWebServicesHeaders()
+		);
+	}
 }

--- a/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutApiHelper.ts
+++ b/modules/test/playwright/helpers/json-web-services/JSONWebServicesLayoutApiHelper.ts
@@ -39,4 +39,17 @@ export class JSONWebServicesLayoutApiHelper {
 			await this.apiHelpers.getJSONWebServicesHeaders()
 		);
 	}
+
+	async deleteLayout(plid: number): Promise<Layout> {
+		const urlSearchParams = new URLSearchParams();
+
+		urlSearchParams.append('plid', `${plid}`);
+
+		return this.apiHelpers.post(
+			`${liferayConfig.environment.baseUrl}${this.basePath}/delete-layout`,
+			urlSearchParams.toString(),
+			true,
+			await this.apiHelpers.getJSONWebServicesHeaders()
+		);
+	}
 }

--- a/modules/test/playwright/tests/layout-admin-web/pageFriendlyURL.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pageFriendlyURL.spec.ts
@@ -49,11 +49,11 @@ test('This is a test for LPD-21554. Some page names result in 404 friendly URLs.
 	// Check that page friendlyURL does not contain the page name (which
 	// should have been replaced by layoutId)
 
-	await expect(sitePage.friendlyUrlPath).not.toContain(`${pageName}`);
+	await expect.soft(sitePage.friendlyUrlPath).not.toContain(`${pageName}`);
 
 	await page.goto(sitePage.friendlyUrlPath);
 
-	await expect(page.getByText('Heading Example')).toBeVisible();
+	await expect.soft(page.getByText('Heading Example')).toBeVisible();
 
 	await apiHelpers.jsonWebServicesLayout.deleteLayout(sitePage.id);
 });

--- a/modules/test/playwright/tests/layout-admin-web/pageFriendlyURL.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pageFriendlyURL.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
+import {loginTest} from '../../fixtures/loginTest';
+import getRandomString from '../../utils/getRandomString';
+import getFragmentDefinition from '../layout-content-page-editor-web/utils/getFragmentDefinition';
+import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
+
+export const test = mergeTests(
+	apiHelpersTest,
+	featureFlagsTest({
+		'LPS-178052': true,
+	}),
+	loginTest()
+);
+
+test('This is a test for LPD-21554. Some page names result in 404 friendly URLs.', async ({
+	apiHelpers,
+	page,
+}) => {
+	const company = await apiHelpers.jsonWebServicesCompany.getCompanyByWebId(
+		'liferay.com'
+	);
+
+	const group = await apiHelpers.jsonWebServicesGroup.getGroup(
+		company.companyId,
+		'Guest'
+	);
+
+	// Create a page in Guest site with name matching a supported locale which
+	// is not an available locale for the site
+
+	const pageName = 'th';
+
+	const sitePage = await apiHelpers.headlessDelivery.createSitePage({
+		pageDefinition: getPageDefinition([
+			getFragmentDefinition(getRandomString(), 'BASIC_COMPONENT-heading'),
+		]),
+		siteId: group.groupId,
+		title: pageName,
+	});
+
+	// Check that page friendlyURL does not contain the page name (which
+	// should have been replaced by layoutId)
+
+	await expect(sitePage.friendlyUrlPath).not.toContain(`${pageName}`);
+
+	await page.goto(sitePage.friendlyUrlPath);
+
+	await expect(page.getByText('Heading Example')).toBeVisible();
+
+	await apiHelpers.jsonWebServicesLayout.deleteLayout(sitePage.id);
+});

--- a/modules/test/playwright/types/content-page.d.ts
+++ b/modules/test/playwright/types/content-page.d.ts
@@ -5,6 +5,7 @@
 
 type Layout = {
 	friendlyUrlPath: string;
+	id: number;
 };
 
 type PageDefinition = {

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -56,6 +56,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.util.comparator.LayoutPriorityComparator;
 import com.liferay.portal.model.impl.LayoutImpl;
 import com.liferay.portal.util.LayoutTypeControllerTracker;
+import com.liferay.portal.util.PropsValues;
 
 import java.util.HashMap;
 import java.util.List;
@@ -523,13 +524,14 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 			}
 		}
 
-		for (Locale locale : LanguageUtil.getAvailableLocales()) {
-			String languageId = StringUtil.toLowerCase(
-				LocaleUtil.toLanguageId(locale));
+		for (String languageId : PropsValues.LOCALES) {
+			languageId = StringUtil.toLowerCase(languageId);
 
 			String i18nPathLanguageId =
 				StringPool.SLASH +
-					PortalUtil.getI18nPathLanguageId(locale, languageId);
+					PortalUtil.getI18nPathLanguageId(
+						LocaleUtil.fromLanguageId(languageId, false),
+						languageId);
 
 			String underlineI18nPathLanguageId = StringUtil.replace(
 				i18nPathLanguageId, CharPool.DASH, CharPool.UNDERLINE);


### PR DESCRIPTION
Description from original PR: https://github.com/liferay-echo/liferay-portal/pull/15419

Motivation
=======
**Given** a page being created with a 2 letter locale code as its name
**When** that locale IS NOT available for the site
**Then** the locale code will be used as friendlyURL for the page

but,
**When** that locale IS available for the site
**Then** the `layoutId` will be used as friendlyURL for the page

Because URLs with locale codes are reserved for language changes and will not render pages. If the locale is not available, a 404 page will be displayed.

[LPD-21554](https://liferay.atlassian.net/browse/LPD-21554)

Proposed Solution
========
During page friendlyURL validation use all the supported locales to prevent the generation of a reserved friendlyURL

Steps to Verify
========
1. Create a Widget Page named `th`
2. Navigate to the home page
3. Click the `th` link in the navigation bar

**Expected behaviour:** The widget page opens
**Actual behaviour:** A 404 page opens

//@balazsk