### PR TITLE
[CLDR] LPD-18590 Fix LocalizationWithSites#CannotRemoveSiteDefaultLanguageInInstanceSettings to work with CLDR java locale provider

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/macros/PortalSettings.macro
+++ b/portal-web/test/functional/com/liferay/portalweb/macros/PortalSettings.macro
@@ -129,7 +129,7 @@ definition {
 	}
 
 	@summary = "Default summary"
-	macro configureCurrentLanguagesCP(failExpected = null, errorMessage = null, currentPortalLanguages = null) {
+	macro configureCurrentLanguagesCP(failExpected = null, errorMessage = null, currentPortalLanguages = null, useLanguageKey = null) {
 		if (isSet(currentPortalLanguages)) {
 			while (IsElementPresent(locator1 = "LanguageConfiguration#LANGUAGES_CURRENT_SELECT")) {
 				AddSelection(
@@ -142,15 +142,25 @@ definition {
 			for (var currentPortalLanguage : list ${currentPortalLanguages}) {
 				var currentPortalLanguage = ${currentPortalLanguage};
 
-				AddSelection(
-					locator1 = "LanguageConfiguration#LANGUAGES_AVAILABLE",
-					value1 = ${currentPortalLanguage});
+				if (${useLanguageKey} == "true") {
+					Click.clickNoMouseOver(locator1 = "//select[contains(@id,'availableLanguageIds')]/option[@value='${currentPortalLanguage}']");
+				}
+				else {
+					AddSelection(
+						locator1 = "LanguageConfiguration#LANGUAGES_AVAILABLE",
+						value1 = ${currentPortalLanguage});
+				}
 
 				Click(locator1 = "Button#MOVE_AVAILABLE_TO_CURRENT");
 
-				AssertTextEquals.assertPartialText(
-					locator1 = "LanguageConfiguration#LANGUAGES_CURRENT",
-					value1 = ${currentPortalLanguage});
+				if (${useLanguageKey} == "true") {
+					AssertElementPresent(locator1 = "//select[contains(@id,'currentLanguageIds')]/option[@value='${currentPortalLanguage}']");
+				}
+				else {
+					AssertTextEquals.assertPartialText(
+						locator1 = "LanguageConfiguration#LANGUAGES_CURRENT",
+						value1 = ${currentPortalLanguage});
+				}
 			}
 		}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/LocalizationWithSites.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/site/LocalizationWithSites.testcase
@@ -102,9 +102,10 @@ definition {
 				configurationScope = "Virtual Instance Scope");
 
 			PortalSettings.configureCurrentLanguagesCP(
-				currentPortalLanguages = "Arabic (Saudi Arabia),Czech (Czechia),French (France)",
+				currentPortalLanguages = "ar_SA,cs_CZ,fr_FR",
 				errorMessage = "Error: You cannot remove a language that is the current default language.",
-				failExpected = "true");
+				failExpected = "true",
+				useLanguageKey = "true");
 		}
 	}
 


### PR DESCRIPTION
Hi Team, 
This issue is reopened today by me after further test analysis: https://liferay.atlassian.net/browse/LPD-18590

Since we are changing to java locale provider CLDR in the near future, some language option labels will have different text. I added additional option to use language key value to select the option in `PortalSettings.macro` and applied it to this fucntional testcase.

Below is a screenshot from the original ci failure on CLDR
![image](https://github.com/liferay-echo/liferay-portal/assets/71372051/917b689e-ece4-4842-8f18-667ccdccedee)

We can see that the test is looking for an option with label `Czech (Czechia)`
but this label becomes `Czech (Czech Republic)` under CLDR environment

Thank you!


