### PR TITLE
LPD-22783 Add methods to Playwright to create vocabularies, categories and tags

### DIFF
--- a/modules/test/playwright/helpers/ApiHelpers.ts
+++ b/modules/test/playwright/helpers/ApiHelpers.ts
@@ -12,6 +12,7 @@ import {ApiBuilderHelper} from './ApiBuilderHelper';
 import {DataEngineApiHelper} from './DataEngineApiHelper';
 import {FeatureFlagApiHelper} from './FeatureFlagApiHelper';
 import {HeadlessAdminContentApiHelper} from './HeadlessAdminContentApiHelper';
+import {HeadlessAdminTaxonomyApiHelper} from './HeadlessAdminTaxonomyApiHelper';
 import {HeadlessAdminUserApiHelper} from './HeadlessAdminUserApiHelper';
 import {HeadlessAdminWorkflowApiHelper} from './HeadlessAdminWorkflowApiHelper';
 import {HeadlessChangeTrackingApiHelper} from './HeadlessChangeTrackingApiHelper';
@@ -46,6 +47,7 @@ export class ApiHelpers {
 	readonly featureFlag: FeatureFlagApiHelper;
 	readonly dataEngine: DataEngineApiHelper;
 	readonly headlessAdminContent: HeadlessAdminContentApiHelper;
+	readonly headlessAdminTaxonomy: HeadlessAdminTaxonomyApiHelper;
 	readonly headlessAdminUser: HeadlessAdminUserApiHelper;
 	readonly headlessAdminWorkflow: HeadlessAdminWorkflowApiHelper;
 	readonly headlessChangeTracking: HeadlessChangeTrackingApiHelper;
@@ -80,6 +82,7 @@ export class ApiHelpers {
 		this.featureFlag = new FeatureFlagApiHelper(page);
 		this.dataEngine = new DataEngineApiHelper(this);
 		this.headlessAdminContent = new HeadlessAdminContentApiHelper(this);
+		this.headlessAdminTaxonomy = new HeadlessAdminTaxonomyApiHelper(this);
 		this.headlessAdminUser = new HeadlessAdminUserApiHelper(this);
 		this.headlessAdminWorkflow = new HeadlessAdminWorkflowApiHelper(this);
 		this.headlessChangeTracking = new HeadlessChangeTrackingApiHelper(this);

--- a/modules/test/playwright/helpers/HeadlessAdminContentApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminContentApiHelper.ts
@@ -14,12 +14,12 @@ export class HeadlessAdminContentApiHelper {
 		this.basePath = 'headless-admin-content/v1.0';
 	}
 
-	async postStructuredContentDraft(
-		siteId: string,
-		contentStructureId: number,
-		datePublished: string,
-		title: string
-	): Promise<StructuredContent> {
+	async postStructuredContentDraft({
+		contentStructureId,
+		datePublished,
+		siteId,
+		title,
+	}): Promise<StructuredContent> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/structured-contents/draft`,
 			{contentStructureId, datePublished, title},

--- a/modules/test/playwright/helpers/HeadlessAdminContentApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminContentApiHelper.ts
@@ -15,14 +15,29 @@ export class HeadlessAdminContentApiHelper {
 	}
 
 	async postStructuredContentDraft({
+		categoryIds,
 		contentStructureId,
 		datePublished,
 		siteId,
+		tags,
 		title,
+	}: {
+		categoryIds?: number[];
+		contentStructureId: number;
+		datePublished: string;
+		siteId: string;
+		tags?: string[];
+		title: string;
 	}): Promise<StructuredContent> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/structured-contents/draft`,
-			{contentStructureId, datePublished, title},
+			{
+				contentStructureId,
+				datePublished,
+				keywords: tags,
+				taxonomyCategoryIds: categoryIds,
+				title,
+			},
 			true
 		);
 	}

--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -15,6 +15,11 @@ interface createVocabularyProps {
 	siteId: string;
 }
 
+interface createCategoryProps {
+	name: string;
+	vocabularyId: number;
+}
+
 export class HeadlessAdminTaxonomyApiHelper {
 	readonly apiHelpers: ApiHelpers;
 	readonly basePath: string;
@@ -40,6 +45,23 @@ export class HeadlessAdminTaxonomyApiHelper {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/taxonomy-vocabularies`,
 			{assetTypes, name}
+		);
+	}
+
+	/**
+	 * It allows creating a category inside a vocabulary.
+	 *
+	 * @param name the name of the category
+	 * @param vocabularyId the parent vocabulary id
+	 */
+
+	async createCategory({
+		name,
+		vocabularyId,
+	}: createCategoryProps): Promise<{id: number}> {
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-vocabularies/${vocabularyId}/taxonomy-categories`,
+			{name}
 		);
 	}
 }

--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -20,6 +20,11 @@ interface createCategoryProps {
 	vocabularyId: number;
 }
 
+interface createTagProps {
+	name: string;
+	siteId: string;
+}
+
 export class HeadlessAdminTaxonomyApiHelper {
 	readonly apiHelpers: ApiHelpers;
 	readonly basePath: string;
@@ -61,6 +66,20 @@ export class HeadlessAdminTaxonomyApiHelper {
 	}: createCategoryProps): Promise<{id: number}> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/taxonomy-vocabularies/${vocabularyId}/taxonomy-categories`,
+			{name}
+		);
+	}
+
+	/**
+	 * It allows creating a tag inside a site.
+	 *
+	 * @param name the name of the tag
+	 * @param siteId the id of the site in which the tag will be created
+	 */
+
+	async createTag({name, siteId}: createTagProps): Promise<{id: number}> {
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/keywords`,
 			{name}
 		);
 	}

--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {ApiHelpers} from './ApiHelpers';
+
+export class HeadlessAdminTaxonomyApiHelper {
+	readonly apiHelpers: ApiHelpers;
+	readonly basePath: string;
+
+	constructor(apiHelpers: ApiHelpers) {
+		this.apiHelpers = apiHelpers;
+		this.basePath = 'headless-admin-taxonomy/v1.0';
+	}
+}

--- a/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessAdminTaxonomyApiHelper.ts
@@ -5,6 +5,16 @@
 
 import {ApiHelpers} from './ApiHelpers';
 
+interface createVocabularyProps {
+	assetTypes: {
+		required: boolean;
+		subtype: 'AllAssetSubtypes';
+		type: 'AllAssetTypes';
+	}[];
+	name: string;
+	siteId: string;
+}
+
 export class HeadlessAdminTaxonomyApiHelper {
 	readonly apiHelpers: ApiHelpers;
 	readonly basePath: string;
@@ -12,5 +22,24 @@ export class HeadlessAdminTaxonomyApiHelper {
 	constructor(apiHelpers: ApiHelpers) {
 		this.apiHelpers = apiHelpers;
 		this.basePath = 'headless-admin-taxonomy/v1.0';
+	}
+
+	/**
+	 * It allows creating a vocabulary inside a site.
+	 *
+	 * @param siteId the id of the site in which the vocabulary will be created
+	 * @param name the name of the vocabulary
+	 * @param assetTypes the asset types to which the vocabulary can be used
+	 */
+
+	async createVocabulary({
+		assetTypes,
+		name,
+		siteId,
+	}: createVocabularyProps): Promise<{id: number}> {
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/taxonomy-vocabularies`,
+			{assetTypes, name}
+		);
 	}
 }

--- a/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
@@ -64,12 +64,17 @@ export class HeadlessDeliveryApiHelper {
 		);
 	}
 
-	async postStructuredContent(
-		siteId: string,
-		contentStructureId: number,
-		datePublished: string,
-		title: string
-	): Promise<StructuredContent> {
+	async postStructuredContent({
+		contentStructureId,
+		datePublished,
+		siteId,
+		title,
+	}: {
+		contentStructureId: number;
+		datePublished: string;
+		siteId: string;
+		title: string;
+	}): Promise<StructuredContent> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/structured-contents`,
 			{contentStructureId, datePublished, title},

--- a/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
+++ b/modules/test/playwright/helpers/HeadlessDeliveryApiHelper.ts
@@ -65,19 +65,29 @@ export class HeadlessDeliveryApiHelper {
 	}
 
 	async postStructuredContent({
+		categoryIds,
 		contentStructureId,
 		datePublished,
 		siteId,
+		tags,
 		title,
 	}: {
+		categoryIds?: number[];
 		contentStructureId: number;
 		datePublished: string;
 		siteId: string;
+		tags?: string[];
 		title: string;
 	}): Promise<StructuredContent> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/sites/${siteId}/structured-contents`,
-			{contentStructureId, datePublished, title},
+			{
+				contentStructureId,
+				datePublished,
+				keywords: tags,
+				taxonomyCategoryIds: categoryIds,
+				title,
+			},
 			true
 		);
 	}

--- a/modules/test/playwright/tests/commerce/commerceSearchSuggestions.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceSearchSuggestions.spec.ts
@@ -36,7 +36,9 @@ test('LPD-18809 search suggestions should filter by product visibility with the 
 
 	// setup
 
-	const site = await apiHelpers.headlessSite.createSite(getRandomString());
+	const site = await apiHelpers.headlessSite.createSite({
+		name: getRandomString(),
+	});
 
 	const channel = await apiHelpers.headlessCommerceAdminChannel.postChannel({
 		siteGroupId: site.id,

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -106,12 +106,12 @@ keepTitlesUntranslated(
 
 		const title = 'add-web-content';
 
-		await addApprovedStructuredContent(
+		await addApprovedStructuredContent({
 			apiHelpers,
-			site.id,
 			contentStructureId,
-			title
-		);
+			siteId: site.id,
+			title,
+		});
 
 		await journalPage.goto(site.friendlyUrlPath);
 
@@ -144,12 +144,12 @@ privateContentIconTest(
 
 		const title = getRandomString();
 
-		await addApprovedStructuredContent(
+		await addApprovedStructuredContent({
 			apiHelpers,
-			site.id,
 			contentStructureId,
-			title
-		);
+			siteId: site.id,
+			title,
+		});
 
 		await journalPage.goto(site.friendlyUrlPath);
 
@@ -174,21 +174,21 @@ privateContentIconTest(
 			apiHelpers
 		);
 
-		await addApprovedStructuredContent(
+		await addApprovedStructuredContent({
 			apiHelpers,
-			site.id,
 			contentStructureId,
-			getRandomString()
-		);
+			siteId: site.id,
+			title: getRandomString(),
+		});
 
 		const title = getRandomString();
 
-		await addApprovedStructuredContent(
+		await addApprovedStructuredContent({
 			apiHelpers,
-			site.id,
 			contentStructureId,
-			title
-		);
+			siteId: site.id,
+			title,
+		});
 
 		await journalPage.goto(site.friendlyUrlPath);
 
@@ -226,12 +226,12 @@ prefixUrlTest(
 			apiHelpers
 		);
 
-		await addApprovedStructuredContent(
+		await addApprovedStructuredContent({
 			apiHelpers,
-			site.id,
 			contentStructureId,
-			articleTitle
-		);
+			siteId: site.id,
+			title: articleTitle,
+		});
 
 		await displayPageTemplatesPage.goto(site.friendlyUrlPath);
 
@@ -349,12 +349,12 @@ translationTest(
 
 		const title = getRandomString();
 
-		await addApprovedStructuredContent(
+		await addApprovedStructuredContent({
 			apiHelpers,
-			site.id,
 			contentStructureId,
-			title
-		);
+			siteId: site.id,
+			title,
+		});
 
 		await journalPage.goto(site.friendlyUrlPath);
 
@@ -387,19 +387,19 @@ bulkTest(
 		const title1 = getRandomString();
 		const title2 = getRandomString();
 
-		await addApprovedStructuredContent(
+		await addApprovedStructuredContent({
 			apiHelpers,
-			site.id,
 			contentStructureId,
-			title1
-		);
+			siteId: site.id,
+			title: title1,
+		});
 
-		await addApprovedStructuredContent(
+		await addApprovedStructuredContent({
 			apiHelpers,
-			site.id,
 			contentStructureId,
-			title2
-		);
+			siteId: site.id,
+			title: title2,
+		});
 
 		await journalPage.goto(site.friendlyUrlPath);
 

--- a/modules/test/playwright/tests/product-navigation-control-menu-web/addContentPanel.spec.ts
+++ b/modules/test/playwright/tests/product-navigation-control-menu-web/addContentPanel.spec.ts
@@ -39,12 +39,12 @@ test('LPD-15256 Approved and scheduled web contents should be displayed in the "
 			apiHelpers
 		);
 
-		await addApprovedStructuredContent(
+		await addApprovedStructuredContent({
 			apiHelpers,
-			site.id,
 			contentStructureId,
-			approvedWebContentTitle
-		);
+			siteId: site.id,
+			title: approvedWebContentTitle,
+		});
 
 		await addDraftStructuredContent({
 			apiHelpers,

--- a/modules/test/playwright/tests/product-navigation-control-menu-web/addContentPanel.spec.ts
+++ b/modules/test/playwright/tests/product-navigation-control-menu-web/addContentPanel.spec.ts
@@ -45,12 +45,13 @@ test('LPD-15256 Approved and scheduled web contents should be displayed in the "
 			contentStructureId,
 			approvedWebContentTitle
 		);
-		await addDraftStructuredContent(
+
+		await addDraftStructuredContent({
 			apiHelpers,
-			site.id,
 			contentStructureId,
-			draftWebContentTitle
-		);
+			siteId: site.id,
+			title: draftWebContentTitle,
+		});
 		await addExpiredStructuredContent(
 			apiHelpers,
 			site.id,

--- a/modules/test/playwright/utils/structured-content/addApprovedStructuredContent.ts
+++ b/modules/test/playwright/utils/structured-content/addApprovedStructuredContent.ts
@@ -5,16 +5,21 @@
 
 import {ApiHelpers} from '../../helpers/ApiHelpers';
 
-export default function addApprovedStructuredContent(
-	apiHelpers: ApiHelpers,
-	siteId: string,
-	contentStructureId: number,
-	title: string
-): Promise<StructuredContent> {
-	return apiHelpers.headlessDelivery.postStructuredContent(
-		siteId,
+export default function addApprovedStructuredContent({
+	apiHelpers,
+	contentStructureId,
+	siteId,
+	title,
+}: {
+	apiHelpers: ApiHelpers;
+	contentStructureId: number;
+	siteId: string;
+	title: string;
+}): Promise<StructuredContent> {
+	return apiHelpers.headlessDelivery.postStructuredContent({
 		contentStructureId,
-		null,
-		title
-	);
+		datePublished: null,
+		siteId,
+		title,
+	});
 }

--- a/modules/test/playwright/utils/structured-content/addApprovedStructuredContent.ts
+++ b/modules/test/playwright/utils/structured-content/addApprovedStructuredContent.ts
@@ -7,19 +7,25 @@ import {ApiHelpers} from '../../helpers/ApiHelpers';
 
 export default function addApprovedStructuredContent({
 	apiHelpers,
+	categoryIds,
 	contentStructureId,
 	siteId,
+	tags,
 	title,
 }: {
 	apiHelpers: ApiHelpers;
+	categoryIds?: number[];
 	contentStructureId: number;
 	siteId: string;
+	tags?: string[];
 	title: string;
 }): Promise<StructuredContent> {
 	return apiHelpers.headlessDelivery.postStructuredContent({
+		categoryIds,
 		contentStructureId,
 		datePublished: null,
 		siteId,
+		tags,
 		title,
 	});
 }

--- a/modules/test/playwright/utils/structured-content/addDraftStructuredContent.ts
+++ b/modules/test/playwright/utils/structured-content/addDraftStructuredContent.ts
@@ -7,19 +7,25 @@ import {ApiHelpers} from '../../helpers/ApiHelpers';
 
 export default function addDraftStructuredContent({
 	apiHelpers,
+	categoryIds,
 	contentStructureId,
 	siteId,
+	tags,
 	title,
 }: {
 	apiHelpers: ApiHelpers;
+	categoryIds?: number[];
 	contentStructureId: number;
 	siteId: string;
+	tags?: string[];
 	title: string;
 }): Promise<StructuredContent> {
 	return apiHelpers.headlessAdminContent.postStructuredContentDraft({
+		categoryIds,
 		contentStructureId,
 		datePublished: null,
 		siteId,
+		tags,
 		title,
 	});
 }

--- a/modules/test/playwright/utils/structured-content/addDraftStructuredContent.ts
+++ b/modules/test/playwright/utils/structured-content/addDraftStructuredContent.ts
@@ -5,16 +5,21 @@
 
 import {ApiHelpers} from '../../helpers/ApiHelpers';
 
-export default function addDraftStructuredContent(
-	apiHelpers: ApiHelpers,
-	siteId: string,
-	contentStructureId: number,
-	title: string
-): Promise<StructuredContent> {
-	return apiHelpers.headlessAdminContent.postStructuredContentDraft(
-		siteId,
+export default function addDraftStructuredContent({
+	apiHelpers,
+	contentStructureId,
+	siteId,
+	title,
+}: {
+	apiHelpers: ApiHelpers;
+	contentStructureId: number;
+	siteId: string;
+	title: string;
+}): Promise<StructuredContent> {
+	return apiHelpers.headlessAdminContent.postStructuredContentDraft({
 		contentStructureId,
-		null,
-		title
-	);
+		datePublished: null,
+		siteId,
+		title,
+	});
 }

--- a/modules/test/playwright/utils/structured-content/addExpiredStructuredContent.ts
+++ b/modules/test/playwright/utils/structured-content/addExpiredStructuredContent.ts
@@ -12,12 +12,12 @@ export default async function addExpiredStructuredContent(
 	title: string
 ): Promise<StructuredContent> {
 	const structuredContent =
-		await apiHelpers.headlessDelivery.postStructuredContent(
-			siteId,
+		await apiHelpers.headlessDelivery.postStructuredContent({
 			contentStructureId,
-			null,
-			title
-		);
+			datePublished: null,
+			siteId,
+			title,
+		});
 
 	await apiHelpers.jsonWebServicesJournal.expireArticle(
 		siteId,

--- a/modules/test/playwright/utils/structured-content/addInTrashStructuredContent.ts
+++ b/modules/test/playwright/utils/structured-content/addInTrashStructuredContent.ts
@@ -12,12 +12,12 @@ export default async function addInTrashStructuredContent(
 	title: string
 ): Promise<StructuredContent> {
 	const structuredContent =
-		await apiHelpers.headlessDelivery.postStructuredContent(
-			siteId,
+		await apiHelpers.headlessDelivery.postStructuredContent({
 			contentStructureId,
-			null,
-			title
-		);
+			datePublished: null,
+			siteId,
+			title,
+		});
 
 	await apiHelpers.jsonWebServicesJournal.moveArticleToTrash(
 		siteId,

--- a/modules/test/playwright/utils/structured-content/addScheduledStructuredContent.ts
+++ b/modules/test/playwright/utils/structured-content/addScheduledStructuredContent.ts
@@ -19,10 +19,10 @@ export default function addScheduledStructuredContent(
 		nowDate.getDate()
 	);
 
-	return apiHelpers.headlessDelivery.postStructuredContent(
-		siteId,
+	return apiHelpers.headlessDelivery.postStructuredContent({
 		contentStructureId,
-		oneYearFromNowDate.toISOString(),
-		title
-	);
+		datePublished: oneYearFromNowDate.toISOString(),
+		siteId,
+		title,
+	});
 }


### PR DESCRIPTION
In this PR, new methods are added to playwright to create vocabularies, categories and tags. They are also added to be able to create a Web Content directly with categories and tags.