### PR TITLE
LPD-22144 | Global Information Template not showing on Display Page Template for Custom objects

### DIFF
--- a/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/item/provider/TemplateInfoItemFieldSetProviderImpl.java
+++ b/modules/apps/template/template-service/src/main/java/com/liferay/template/internal/info/item/provider/TemplateInfoItemFieldSetProviderImpl.java
@@ -19,8 +19,11 @@ import com.liferay.info.item.provider.InfoItemFieldValuesProvider;
 import com.liferay.info.localized.InfoLocalizedValue;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
+import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.service.CompanyLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -38,8 +41,10 @@ import com.liferay.template.transformer.TemplateNodeFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -127,7 +132,19 @@ public class TemplateInfoItemFieldSetProviderImpl
 			return Collections.emptyList();
 		}
 
-		List<Long> groupIds = new ArrayList<>();
+		Set<Long> groupIds = new HashSet<>();
+
+		Company company = _companyLocalService.fetchCompany(
+			serviceContext.getCompanyId());
+
+		if (company != null) {
+			try {
+				groupIds.add(company.getGroupId());
+			}
+			catch (PortalException portalException) {
+				_log.error(portalException);
+			}
+		}
 
 		long ddmStructureKey = GetterUtil.getLong(infoItemFormVariationKey);
 
@@ -220,6 +237,9 @@ public class TemplateInfoItemFieldSetProviderImpl
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		TemplateInfoItemFieldSetProviderImpl.class);
+
+	@Reference
+	private CompanyLocalService _companyLocalService;
 
 	@Reference
 	private DDMStructureLocalService _ddmStructureLocalService;

--- a/modules/apps/template/template-test/build.gradle
+++ b/modules/apps/template/template-test/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
 	testIntegrationImplementation project(":apps:asset:asset-test-util")
+	testIntegrationImplementation project(":apps:blogs:blogs-api")
 	testIntegrationImplementation project(":apps:data-engine:data-engine-rest-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	testIntegrationImplementation project(":apps:dynamic-data-mapping:dynamic-data-mapping-form-field-type-api")

--- a/modules/apps/template/template-test/src/testIntegration/java/com/liferay/template/info/item/provider/test/TemplateInfoItemFieldSetProviderTest.java
+++ b/modules/apps/template/template-test/src/testIntegration/java/com/liferay/template/info/item/provider/test/TemplateInfoItemFieldSetProviderTest.java
@@ -11,6 +11,7 @@ import com.liferay.asset.kernel.model.AssetVocabulary;
 import com.liferay.asset.kernel.service.AssetCategoryLocalService;
 import com.liferay.asset.kernel.service.AssetVocabularyLocalService;
 import com.liferay.asset.test.util.AssetTestUtil;
+import com.liferay.blogs.model.BlogsEntry;
 import com.liferay.data.engine.rest.resource.v2_0.DataDefinitionResource;
 import com.liferay.dynamic.data.mapping.form.field.type.constants.DDMFormFieldTypeConstants;
 import com.liferay.dynamic.data.mapping.model.DDMFormField;
@@ -189,6 +190,42 @@ public class TemplateInfoItemFieldSetProviderTest {
 			infoFields.toString(),
 			PortletDisplayTemplate.DISPLAY_STYLE_PREFIX +
 				journalArticleTemplateEntry.getTemplateEntryId(),
+			infoField.getName());
+	}
+
+	@Test
+	public void testGetInfoFieldSetByClassNameFromGlobalGroupWhenTemplateEntryExists()
+		throws PortalException {
+
+		long groupId = _serviceContext.getScopeGroupId();
+
+		_serviceContext.setScopeGroupId(_company.getGroupId());
+
+		TemplateEntry blogsEntryTemplateEntry =
+			TemplateTestUtil.addTemplateEntry(
+				BlogsEntry.class.getName(), StringPool.BLANK, _serviceContext);
+
+		_serviceContext.setScopeGroupId(groupId);
+
+		TemplateTestUtil.addTemplateEntry(
+			AssetCategory.class.getName(), StringPool.BLANK, _serviceContext);
+
+		InfoFieldSet infoFieldSet =
+			_templateInfoItemFieldSetProvider.getInfoFieldSet(
+				BlogsEntry.class.getName(), StringPool.BLANK);
+
+		List<InfoField<?>> infoFields = infoFieldSet.getAllInfoFields();
+
+		Assert.assertEquals(infoFields.toString(), 1, infoFields.size());
+
+		InfoField infoField = infoFields.get(0);
+
+		Assert.assertTrue(
+			infoField.getInfoFieldType() instanceof HTMLInfoFieldType);
+		Assert.assertEquals(
+			infoFields.toString(),
+			PortletDisplayTemplate.DISPLAY_STYLE_PREFIX +
+				blogsEntryTemplateEntry.getTemplateEntryId(),
 			infoField.getName());
 	}
 


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPD-22144
best,
Attila

-----
The root cause of the issue is that the global scope is not considered when the information templates are collected. My solution is to get the current company's global group and add it to the localService scope.