### PR TITLE
LPD-22610 Preserve the sitemap settings in the typesettings

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/PublishLayoutMVCActionCommand.java
@@ -6,6 +6,7 @@
 package com.liferay.layout.content.page.editor.web.internal.portlet.action;
 
 import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
+import com.liferay.layout.admin.kernel.model.LayoutTypePortletConstants;
 import com.liferay.layout.constants.LayoutTypeSettingsConstants;
 import com.liferay.layout.content.page.editor.constants.ContentPageEditorPortletKeys;
 import com.liferay.layout.content.page.editor.web.internal.util.layout.structure.LayoutStructureUtil;
@@ -146,10 +147,37 @@ public class PublishLayoutMVCActionCommand
 
 			LayoutSet layoutSet = layout.getLayoutSet();
 
-			if (layoutSet.isLayoutSetPrototypeLinkActive()) {
-				UnicodeProperties updatedTypeSettingsUnicodeProperties =
-					layout.getTypeSettingsProperties();
+			UnicodeProperties updatedTypeSettingsUnicodeProperties =
+				layout.getTypeSettingsProperties();
 
+			if (originalTypeSettingsUnicodeProperties.containsKey(
+					LayoutTypePortletConstants.SITEMAP_CHANGEFREQ)) {
+
+				updatedTypeSettingsUnicodeProperties.put(
+					LayoutTypePortletConstants.SITEMAP_CHANGEFREQ,
+					originalTypeSettingsUnicodeProperties.get(
+						LayoutTypePortletConstants.SITEMAP_CHANGEFREQ));
+			}
+
+			if (originalTypeSettingsUnicodeProperties.containsKey(
+					LayoutTypePortletConstants.SITEMAP_INCLUDE)) {
+
+				updatedTypeSettingsUnicodeProperties.put(
+					LayoutTypePortletConstants.SITEMAP_INCLUDE,
+					originalTypeSettingsUnicodeProperties.get(
+						LayoutTypePortletConstants.SITEMAP_INCLUDE));
+			}
+
+			if (originalTypeSettingsUnicodeProperties.containsKey(
+					LayoutTypePortletConstants.SITEMAP_PRIORITY)) {
+
+				updatedTypeSettingsUnicodeProperties.put(
+					LayoutTypePortletConstants.SITEMAP_PRIORITY,
+					originalTypeSettingsUnicodeProperties.get(
+						LayoutTypePortletConstants.SITEMAP_PRIORITY));
+			}
+
+			if (layoutSet.isLayoutSetPrototypeLinkActive()) {
 				if (originalTypeSettingsUnicodeProperties.containsKey(
 						Sites.LAST_MERGE_LAYOUT_MODIFIED_TIME)) {
 


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPD-22610
best,
Attila

-----

The root cause of the issue is that we override the typeSettings of the live page with the draft page and the sitemap relevant information is only stored in the live page typesetting. My solution is to preserve these settings if they exist.