### PR TITLE
LRCI-4176 Removes it from stable.

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -9864,7 +9864,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         modules-compile-jdk8,\
         modules-integration-mysql57-jdk8_stable,\
         modules-unit-jdk8_stable,\
-        #modules-unit-project-templates-jdk8,\
         playwright-compile-jdk8,\
         playwright-js-tomcat90-mysql57-jdk8_stable,\
         pmd-jdk8,\


### PR DESCRIPTION
From Lawrence Lee

The frequency the tests are run was a decision that was made when portal releases where not regular. Now that we are on weekly releases, the gauntlet tests are sufficient to catch breaking changes in time before we introduce them to customers.