### PR TITLE
LRCI-4185 Removes lpkg-controller tests from relevant.

### DIFF
--- a/test.properties
+++ b/test.properties
@@ -8584,7 +8584,6 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     test.batch.names[relevant]=\
         ${test.batch.names[stable]},\
         empty-osgi-core-dir-mysql57-jdk8,\
-        lpkg-controller-mysql57-jdk8,\
         modules-integration-mysql57-jdk8,\
         modules-semantic-versioning-jdk8,\
         modules-unit-jdk8,\


### PR DESCRIPTION
Comment from Victor Ware:

"That said, we can move out of stable for now because it is not high risk to break. Coverage is present in ci:test:lpkg."