### PR TITLE
LPD-22609 Excludes portal-fragment-bundle-watcher-test from echo tests, since it is causing conflict with "**/fragment/**/*Test.java"

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -4915,7 +4915,8 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
         **/asset-auto-tagger-google-cloud-natural-language-test/**/*Test.java,\
         **/asset-auto-tagger-opennlp-test/**/*Test.java,\
         **/asset-auto-tagger-service/**/*Test.java,\
-        **/asset-auto-tagger-test/**/*Test.java
+        **/asset-auto-tagger-test/**/*Test.java,\
+        **/portal-fragment-bundle-watcher-test/**/*Test.java
 
     test.batch.class.names.includes[echo]=\
         **/asset/asset-display-page-service/**/*Test.java,\


### PR DESCRIPTION
…