### PR TITLE
LPD-22756 Save context object in the request to avoid extra calculations.

### DIFF
--- a/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProvider.java
+++ b/modules/apps/object/object-web/src/main/java/com/liferay/object/web/internal/info/item/provider/ObjectEntryInfoItemObjectProvider.java
@@ -24,6 +24,11 @@ import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.vulcan.dto.converter.DefaultDTOConverterContext;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.servlet.http.HttpServletRequest;
+
 /**
  * @author Guilherme Camacho
  */
@@ -67,17 +72,24 @@ public class ObjectEntryInfoItemObjectProvider
 			return objectEntry;
 		}
 
-		ObjectEntryManager objectEntryManager =
-			_objectEntryManagerRegistry.getObjectEntryManager(
-				_objectDefinition.getStorageType());
-
 		ServiceContext serviceContext =
 			ServiceContextThreadLocal.getServiceContext();
 
-		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
-
 		ERCInfoItemIdentifier ercInfoItemIdentifier =
 			(ERCInfoItemIdentifier)infoItemIdentifier;
+
+		Map<InfoItemIdentifier, ObjectEntry> objectEntries = _getObjectEntries(
+			serviceContext.getRequest());
+
+		if (objectEntries.containsKey(ercInfoItemIdentifier)) {
+			return objectEntries.get(ercInfoItemIdentifier);
+		}
+
+		ThemeDisplay themeDisplay = serviceContext.getThemeDisplay();
+
+		ObjectEntryManager objectEntryManager =
+			_objectEntryManagerRegistry.getObjectEntryManager(
+				_objectDefinition.getStorageType());
 
 		try {
 			Group group = themeDisplay.getScopeGroup();
@@ -92,8 +104,12 @@ public class ObjectEntryInfoItemObjectProvider
 					_objectDefinition, group.getGroupKey());
 
 			if (objectEntry != null) {
-				return ObjectEntryUtil.toObjectEntry(
+				ObjectEntry nextObjectEntry = ObjectEntryUtil.toObjectEntry(
 					_objectDefinition.getObjectDefinitionId(), objectEntry);
+
+				objectEntries.put(ercInfoItemIdentifier, nextObjectEntry);
+
+				return nextObjectEntry;
 			}
 		}
 		catch (Exception exception) {
@@ -106,6 +122,28 @@ public class ObjectEntryInfoItemObjectProvider
 			"Unable to get object entry " +
 				ercInfoItemIdentifier.getExternalReferenceCode());
 	}
+
+	private Map<InfoItemIdentifier, ObjectEntry> _getObjectEntries(
+		HttpServletRequest httpServletRequest) {
+
+		if (httpServletRequest == null) {
+			return new HashMap<>();
+		}
+
+		Map<InfoItemIdentifier, ObjectEntry> objectEntries =
+			(Map<InfoItemIdentifier, ObjectEntry>)
+				httpServletRequest.getAttribute(_OBJECT_ENTRIES);
+
+		if (objectEntries == null) {
+			objectEntries = new HashMap<>();
+
+			httpServletRequest.setAttribute(_OBJECT_ENTRIES, objectEntries);
+		}
+
+		return objectEntries;
+	}
+
+	private static final String _OBJECT_ENTRIES = "OBJECT_ENTRIES";
 
 	private static final Log _log = LogFactoryUtil.getLog(
 		ObjectEntryInfoItemObjectProvider.class);


### PR DESCRIPTION
I went for the easiest solution since this is an optimization is fine if the service context is not available

Steps to reproduce:
- Create some webcontents (4-5)
- Create a dynamic collection for basic web contnent
- Create a content page
- Add a collection display fragment and configure it to use the collection
- Add two heading to a row and map each to a different field
- Publish

**Expected result**
The fields of the collection objects should be calculated once.

**Actual result**
The fields of the collection object is calculated one time per fragment in the collection display.

This is normally not a problem but when using proxy objects each time we calculate the fields we have to make a request to a external service

For tesing it I added some logs in this point: https://github.com/liferay-echo/liferay-portal/pull/15489/files#diff-205dd9e5b0400c37c379d5f390fba3d24c386937bcb995eca83d3c079df62769R655 that should only be displayed the same number of times as the items on the list