### PR TITLE
LPD-24482 | Content from Global site cannot be selected when using an embedded porlet scoped to global

### DIFF
--- a/modules/apps/portlet-configuration/portlet-configuration-test/src/testIntegration/java/com/liferay/portlet/configuration/web/internal/portlet/test/PortletConfigurationPortletTest.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-test/src/testIntegration/java/com/liferay/portlet/configuration/web/internal/portlet/test/PortletConfigurationPortletTest.java
@@ -12,11 +12,14 @@ import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Company;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.ResourceConstants;
 import com.liferay.portal.kernel.model.Role;
 import com.liferay.portal.kernel.model.role.RoleConstants;
 import com.liferay.portal.kernel.security.permission.PermissionCheckerFactoryUtil;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.PortletLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
 import com.liferay.portal.kernel.servlet.PortletServlet;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
@@ -27,6 +30,9 @@ import com.liferay.portal.kernel.test.util.GroupTestUtil;
 import com.liferay.portal.kernel.test.util.RoleTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.portal.test.rule.Inject;
@@ -35,7 +41,9 @@ import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
 import com.liferay.portletmvc4spring.test.mock.web.portlet.MockActionResponse;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.portlet.ActionParameters;
@@ -43,6 +51,7 @@ import javax.portlet.ActionRequest;
 import javax.portlet.ActionResponse;
 import javax.portlet.MutableActionParameters;
 import javax.portlet.Portlet;
+import javax.portlet.PortletPreferences;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -71,6 +80,85 @@ public class PortletConfigurationPortletTest {
 		_group = GroupTestUtil.addGroup();
 
 		_company = _companyLocalService.getCompany(_group.getCompanyId());
+
+		_testPortlet = _portletLocalService.getPortletById(
+			_company.getCompanyId(), PortletKeys.BLOGS);
+	}
+
+	@Test
+	public void testEditScopeForLayoutPortlet() throws Exception {
+		Layout layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		_portletPreferencesLocalService.addPortletPreferences(
+			_company.getCompanyId(), PortletKeys.PREFS_OWNER_ID_DEFAULT,
+			PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
+			_testPortlet.getPortletId(), _testPortlet,
+			_getDefaultPreferences(
+				HashMapBuilder.put(
+					"lfrScopeLayoutUuid", StringPool.BLANK
+				).put(
+					"lfrScopeType", StringPool.BLANK
+				).put(
+					"portletSetupTitle_en_US", "blogs"
+				).put(
+					"portletSetupUseCustomTitle", Boolean.TRUE.toString()
+				).build()));
+
+		ReflectionTestUtil.invoke(
+			_portlet, "_updateScope", new Class<?>[] {ActionRequest.class},
+			_getMockActionRequestForScopeTest(layout));
+
+		PortletPreferences portletPreferences =
+			_portletPreferencesLocalService.getPreferences(
+				_company.getCompanyId(), PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
+				_testPortlet.getPortletId());
+
+		String scope = portletPreferences.getValue(
+			"lfrScopeType", StringPool.BLANK);
+
+		Assert.assertEquals("company", scope);
+	}
+
+	@Test
+	public void testEditScopeForSharedPortlet() throws Exception {
+		Layout layout = LayoutTestUtil.addTypePortletLayout(_group);
+
+		String defaultPreferences = _getDefaultPreferences(
+			HashMapBuilder.put(
+				"lfrScopeLayoutUuid", StringPool.BLANK
+			).put(
+				"lfrScopeType", StringPool.BLANK
+			).put(
+				"portletSetupTitle_en_US", "blogs"
+			).put(
+				"portletSetupUseCustomTitle", Boolean.TRUE.toString()
+			).build());
+
+		_portletPreferencesLocalService.addPortletPreferences(
+			_company.getCompanyId(), _group.getGroupId(),
+			PortletKeys.PREFS_OWNER_TYPE_LAYOUT, PortletKeys.PREFS_PLID_SHARED,
+			_testPortlet.getPortletId(), _testPortlet, defaultPreferences);
+
+		_portletPreferencesLocalService.addPortletPreferences(
+			_company.getCompanyId(), PortletKeys.PREFS_OWNER_ID_DEFAULT,
+			PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
+			_testPortlet.getPortletId(), _testPortlet, defaultPreferences);
+
+		ReflectionTestUtil.invoke(
+			_portlet, "_updateScope", new Class<?>[] {ActionRequest.class},
+			_getMockActionRequestForScopeTest(layout));
+
+		PortletPreferences portletPreferences =
+			_portletPreferencesLocalService.getPreferences(
+				_company.getCompanyId(), _group.getGroupId(),
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT,
+				PortletKeys.PREFS_PLID_SHARED, _testPortlet.getPortletId());
+
+		String scope = portletPreferences.getValue(
+			"lfrScopeType", StringPool.BLANK);
+
+		Assert.assertEquals("company", scope);
 	}
 
 	@Test
@@ -137,6 +225,24 @@ public class PortletConfigurationPortletTest {
 		}
 	}
 
+	private String _getDefaultPreferences(HashMap<String, String> preferences) {
+		StringBundler sb = new StringBundler();
+
+		sb.append("<portlet-preferences>");
+
+		for (Map.Entry<String, String> entry : preferences.entrySet()) {
+			sb.append("<preference><name>");
+			sb.append(entry.getKey());
+			sb.append("</name><value>");
+			sb.append(entry.getValue());
+			sb.append("</value></preference>");
+		}
+
+		sb.append("</portlet-preferences>");
+
+		return sb.toString();
+	}
+
 	private MockActionRequest _getMockActionRequest(
 			List<String> plids, List<Long> roleIds)
 		throws Exception {
@@ -176,6 +282,33 @@ public class PortletConfigurationPortletTest {
 		return mockActionRequest;
 	}
 
+	private MockActionRequest _getMockActionRequestForScopeTest(Layout layout)
+		throws Exception {
+
+		MockActionRequest mockActionRequest = new MockActionRequest();
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		mockActionRequest.setParameter("scope", "company");
+
+		mockHttpServletRequest.setParameter("scope", "company");
+
+		mockActionRequest.setParameter(
+			"portletResource", _testPortlet.getPortletId());
+
+		mockHttpServletRequest.setParameter(
+			"portletResource", _testPortlet.getPortletId());
+
+		mockActionRequest.setAttribute(
+			PortletServlet.PORTLET_SERVLET_REQUEST, mockHttpServletRequest);
+
+		mockActionRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, _getThemeDisplay(layout));
+
+		return mockActionRequest;
+	}
+
 	private ThemeDisplay _getThemeDisplay() throws Exception {
 		ThemeDisplay themeDisplay = new ThemeDisplay();
 
@@ -186,6 +319,26 @@ public class PortletConfigurationPortletTest {
 		themeDisplay.setLayout(layout);
 		themeDisplay.setLayoutSet(layout.getLayoutSet());
 
+		themeDisplay.setPermissionChecker(
+			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
+		themeDisplay.setScopeGroupId(_group.getGroupId());
+		themeDisplay.setSiteGroupId(_group.getGroupId());
+		themeDisplay.setUser(TestPropsValues.getUser());
+
+		return themeDisplay;
+	}
+
+	private ThemeDisplay _getThemeDisplay(Layout layout) throws Exception {
+		ThemeDisplay themeDisplay = new ThemeDisplay();
+
+		themeDisplay.setCompany(_company);
+
+		themeDisplay.setLayout(layout);
+		themeDisplay.setLayoutSet(layout.getLayoutSet());
+
+		themeDisplay.setLanguageId(LocaleUtil.toLanguageId(LocaleUtil.US));
+		themeDisplay.setLayoutTypePortlet(
+			(LayoutTypePortlet)layout.getLayoutType());
 		themeDisplay.setPermissionChecker(
 			PermissionCheckerFactoryUtil.create(TestPropsValues.getUser()));
 		themeDisplay.setScopeGroupId(_group.getGroupId());
@@ -209,7 +362,15 @@ public class PortletConfigurationPortletTest {
 	private Portlet _portlet;
 
 	@Inject
+	private PortletLocalService _portletLocalService;
+
+	@Inject
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	@Inject
 	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	private com.liferay.portal.kernel.model.Portlet _testPortlet;
 
 	private static class MockActionRequest
 		extends MockLiferayPortletActionRequest {

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
@@ -1065,8 +1065,12 @@ public class PortletConfigurationPortlet extends MVCPortlet {
 	private void _updateScope(ActionRequest actionRequest) throws Exception {
 		Portlet portlet = ActionUtil.getPortlet(actionRequest);
 
+		ThemeDisplay themeDisplay = (ThemeDisplay)actionRequest.getAttribute(
+			WebKeys.THEME_DISPLAY);
+
 		PortletPreferences portletPreferences =
-			ActionUtil.getLayoutPortletSetup(actionRequest, portlet);
+			themeDisplay.getStrictLayoutPortletSetup(
+				themeDisplay.getLayout(), portlet.getPortletId());
 
 		actionRequest = ActionUtil.getWrappedActionRequest(
 			actionRequest, portletPreferences);
@@ -1099,9 +1103,6 @@ public class PortletConfigurationPortlet extends MVCPortlet {
 			portletTitle, oldScopeName, newScopeName);
 
 		if (!newPortletTitle.equals(portletTitle)) {
-			ThemeDisplay themeDisplay =
-				(ThemeDisplay)actionRequest.getAttribute(WebKeys.THEME_DISPLAY);
-
 			portletPreferences.setValue(
 				"portletSetupTitle_" + themeDisplay.getLanguageId(),
 				newPortletTitle);

--- a/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
+++ b/modules/apps/portlet-configuration/portlet-configuration-web/src/main/java/com/liferay/portlet/configuration/web/internal/portlet/PortletConfigurationPortlet.java
@@ -281,15 +281,7 @@ public class PortletConfigurationPortlet extends MVCPortlet {
 			ActionRequest actionRequest, ActionResponse actionResponse)
 		throws Exception {
 
-		Portlet portlet = ActionUtil.getPortlet(actionRequest);
-
-		PortletPreferences portletPreferences =
-			ActionUtil.getLayoutPortletSetup(actionRequest, portlet);
-
-		actionRequest = ActionUtil.getWrappedActionRequest(
-			actionRequest, portletPreferences);
-
-		_updateScope(actionRequest, portlet);
+		_updateScope(actionRequest);
 
 		if (!SessionErrors.isEmpty(actionRequest)) {
 			return;
@@ -1070,12 +1062,16 @@ public class PortletConfigurationPortlet extends MVCPortlet {
 			String.valueOf(netvibesShowAddAppLink));
 	}
 
-	private void _updateScope(ActionRequest actionRequest, Portlet portlet)
-		throws Exception {
+	private void _updateScope(ActionRequest actionRequest) throws Exception {
+		Portlet portlet = ActionUtil.getPortlet(actionRequest);
+
+		PortletPreferences portletPreferences =
+			ActionUtil.getLayoutPortletSetup(actionRequest, portlet);
+
+		actionRequest = ActionUtil.getWrappedActionRequest(
+			actionRequest, portletPreferences);
 
 		String oldScopeName = _getOldScopeName(actionRequest);
-
-		PortletPreferences portletPreferences = actionRequest.getPreferences();
 
 		String[] scopes = StringUtil.split(
 			ParamUtil.getString(actionRequest, "scope"));


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPD-24482
best,
Attila

-------
The root cause of the issue is that the getLayoutPortletSetup uses the layout plid so there is no way to retrieve the sharedPreferences. (see [PortletPreferencesFactoryImpl.java#L272-L285](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portlet/PortletPreferencesFactoryImpl.java#L272-L285))
I extracted the original logic to make it testable and after that, my solution simply used the themeDisplay.getStrictLayoutPortletSetup method. This way the getStrictPreferences method will retrieve both the shared and layout-related portlet preferences(see [PortletPreferencesLocalServiceImpl.java#L626-L688](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java#L626-L688)).