### PR TITLE
LPD-24491 Add External Reference Code to Fragment Sets

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/BaseTemplateUpgradeProcessTestCase.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-test/src/testIntegration/java/com/liferay/dynamic/data/mapping/service/test/BaseTemplateUpgradeProcessTestCase.java
@@ -70,8 +70,8 @@ public abstract class BaseTemplateUpgradeProcessTestCase {
 	protected void addFragmentEntry(String filePath) throws Exception {
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionService.addFragmentCollection(
-				_group.getGroupId(), "Fragment Collection", StringPool.BLANK,
-				_serviceContext);
+				null, _group.getGroupId(), "Fragment Collection",
+				StringPool.BLANK, _serviceContext);
 
 		_fragmentEntry = _fragmentEntryService.addFragmentEntry(
 			_group.getGroupId(), fragmentCollection.getFragmentCollectionId(),

--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 43.2.0
+Bundle-Version: 44.0.0
 Export-Package:\
 	com.liferay.fragment.cache,\
 	com.liferay.fragment.configuration,\

--- a/modules/apps/fragment/fragment-api/bnd.bnd
+++ b/modules/apps/fragment/fragment-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Fragment API
 Bundle-SymbolicName: com.liferay.fragment.api
-Bundle-Version: 43.1.1
+Bundle-Version: 43.2.0
 Export-Package:\
 	com.liferay.fragment.cache,\
 	com.liferay.fragment.configuration,\

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/exception/DuplicateFragmentCollectionExternalReferenceCodeException.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/exception/DuplicateFragmentCollectionExternalReferenceCodeException.java
@@ -1,0 +1,37 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.fragment.exception;
+
+import com.liferay.portal.kernel.exception.DuplicateExternalReferenceCodeException;
+
+/**
+ * @author Brian Wing Shun Chan
+ */
+public class DuplicateFragmentCollectionExternalReferenceCodeException
+	extends DuplicateExternalReferenceCodeException {
+
+	public DuplicateFragmentCollectionExternalReferenceCodeException() {
+	}
+
+	public DuplicateFragmentCollectionExternalReferenceCodeException(
+		String msg) {
+
+		super(msg);
+	}
+
+	public DuplicateFragmentCollectionExternalReferenceCodeException(
+		String msg, Throwable throwable) {
+
+		super(msg, throwable);
+	}
+
+	public DuplicateFragmentCollectionExternalReferenceCodeException(
+		Throwable throwable) {
+
+		super(throwable);
+	}
+
+}

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionModel.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionModel.java
@@ -7,6 +7,7 @@ package com.liferay.fragment.model;
 
 import com.liferay.portal.kernel.bean.AutoEscape;
 import com.liferay.portal.kernel.model.BaseModel;
+import com.liferay.portal.kernel.model.ExternalReferenceCodeModel;
 import com.liferay.portal.kernel.model.MVCCModel;
 import com.liferay.portal.kernel.model.ShardedModel;
 import com.liferay.portal.kernel.model.StagedGroupedModel;
@@ -30,7 +31,8 @@ import org.osgi.annotation.versioning.ProviderType;
 @ProviderType
 public interface FragmentCollectionModel
 	extends BaseModel<FragmentCollection>, CTModel<FragmentCollection>,
-			MVCCModel, ShardedModel, StagedGroupedModel {
+			ExternalReferenceCodeModel, MVCCModel, ShardedModel,
+			StagedGroupedModel {
 
 	/*
 	 * NOTE FOR DEVELOPERS:
@@ -102,6 +104,23 @@ public interface FragmentCollectionModel
 	 */
 	@Override
 	public void setUuid(String uuid);
+
+	/**
+	 * Returns the external reference code of this fragment collection.
+	 *
+	 * @return the external reference code of this fragment collection
+	 */
+	@AutoEscape
+	@Override
+	public String getExternalReferenceCode();
+
+	/**
+	 * Sets the external reference code of this fragment collection.
+	 *
+	 * @param externalReferenceCode the external reference code of this fragment collection
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode);
 
 	/**
 	 * Returns the fragment collection ID of this fragment collection.

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionTable.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionTable.java
@@ -33,6 +33,10 @@ public class FragmentCollectionTable
 			"ctCollectionId", Long.class, Types.BIGINT, Column.FLAG_PRIMARY);
 	public final Column<FragmentCollectionTable, String> uuid = createColumn(
 		"uuid_", String.class, Types.VARCHAR, Column.FLAG_DEFAULT);
+	public final Column<FragmentCollectionTable, String> externalReferenceCode =
+		createColumn(
+			"externalReferenceCode", String.class, Types.VARCHAR,
+			Column.FLAG_DEFAULT);
 	public final Column<FragmentCollectionTable, Long> fragmentCollectionId =
 		createColumn(
 			"fragmentCollectionId", Long.class, Types.BIGINT,

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/model/FragmentCollectionWrapper.java
@@ -39,6 +39,7 @@ public class FragmentCollectionWrapper
 		attributes.put("mvccVersion", getMvccVersion());
 		attributes.put("ctCollectionId", getCtCollectionId());
 		attributes.put("uuid", getUuid());
+		attributes.put("externalReferenceCode", getExternalReferenceCode());
 		attributes.put("fragmentCollectionId", getFragmentCollectionId());
 		attributes.put("groupId", getGroupId());
 		attributes.put("companyId", getCompanyId());
@@ -72,6 +73,13 @@ public class FragmentCollectionWrapper
 
 		if (uuid != null) {
 			setUuid(uuid);
+		}
+
+		String externalReferenceCode = (String)attributes.get(
+			"externalReferenceCode");
+
+		if (externalReferenceCode != null) {
+			setExternalReferenceCode(externalReferenceCode);
 		}
 
 		Long fragmentCollectionId = (Long)attributes.get(
@@ -186,6 +194,16 @@ public class FragmentCollectionWrapper
 	@Override
 	public String getDescription() {
 		return model.getDescription();
+	}
+
+	/**
+	 * Returns the external reference code of this fragment collection.
+	 *
+	 * @return the external reference code of this fragment collection
+	 */
+	@Override
+	public String getExternalReferenceCode() {
+		return model.getExternalReferenceCode();
 	}
 
 	/**
@@ -411,6 +429,16 @@ public class FragmentCollectionWrapper
 	@Override
 	public void setDescription(String description) {
 		model.setDescription(description);
+	}
+
+	/**
+	 * Sets the external reference code of this fragment collection.
+	 *
+	 * @param externalReferenceCode the external reference code of this fragment collection
+	 */
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		model.setExternalReferenceCode(externalReferenceCode);
 	}
 
 	/**

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionLocalService.java
@@ -224,6 +224,10 @@ public interface FragmentCollectionLocalService
 	public FragmentCollection fetchFragmentCollection(
 		long groupId, String fragmentCollectionKey);
 
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FragmentCollection fetchFragmentCollectionByExternalReferenceCode(
+		String externalReferenceCode, long groupId);
+
 	/**
 	 * Returns the fragment collection matching the UUID and group.
 	 *
@@ -253,6 +257,11 @@ public interface FragmentCollectionLocalService
 	 */
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FragmentCollection getFragmentCollection(long fragmentCollectionId)
+		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FragmentCollection getFragmentCollectionByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	/**

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionLocalService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionLocalService.java
@@ -79,13 +79,14 @@ public interface FragmentCollectionLocalService
 		FragmentCollection fragmentCollection);
 
 	public FragmentCollection addFragmentCollection(
-			long userId, long groupId, String name, String description,
-			ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long groupId,
+			String name, String description, ServiceContext serviceContext)
 		throws PortalException;
 
 	public FragmentCollection addFragmentCollection(
-			long userId, long groupId, String fragmentCollectionKey,
-			String name, String description, ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long groupId,
+			String fragmentCollectionKey, String name, String description,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	/**
@@ -135,6 +136,10 @@ public interface FragmentCollectionLocalService
 	@Indexable(type = IndexableType.DELETE)
 	public FragmentCollection deleteFragmentCollection(
 			long fragmentCollectionId)
+		throws PortalException;
+
+	public FragmentCollection deleteFragmentCollection(
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	/**
@@ -223,6 +228,10 @@ public interface FragmentCollectionLocalService
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FragmentCollection fetchFragmentCollection(
 		long groupId, String fragmentCollectionKey);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FragmentCollection fetchFragmentCollection(
+		String externalReferenceCode, long groupId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FragmentCollection fetchFragmentCollectionByExternalReferenceCode(
@@ -381,6 +390,11 @@ public interface FragmentCollectionLocalService
 
 	public FragmentCollection updateFragmentCollection(
 			long fragmentCollectionId, String name, String description)
+		throws PortalException;
+
+	public FragmentCollection updateFragmentCollection(
+			String externalReferenceCode, long groupId, String name,
+			String description)
 		throws PortalException;
 
 	@Override

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionLocalServiceUtil.java
@@ -238,6 +238,14 @@ public class FragmentCollectionLocalServiceUtil {
 			groupId, fragmentCollectionKey);
 	}
 
+	public static FragmentCollection
+		fetchFragmentCollectionByExternalReferenceCode(
+			String externalReferenceCode, long groupId) {
+
+		return getService().fetchFragmentCollectionByExternalReferenceCode(
+			externalReferenceCode, groupId);
+	}
+
 	/**
 	 * Returns the fragment collection matching the UUID and group.
 	 *
@@ -284,6 +292,15 @@ public class FragmentCollectionLocalServiceUtil {
 		throws PortalException {
 
 		return getService().getFragmentCollection(fragmentCollectionId);
+	}
+
+	public static FragmentCollection
+			getFragmentCollectionByExternalReferenceCode(
+				String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return getService().getFragmentCollectionByExternalReferenceCode(
+			externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionLocalServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionLocalServiceUtil.java
@@ -53,23 +53,25 @@ public class FragmentCollectionLocalServiceUtil {
 	}
 
 	public static FragmentCollection addFragmentCollection(
-			long userId, long groupId, String name, String description,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().addFragmentCollection(
-			userId, groupId, name, description, serviceContext);
-	}
-
-	public static FragmentCollection addFragmentCollection(
-			long userId, long groupId, String fragmentCollectionKey,
+			String externalReferenceCode, long userId, long groupId,
 			String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addFragmentCollection(
-			userId, groupId, fragmentCollectionKey, name, description,
+			externalReferenceCode, userId, groupId, name, description,
 			serviceContext);
+	}
+
+	public static FragmentCollection addFragmentCollection(
+			String externalReferenceCode, long userId, long groupId,
+			String fragmentCollectionKey, String name, String description,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addFragmentCollection(
+			externalReferenceCode, userId, groupId, fragmentCollectionKey, name,
+			description, serviceContext);
 	}
 
 	/**
@@ -128,6 +130,14 @@ public class FragmentCollectionLocalServiceUtil {
 		throws PortalException {
 
 		return getService().deleteFragmentCollection(fragmentCollectionId);
+	}
+
+	public static FragmentCollection deleteFragmentCollection(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return getService().deleteFragmentCollection(
+			externalReferenceCode, groupId);
 	}
 
 	/**
@@ -236,6 +246,13 @@ public class FragmentCollectionLocalServiceUtil {
 
 		return getService().fetchFragmentCollection(
 			groupId, fragmentCollectionKey);
+	}
+
+	public static FragmentCollection fetchFragmentCollection(
+		String externalReferenceCode, long groupId) {
+
+		return getService().fetchFragmentCollection(
+			externalReferenceCode, groupId);
 	}
 
 	public static FragmentCollection
@@ -460,6 +477,15 @@ public class FragmentCollectionLocalServiceUtil {
 
 		return getService().updateFragmentCollection(
 			fragmentCollectionId, name, description);
+	}
+
+	public static FragmentCollection updateFragmentCollection(
+			String externalReferenceCode, long groupId, String name,
+			String description)
+		throws PortalException {
+
+		return getService().updateFragmentCollection(
+			externalReferenceCode, groupId, name, description);
 	}
 
 	public static FragmentCollectionLocalService getService() {

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionLocalServiceWrapper.java
@@ -269,6 +269,15 @@ public class FragmentCollectionLocalServiceWrapper
 			groupId, fragmentCollectionKey);
 	}
 
+	@Override
+	public FragmentCollection fetchFragmentCollectionByExternalReferenceCode(
+		String externalReferenceCode, long groupId) {
+
+		return _fragmentCollectionLocalService.
+			fetchFragmentCollectionByExternalReferenceCode(
+				externalReferenceCode, groupId);
+	}
+
 	/**
 	 * Returns the fragment collection matching the UUID and group.
 	 *
@@ -320,6 +329,16 @@ public class FragmentCollectionLocalServiceWrapper
 
 		return _fragmentCollectionLocalService.getFragmentCollection(
 			fragmentCollectionId);
+	}
+
+	@Override
+	public FragmentCollection getFragmentCollectionByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _fragmentCollectionLocalService.
+			getFragmentCollectionByExternalReferenceCode(
+				externalReferenceCode, groupId);
 	}
 
 	/**

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionLocalServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionLocalServiceWrapper.java
@@ -52,24 +52,26 @@ public class FragmentCollectionLocalServiceWrapper
 
 	@Override
 	public FragmentCollection addFragmentCollection(
-			long userId, long groupId, String name, String description,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _fragmentCollectionLocalService.addFragmentCollection(
-			userId, groupId, name, description, serviceContext);
-	}
-
-	@Override
-	public FragmentCollection addFragmentCollection(
-			long userId, long groupId, String fragmentCollectionKey,
+			String externalReferenceCode, long userId, long groupId,
 			String name, String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _fragmentCollectionLocalService.addFragmentCollection(
-			userId, groupId, fragmentCollectionKey, name, description,
+			externalReferenceCode, userId, groupId, name, description,
 			serviceContext);
+	}
+
+	@Override
+	public FragmentCollection addFragmentCollection(
+			String externalReferenceCode, long userId, long groupId,
+			String fragmentCollectionKey, String name, String description,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _fragmentCollectionLocalService.addFragmentCollection(
+			externalReferenceCode, userId, groupId, fragmentCollectionKey, name,
+			description, serviceContext);
 	}
 
 	/**
@@ -136,6 +138,15 @@ public class FragmentCollectionLocalServiceWrapper
 
 		return _fragmentCollectionLocalService.deleteFragmentCollection(
 			fragmentCollectionId);
+	}
+
+	@Override
+	public FragmentCollection deleteFragmentCollection(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _fragmentCollectionLocalService.deleteFragmentCollection(
+			externalReferenceCode, groupId);
 	}
 
 	/**
@@ -267,6 +278,14 @@ public class FragmentCollectionLocalServiceWrapper
 
 		return _fragmentCollectionLocalService.fetchFragmentCollection(
 			groupId, fragmentCollectionKey);
+	}
+
+	@Override
+	public FragmentCollection fetchFragmentCollection(
+		String externalReferenceCode, long groupId) {
+
+		return _fragmentCollectionLocalService.fetchFragmentCollection(
+			externalReferenceCode, groupId);
 	}
 
 	@Override
@@ -521,6 +540,16 @@ public class FragmentCollectionLocalServiceWrapper
 
 		return _fragmentCollectionLocalService.updateFragmentCollection(
 			fragmentCollectionId, name, description);
+	}
+
+	@Override
+	public FragmentCollection updateFragmentCollection(
+			String externalReferenceCode, long groupId, String name,
+			String description)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _fragmentCollectionLocalService.updateFragmentCollection(
+			externalReferenceCode, groupId, name, description);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionService.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionService.java
@@ -48,17 +48,22 @@ public interface FragmentCollectionService extends BaseService {
 	 * Never modify this interface directly. Add custom service methods to <code>com.liferay.fragment.service.impl.FragmentCollectionServiceImpl</code> and rerun ServiceBuilder to automatically copy the method declarations to this interface. Consume the fragment collection remote service via injection or a <code>org.osgi.util.tracker.ServiceTracker</code>. Use {@link FragmentCollectionServiceUtil} if injection and service tracking are not available.
 	 */
 	public FragmentCollection addFragmentCollection(
-			long groupId, String name, String description,
-			ServiceContext serviceContext)
+			String externalReferenceCode, long groupId, String name,
+			String description, ServiceContext serviceContext)
 		throws PortalException;
 
 	public FragmentCollection addFragmentCollection(
-			long groupId, String fragmentCollectionKey, String name,
-			String description, ServiceContext serviceContext)
+			String externalReferenceCode, long groupId,
+			String fragmentCollectionKey, String name, String description,
+			ServiceContext serviceContext)
 		throws PortalException;
 
 	public FragmentCollection deleteFragmentCollection(
 			long fragmentCollectionId)
+		throws PortalException;
+
+	public FragmentCollection deleteFragmentCollection(
+			String externalReferenceCode, long groupId)
 		throws PortalException;
 
 	public void deleteFragmentCollections(long[] fragmentCollectionIds)
@@ -67,6 +72,10 @@ public interface FragmentCollectionService extends BaseService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FragmentCollection fetchFragmentCollection(long fragmentCollectionId)
 		throws PortalException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FragmentCollection fetchFragmentCollection(
+		String externalReferenceCode, long groupId);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public List<FileEntry> getFragmentCollectionFileEntries(
@@ -149,6 +158,11 @@ public interface FragmentCollectionService extends BaseService {
 
 	public FragmentCollection updateFragmentCollection(
 			long fragmentCollectionId, String name, String description)
+		throws PortalException;
+
+	public FragmentCollection updateFragmentCollection(
+			String externalReferenceCode, long groupId, String name,
+			String description)
 		throws PortalException;
 
 }

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionServiceUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionServiceUtil.java
@@ -31,22 +31,24 @@ public class FragmentCollectionServiceUtil {
 	 * Never modify this class directly. Add custom service methods to <code>com.liferay.fragment.service.impl.FragmentCollectionServiceImpl</code> and rerun ServiceBuilder to regenerate this class.
 	 */
 	public static FragmentCollection addFragmentCollection(
-			long groupId, String name, String description,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws PortalException {
-
-		return getService().addFragmentCollection(
-			groupId, name, description, serviceContext);
-	}
-
-	public static FragmentCollection addFragmentCollection(
-			long groupId, String fragmentCollectionKey, String name,
+			String externalReferenceCode, long groupId, String name,
 			String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws PortalException {
 
 		return getService().addFragmentCollection(
-			groupId, fragmentCollectionKey, name, description, serviceContext);
+			externalReferenceCode, groupId, name, description, serviceContext);
+	}
+
+	public static FragmentCollection addFragmentCollection(
+			String externalReferenceCode, long groupId,
+			String fragmentCollectionKey, String name, String description,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws PortalException {
+
+		return getService().addFragmentCollection(
+			externalReferenceCode, groupId, fragmentCollectionKey, name,
+			description, serviceContext);
 	}
 
 	public static FragmentCollection deleteFragmentCollection(
@@ -54,6 +56,14 @@ public class FragmentCollectionServiceUtil {
 		throws PortalException {
 
 		return getService().deleteFragmentCollection(fragmentCollectionId);
+	}
+
+	public static FragmentCollection deleteFragmentCollection(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return getService().deleteFragmentCollection(
+			externalReferenceCode, groupId);
 	}
 
 	public static void deleteFragmentCollections(long[] fragmentCollectionIds)
@@ -67,6 +77,13 @@ public class FragmentCollectionServiceUtil {
 		throws PortalException {
 
 		return getService().fetchFragmentCollection(fragmentCollectionId);
+	}
+
+	public static FragmentCollection fetchFragmentCollection(
+		String externalReferenceCode, long groupId) {
+
+		return getService().fetchFragmentCollection(
+			externalReferenceCode, groupId);
 	}
 
 	public static List<com.liferay.portal.kernel.repository.model.FileEntry>
@@ -201,6 +218,15 @@ public class FragmentCollectionServiceUtil {
 
 		return getService().updateFragmentCollection(
 			fragmentCollectionId, name, description);
+	}
+
+	public static FragmentCollection updateFragmentCollection(
+			String externalReferenceCode, long groupId, String name,
+			String description)
+		throws PortalException {
+
+		return getService().updateFragmentCollection(
+			externalReferenceCode, groupId, name, description);
 	}
 
 	public static FragmentCollectionService getService() {

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionServiceWrapper.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/FragmentCollectionServiceWrapper.java
@@ -31,23 +31,25 @@ public class FragmentCollectionServiceWrapper
 
 	@Override
 	public FragmentCollection addFragmentCollection(
-			long groupId, String name, String description,
-			com.liferay.portal.kernel.service.ServiceContext serviceContext)
-		throws com.liferay.portal.kernel.exception.PortalException {
-
-		return _fragmentCollectionService.addFragmentCollection(
-			groupId, name, description, serviceContext);
-	}
-
-	@Override
-	public FragmentCollection addFragmentCollection(
-			long groupId, String fragmentCollectionKey, String name,
+			String externalReferenceCode, long groupId, String name,
 			String description,
 			com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
 		return _fragmentCollectionService.addFragmentCollection(
-			groupId, fragmentCollectionKey, name, description, serviceContext);
+			externalReferenceCode, groupId, name, description, serviceContext);
+	}
+
+	@Override
+	public FragmentCollection addFragmentCollection(
+			String externalReferenceCode, long groupId,
+			String fragmentCollectionKey, String name, String description,
+			com.liferay.portal.kernel.service.ServiceContext serviceContext)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _fragmentCollectionService.addFragmentCollection(
+			externalReferenceCode, groupId, fragmentCollectionKey, name,
+			description, serviceContext);
 	}
 
 	@Override
@@ -57,6 +59,15 @@ public class FragmentCollectionServiceWrapper
 
 		return _fragmentCollectionService.deleteFragmentCollection(
 			fragmentCollectionId);
+	}
+
+	@Override
+	public FragmentCollection deleteFragmentCollection(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _fragmentCollectionService.deleteFragmentCollection(
+			externalReferenceCode, groupId);
 	}
 
 	@Override
@@ -73,6 +84,14 @@ public class FragmentCollectionServiceWrapper
 
 		return _fragmentCollectionService.fetchFragmentCollection(
 			fragmentCollectionId);
+	}
+
+	@Override
+	public FragmentCollection fetchFragmentCollection(
+		String externalReferenceCode, long groupId) {
+
+		return _fragmentCollectionService.fetchFragmentCollection(
+			externalReferenceCode, groupId);
 	}
 
 	@Override
@@ -236,6 +255,16 @@ public class FragmentCollectionServiceWrapper
 
 		return _fragmentCollectionService.updateFragmentCollection(
 			fragmentCollectionId, name, description);
+	}
+
+	@Override
+	public FragmentCollection updateFragmentCollection(
+			String externalReferenceCode, long groupId, String name,
+			String description)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		return _fragmentCollectionService.updateFragmentCollection(
+			externalReferenceCode, groupId, name, description);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/persistence/FragmentCollectionPersistence.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/persistence/FragmentCollectionPersistence.java
@@ -886,6 +886,59 @@ public interface FragmentCollectionPersistence
 	public int countByG_LikeN(long[] groupIds, String name);
 
 	/**
+	 * Returns the fragment collection where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchCollectionException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching fragment collection
+	 * @throws NoSuchCollectionException if a matching fragment collection could not be found
+	 */
+	public FragmentCollection findByERC_G(
+			String externalReferenceCode, long groupId)
+		throws NoSuchCollectionException;
+
+	/**
+	 * Returns the fragment collection where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching fragment collection, or <code>null</code> if a matching fragment collection could not be found
+	 */
+	public FragmentCollection fetchByERC_G(
+		String externalReferenceCode, long groupId);
+
+	/**
+	 * Returns the fragment collection where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching fragment collection, or <code>null</code> if a matching fragment collection could not be found
+	 */
+	public FragmentCollection fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache);
+
+	/**
+	 * Removes the fragment collection where externalReferenceCode = &#63; and groupId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the fragment collection that was removed
+	 */
+	public FragmentCollection removeByERC_G(
+			String externalReferenceCode, long groupId)
+		throws NoSuchCollectionException;
+
+	/**
+	 * Returns the number of fragment collections where externalReferenceCode = &#63; and groupId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the number of matching fragment collections
+	 */
+	public int countByERC_G(String externalReferenceCode, long groupId);
+
+	/**
 	 * Caches the fragment collection in the entity cache if it is enabled.
 	 *
 	 * @param fragmentCollection the fragment collection

--- a/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/persistence/FragmentCollectionUtil.java
+++ b/modules/apps/fragment/fragment-api/src/main/java/com/liferay/fragment/service/persistence/FragmentCollectionUtil.java
@@ -1129,6 +1129,74 @@ public class FragmentCollectionUtil {
 	}
 
 	/**
+	 * Returns the fragment collection where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchCollectionException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching fragment collection
+	 * @throws NoSuchCollectionException if a matching fragment collection could not be found
+	 */
+	public static FragmentCollection findByERC_G(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.fragment.exception.NoSuchCollectionException {
+
+		return getPersistence().findByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
+	 * Returns the fragment collection where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching fragment collection, or <code>null</code> if a matching fragment collection could not be found
+	 */
+	public static FragmentCollection fetchByERC_G(
+		String externalReferenceCode, long groupId) {
+
+		return getPersistence().fetchByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
+	 * Returns the fragment collection where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching fragment collection, or <code>null</code> if a matching fragment collection could not be found
+	 */
+	public static FragmentCollection fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
+
+		return getPersistence().fetchByERC_G(
+			externalReferenceCode, groupId, useFinderCache);
+	}
+
+	/**
+	 * Removes the fragment collection where externalReferenceCode = &#63; and groupId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the fragment collection that was removed
+	 */
+	public static FragmentCollection removeByERC_G(
+			String externalReferenceCode, long groupId)
+		throws com.liferay.fragment.exception.NoSuchCollectionException {
+
+		return getPersistence().removeByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
+	 * Returns the number of fragment collections where externalReferenceCode = &#63; and groupId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the number of matching fragment collections
+	 */
+	public static int countByERC_G(String externalReferenceCode, long groupId) {
+		return getPersistence().countByERC_G(externalReferenceCode, groupId);
+	}
+
+	/**
 	 * Caches the fragment collection in the entity cache if it is enabled.
 	 *
 	 * @param fragmentCollection the fragment collection

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/exception/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/exception/packageinfo
@@ -1,1 +1,1 @@
-version 1.7.0
+version 1.8.0

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/model/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/model/packageinfo
@@ -1,1 +1,1 @@
-version 3.5.0
+version 3.6.0

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.1.0

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/packageinfo
@@ -1,1 +1,1 @@
-version 9.1.0
+version 10.0.0

--- a/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/persistence/packageinfo
+++ b/modules/apps/fragment/fragment-api/src/main/resources/com/liferay/fragment/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 9.0.0
+version 9.1.0

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/src/testIntegration/java/com/liferay/fragment/entry/processor/editable/test/EditableFragmentEntryProcessorTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-editable-test/src/testIntegration/java/com/liferay/fragment/entry/processor/editable/test/EditableFragmentEntryProcessorTest.java
@@ -1177,8 +1177,8 @@ public class EditableFragmentEntryProcessorTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionService.addFragmentCollection(
-				_group.getGroupId(), "Fragment Collection", StringPool.BLANK,
-				serviceContext);
+				null, _group.getGroupId(), "Fragment Collection",
+				StringPool.BLANK, serviceContext);
 
 		return _fragmentEntryService.addFragmentEntry(
 			_group.getGroupId(), fragmentCollection.getFragmentCollectionId(),

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/java/com/liferay/fragment/entry/processor/freemarker/test/FreemarkerFragmentEntryProcessorTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-freemarker-test/src/testIntegration/java/com/liferay/fragment/entry/processor/freemarker/test/FreemarkerFragmentEntryProcessorTest.java
@@ -131,7 +131,7 @@ public class FreemarkerFragmentEntryProcessorTest {
 
 			FragmentCollection fragmentCollection =
 				_fragmentCollectionService.addFragmentCollection(
-					_group.getGroupId(), "Fragment Collection",
+					null, _group.getGroupId(), "Fragment Collection",
 					StringPool.BLANK, serviceContext);
 
 			FragmentEntry draftFragmentEntry =
@@ -159,8 +159,8 @@ public class FreemarkerFragmentEntryProcessorTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionService.addFragmentCollection(
-				_group.getGroupId(), "Fragment Collection", StringPool.BLANK,
-				serviceContext);
+				null, _group.getGroupId(), "Fragment Collection",
+				StringPool.BLANK, serviceContext);
 
 		FragmentEntry fragmentEntry = _fragmentEntryService.addFragmentEntry(
 			_group.getGroupId(), fragmentCollection.getFragmentCollectionId(),
@@ -197,8 +197,8 @@ public class FreemarkerFragmentEntryProcessorTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionService.addFragmentCollection(
-				_group.getGroupId(), "Fragment Collection", StringPool.BLANK,
-				serviceContext);
+				null, _group.getGroupId(), "Fragment Collection",
+				StringPool.BLANK, serviceContext);
 
 		FragmentEntry fragmentEntry = _fragmentEntryService.addFragmentEntry(
 			_group.getGroupId(), fragmentCollection.getFragmentCollectionId(),
@@ -635,8 +635,8 @@ public class FreemarkerFragmentEntryProcessorTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionService.addFragmentCollection(
-				_group.getGroupId(), "Fragment Collection", StringPool.BLANK,
-				serviceContext);
+				null, _group.getGroupId(), "Fragment Collection",
+				StringPool.BLANK, serviceContext);
 
 		String configuration = null;
 

--- a/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet-test/src/testIntegration/java/com/liferay/fragment/entry/processor/portlet/test/PortletFragmentEntryProcessorTest.java
+++ b/modules/apps/fragment/fragment-entry-processor/fragment-entry-processor-portlet-test/src/testIntegration/java/com/liferay/fragment/entry/processor/portlet/test/PortletFragmentEntryProcessorTest.java
@@ -163,8 +163,8 @@ public class PortletFragmentEntryProcessorTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionService.addFragmentCollection(
-				_group.getGroupId(), "Fragment Collection", StringPool.BLANK,
-				serviceContext);
+				null, _group.getGroupId(), "Fragment Collection",
+				StringPool.BLANK, serviceContext);
 
 		return _fragmentEntryService.addFragmentEntry(
 			_group.getGroupId(), fragmentCollection.getFragmentCollectionId(),

--- a/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
+++ b/modules/apps/fragment/fragment-impl/src/main/java/com/liferay/fragment/internal/importer/FragmentsImporterImpl.java
@@ -244,7 +244,7 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 		if (fragmentCollection == null) {
 			fragmentCollection =
 				_fragmentCollectionService.addFragmentCollection(
-					groupId, fragmentCollectionKey, name, description,
+					null, groupId, fragmentCollectionKey, name, description,
 					ServiceContextThreadLocal.getServiceContext());
 		}
 		else if (Objects.equals(
@@ -259,7 +259,7 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 
 			fragmentCollection =
 				_fragmentCollectionService.addFragmentCollection(
-					groupId,
+					null, groupId,
 					_fragmentCollectionLocalService.
 						generateFragmentCollectionKey(
 							groupId, fragmentCollectionKey),
@@ -553,7 +553,7 @@ public class FragmentsImporterImpl implements FragmentsImporter {
 		}
 
 		return _fragmentCollectionService.addFragmentCollection(
-			groupId, _FRAGMENT_COLLECTION_KEY_DEFAULT,
+			null, groupId, _FRAGMENT_COLLECTION_KEY_DEFAULT,
 			_language.get(
 				_portal.getSiteDefaultLocale(groupId),
 				_FRAGMENT_COLLECTION_KEY_DEFAULT),

--- a/modules/apps/fragment/fragment-renderer-collection-filter-impl-test/src/testIntegration/java/com/liferay/fragment/renderer/collection/filter/internal/display/context/test/CollectionAppliedFiltersFragmentRendererDisplayContextTest.java
+++ b/modules/apps/fragment/fragment-renderer-collection-filter-impl-test/src/testIntegration/java/com/liferay/fragment/renderer/collection/filter/internal/display/context/test/CollectionAppliedFiltersFragmentRendererDisplayContextTest.java
@@ -137,7 +137,7 @@ public class CollectionAppliedFiltersFragmentRendererDisplayContextTest {
 	private FragmentEntry _getFragmentEntry() throws Exception {
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), StringPool.BLANK,
 				_serviceContext);
 

--- a/modules/apps/fragment/fragment-service/service.xml
+++ b/modules/apps/fragment/fragment-service/service.xml
@@ -3,7 +3,7 @@
 
 <service-builder auto-import-default-references="false" auto-namespace-tables="false" change-tracking-enabled="true" dependency-injector="ds" mvcc-enabled="true" package-path="com.liferay.fragment">
 	<namespace>Fragment</namespace>
-	<entity local-service="true" name="FragmentCollection" remote-service="true" uuid="true">
+	<entity external-reference-code="group" local-service="true" name="FragmentCollection" remote-service="true" uuid="true">
 
 		<!-- PK fields -->
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/staged/model/repository/FragmentCollectionStagedModelRepository.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/exportimport/staged/model/repository/FragmentCollectionStagedModelRepository.java
@@ -48,9 +48,9 @@ public class FragmentCollectionStagedModelRepository
 		}
 
 		return _fragmentCollectionLocalService.addFragmentCollection(
-			userId, fragmentCollection.getGroupId(),
-			fragmentCollection.getName(), fragmentCollection.getDescription(),
-			serviceContext);
+			fragmentCollection.getExternalReferenceCode(), userId,
+			fragmentCollection.getGroupId(), fragmentCollection.getName(),
+			fragmentCollection.getDescription(), serviceContext);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionCacheModel.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionCacheModel.java
@@ -69,7 +69,7 @@ public class FragmentCollectionCacheModel
 
 	@Override
 	public String toString() {
-		StringBundler sb = new StringBundler(29);
+		StringBundler sb = new StringBundler(31);
 
 		sb.append("{mvccVersion=");
 		sb.append(mvccVersion);
@@ -77,6 +77,8 @@ public class FragmentCollectionCacheModel
 		sb.append(ctCollectionId);
 		sb.append(", uuid=");
 		sb.append(uuid);
+		sb.append(", externalReferenceCode=");
+		sb.append(externalReferenceCode);
 		sb.append(", fragmentCollectionId=");
 		sb.append(fragmentCollectionId);
 		sb.append(", groupId=");
@@ -117,6 +119,14 @@ public class FragmentCollectionCacheModel
 		}
 		else {
 			fragmentCollectionImpl.setUuid(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			fragmentCollectionImpl.setExternalReferenceCode("");
+		}
+		else {
+			fragmentCollectionImpl.setExternalReferenceCode(
+				externalReferenceCode);
 		}
 
 		fragmentCollectionImpl.setFragmentCollectionId(fragmentCollectionId);
@@ -186,6 +196,7 @@ public class FragmentCollectionCacheModel
 
 		ctCollectionId = objectInput.readLong();
 		uuid = objectInput.readUTF();
+		externalReferenceCode = objectInput.readUTF();
 
 		fragmentCollectionId = objectInput.readLong();
 
@@ -214,6 +225,13 @@ public class FragmentCollectionCacheModel
 		}
 		else {
 			objectOutput.writeUTF(uuid);
+		}
+
+		if (externalReferenceCode == null) {
+			objectOutput.writeUTF("");
+		}
+		else {
+			objectOutput.writeUTF(externalReferenceCode);
 		}
 
 		objectOutput.writeLong(fragmentCollectionId);
@@ -261,6 +279,7 @@ public class FragmentCollectionCacheModel
 	public long mvccVersion;
 	public long ctCollectionId;
 	public String uuid;
+	public String externalReferenceCode;
 	public long fragmentCollectionId;
 	public long groupId;
 	public long companyId;

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionModelImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/model/impl/FragmentCollectionModelImpl.java
@@ -66,10 +66,11 @@ public class FragmentCollectionModelImpl
 
 	public static final Object[][] TABLE_COLUMNS = {
 		{"mvccVersion", Types.BIGINT}, {"ctCollectionId", Types.BIGINT},
-		{"uuid_", Types.VARCHAR}, {"fragmentCollectionId", Types.BIGINT},
-		{"groupId", Types.BIGINT}, {"companyId", Types.BIGINT},
-		{"userId", Types.BIGINT}, {"userName", Types.VARCHAR},
-		{"createDate", Types.TIMESTAMP}, {"modifiedDate", Types.TIMESTAMP},
+		{"uuid_", Types.VARCHAR}, {"externalReferenceCode", Types.VARCHAR},
+		{"fragmentCollectionId", Types.BIGINT}, {"groupId", Types.BIGINT},
+		{"companyId", Types.BIGINT}, {"userId", Types.BIGINT},
+		{"userName", Types.VARCHAR}, {"createDate", Types.TIMESTAMP},
+		{"modifiedDate", Types.TIMESTAMP},
 		{"fragmentCollectionKey", Types.VARCHAR}, {"name", Types.VARCHAR},
 		{"description", Types.VARCHAR}, {"lastPublishDate", Types.TIMESTAMP}
 	};
@@ -81,6 +82,7 @@ public class FragmentCollectionModelImpl
 		TABLE_COLUMNS_MAP.put("mvccVersion", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("ctCollectionId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("uuid_", Types.VARCHAR);
+		TABLE_COLUMNS_MAP.put("externalReferenceCode", Types.VARCHAR);
 		TABLE_COLUMNS_MAP.put("fragmentCollectionId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("groupId", Types.BIGINT);
 		TABLE_COLUMNS_MAP.put("companyId", Types.BIGINT);
@@ -95,7 +97,7 @@ public class FragmentCollectionModelImpl
 	}
 
 	public static final String TABLE_SQL_CREATE =
-		"create table FragmentCollection (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,fragmentCollectionId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,fragmentCollectionKey VARCHAR(75) null,name VARCHAR(75) null,description STRING null,lastPublishDate DATE null,primary key (fragmentCollectionId, ctCollectionId))";
+		"create table FragmentCollection (mvccVersion LONG default 0 not null,ctCollectionId LONG default 0 not null,uuid_ VARCHAR(75) null,externalReferenceCode VARCHAR(75) null,fragmentCollectionId LONG not null,groupId LONG,companyId LONG,userId LONG,userName VARCHAR(75) null,createDate DATE null,modifiedDate DATE null,fragmentCollectionKey VARCHAR(75) null,name VARCHAR(75) null,description STRING null,lastPublishDate DATE null,primary key (fragmentCollectionId, ctCollectionId))";
 
 	public static final String TABLE_SQL_DROP = "drop table FragmentCollection";
 
@@ -121,25 +123,31 @@ public class FragmentCollectionModelImpl
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long FRAGMENTCOLLECTIONKEY_COLUMN_BITMASK = 2L;
+	public static final long EXTERNALREFERENCECODE_COLUMN_BITMASK = 2L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long GROUPID_COLUMN_BITMASK = 4L;
+	public static final long FRAGMENTCOLLECTIONKEY_COLUMN_BITMASK = 4L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long NAME_COLUMN_BITMASK = 8L;
+	public static final long GROUPID_COLUMN_BITMASK = 8L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
 	 */
 	@Deprecated
-	public static final long UUID_COLUMN_BITMASK = 16L;
+	public static final long NAME_COLUMN_BITMASK = 16L;
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link #getColumnBitmask(String)}
+	 */
+	@Deprecated
+	public static final long UUID_COLUMN_BITMASK = 32L;
 
 	/**
 	 * @deprecated As of Athanasius (7.3.x), with no direct replacement
@@ -257,6 +265,9 @@ public class FragmentCollectionModelImpl
 				"ctCollectionId", FragmentCollection::getCtCollectionId);
 			attributeGetterFunctions.put("uuid", FragmentCollection::getUuid);
 			attributeGetterFunctions.put(
+				"externalReferenceCode",
+				FragmentCollection::getExternalReferenceCode);
+			attributeGetterFunctions.put(
 				"fragmentCollectionId",
 				FragmentCollection::getFragmentCollectionId);
 			attributeGetterFunctions.put(
@@ -309,6 +320,10 @@ public class FragmentCollectionModelImpl
 				"uuid",
 				(BiConsumer<FragmentCollection, String>)
 					FragmentCollection::setUuid);
+			attributeSetterBiConsumers.put(
+				"externalReferenceCode",
+				(BiConsumer<FragmentCollection, String>)
+					FragmentCollection::setExternalReferenceCode);
 			attributeSetterBiConsumers.put(
 				"fragmentCollectionId",
 				(BiConsumer<FragmentCollection, Long>)
@@ -417,6 +432,35 @@ public class FragmentCollectionModelImpl
 	@Deprecated
 	public String getOriginalUuid() {
 		return getColumnOriginalValue("uuid_");
+	}
+
+	@JSON
+	@Override
+	public String getExternalReferenceCode() {
+		if (_externalReferenceCode == null) {
+			return "";
+		}
+		else {
+			return _externalReferenceCode;
+		}
+	}
+
+	@Override
+	public void setExternalReferenceCode(String externalReferenceCode) {
+		if (_columnOriginalValues == Collections.EMPTY_MAP) {
+			_setColumnOriginalValues();
+		}
+
+		_externalReferenceCode = externalReferenceCode;
+	}
+
+	/**
+	 * @deprecated As of Athanasius (7.3.x), replaced by {@link
+	 *             #getColumnOriginalValue(String)}
+	 */
+	@Deprecated
+	public String getOriginalExternalReferenceCode() {
+		return getColumnOriginalValue("externalReferenceCode");
 	}
 
 	@JSON
@@ -730,6 +774,8 @@ public class FragmentCollectionModelImpl
 		fragmentCollectionImpl.setMvccVersion(getMvccVersion());
 		fragmentCollectionImpl.setCtCollectionId(getCtCollectionId());
 		fragmentCollectionImpl.setUuid(getUuid());
+		fragmentCollectionImpl.setExternalReferenceCode(
+			getExternalReferenceCode());
 		fragmentCollectionImpl.setFragmentCollectionId(
 			getFragmentCollectionId());
 		fragmentCollectionImpl.setGroupId(getGroupId());
@@ -760,6 +806,8 @@ public class FragmentCollectionModelImpl
 			this.<Long>getColumnOriginalValue("ctCollectionId"));
 		fragmentCollectionImpl.setUuid(
 			this.<String>getColumnOriginalValue("uuid_"));
+		fragmentCollectionImpl.setExternalReferenceCode(
+			this.<String>getColumnOriginalValue("externalReferenceCode"));
 		fragmentCollectionImpl.setFragmentCollectionId(
 			this.<Long>getColumnOriginalValue("fragmentCollectionId"));
 		fragmentCollectionImpl.setGroupId(
@@ -868,6 +916,18 @@ public class FragmentCollectionModelImpl
 
 		if ((uuid != null) && (uuid.length() == 0)) {
 			fragmentCollectionCacheModel.uuid = null;
+		}
+
+		fragmentCollectionCacheModel.externalReferenceCode =
+			getExternalReferenceCode();
+
+		String externalReferenceCode =
+			fragmentCollectionCacheModel.externalReferenceCode;
+
+		if ((externalReferenceCode != null) &&
+			(externalReferenceCode.length() == 0)) {
+
+			fragmentCollectionCacheModel.externalReferenceCode = null;
 		}
 
 		fragmentCollectionCacheModel.fragmentCollectionId =
@@ -1008,6 +1068,7 @@ public class FragmentCollectionModelImpl
 	private long _mvccVersion;
 	private long _ctCollectionId;
 	private String _uuid;
+	private String _externalReferenceCode;
 	private long _fragmentCollectionId;
 	private long _groupId;
 	private long _companyId;
@@ -1055,6 +1116,8 @@ public class FragmentCollectionModelImpl
 		_columnOriginalValues.put("ctCollectionId", _ctCollectionId);
 		_columnOriginalValues.put("uuid_", _uuid);
 		_columnOriginalValues.put(
+			"externalReferenceCode", _externalReferenceCode);
+		_columnOriginalValues.put(
 			"fragmentCollectionId", _fragmentCollectionId);
 		_columnOriginalValues.put("groupId", _groupId);
 		_columnOriginalValues.put("companyId", _companyId);
@@ -1096,27 +1159,29 @@ public class FragmentCollectionModelImpl
 
 		columnBitmasks.put("uuid_", 4L);
 
-		columnBitmasks.put("fragmentCollectionId", 8L);
+		columnBitmasks.put("externalReferenceCode", 8L);
 
-		columnBitmasks.put("groupId", 16L);
+		columnBitmasks.put("fragmentCollectionId", 16L);
 
-		columnBitmasks.put("companyId", 32L);
+		columnBitmasks.put("groupId", 32L);
 
-		columnBitmasks.put("userId", 64L);
+		columnBitmasks.put("companyId", 64L);
 
-		columnBitmasks.put("userName", 128L);
+		columnBitmasks.put("userId", 128L);
 
-		columnBitmasks.put("createDate", 256L);
+		columnBitmasks.put("userName", 256L);
 
-		columnBitmasks.put("modifiedDate", 512L);
+		columnBitmasks.put("createDate", 512L);
 
-		columnBitmasks.put("fragmentCollectionKey", 1024L);
+		columnBitmasks.put("modifiedDate", 1024L);
 
-		columnBitmasks.put("name", 2048L);
+		columnBitmasks.put("fragmentCollectionKey", 2048L);
 
-		columnBitmasks.put("description", 4096L);
+		columnBitmasks.put("name", 4096L);
 
-		columnBitmasks.put("lastPublishDate", 8192L);
+		columnBitmasks.put("description", 8192L);
+
+		columnBitmasks.put("lastPublishDate", 16384L);
 
 		_columnBitmasks = Collections.unmodifiableMap(columnBitmasks);
 	}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/base/FragmentCollectionLocalServiceBaseImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/base/FragmentCollectionLocalServiceBaseImpl.java
@@ -272,6 +272,23 @@ public abstract class FragmentCollectionLocalServiceBaseImpl
 		return fragmentCollectionPersistence.fetchByUUID_G(uuid, groupId);
 	}
 
+	@Override
+	public FragmentCollection fetchFragmentCollectionByExternalReferenceCode(
+		String externalReferenceCode, long groupId) {
+
+		return fragmentCollectionPersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
+	}
+
+	@Override
+	public FragmentCollection getFragmentCollectionByExternalReferenceCode(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return fragmentCollectionPersistence.findByERC_G(
+			externalReferenceCode, groupId);
+	}
+
 	/**
 	 * Returns the fragment collection with the primary key.
 	 *

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/http/FragmentCollectionServiceHttp.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/http/FragmentCollectionServiceHttp.java
@@ -43,8 +43,8 @@ public class FragmentCollectionServiceHttp {
 
 	public static com.liferay.fragment.model.FragmentCollection
 			addFragmentCollection(
-				HttpPrincipal httpPrincipal, long groupId, String name,
-				String description,
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long groupId, String name, String description,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -54,7 +54,8 @@ public class FragmentCollectionServiceHttp {
 				_addFragmentCollectionParameterTypes0);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, name, description, serviceContext);
+				methodKey, externalReferenceCode, groupId, name, description,
+				serviceContext);
 
 			Object returnObj = null;
 
@@ -86,8 +87,9 @@ public class FragmentCollectionServiceHttp {
 
 	public static com.liferay.fragment.model.FragmentCollection
 			addFragmentCollection(
-				HttpPrincipal httpPrincipal, long groupId,
-				String fragmentCollectionKey, String name, String description,
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long groupId, String fragmentCollectionKey, String name,
+				String description,
 				com.liferay.portal.kernel.service.ServiceContext serviceContext)
 		throws com.liferay.portal.kernel.exception.PortalException {
 
@@ -97,8 +99,8 @@ public class FragmentCollectionServiceHttp {
 				_addFragmentCollectionParameterTypes1);
 
 			MethodHandler methodHandler = new MethodHandler(
-				methodKey, groupId, fragmentCollectionKey, name, description,
-				serviceContext);
+				methodKey, externalReferenceCode, groupId,
+				fragmentCollectionKey, name, description, serviceContext);
 
 			Object returnObj = null;
 
@@ -169,6 +171,48 @@ public class FragmentCollectionServiceHttp {
 		}
 	}
 
+	public static com.liferay.fragment.model.FragmentCollection
+			deleteFragmentCollection(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long groupId)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				FragmentCollectionServiceUtil.class, "deleteFragmentCollection",
+				_deleteFragmentCollectionParameterTypes3);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, groupId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.fragment.model.FragmentCollection)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static void deleteFragmentCollections(
 			HttpPrincipal httpPrincipal, long[] fragmentCollectionIds)
 		throws com.liferay.portal.kernel.exception.PortalException {
@@ -177,7 +221,7 @@ public class FragmentCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class,
 				"deleteFragmentCollections",
-				_deleteFragmentCollectionsParameterTypes3);
+				_deleteFragmentCollectionsParameterTypes4);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fragmentCollectionIds);
@@ -214,7 +258,7 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "fetchFragmentCollection",
-				_fetchFragmentCollectionParameterTypes4);
+				_fetchFragmentCollectionParameterTypes5);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fragmentCollectionId);
@@ -247,6 +291,40 @@ public class FragmentCollectionServiceHttp {
 		}
 	}
 
+	public static com.liferay.fragment.model.FragmentCollection
+		fetchFragmentCollection(
+			HttpPrincipal httpPrincipal, String externalReferenceCode,
+			long groupId) {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				FragmentCollectionServiceUtil.class, "fetchFragmentCollection",
+				_fetchFragmentCollectionParameterTypes6);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, groupId);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.fragment.model.FragmentCollection)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
 	public static java.util.List
 		<com.liferay.portal.kernel.repository.model.FileEntry>
 				getFragmentCollectionFileEntries(
@@ -257,7 +335,7 @@ public class FragmentCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class,
 				"getFragmentCollectionFileEntries",
-				_getFragmentCollectionFileEntriesParameterTypes5);
+				_getFragmentCollectionFileEntriesParameterTypes7);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fragmentCollectionId);
@@ -298,7 +376,7 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "getFragmentCollections",
-				_getFragmentCollectionsParameterTypes6);
+				_getFragmentCollectionsParameterTypes8);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -331,7 +409,7 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "getFragmentCollections",
-				_getFragmentCollectionsParameterTypes7);
+				_getFragmentCollectionsParameterTypes9);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, includeSystem);
@@ -369,7 +447,7 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "getFragmentCollections",
-				_getFragmentCollectionsParameterTypes8);
+				_getFragmentCollectionsParameterTypes10);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, includeSystem, start, end,
@@ -404,7 +482,7 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "getFragmentCollections",
-				_getFragmentCollectionsParameterTypes9);
+				_getFragmentCollectionsParameterTypes11);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, start, end);
@@ -441,7 +519,7 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "getFragmentCollections",
-				_getFragmentCollectionsParameterTypes10);
+				_getFragmentCollectionsParameterTypes12);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, start, end, orderByComparator);
@@ -479,7 +557,7 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "getFragmentCollections",
-				_getFragmentCollectionsParameterTypes11);
+				_getFragmentCollectionsParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, includeSystem, start, end,
@@ -518,7 +596,7 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "getFragmentCollections",
-				_getFragmentCollectionsParameterTypes12);
+				_getFragmentCollectionsParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, start, end, orderByComparator);
@@ -551,7 +629,7 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "getFragmentCollections",
-				_getFragmentCollectionsParameterTypes13);
+				_getFragmentCollectionsParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds);
@@ -588,7 +666,7 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "getFragmentCollections",
-				_getFragmentCollectionsParameterTypes14);
+				_getFragmentCollectionsParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds, start, end, orderByComparator);
@@ -626,7 +704,7 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "getFragmentCollections",
-				_getFragmentCollectionsParameterTypes15);
+				_getFragmentCollectionsParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds, name, start, end, orderByComparator);
@@ -660,7 +738,7 @@ public class FragmentCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class,
 				"getFragmentCollectionsCount",
-				_getFragmentCollectionsCountParameterTypes16);
+				_getFragmentCollectionsCountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -692,7 +770,7 @@ public class FragmentCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class,
 				"getFragmentCollectionsCount",
-				_getFragmentCollectionsCountParameterTypes17);
+				_getFragmentCollectionsCountParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, includeSystem);
@@ -725,7 +803,7 @@ public class FragmentCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class,
 				"getFragmentCollectionsCount",
-				_getFragmentCollectionsCountParameterTypes18);
+				_getFragmentCollectionsCountParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name);
@@ -759,7 +837,7 @@ public class FragmentCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class,
 				"getFragmentCollectionsCount",
-				_getFragmentCollectionsCountParameterTypes19);
+				_getFragmentCollectionsCountParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, name, includeSystem);
@@ -792,7 +870,7 @@ public class FragmentCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class,
 				"getFragmentCollectionsCount",
-				_getFragmentCollectionsCountParameterTypes20);
+				_getFragmentCollectionsCountParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds);
@@ -825,7 +903,7 @@ public class FragmentCollectionServiceHttp {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class,
 				"getFragmentCollectionsCount",
-				_getFragmentCollectionsCountParameterTypes21);
+				_getFragmentCollectionsCountParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupIds, name);
@@ -858,7 +936,7 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "getTempFileNames",
-				_getTempFileNamesParameterTypes22);
+				_getTempFileNamesParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, groupId, folderName);
@@ -900,10 +978,52 @@ public class FragmentCollectionServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(
 				FragmentCollectionServiceUtil.class, "updateFragmentCollection",
-				_updateFragmentCollectionParameterTypes23);
+				_updateFragmentCollectionParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(
 				methodKey, fragmentCollectionId, name, description);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception exception) {
+				if (exception instanceof
+						com.liferay.portal.kernel.exception.PortalException) {
+
+					throw (com.liferay.portal.kernel.exception.PortalException)
+						exception;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(
+					exception);
+			}
+
+			return (com.liferay.fragment.model.FragmentCollection)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException
+					systemException) {
+
+			_log.error(systemException, systemException);
+
+			throw systemException;
+		}
+	}
+
+	public static com.liferay.fragment.model.FragmentCollection
+			updateFragmentCollection(
+				HttpPrincipal httpPrincipal, String externalReferenceCode,
+				long groupId, String name, String description)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		try {
+			MethodKey methodKey = new MethodKey(
+				FragmentCollectionServiceUtil.class, "updateFragmentCollection",
+				_updateFragmentCollectionParameterTypes26);
+
+			MethodHandler methodHandler = new MethodHandler(
+				methodKey, externalReferenceCode, groupId, name, description);
 
 			Object returnObj = null;
 
@@ -938,87 +1058,93 @@ public class FragmentCollectionServiceHttp {
 
 	private static final Class<?>[] _addFragmentCollectionParameterTypes0 =
 		new Class[] {
-			long.class, String.class, String.class,
+			String.class, long.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _addFragmentCollectionParameterTypes1 =
 		new Class[] {
-			long.class, String.class, String.class, String.class,
+			String.class, long.class, String.class, String.class, String.class,
 			com.liferay.portal.kernel.service.ServiceContext.class
 		};
 	private static final Class<?>[] _deleteFragmentCollectionParameterTypes2 =
 		new Class[] {long.class};
-	private static final Class<?>[] _deleteFragmentCollectionsParameterTypes3 =
+	private static final Class<?>[] _deleteFragmentCollectionParameterTypes3 =
+		new Class[] {String.class, long.class};
+	private static final Class<?>[] _deleteFragmentCollectionsParameterTypes4 =
 		new Class[] {long[].class};
-	private static final Class<?>[] _fetchFragmentCollectionParameterTypes4 =
+	private static final Class<?>[] _fetchFragmentCollectionParameterTypes5 =
 		new Class[] {long.class};
+	private static final Class<?>[] _fetchFragmentCollectionParameterTypes6 =
+		new Class[] {String.class, long.class};
 	private static final Class<?>[]
-		_getFragmentCollectionFileEntriesParameterTypes5 = new Class[] {
+		_getFragmentCollectionFileEntriesParameterTypes7 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getFragmentCollectionsParameterTypes6 =
-		new Class[] {long.class};
-	private static final Class<?>[] _getFragmentCollectionsParameterTypes7 =
-		new Class[] {long.class, boolean.class};
 	private static final Class<?>[] _getFragmentCollectionsParameterTypes8 =
+		new Class[] {long.class};
+	private static final Class<?>[] _getFragmentCollectionsParameterTypes9 =
+		new Class[] {long.class, boolean.class};
+	private static final Class<?>[] _getFragmentCollectionsParameterTypes10 =
 		new Class[] {
 			long.class, boolean.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFragmentCollectionsParameterTypes9 =
+	private static final Class<?>[] _getFragmentCollectionsParameterTypes11 =
 		new Class[] {long.class, int.class, int.class};
-	private static final Class<?>[] _getFragmentCollectionsParameterTypes10 =
+	private static final Class<?>[] _getFragmentCollectionsParameterTypes12 =
 		new Class[] {
 			long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFragmentCollectionsParameterTypes11 =
+	private static final Class<?>[] _getFragmentCollectionsParameterTypes13 =
 		new Class[] {
 			long.class, String.class, boolean.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFragmentCollectionsParameterTypes12 =
+	private static final Class<?>[] _getFragmentCollectionsParameterTypes14 =
 		new Class[] {
 			long.class, String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFragmentCollectionsParameterTypes13 =
+	private static final Class<?>[] _getFragmentCollectionsParameterTypes15 =
 		new Class[] {long[].class};
-	private static final Class<?>[] _getFragmentCollectionsParameterTypes14 =
+	private static final Class<?>[] _getFragmentCollectionsParameterTypes16 =
 		new Class[] {
 			long[].class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getFragmentCollectionsParameterTypes15 =
+	private static final Class<?>[] _getFragmentCollectionsParameterTypes17 =
 		new Class[] {
 			long[].class, String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[]
-		_getFragmentCollectionsCountParameterTypes16 = new Class[] {long.class};
+		_getFragmentCollectionsCountParameterTypes18 = new Class[] {long.class};
 	private static final Class<?>[]
-		_getFragmentCollectionsCountParameterTypes17 = new Class[] {
+		_getFragmentCollectionsCountParameterTypes19 = new Class[] {
 			long.class, boolean.class
 		};
 	private static final Class<?>[]
-		_getFragmentCollectionsCountParameterTypes18 = new Class[] {
+		_getFragmentCollectionsCountParameterTypes20 = new Class[] {
 			long.class, String.class
 		};
 	private static final Class<?>[]
-		_getFragmentCollectionsCountParameterTypes19 = new Class[] {
+		_getFragmentCollectionsCountParameterTypes21 = new Class[] {
 			long.class, String.class, boolean.class
 		};
 	private static final Class<?>[]
-		_getFragmentCollectionsCountParameterTypes20 = new Class[] {
+		_getFragmentCollectionsCountParameterTypes22 = new Class[] {
 			long[].class
 		};
 	private static final Class<?>[]
-		_getFragmentCollectionsCountParameterTypes21 = new Class[] {
+		_getFragmentCollectionsCountParameterTypes23 = new Class[] {
 			long[].class, String.class
 		};
-	private static final Class<?>[] _getTempFileNamesParameterTypes22 =
+	private static final Class<?>[] _getTempFileNamesParameterTypes24 =
 		new Class[] {long.class, String.class};
-	private static final Class<?>[] _updateFragmentCollectionParameterTypes23 =
+	private static final Class<?>[] _updateFragmentCollectionParameterTypes25 =
 		new Class[] {long.class, String.class, String.class};
+	private static final Class<?>[] _updateFragmentCollectionParameterTypes26 =
+		new Class[] {String.class, long.class, String.class, String.class};
 
 }

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionLocalServiceImpl.java
@@ -186,6 +186,14 @@ public class FragmentCollectionLocalServiceImpl
 	}
 
 	@Override
+	public FragmentCollection fetchFragmentCollection(
+		String externalReferenceCode, long groupId) {
+
+		return fragmentCollectionPersistence.fetchByERC_G(
+			externalReferenceCode, groupId);
+	}
+
+	@Override
 	public String generateFragmentCollectionKey(long groupId, String name) {
 		String fragmentCollectionKey = _getFragmentCollectionKey(name);
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionLocalServiceImpl.java
@@ -50,19 +50,20 @@ public class FragmentCollectionLocalServiceImpl
 
 	@Override
 	public FragmentCollection addFragmentCollection(
-			long userId, long groupId, String name, String description,
-			ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long groupId,
+			String name, String description, ServiceContext serviceContext)
 		throws PortalException {
 
 		return addFragmentCollection(
-			userId, groupId, StringPool.BLANK, name, description,
-			serviceContext);
+			externalReferenceCode, userId, groupId, StringPool.BLANK, name,
+			description, serviceContext);
 	}
 
 	@Override
 	public FragmentCollection addFragmentCollection(
-			long userId, long groupId, String fragmentCollectionKey,
-			String name, String description, ServiceContext serviceContext)
+			String externalReferenceCode, long userId, long groupId,
+			String fragmentCollectionKey, String name, String description,
+			ServiceContext serviceContext)
 		throws PortalException {
 
 		// Fragment collection
@@ -96,6 +97,7 @@ public class FragmentCollectionLocalServiceImpl
 			fragmentCollectionPersistence.create(fragmentCollectionId);
 
 		fragmentCollection.setUuid(serviceContext.getUuid());
+		fragmentCollection.setExternalReferenceCode(externalReferenceCode);
 		fragmentCollection.setGroupId(groupId);
 		fragmentCollection.setCompanyId(companyId);
 		fragmentCollection.setUserId(user.getUserId());

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionLocalServiceImpl.java
@@ -170,6 +170,15 @@ public class FragmentCollectionLocalServiceImpl
 	}
 
 	@Override
+	public FragmentCollection deleteFragmentCollection(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		return fragmentCollectionLocalService.deleteFragmentCollection(
+			fetchFragmentCollection(externalReferenceCode, groupId));
+	}
+
+	@Override
 	public FragmentCollection fetchFragmentCollection(
 		long fragmentCollectionId) {
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionLocalServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionLocalServiceImpl.java
@@ -300,13 +300,20 @@ public class FragmentCollectionLocalServiceImpl
 			fragmentCollectionPersistence.findByPrimaryKey(
 				fragmentCollectionId);
 
-		_validate(name);
+		return _updateFragmentCollection(fragmentCollection, name, description);
+	}
 
-		fragmentCollection.setModifiedDate(new Date());
-		fragmentCollection.setName(name);
-		fragmentCollection.setDescription(description);
+	@Override
+	public FragmentCollection updateFragmentCollection(
+			String externalReferenceCode, long groupId, String name,
+			String description)
+		throws PortalException {
 
-		return fragmentCollectionPersistence.update(fragmentCollection);
+		FragmentCollection fragmentCollection =
+			fragmentCollectionPersistence.findByERC_G(
+				externalReferenceCode, groupId);
+
+		return _updateFragmentCollection(fragmentCollection, name, description);
 	}
 
 	private String _getFragmentCollectionKey(String fragmentCollectionKey) {
@@ -317,6 +324,20 @@ public class FragmentCollectionLocalServiceImpl
 		}
 
 		return StringPool.BLANK;
+	}
+
+	private FragmentCollection _updateFragmentCollection(
+			FragmentCollection fragmentCollection, String name,
+			String description)
+		throws PortalException {
+
+		_validate(name);
+
+		fragmentCollection.setModifiedDate(new Date());
+		fragmentCollection.setName(name);
+		fragmentCollection.setDescription(description);
+
+		return fragmentCollectionPersistence.update(fragmentCollection);
 	}
 
 	private void _validate(String name) throws PortalException {

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionServiceImpl.java
@@ -89,6 +89,25 @@ public class FragmentCollectionServiceImpl
 	}
 
 	@Override
+	public FragmentCollection deleteFragmentCollection(
+			String externalReferenceCode, long groupId)
+		throws PortalException {
+
+		FragmentCollection fragmentCollection =
+			fragmentCollectionLocalService.fetchFragmentCollection(
+				externalReferenceCode, groupId);
+
+		if (fragmentCollection != null) {
+			_portletResourcePermission.check(
+				getPermissionChecker(), fragmentCollection.getGroupId(),
+				FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
+		}
+
+		return fragmentCollectionLocalService.deleteFragmentCollection(
+			fragmentCollection);
+	}
+
+	@Override
 	public void deleteFragmentCollections(long[] fragmentCollectionIds)
 		throws PortalException {
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionServiceImpl.java
@@ -42,21 +42,7 @@ public class FragmentCollectionServiceImpl
 
 	@Override
 	public FragmentCollection addFragmentCollection(
-			long groupId, String name, String description,
-			ServiceContext serviceContext)
-		throws PortalException {
-
-		_portletResourcePermission.check(
-			getPermissionChecker(), groupId,
-			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
-
-		return fragmentCollectionLocalService.addFragmentCollection(
-			getUserId(), groupId, name, description, serviceContext);
-	}
-
-	@Override
-	public FragmentCollection addFragmentCollection(
-			long groupId, String fragmentCollectionKey, String name,
+			String externalReferenceCode, long groupId, String name,
 			String description, ServiceContext serviceContext)
 		throws PortalException {
 
@@ -65,8 +51,24 @@ public class FragmentCollectionServiceImpl
 			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
 
 		return fragmentCollectionLocalService.addFragmentCollection(
-			getUserId(), groupId, fragmentCollectionKey, name, description,
+			externalReferenceCode, getUserId(), groupId, name, description,
 			serviceContext);
+	}
+
+	@Override
+	public FragmentCollection addFragmentCollection(
+			String externalReferenceCode, long groupId,
+			String fragmentCollectionKey, String name, String description,
+			ServiceContext serviceContext)
+		throws PortalException {
+
+		_portletResourcePermission.check(
+			getPermissionChecker(), groupId,
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
+
+		return fragmentCollectionLocalService.addFragmentCollection(
+			externalReferenceCode, getUserId(), groupId, fragmentCollectionKey,
+			name, description, serviceContext);
 	}
 
 	@Override

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionServiceImpl.java
@@ -115,6 +115,14 @@ public class FragmentCollectionServiceImpl
 	}
 
 	@Override
+	public FragmentCollection fetchFragmentCollection(
+		String externalReferenceCode, long groupId) {
+
+		return fragmentCollectionLocalService.fetchFragmentCollection(
+			externalReferenceCode, groupId);
+	}
+
+	@Override
 	public List<FileEntry> getFragmentCollectionFileEntries(
 			long fragmentCollectionId)
 		throws PortalException {

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentCollectionServiceImpl.java
@@ -315,6 +315,24 @@ public class FragmentCollectionServiceImpl
 			fragmentCollectionId, name, description);
 	}
 
+	@Override
+	public FragmentCollection updateFragmentCollection(
+			String externalReferenceCode, long groupId, String name,
+			String description)
+		throws PortalException {
+
+		FragmentCollection fragmentCollection =
+			fragmentCollectionLocalService.fetchFragmentCollection(
+				externalReferenceCode, groupId);
+
+		_portletResourcePermission.check(
+			getPermissionChecker(), fragmentCollection.getGroupId(),
+			FragmentActionKeys.MANAGE_FRAGMENT_ENTRIES);
+
+		return fragmentCollectionLocalService.updateFragmentCollection(
+			externalReferenceCode, groupId, name, description);
+	}
+
 	private long[] _getGroupIds(long groupId, boolean includeSystem) {
 		long[] groupIds = {groupId};
 

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/persistence/impl/FragmentCollectionPersistenceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/persistence/impl/FragmentCollectionPersistenceImpl.java
@@ -5,6 +5,7 @@
 
 package com.liferay.fragment.service.persistence.impl;
 
+import com.liferay.fragment.exception.DuplicateFragmentCollectionExternalReferenceCodeException;
 import com.liferay.fragment.exception.NoSuchCollectionException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.model.FragmentCollectionTable;
@@ -26,14 +27,20 @@ import com.liferay.portal.kernel.dao.orm.QueryPos;
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.dao.orm.Session;
 import com.liferay.portal.kernel.dao.orm.SessionFactory;
+import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.sanitizer.Sanitizer;
+import com.liferay.portal.kernel.sanitizer.SanitizerException;
+import com.liferay.portal.kernel.sanitizer.SanitizerUtil;
 import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
+import com.liferay.portal.kernel.security.auth.PrincipalThreadLocal;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.service.ServiceContextThreadLocal;
 import com.liferay.portal.kernel.service.persistence.change.tracking.helper.CTPersistenceHelper;
 import com.liferay.portal.kernel.service.persistence.impl.BasePersistenceImpl;
 import com.liferay.portal.kernel.util.ArrayUtil;
+import com.liferay.portal.kernel.util.ContentTypes;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
 import com.liferay.portal.kernel.util.PropsKeys;
@@ -3450,6 +3457,274 @@ public class FragmentCollectionPersistenceImpl
 	private static final String _FINDER_COLUMN_G_LIKEN_NAME_3 =
 		"(fragmentCollection.name IS NULL OR fragmentCollection.name LIKE '')";
 
+	private FinderPath _finderPathFetchByERC_G;
+	private FinderPath _finderPathCountByERC_G;
+
+	/**
+	 * Returns the fragment collection where externalReferenceCode = &#63; and groupId = &#63; or throws a <code>NoSuchCollectionException</code> if it could not be found.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching fragment collection
+	 * @throws NoSuchCollectionException if a matching fragment collection could not be found
+	 */
+	@Override
+	public FragmentCollection findByERC_G(
+			String externalReferenceCode, long groupId)
+		throws NoSuchCollectionException {
+
+		FragmentCollection fragmentCollection = fetchByERC_G(
+			externalReferenceCode, groupId);
+
+		if (fragmentCollection == null) {
+			StringBundler sb = new StringBundler(6);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("externalReferenceCode=");
+			sb.append(externalReferenceCode);
+
+			sb.append(", groupId=");
+			sb.append(groupId);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchCollectionException(sb.toString());
+		}
+
+		return fragmentCollection;
+	}
+
+	/**
+	 * Returns the fragment collection where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the matching fragment collection, or <code>null</code> if a matching fragment collection could not be found
+	 */
+	@Override
+	public FragmentCollection fetchByERC_G(
+		String externalReferenceCode, long groupId) {
+
+		return fetchByERC_G(externalReferenceCode, groupId, true);
+	}
+
+	/**
+	 * Returns the fragment collection where externalReferenceCode = &#63; and groupId = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching fragment collection, or <code>null</code> if a matching fragment collection could not be found
+	 */
+	@Override
+	public FragmentCollection fetchByERC_G(
+		String externalReferenceCode, long groupId, boolean useFinderCache) {
+
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					FragmentCollection.class)) {
+
+			externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+			Object[] finderArgs = null;
+
+			if (useFinderCache) {
+				finderArgs = new Object[] {externalReferenceCode, groupId};
+			}
+
+			Object result = null;
+
+			if (useFinderCache) {
+				result = finderCache.getResult(
+					_finderPathFetchByERC_G, finderArgs, this);
+			}
+
+			if (result instanceof FragmentCollection) {
+				FragmentCollection fragmentCollection =
+					(FragmentCollection)result;
+
+				if (!Objects.equals(
+						externalReferenceCode,
+						fragmentCollection.getExternalReferenceCode()) ||
+					(groupId != fragmentCollection.getGroupId())) {
+
+					result = null;
+				}
+			}
+
+			if (result == null) {
+				StringBundler sb = new StringBundler(4);
+
+				sb.append(_SQL_SELECT_FRAGMENTCOLLECTION_WHERE);
+
+				boolean bindExternalReferenceCode = false;
+
+				if (externalReferenceCode.isEmpty()) {
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
+				}
+				else {
+					bindExternalReferenceCode = true;
+
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
+				}
+
+				sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					if (bindExternalReferenceCode) {
+						queryPos.add(externalReferenceCode);
+					}
+
+					queryPos.add(groupId);
+
+					List<FragmentCollection> list = query.list();
+
+					if (list.isEmpty()) {
+						if (useFinderCache) {
+							finderCache.putResult(
+								_finderPathFetchByERC_G, finderArgs, list);
+						}
+					}
+					else {
+						FragmentCollection fragmentCollection = list.get(0);
+
+						result = fragmentCollection;
+
+						cacheResult(fragmentCollection);
+					}
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			if (result instanceof List<?>) {
+				return null;
+			}
+			else {
+				return (FragmentCollection)result;
+			}
+		}
+	}
+
+	/**
+	 * Removes the fragment collection where externalReferenceCode = &#63; and groupId = &#63; from the database.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the fragment collection that was removed
+	 */
+	@Override
+	public FragmentCollection removeByERC_G(
+			String externalReferenceCode, long groupId)
+		throws NoSuchCollectionException {
+
+		FragmentCollection fragmentCollection = findByERC_G(
+			externalReferenceCode, groupId);
+
+		return remove(fragmentCollection);
+	}
+
+	/**
+	 * Returns the number of fragment collections where externalReferenceCode = &#63; and groupId = &#63;.
+	 *
+	 * @param externalReferenceCode the external reference code
+	 * @param groupId the group ID
+	 * @return the number of matching fragment collections
+	 */
+	@Override
+	public int countByERC_G(String externalReferenceCode, long groupId) {
+		try (SafeCloseable safeCloseable =
+				ctPersistenceHelper.setCTCollectionIdWithSafeCloseable(
+					FragmentCollection.class)) {
+
+			externalReferenceCode = Objects.toString(externalReferenceCode, "");
+
+			FinderPath finderPath = _finderPathCountByERC_G;
+
+			Object[] finderArgs = new Object[] {externalReferenceCode, groupId};
+
+			Long count = (Long)finderCache.getResult(
+				finderPath, finderArgs, this);
+
+			if (count == null) {
+				StringBundler sb = new StringBundler(3);
+
+				sb.append(_SQL_COUNT_FRAGMENTCOLLECTION_WHERE);
+
+				boolean bindExternalReferenceCode = false;
+
+				if (externalReferenceCode.isEmpty()) {
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3);
+				}
+				else {
+					bindExternalReferenceCode = true;
+
+					sb.append(_FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2);
+				}
+
+				sb.append(_FINDER_COLUMN_ERC_G_GROUPID_2);
+
+				String sql = sb.toString();
+
+				Session session = null;
+
+				try {
+					session = openSession();
+
+					Query query = session.createQuery(sql);
+
+					QueryPos queryPos = QueryPos.getInstance(query);
+
+					if (bindExternalReferenceCode) {
+						queryPos.add(externalReferenceCode);
+					}
+
+					queryPos.add(groupId);
+
+					count = (Long)query.uniqueResult();
+
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+				catch (Exception exception) {
+					throw processException(exception);
+				}
+				finally {
+					closeSession(session);
+				}
+			}
+
+			return count.intValue();
+		}
+	}
+
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_2 =
+		"fragmentCollection.externalReferenceCode = ? AND ";
+
+	private static final String _FINDER_COLUMN_ERC_G_EXTERNALREFERENCECODE_3 =
+		"(fragmentCollection.externalReferenceCode IS NULL OR fragmentCollection.externalReferenceCode = '') AND ";
+
+	private static final String _FINDER_COLUMN_ERC_G_GROUPID_2 =
+		"fragmentCollection.groupId = ?";
+
 	public FragmentCollectionPersistenceImpl() {
 		Map<String, String> dbColumnNames = new HashMap<String, String>();
 
@@ -3493,6 +3768,14 @@ public class FragmentCollectionPersistenceImpl
 				new Object[] {
 					fragmentCollection.getGroupId(),
 					fragmentCollection.getFragmentCollectionKey()
+				},
+				fragmentCollection);
+
+			finderCache.putResult(
+				_finderPathFetchByERC_G,
+				new Object[] {
+					fragmentCollection.getExternalReferenceCode(),
+					fragmentCollection.getGroupId()
 				},
 				fragmentCollection);
 		}
@@ -3600,6 +3883,16 @@ public class FragmentCollectionPersistenceImpl
 				_finderPathCountByG_FCK, args, Long.valueOf(1));
 			finderCache.putResult(
 				_finderPathFetchByG_FCK, args, fragmentCollectionModelImpl);
+
+			args = new Object[] {
+				fragmentCollectionModelImpl.getExternalReferenceCode(),
+				fragmentCollectionModelImpl.getGroupId()
+			};
+
+			finderCache.putResult(
+				_finderPathCountByERC_G, args, Long.valueOf(1));
+			finderCache.putResult(
+				_finderPathFetchByERC_G, args, fragmentCollectionModelImpl);
 		}
 	}
 
@@ -3746,6 +4039,72 @@ public class FragmentCollectionPersistenceImpl
 			String uuid = PortalUUIDUtil.generate();
 
 			fragmentCollection.setUuid(uuid);
+		}
+
+		if (Validator.isNull(fragmentCollection.getExternalReferenceCode())) {
+			fragmentCollection.setExternalReferenceCode(
+				fragmentCollection.getUuid());
+		}
+		else {
+			if (!Objects.equals(
+					fragmentCollectionModelImpl.getColumnOriginalValue(
+						"externalReferenceCode"),
+					fragmentCollection.getExternalReferenceCode())) {
+
+				long userId = GetterUtil.getLong(
+					PrincipalThreadLocal.getName());
+
+				if (userId > 0) {
+					long companyId = fragmentCollection.getCompanyId();
+
+					long groupId = fragmentCollection.getGroupId();
+
+					long classPK = 0;
+
+					if (!isNew) {
+						classPK = fragmentCollection.getPrimaryKey();
+					}
+
+					try {
+						fragmentCollection.setExternalReferenceCode(
+							SanitizerUtil.sanitize(
+								companyId, groupId, userId,
+								FragmentCollection.class.getName(), classPK,
+								ContentTypes.TEXT_HTML, Sanitizer.MODE_ALL,
+								fragmentCollection.getExternalReferenceCode(),
+								null));
+					}
+					catch (SanitizerException sanitizerException) {
+						throw new SystemException(sanitizerException);
+					}
+				}
+			}
+
+			FragmentCollection ercFragmentCollection = fetchByERC_G(
+				fragmentCollection.getExternalReferenceCode(),
+				fragmentCollection.getGroupId());
+
+			if (isNew) {
+				if (ercFragmentCollection != null) {
+					throw new DuplicateFragmentCollectionExternalReferenceCodeException(
+						"Duplicate fragment collection with external reference code " +
+							fragmentCollection.getExternalReferenceCode() +
+								" and group " +
+									fragmentCollection.getGroupId());
+				}
+			}
+			else {
+				if ((ercFragmentCollection != null) &&
+					(fragmentCollection.getFragmentCollectionId() !=
+						ercFragmentCollection.getFragmentCollectionId())) {
+
+					throw new DuplicateFragmentCollectionExternalReferenceCodeException(
+						"Duplicate fragment collection with external reference code " +
+							fragmentCollection.getExternalReferenceCode() +
+								" and group " +
+									fragmentCollection.getGroupId());
+				}
+			}
 		}
 
 		ServiceContext serviceContext =
@@ -4297,6 +4656,7 @@ public class FragmentCollectionPersistenceImpl
 		ctControlColumnNames.add("mvccVersion");
 		ctControlColumnNames.add("ctCollectionId");
 		ctStrictColumnNames.add("uuid_");
+		ctStrictColumnNames.add("externalReferenceCode");
 		ctStrictColumnNames.add("groupId");
 		ctStrictColumnNames.add("companyId");
 		ctStrictColumnNames.add("userId");
@@ -4322,6 +4682,9 @@ public class FragmentCollectionPersistenceImpl
 
 		_uniqueIndexColumnNames.add(
 			new String[] {"groupId", "fragmentCollectionKey"});
+
+		_uniqueIndexColumnNames.add(
+			new String[] {"externalReferenceCode", "groupId"});
 	}
 
 	/**
@@ -4437,6 +4800,16 @@ public class FragmentCollectionPersistenceImpl
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "countByG_LikeN",
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"groupId", "name"}, false);
+
+		_finderPathFetchByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, true);
+
+		_finderPathCountByERC_G = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByERC_G",
+			new String[] {String.class.getName(), Long.class.getName()},
+			new String[] {"externalReferenceCode", "groupId"}, false);
 
 		FragmentCollectionUtil.setPersistence(this);
 	}

--- a/modules/apps/fragment/fragment-service/src/main/resources/META-INF/module-hbm.xml
+++ b/modules/apps/fragment/fragment-service/src/main/resources/META-INF/module-hbm.xml
@@ -14,6 +14,7 @@
 		<version access="com.liferay.portal.dao.orm.hibernate.PrivateFieldPropertyAccessor" name="mvccVersion" type="long" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="ctCollectionId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" column="uuid_" name="uuid" type="com.liferay.portal.dao.orm.hibernate.StringType" />
+		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="externalReferenceCode" type="com.liferay.portal.dao.orm.hibernate.StringType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="groupId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="companyId" type="com.liferay.portal.dao.orm.hibernate.LongType" />
 		<property access="com.liferay.portal.dao.orm.hibernate.MethodPropertyAccessor" name="userId" type="com.liferay.portal.dao.orm.hibernate.LongType" />

--- a/modules/apps/fragment/fragment-service/src/main/resources/META-INF/portlet-model-hints.xml
+++ b/modules/apps/fragment/fragment-service/src/main/resources/META-INF/portlet-model-hints.xml
@@ -5,6 +5,7 @@
 		<field name="mvccVersion" type="long" />
 		<field name="ctCollectionId" type="long" />
 		<field name="uuid" type="String" />
+		<field name="externalReferenceCode" type="String" />
 		<field name="fragmentCollectionId" type="long" />
 		<field name="groupId" type="long" />
 		<field name="companyId" type="long" />

--- a/modules/apps/fragment/fragment-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/fragment/fragment-service/src/main/resources/META-INF/sql/indexes.sql
@@ -1,6 +1,7 @@
+create unique index IX_3C778AA9 on FragmentCollection (groupId, ctCollectionId, externalReferenceCode[$COLUMN_LENGTH:75$]);
 create unique index IX_9BFCBA4D on FragmentCollection (groupId, ctCollectionId, fragmentCollectionKey[$COLUMN_LENGTH:75$]);
+create unique index IX_33201F20 on FragmentCollection (groupId, ctCollectionId, uuid_[$COLUMN_LENGTH:75$]);
 create index IX_536510F5 on FragmentCollection (groupId, name[$COLUMN_LENGTH:75$]);
-create unique index IX_AD02299C on FragmentCollection (groupId, uuid_[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_8FB7E9C0 on FragmentCollection (uuid_[$COLUMN_LENGTH:75$]);
 
 create index IX_5C61E2DD on FragmentComposition (fragmentCollectionId);

--- a/modules/apps/fragment/fragment-service/src/main/resources/META-INF/sql/tables.sql
+++ b/modules/apps/fragment/fragment-service/src/main/resources/META-INF/sql/tables.sql
@@ -2,6 +2,7 @@ create table FragmentCollection (
 	mvccVersion LONG default 0 not null,
 	ctCollectionId LONG default 0 not null,
 	uuid_ VARCHAR(75) null,
+	externalReferenceCode VARCHAR(75) null,
 	fragmentCollectionId LONG not null,
 	groupId LONG,
 	companyId LONG,

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/CopyFragmentEntryMVCActionCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/CopyFragmentEntryMVCActionCommandTest.java
@@ -96,7 +96,7 @@ public class CopyFragmentEntryMVCActionCommandTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				null);
 
@@ -138,7 +138,7 @@ public class CopyFragmentEntryMVCActionCommandTest {
 	public void testCopyFragmentEntry() throws Exception {
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				null);
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/ImportMVCResourceCommandTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/portlet/action/test/ImportMVCResourceCommandTest.java
@@ -117,8 +117,9 @@ public class ImportMVCResourceCommandTest {
 		throws Exception {
 
 		_fragmentCollectionLocalService.addFragmentCollection(
-			TestPropsValues.getUserId(), _group.getGroupId(), "collection",
-			"Resources Collection", StringPool.BLANK, _serviceContext);
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			"collection", "Resources Collection", StringPool.BLANK,
+			_serviceContext);
 
 		_assertImportResultsJSONObject(
 			2, 4, 2, _importFragmentEntries(FragmentsImportStrategy.KEEP_BOTH));
@@ -186,7 +187,7 @@ public class ImportMVCResourceCommandTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				"Resources Collection", StringPool.BLANK, _serviceContext);
 
 		return _fragmentEntryLocalService.addFragmentEntry(

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCollectionPersistenceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/persistence/test/FragmentCollectionPersistenceTest.java
@@ -6,6 +6,7 @@
 package com.liferay.fragment.service.persistence.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.fragment.exception.DuplicateFragmentCollectionExternalReferenceCodeException;
 import com.liferay.fragment.exception.NoSuchCollectionException;
 import com.liferay.fragment.model.FragmentCollection;
 import com.liferay.fragment.service.FragmentCollectionLocalServiceUtil;
@@ -122,6 +123,9 @@ public class FragmentCollectionPersistenceTest {
 
 		newFragmentCollection.setUuid(RandomTestUtil.randomString());
 
+		newFragmentCollection.setExternalReferenceCode(
+			RandomTestUtil.randomString());
+
 		newFragmentCollection.setGroupId(RandomTestUtil.nextLong());
 
 		newFragmentCollection.setCompanyId(RandomTestUtil.nextLong());
@@ -159,6 +163,9 @@ public class FragmentCollectionPersistenceTest {
 			existingFragmentCollection.getUuid(),
 			newFragmentCollection.getUuid());
 		Assert.assertEquals(
+			existingFragmentCollection.getExternalReferenceCode(),
+			newFragmentCollection.getExternalReferenceCode());
+		Assert.assertEquals(
 			existingFragmentCollection.getFragmentCollectionId(),
 			newFragmentCollection.getFragmentCollectionId());
 		Assert.assertEquals(
@@ -193,6 +200,28 @@ public class FragmentCollectionPersistenceTest {
 			Time.getShortTimestamp(
 				existingFragmentCollection.getLastPublishDate()),
 			Time.getShortTimestamp(newFragmentCollection.getLastPublishDate()));
+	}
+
+	@Test(
+		expected = DuplicateFragmentCollectionExternalReferenceCodeException.class
+	)
+	public void testUpdateWithExistingExternalReferenceCode() throws Exception {
+		FragmentCollection fragmentCollection = addFragmentCollection();
+
+		FragmentCollection newFragmentCollection = addFragmentCollection();
+
+		newFragmentCollection.setGroupId(fragmentCollection.getGroupId());
+
+		newFragmentCollection = _persistence.update(newFragmentCollection);
+
+		Session session = _persistence.getCurrentSession();
+
+		session.evict(newFragmentCollection);
+
+		newFragmentCollection.setExternalReferenceCode(
+			fragmentCollection.getExternalReferenceCode());
+
+		_persistence.update(newFragmentCollection);
 	}
 
 	@Test
@@ -260,6 +289,15 @@ public class FragmentCollectionPersistenceTest {
 	}
 
 	@Test
+	public void testCountByERC_G() throws Exception {
+		_persistence.countByERC_G("", RandomTestUtil.nextLong());
+
+		_persistence.countByERC_G("null", 0L);
+
+		_persistence.countByERC_G((String)null, 0L);
+	}
+
+	@Test
 	public void testFindByPrimaryKeyExisting() throws Exception {
 		FragmentCollection newFragmentCollection = addFragmentCollection();
 
@@ -286,10 +324,11 @@ public class FragmentCollectionPersistenceTest {
 	protected OrderByComparator<FragmentCollection> getOrderByComparator() {
 		return OrderByComparatorFactoryUtil.create(
 			"FragmentCollection", "mvccVersion", true, "ctCollectionId", true,
-			"uuid", true, "fragmentCollectionId", true, "groupId", true,
-			"companyId", true, "userId", true, "userName", true, "createDate",
-			true, "modifiedDate", true, "fragmentCollectionKey", true, "name",
-			true, "description", true, "lastPublishDate", true);
+			"uuid", true, "externalReferenceCode", true, "fragmentCollectionId",
+			true, "groupId", true, "companyId", true, "userId", true,
+			"userName", true, "createDate", true, "modifiedDate", true,
+			"fragmentCollectionKey", true, "name", true, "description", true,
+			"lastPublishDate", true);
 	}
 
 	@Test
@@ -589,6 +628,17 @@ public class FragmentCollectionPersistenceTest {
 			ReflectionTestUtil.invoke(
 				fragmentCollection, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "fragmentCollectionKey"));
+
+		Assert.assertEquals(
+			fragmentCollection.getExternalReferenceCode(),
+			ReflectionTestUtil.invoke(
+				fragmentCollection, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "externalReferenceCode"));
+		Assert.assertEquals(
+			Long.valueOf(fragmentCollection.getGroupId()),
+			ReflectionTestUtil.<Long>invoke(
+				fragmentCollection, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "groupId"));
 	}
 
 	protected FragmentCollection addFragmentCollection() throws Exception {
@@ -601,6 +651,9 @@ public class FragmentCollectionPersistenceTest {
 		fragmentCollection.setCtCollectionId(RandomTestUtil.nextLong());
 
 		fragmentCollection.setUuid(RandomTestUtil.randomString());
+
+		fragmentCollection.setExternalReferenceCode(
+			RandomTestUtil.randomString());
 
 		fragmentCollection.setGroupId(RandomTestUtil.nextLong());
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentCollectionServicePermissionTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentCollectionServicePermissionTest.java
@@ -79,7 +79,7 @@ public class FragmentCollectionServicePermissionTest {
 		UserTestUtil.setUser(_user);
 
 		_fragmentCollectionService.addFragmentCollection(
-			_group.getGroupId(), RandomTestUtil.randomString(),
+			null, _group.getGroupId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 	}
 
@@ -95,7 +95,7 @@ public class FragmentCollectionServicePermissionTest {
 		UserTestUtil.setUser(_user);
 
 		_fragmentCollectionService.addFragmentCollection(
-			_group.getGroupId(), RandomTestUtil.randomString(),
+			null, _group.getGroupId(), RandomTestUtil.randomString(),
 			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 	}
 
@@ -107,7 +107,7 @@ public class FragmentCollectionServicePermissionTest {
 		UserTestUtil.setUser(_user);
 
 		_fragmentCollectionService.addFragmentCollection(
-			_group.getGroupId(), RandomTestUtil.randomString(),
+			null, _group.getGroupId(), RandomTestUtil.randomString(),
 			StringPool.BLANK, serviceContext);
 	}
 
@@ -121,7 +121,7 @@ public class FragmentCollectionServicePermissionTest {
 		UserTestUtil.setUser(_user);
 
 		_fragmentCollectionService.addFragmentCollection(
-			_group.getGroupId(), RandomTestUtil.randomString(),
+			null, _group.getGroupId(), RandomTestUtil.randomString(),
 			StringPool.BLANK, serviceContext);
 	}
 

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentCollectionServiceTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/service/test/FragmentCollectionServiceTest.java
@@ -75,7 +75,8 @@ public class FragmentCollectionServiceTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionService.addFragmentCollection(
-				_group.getGroupId(), name, StringPool.BLANK, serviceContext);
+				null, _group.getGroupId(), name, StringPool.BLANK,
+				serviceContext);
 
 		FragmentCollection persistedFragmentCollection =
 			_fragmentCollectionPersistence.findByPrimaryKey(
@@ -96,7 +97,7 @@ public class FragmentCollectionServiceTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionService.addFragmentCollection(
-				_group.getGroupId(), RandomTestUtil.randomString(), name,
+				null, _group.getGroupId(), RandomTestUtil.randomString(), name,
 				StringPool.BLANK, serviceContext);
 
 		FragmentCollection persistedFragmentCollection =
@@ -158,7 +159,7 @@ public class FragmentCollectionServiceTest {
 	public void testGetFragmentCollectionFileEntries() throws Exception {
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionService.addFragmentCollection(
-				_group.getGroupId(), RandomTestUtil.randomString(),
+				null, _group.getGroupId(), RandomTestUtil.randomString(),
 				RandomTestUtil.randomString(), StringPool.BLANK,
 				ServiceContextTestUtil.getServiceContext(
 					_group, TestPropsValues.getUserId()));
@@ -455,7 +456,7 @@ public class FragmentCollectionServiceTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionService.addFragmentCollection(
-				_group.getGroupId(), RandomTestUtil.randomString(), name,
+				null, _group.getGroupId(), RandomTestUtil.randomString(), name,
 				StringPool.BLANK,
 				ServiceContextTestUtil.getServiceContext(
 					_group, TestPropsValues.getUserId()));

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/AddFragmentCollectionMVCResourceCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/AddFragmentCollectionMVCResourceCommand.java
@@ -58,7 +58,7 @@ public class AddFragmentCollectionMVCResourceCommand
 
 			FragmentCollection fragmentCollection =
 				_fragmentCollectionService.addFragmentCollection(
-					serviceContext.getScopeGroupId(), name, description,
+					null, serviceContext.getScopeGroupId(), name, description,
 					serviceContext);
 
 			jsonObject.put(

--- a/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/EditFragmentCollectionMVCActionCommand.java
+++ b/modules/apps/fragment/fragment-web/src/main/java/com/liferay/fragment/web/internal/portlet/action/EditFragmentCollectionMVCActionCommand.java
@@ -57,7 +57,7 @@ public class EditFragmentCollectionMVCActionCommand
 
 			fragmentCollection =
 				_fragmentCollectionService.addFragmentCollection(
-					serviceContext.getScopeGroupId(), name, description,
+					null, serviceContext.getScopeGroupId(), name, description,
 					serviceContext);
 		}
 		else {

--- a/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
+++ b/modules/apps/headless/headless-delivery/headless-delivery-test/src/testIntegration/java/com/liferay/headless/delivery/resource/v1_0/test/SitePageResourceTest.java
@@ -892,7 +892,7 @@ public class SitePageResourceTest extends BaseSitePageResourceTestCase {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				testGroup.getCreatorUserId(), testGroup.getGroupId(),
+				null, testGroup.getCreatorUserId(), testGroup.getGroupId(),
 				RandomTestUtil.randomString(), RandomTestUtil.randomString(),
 				serviceContext);
 

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/CopyLayoutMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/portlet/action/test/CopyLayoutMVCActionCommandTest.java
@@ -339,7 +339,7 @@ public class CopyLayoutMVCActionCommandTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), StringPool.BLANK,
 				_serviceContext);
 

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentCompositionMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentCompositionMVCActionCommandTest.java
@@ -174,7 +174,7 @@ public class AddFragmentCompositionMVCActionCommandTest {
 
 		FragmentCollection newFragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				StringUtil.randomString(), StringPool.BLANK,
 				ServiceContextThreadLocal.getServiceContext());
 
@@ -224,7 +224,7 @@ public class AddFragmentCompositionMVCActionCommandTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), StringPool.BLANK,
 				_serviceContext);
 
@@ -421,7 +421,7 @@ public class AddFragmentCompositionMVCActionCommandTest {
 
 		FragmentCollection newFragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				StringUtil.randomString(), StringPool.BLANK,
 				ServiceContextThreadLocal.getServiceContext());
 

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinkMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinkMVCActionCommandTest.java
@@ -198,8 +198,8 @@ public class AddFragmentEntryLinkMVCActionCommandTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), groupId, StringUtil.randomString(),
-				StringPool.BLANK, serviceContext);
+				null, TestPropsValues.getUserId(), groupId,
+				StringUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		return _fragmentEntryLocalService.addFragmentEntry(
 			TestPropsValues.getUserId(), groupId,

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/AddFragmentEntryLinksMVCActionCommandTest.java
@@ -148,7 +148,7 @@ public class AddFragmentEntryLinksMVCActionCommandTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				StringUtil.randomString(), StringPool.BLANK, _serviceContext);
 
 		FragmentEntry fragmentEntry =

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DuplicateItemMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DuplicateItemMVCActionCommandTest.java
@@ -244,7 +244,7 @@ public class DuplicateItemMVCActionCommandTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				StringUtil.randomString(), StringPool.BLANK, _serviceContext);
 
 		FragmentEntry fragmentEntry =

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/FragmentDropZoneMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/FragmentDropZoneMVCActionCommandTest.java
@@ -376,7 +376,7 @@ public class FragmentDropZoneMVCActionCommandTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				StringUtil.randomString(), StringPool.BLANK, serviceContext);
 
 		return _fragmentEntryLocalService.addFragmentEntry(

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/PublishLayoutMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/PublishLayoutMVCActionCommandTest.java
@@ -437,7 +437,7 @@ public class PublishLayoutMVCActionCommandTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), null, serviceContext);
 
 		FragmentEntry fragmentEntry =

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/SaveVariantSegmentsExperienceMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/SaveVariantSegmentsExperienceMVCActionCommandTest.java
@@ -218,7 +218,7 @@ public class SaveVariantSegmentsExperienceMVCActionCommandTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), StringPool.BLANK,
 				_serviceContext);
 		String html = "<div data-lfr-styles><span>Test</span>Fragment</div>";

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentCompositionMVCActionCommand.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/AddFragmentCompositionMVCActionCommand.java
@@ -86,8 +86,9 @@ public class AddFragmentCompositionMVCActionCommand
 
 			fragmentCollection =
 				_fragmentCollectionService.addFragmentCollection(
-					themeDisplay.getScopeGroupId(), fragmentCollectionName,
-					fragmentCollectionName, serviceContext);
+					null, themeDisplay.getScopeGroupId(),
+					fragmentCollectionName, fragmentCollectionName,
+					serviceContext);
 		}
 
 		String name = ParamUtil.getString(actionRequest, "name");

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/importer/test/LayoutsImporterTest.java
@@ -302,7 +302,7 @@ public class LayoutsImporterTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), groupId, "Test Collection",
+				null, TestPropsValues.getUserId(), groupId, "Test Collection",
 				StringPool.BLANK, serviceContext);
 
 		return _fragmentEntryLocalService.addFragmentEntry(

--- a/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
+++ b/modules/apps/layout/layout-page-template-admin-web-test/src/testIntegration/java/com/liferay/layout/page/template/admin/web/internal/portlet/action/test/ImportExportLayoutPageTemplateEntriesTest.java
@@ -1362,7 +1362,7 @@ public class ImportExportLayoutPageTemplateEntriesTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), groupId, "Test Collection",
+				null, TestPropsValues.getUserId(), groupId, "Test Collection",
 				StringPool.BLANK, serviceContext);
 
 		return _fragmentEntryLocalService.addFragmentEntry(

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/PageTemplatesImporterTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/importer/test/PageTemplatesImporterTest.java
@@ -561,7 +561,7 @@ public class PageTemplatesImporterTest {
 
 			FragmentCollection fragmentCollection =
 				_fragmentCollectionLocalService.addFragmentCollection(
-					TestPropsValues.getUserId(), _group.getGroupId(),
+					null, TestPropsValues.getUserId(), _group.getGroupId(),
 					RandomTestUtil.randomString(),
 					RandomTestUtil.randomString(), serviceContext);
 
@@ -644,7 +644,7 @@ public class PageTemplatesImporterTest {
 
 			FragmentCollection fragmentCollection =
 				_fragmentCollectionLocalService.addFragmentCollection(
-					TestPropsValues.getUserId(), _group.getGroupId(),
+					null, TestPropsValues.getUserId(), _group.getGroupId(),
 					RandomTestUtil.randomString(),
 					RandomTestUtil.randomString(), serviceContext);
 
@@ -730,7 +730,7 @@ public class PageTemplatesImporterTest {
 
 			FragmentCollection fragmentCollection =
 				_fragmentCollectionLocalService.addFragmentCollection(
-					TestPropsValues.getUserId(), _group.getGroupId(),
+					null, TestPropsValues.getUserId(), _group.getGroupId(),
 					RandomTestUtil.randomString(),
 					RandomTestUtil.randomString(), serviceContext);
 
@@ -832,7 +832,7 @@ public class PageTemplatesImporterTest {
 
 			FragmentCollection fragmentCollection =
 				_fragmentCollectionLocalService.addFragmentCollection(
-					TestPropsValues.getUserId(), _group.getGroupId(),
+					null, TestPropsValues.getUserId(), _group.getGroupId(),
 					RandomTestUtil.randomString(),
 					RandomTestUtil.randomString(), serviceContext);
 
@@ -1236,7 +1236,7 @@ public class PageTemplatesImporterTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				"Test Collection", StringPool.BLANK, serviceContext);
 
 		_fragmentEntryLocalService.addFragmentEntry(

--- a/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/model/listener/test/GroupModelListenerTest.java
+++ b/modules/apps/layout/layout-page-template-test/src/testIntegration/java/com/liferay/layout/page/template/internal/model/listener/test/GroupModelListenerTest.java
@@ -153,8 +153,8 @@ public class GroupModelListenerTest {
 				groupId, TestPropsValues.getUserId());
 
 		return _fragmentCollectionLocalService.addFragmentCollection(
-			TestPropsValues.getUserId(), groupId, RandomTestUtil.randomString(),
-			StringPool.BLANK, serviceContext);
+			null, TestPropsValues.getUserId(), groupId,
+			RandomTestUtil.randomString(), StringPool.BLANK, serviceContext);
 	}
 
 	private FragmentEntryLink _addFragmentEntryLink(long groupId, long plid)

--- a/modules/apps/layout/layout-reports-test/src/testIntegration/java/com/liferay/layout/reports/web/internal/struts/test/GetLayoutReportsLayoutItemDataStrutsActionTest.java
+++ b/modules/apps/layout/layout-reports-test/src/testIntegration/java/com/liferay/layout/reports/web/internal/struts/test/GetLayoutReportsLayoutItemDataStrutsActionTest.java
@@ -380,7 +380,7 @@ public class GetLayoutReportsLayoutItemDataStrutsActionTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), StringPool.BLANK,
 				_serviceContext);
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/headless/delivery/dto/v1_0/test/PageDefinitionDTOConverterTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/headless/delivery/dto/v1_0/test/PageDefinitionDTOConverterTest.java
@@ -132,7 +132,7 @@ public class PageDefinitionDTOConverterTest {
 
 		_fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), StringPool.BLANK,
 				_serviceContext);
 	}

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/search/spi/model/index/contributor/test/LayoutModelDocumentContributorTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/search/spi/model/index/contributor/test/LayoutModelDocumentContributorTest.java
@@ -345,7 +345,7 @@ public class LayoutModelDocumentContributorTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), null, serviceContext);
 
 		FragmentEntry fragmentEntry =

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/service/test/LayoutLocalServiceTest.java
@@ -371,7 +371,7 @@ public class LayoutLocalServiceTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), StringPool.BLANK,
 				_serviceContext);
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
@@ -872,7 +872,7 @@ public class RenderLayoutStructureTagTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				StringUtil.randomString(), StringPool.BLANK, _serviceContext);
 
 		FragmentEntry fragmentEntry =

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/test/LayoutCopyHelperTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/test/LayoutCopyHelperTest.java
@@ -881,7 +881,7 @@ public class LayoutCopyHelperTest {
 
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				RandomTestUtil.randomString(), null, serviceContext);
 
 		return _fragmentEntryLocalService.addFragmentEntry(

--- a/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/test/DisplayPageLayoutTypeControllerTest.java
+++ b/modules/apps/layout/layout-type-controller/layout-type-controller-test/src/testIntegration/java/com/liferay/layout/type/controller/display/page/internal/layout/type/controller/test/DisplayPageLayoutTypeControllerTest.java
@@ -197,7 +197,7 @@ public class DisplayPageLayoutTypeControllerTest {
 	private void _addFragmentEntryLink(Layout layout) throws Exception {
 		FragmentCollection fragmentCollection =
 			_fragmentCollectionLocalService.addFragmentCollection(
-				TestPropsValues.getUserId(), _group.getGroupId(),
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
 				StringUtil.randomString(), StringPool.BLANK, _serviceContext);
 
 		FragmentEntry fragmentEntry =


### PR DESCRIPTION
Add External Reference Code to Fragment Sets

Story: https://liferay.atlassian.net/browse/LPD-23179
Task: https://liferay.atlassian.net/browse/LPD-24491

As discussed with @ealonso 
> Add upgrade process that sets external reference code for entities that were created in previous versions
is not included.

I've also opened https://liferay.atlassian.net/browse/LPD-24549 to track the ZIP export/importer separately.