### PR TITLE
LPD-23396 Fix the Orphan Widgets page title

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view_orphan_portlets.jsp
+++ b/modules/apps/layout/layout-admin-web/src/main/resources/META-INF/resources/view_orphan_portlets.jsp
@@ -19,7 +19,7 @@ portletDisplay.setShowBackIcon(true);
 portletDisplay.setURLBack(orphanPortletsDisplayContext.getBackURL());
 portletDisplay.setURLBackTitle(portletDisplay.getPortletDisplayName());
 
-renderResponse.setTitle(LanguageUtil.get(request, "orphan-widgets"));
+renderResponse.setTitle(selLayout.getName(locale) + StringPool.SPACE + LanguageUtil.get(request, "orphan-widgets"));
 %>
 
 <clay:management-toolbar


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPD-23396)

### Changes

Add the name of the page to the title of orphan widgets

## Test scenario 

1. Go to Pages
2. Create a Page
3. Click on the Options Menu of the Page created in the second Step
4. Click Orphan Widgets option
5. Review the title of the page

[Screencast from 2024-04-17 10-12-13.webm](https://github.com/liferay-echo/liferay-portal/assets/93203423/32f27684-73f0-4766-bd6e-304f4eef26f4)
