### PR TITLE
LPD-25228 Use CONTAINS instead of PREFIX in ExpectedLog for MariaDB

### DIFF
--- a/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/test/RedirectNotFoundEntryLocalServiceTest.java
+++ b/modules/apps/redirect/redirect-test/src/testIntegration/java/com/liferay/redirect/service/test/RedirectNotFoundEntryLocalServiceTest.java
@@ -106,7 +106,7 @@ public class RedirectNotFoundEntryLocalServiceTest {
 					@ExpectedLog(
 						expectedDBType = ExpectedDBType.MARIADB,
 						expectedLog = "Duplicate entry '",
-						expectedType = ExpectedType.PREFIX
+						expectedType = ExpectedType.CONTAINS
 					),
 					@ExpectedLog(
 						expectedDBType = ExpectedDBType.MYSQL,


### PR DESCRIPTION
Hi Team,
Could you review this fix?
https://liferay.atlassian.net/browse/LPD-25228
best,
Attila

-----

The root cause of the issue is the new prefix in the error message.
`testAddOrUpdateRedirectNotFoundEntryConcurrently: java.lang.AssertionError:` **`(conn=11)`** `Duplicate entry '42394-url' for key 'IX_84671762'`
I fixed this by changing the matcher from prefix to contains.