### PR TITLE
LPD-23761 Sanitize portletId with method getJsSafePortletId same as i…

### DIFF
--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/processor/PortletRegistryImpl.java
@@ -20,6 +20,7 @@ import com.liferay.portal.kernel.portlet.render.PortletRenderUtil;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -99,7 +100,7 @@ public class PortletRegistryImpl implements PortletRegistry {
 				PortletIdCodec.decodeUserId(portletName),
 				fragmentEntryLink.getNamespace() + element.attr("id"));
 
-			portletIds.add(portletId);
+			portletIds.add(_portal.getJsSafePortletId(portletId));
 		}
 
 		Matcher liferayPortletRuntimeMatcher =
@@ -128,7 +129,7 @@ public class PortletRegistryImpl implements PortletRegistry {
 					instanceId, "fragmentEntryLinkNamespace",
 					fragmentEntryLink.getNamespace()));
 
-			portletIds.add(portletId);
+			portletIds.add(_portal.getJsSafePortletId(portletId));
 		}
 
 		return portletIds;
@@ -256,6 +257,9 @@ public class PortletRegistryImpl implements PortletRegistry {
 
 	@Reference
 	private JSONFactory _jsonFactory;
+
+	@Reference
+	private Portal _portal;
 
 	@Reference
 	private PortletLocalService _portletLocalService;

--- a/modules/apps/fragment/fragment-impl/src/test/java/com/liferay/fragment/internal/processor/PortletRegistryImplTest.java
+++ b/modules/apps/fragment/fragment-impl/src/test/java/com/liferay/fragment/internal/processor/PortletRegistryImplTest.java
@@ -8,15 +8,16 @@ package com.liferay.fragment.internal.processor;
 import com.liferay.fragment.model.FragmentEntryLink;
 import com.liferay.fragment.processor.PortletRegistry;
 import com.liferay.petra.string.StringBundler;
-import com.liferay.petra.string.StringPool;
 import com.liferay.portal.json.JSONFactoryImpl;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.util.JS;
 
 import java.util.List;
 
@@ -27,6 +28,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 /**
  * @author Lourdes Fernández Besada
@@ -49,6 +51,8 @@ public class PortletRegistryImplTest {
 
 		ReflectionTestUtil.setFieldValue(
 			_portletRegistry, "_portletLocalService", _portletLocalService);
+
+		_setUpPortal();
 	}
 
 	@Test
@@ -110,7 +114,7 @@ public class PortletRegistryImplTest {
 			PortletIdCodec.encode(
 				PortletIdCodec.decodePortletName(portletName),
 				PortletIdCodec.decodeUserId(portletName),
-				StringBundler.concat(namespace, StringPool.DASH, instanceId)));
+				namespace + instanceId));
 	}
 
 	@Test
@@ -242,6 +246,25 @@ public class PortletRegistryImplTest {
 		);
 
 		return fragmentEntryLink;
+	}
+
+	private void _setUpPortal() {
+		Portal portal = Mockito.mock(Portal.class);
+
+		Mockito.when(
+			portal.getClassName(Mockito.anyLong())
+		).thenReturn(
+			RandomTestUtil.randomString()
+		);
+
+		Mockito.when(
+			portal.getJsSafePortletId(Mockito.anyString())
+		).thenAnswer(
+			(Answer<String>)invocationOnMock -> JS.getSafeName(
+				invocationOnMock.getArgument(0, String.class))
+		);
+
+		ReflectionTestUtil.setFieldValue(_portletRegistry, "_portal", portal);
 	}
 
 	private PortletLocalService _portletLocalService;

--- a/modules/apps/fragment/fragment-impl/src/test/java/com/liferay/fragment/internal/processor/PortletRegistryImplTest.java
+++ b/modules/apps/fragment/fragment-impl/src/test/java/com/liferay/fragment/internal/processor/PortletRegistryImplTest.java
@@ -199,6 +199,31 @@ public class PortletRegistryImplTest {
 				PortletIdCodec.decodeUserId(portletName), null));
 	}
 
+	@Test
+	public void testGetFragmentEntryLinkPortletIdsWithSpecialCharacters() {
+		String instanceId = RandomTestUtil.randomString();
+		String portletName = RandomTestUtil.randomString();
+		String namespace = RandomTestUtil.randomString();
+		String specialCharacters = "-. ";
+
+		_assertGetFragmentEntryLinkPortletIds(
+			_getFragmentEntryLink(
+				StringBundler.concat(
+					"<div class=\"fragment_1\">", RandomTestUtil.randomString(),
+					"[@liferay_portlet[\"runtime\"]",
+					RandomTestUtil.randomString(),
+					" instanceId=\"fragmentEntryLinkNamespace-", instanceId,
+					specialCharacters, "\"", RandomTestUtil.randomString(),
+					" portletName=\"", portletName, "\"",
+					RandomTestUtil.randomString(), "/]",
+					RandomTestUtil.randomString(), "</div>"),
+				namespace),
+			PortletIdCodec.encode(
+				PortletIdCodec.decodePortletName(portletName),
+				PortletIdCodec.decodeUserId(portletName),
+				namespace + instanceId));
+	}
+
 	private void _assertGetFragmentEntryLinkPortletIds(
 		FragmentEntryLink fragmentEntryLink, String... portletIds) {
 


### PR DESCRIPTION
…s done in RuntimeTag, so it can be correctly identified

For steps please read: https://liferay.atlassian.net/issues/LPD-23761

When we render the embedded portlets, we sanitize the instance id here https://github.com/liferay/liferay-portal/blob/983e9163db9f359a6d468f62165ceb53f14b0cde/util-taglib/src/com/liferay/taglib/portletext/RuntimeTag.java#L174 this calls this method which eliminates all dashes, spaces or dots
https://github.com/liferay/liferay-portal-ee/blob/d3f5c54e4523a1b57f3a6364ef268e9ee772c906/util-java/src/com/liferay/util/JS.java#L92

Note: This on 7.2 was working as we collected the portletIds from portletpreferences table (see [LayoutCopyHelperImpl.java#L361](https://github.com/liferay/liferay-portal-ee/blob/d3f5c54e4523a1b57f3a6364ef268e9ee772c906/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/util/LayoutCopyHelperImpl.java#L361)), and we copied them to the specific layout plid number