### PR TITLE
LPD-22969 LAR import gets exponentially slow with many web contents interconnected through repeatable fields

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/dynamic/data/mapping/util/JournalArticleImportDDMFormFieldValueTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/dynamic/data/mapping/util/JournalArticleImportDDMFormFieldValueTransformer.java
@@ -97,24 +97,26 @@ public class JournalArticleImportDDMFormFieldValueTransformer
 					articlePrimaryKey);
 			}
 
-			if ((journalArticle == null) &&
-				((originalArticlePrimaryKey != 0) || (originalClassPK != 0))) {
-
+			if (journalArticle == null) {
 				if (_log.isWarnEnabled()) {
 					_log.warn(
 						"Unable to get journal article with primary key " +
 							articlePrimaryKey);
 				}
 
-				Map<String, String> postProcess =
-					(Map<String, String>)
-						_portletDataContext.getNewPrimaryKeysMap(
-							JournalArticle.class + ".postProcess");
+				if ((originalArticlePrimaryKey != 0) ||
+					(originalClassPK != 0)) {
 
-				if (!postProcess.containsKey(_stagedModel.getUuid())) {
-					postProcess.put(
-						_stagedModel.getUuid(),
-						ExportImportPathUtil.getModelPath(_stagedModel));
+					Map<String, String> postProcess =
+						(Map<String, String>)
+							_portletDataContext.getNewPrimaryKeysMap(
+								JournalArticle.class + ".postProcess");
+
+					if (!postProcess.containsKey(_stagedModel.getUuid())) {
+						postProcess.put(
+							_stagedModel.getUuid(),
+							ExportImportPathUtil.getModelPath(_stagedModel));
+					}
 				}
 
 				continue;

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/dynamic/data/mapping/util/JournalArticleImportDDMFormFieldValueTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/dynamic/data/mapping/util/JournalArticleImportDDMFormFieldValueTransformer.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 
 import java.util.Locale;
 import java.util.Map;
@@ -82,6 +83,18 @@ public class JournalArticleImportDDMFormFieldValueTransformer
 				journalArticle =
 					_journalArticleLocalService.fetchJournalArticle(
 						articlePrimaryKey);
+			}
+
+			if ((journalArticle == null) && (originalClassPK != 0)) {
+				Map<Long, Long> primaryKeys =
+					(Map<Long, Long>)_portletDataContext.getNewPrimaryKeysMap(
+						JournalArticle.class);
+
+				articlePrimaryKey = MapUtil.getLong(
+					primaryKeys, originalClassPK);
+
+				journalArticle = _journalArticleLocalService.fetchLatestArticle(
+					articlePrimaryKey);
 			}
 
 			if ((journalArticle == null) &&

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/dynamic/data/mapping/util/JournalArticleImportDDMFormFieldValueTransformer.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/dynamic/data/mapping/util/JournalArticleImportDDMFormFieldValueTransformer.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.model.StagedModel;
 import com.liferay.portal.kernel.util.GetterUtil;
 
 import java.util.Locale;
+import java.util.Map;
 
 /**
  * @author Eudaldo Alonso
@@ -68,10 +69,14 @@ public class JournalArticleImportDDMFormFieldValueTransformer
 
 			JournalArticle journalArticle = null;
 
+			long originalArticlePrimaryKey = jsonObject.getLong(
+				"articlePrimaryKey");
+			long originalClassPK = jsonObject.getLong("classPK");
+
 			long articlePrimaryKey = GetterUtil.getLong(
 				_portletDataContext.getNewPrimaryKey(
 					JournalArticle.class + ".primaryKey",
-					jsonObject.getLong("articlePrimaryKey")));
+					originalArticlePrimaryKey));
 
 			if (articlePrimaryKey != 0) {
 				journalArticle =
@@ -79,15 +84,25 @@ public class JournalArticleImportDDMFormFieldValueTransformer
 						articlePrimaryKey);
 			}
 
-			if (journalArticle == null) {
+			if ((journalArticle == null) &&
+				((originalArticlePrimaryKey != 0) || (originalClassPK != 0))) {
+
 				if (_log.isWarnEnabled()) {
 					_log.warn(
 						"Unable to get journal article with primary key " +
 							articlePrimaryKey);
 				}
 
-				_portletDataContext.removePrimaryKey(
-					ExportImportPathUtil.getModelPath(_stagedModel));
+				Map<String, String> postProcess =
+					(Map<String, String>)
+						_portletDataContext.getNewPrimaryKeysMap(
+							JournalArticle.class + ".postProcess");
+
+				if (!postProcess.containsKey(_stagedModel.getUuid())) {
+					postProcess.put(
+						_stagedModel.getUuid(),
+						ExportImportPathUtil.getModelPath(_stagedModel));
+				}
 
 				continue;
 			}

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalPortletDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalPortletDataHandler.java
@@ -65,6 +65,7 @@ import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Element;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.portlet.PortletPreferences;
@@ -465,6 +466,29 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 
 		if (portletDataContext.getBooleanParameter(NAMESPACE, "web-content")) {
 			for (Element articleElement : articleElements) {
+				StagedModelDataHandlerUtil.importStagedModel(
+					portletDataContext, articleElement);
+			}
+
+			Map<String, String> postProcessArticles =
+				(Map<String, String>)portletDataContext.getNewPrimaryKeysMap(
+					JournalArticle.class + ".postProcess");
+
+			for (Map.Entry<String, String> entry :
+					postProcessArticles.entrySet()) {
+
+				portletDataContext.removePrimaryKey(entry.getValue());
+			}
+
+			for (Element articleElement : articleElements) {
+				String uuid = articleElement.attributeValue("uuid");
+
+				if (!postProcessArticles.containsKey(uuid)) {
+					continue;
+				}
+
+				postProcessArticles.remove(uuid);
+
 				StagedModelDataHandlerUtil.importStagedModel(
 					portletDataContext, articleElement);
 			}

--- a/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalExportImportTest.java
+++ b/modules/apps/journal/journal-test/src/testIntegration/java/com/liferay/journal/exportimport/data/handler/test/JournalExportImportTest.java
@@ -33,11 +33,13 @@ import com.liferay.journal.service.JournalArticleLocalServiceUtil;
 import com.liferay.journal.test.util.JournalTestUtil;
 import com.liferay.journal.util.JournalContent;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringBundler;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.configuration.module.configuration.ConfigurationProvider;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
@@ -66,6 +68,9 @@ import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.zip.ZipReaderFactory;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LogEntry;
+import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -262,6 +267,111 @@ public class JournalExportImportTest extends BasePortletExportImportTestCase {
 			1,
 			JournalArticleLocalServiceUtil.getArticlesCount(
 				importedGroup.getGroupId(), importedArticle.getArticleId()));
+	}
+
+	@Test
+	public void testExportImportJournalArticleWithRepeatableWebContentField()
+		throws Exception {
+
+		DataDefinition dataDefinition = DataDefinition.toDTO(
+			_readFileToString(
+				"dependencies/repeatable_journal_field_data_definition.json"));
+
+		dataDefinition.setName(
+			HashMapBuilder.<String, Object>put(
+				String.valueOf(LocaleUtil.US), "TestDataDef"
+			).build());
+
+		DataDefinitionResource.Builder dataDefinitionResourcedBuilder =
+			_dataDefinitionResourceFactory.create();
+
+		DataDefinitionResource dataDefinitionResource =
+			dataDefinitionResourcedBuilder.user(
+				TestPropsValues.getUser()
+			).build();
+
+		dataDefinition =
+			dataDefinitionResource.postSiteDataDefinitionByContentType(
+				group.getGroupId(), "journal", dataDefinition);
+
+		String xml = _readFileToString(
+			"dependencies/repeatable_journal_field_journal_content.xml");
+
+		JournalArticle referencedArticle1 = JournalTestUtil.addArticle(
+			group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+		JournalArticle referencedArticle2 = JournalTestUtil.addArticle(
+			group.getGroupId(),
+			JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID);
+
+		JournalArticle article = JournalTestUtil.addArticleWithXMLContent(
+			group.getGroupId(), JournalFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			JournalArticleConstants.CLASS_NAME_ID_DEFAULT,
+			StringUtil.replace(
+				xml,
+				new String[] {
+					"[$JOURNAL_REF_JSON_1$]", "[$JOURNAL_REF_JSON_2$]"
+				},
+				new String[] {
+					_getArticleReferenceJSONObject(
+						referencedArticle1
+					).toString(),
+					_getArticleReferenceJSONObject(
+						referencedArticle2
+					).toString()
+				}),
+			dataDefinition.getDataDefinitionKey(), null, LocaleUtil.US);
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				"com.liferay.journal.internal.dynamic.data.mapping.util." +
+					"JournalArticleImportDDMFormFieldValueTransformer",
+				LoggerTestUtil.WARN)) {
+
+			exportImportPortlet(JournalPortletKeys.JOURNAL);
+
+			List<LogEntry> logEntries = logCapture.getLogEntries();
+
+			int count = 0;
+
+			for (LogEntry logEntry : logEntries) {
+				String message = logEntry.getMessage();
+
+				if (message.startsWith(
+						"Unable to get journal article with primary key")) {
+
+					count++;
+				}
+			}
+
+			Assert.assertTrue("Unexpected log messages: " + count, count <= 1);
+		}
+
+		article =
+			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
+				article.getUuid(), importedGroup.getGroupId());
+
+		Assert.assertNotNull(article);
+
+		referencedArticle1 =
+			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
+				referencedArticle1.getUuid(), importedGroup.getGroupId());
+
+		Assert.assertNotNull(referencedArticle1);
+
+		referencedArticle2 =
+			JournalArticleLocalServiceUtil.fetchJournalArticleByUuidAndGroupId(
+				referencedArticle2.getUuid(), importedGroup.getGroupId());
+
+		Assert.assertNotNull(referencedArticle2);
+
+		String content = article.getContent();
+
+		_assertContains(
+			content,
+			"\"classPK\":\"" + referencedArticle1.getResourcePrimKey() + "\"");
+		_assertContains(
+			content,
+			"\"classPK\":\"" + referencedArticle2.getResourcePrimKey() + "\"");
 	}
 
 	@Test
@@ -644,6 +754,32 @@ public class JournalExportImportTest extends BasePortletExportImportTestCase {
 
 			validateImportedStagedModel(article, importedArticle);
 		}
+	}
+
+	private void _assertContains(String string, String substring) {
+		Assert.assertTrue(
+			StringBundler.concat(
+				"The string \"", string, "\" should contain the substring \"",
+				substring, "\""),
+			string.contains(substring));
+	}
+
+	private JSONObject _getArticleReferenceJSONObject(JournalArticle article)
+		throws Exception {
+
+		AssetEntry assetEntry = getAssetEntry(article);
+
+		return JSONUtil.put(
+			"assetEntryId", assetEntry.getEntryId()
+		).put(
+			"className", JournalArticle.class.getName()
+		).put(
+			"classNameId", PortalUtil.getClassNameId(JournalArticle.class)
+		).put(
+			"classPK", article.getResourcePrimKey()
+		).put(
+			"type", "Web Content Article"
+		);
 	}
 
 	private String _read(String fileName) throws Exception {

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/exportimport/data/handler/test/dependencies/repeatable_journal_field_data_definition.json
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/exportimport/data/handler/test/dependencies/repeatable_journal_field_data_definition.json
@@ -1,0 +1,78 @@
+{
+	"availableLanguageIds": [
+		"en_US"
+	],
+	"contentType": "journal",
+	"dataDefinitionFields": [
+		{
+			"customProperties": {
+				"dataType": "journal-article",
+				"fieldNamespace": "",
+				"fieldReference": "JournalArticle45391501",
+				"visibilityExpression": ""
+			},
+			"defaultValue": {
+				"en_US": ""
+			},
+			"fieldType": "journal_article",
+			"indexType": "keyword",
+			"indexable": true,
+			"label": {
+				"en_US": "Web Content"
+			},
+			"localizable": true,
+			"name": "JournalArticle45391501",
+			"nestedDataDefinitionFields": [
+			],
+			"readOnly": false,
+			"repeatable": true,
+			"required": false,
+			"showLabel": true,
+			"tip": {
+				"en_US": ""
+			}
+		}
+	],
+	"dataDefinitionKey": "33221",
+	"defaultDataLayout": {
+		"dataLayoutFields": {
+		},
+		"dataLayoutPages": [
+			{
+				"dataLayoutRows": [
+					{
+						"dataLayoutColumns": [
+							{
+								"columnSize": 12,
+								"fieldNames": [
+									"JournalArticle45391501"
+								]
+							}
+						]
+					}
+				],
+				"description": {
+					"en_US": ""
+				},
+				"title": {
+					"en_US": ""
+				}
+			}
+		],
+		"dataRules": [
+		],
+		"description": {
+		},
+		"name": {
+			"en_US": "TestStruct"
+		},
+		"paginationMode": "single-page"
+	},
+	"defaultLanguageId": "en_US",
+	"description": {
+	},
+	"name": {
+		"en_US": "TestStruct"
+	},
+	"storageType": "default"
+}

--- a/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/exportimport/data/handler/test/dependencies/repeatable_journal_field_journal_content.xml
+++ b/modules/apps/journal/journal-test/src/testIntegration/resources/com/liferay/journal/exportimport/data/handler/test/dependencies/repeatable_journal_field_journal_content.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US" version="1.0">
+	<dynamic-element field-reference="JournalArticle45391501" index-type="keyword" instance-id="olTvPKq0" name="JournalArticle45391501" type="journal_article">
+		<dynamic-content language-id="en_US"><![CDATA[[$JOURNAL_REF_JSON_1$]]]></dynamic-content>
+	</dynamic-element>
+	<dynamic-element field-reference="JournalArticle45391501" index-type="keyword" instance-id="ataddg9c" name="JournalArticle45391501" type="journal_article">
+		<dynamic-content language-id="en_US"><![CDATA[[$JOURNAL_REF_JSON_2$]]]></dynamic-content>
+	</dynamic-element>
+</root>


### PR DESCRIPTION
See details: [LPD-22969](https://liferay.atlassian.net/browse/LPD-22969)

### Motivation

A fix in the past, [LPSA-58080](https://liferay.atlassian.net/browse/LPSA-58080) (see [commit](https://github.com/liferay/liferay-portal/commit/d765c5c5106c5981e57fb2eaeaa12dfdf64dc3fd)) introduced a change that can cause performance issues when we are importing large amounts of web contents referencing each other.

Since that change, if not all of the web content field references could be resolved, the web content is removed from the "processed" list of the PortletDataContext. Thus, making the framework import it again, hoping that the references has been imported by then.

The problems this PR trying to solve:
* Empty repeatable web content references were also considered missing.
* Repeatable web content references are exported in a different way: they have `classPK` instead of `articlePrimaryKey`, but only `articlePrimaryKey` was considered.
* If the web contents are too "interconnected", then the import will slow down exponentially, as all web contents are almost always removed from the processed list, and the dependencies are getting resolved very slowly, after thousands of iterations.

### Proposed solution

* Do a post-processing, after all web contents have been imported: https://github.com/liferay-echo/liferay-portal/commit/9a726a040564cd42ba6efc5370e6bf18695ff924
* Try to resolve the references, even when they are coming from a repeatable web content field: https://github.com/liferay-echo/liferay-portal/commit/21b4ce2939e5b0fb0c7d49f15de32767160315f3

Please review my changes.