### PR TITLE
LPD-24100 Create a Test to Cover Object Entry on a Page Template

### DIFF
--- a/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/CreateObject.testcase
@@ -4741,63 +4741,6 @@ definition {
 		CreateObject.assertAddedEntryRelationshipIsDisplayed(entry = 1234567891234567);
 	}
 
-	@description = "LPS-139803 - Verify it the Object Entry Title is displayed on the Item Selector of a fragment on a Display Page"
-	@priority = 4
-	test CanViewObjectEntryTitleOnItemSelectorFragment {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 116",
-			objectName = "CustomObject116",
-			pluralLabelName = "Custom Objects 116");
-
-		ObjectAdmin.addObjectFieldViaAPI(
-			fieldBusinessType = "Text",
-			fieldLabelName = "Custom Field",
-			fieldName = "customObjectField",
-			fieldType = "String",
-			isRequired = "false",
-			objectName = "CustomObject116");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object 116");
-
-		CreateObject.selectTitleField(fieldLabel = "Custom Field");
-
-		CreateObject.saveObject();
-
-		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject116");
-
-		ObjectAdmin.addObjectSingleFieldEntryViaAPI(
-			fieldName = "customObjectField",
-			objectName = "CustomObject116",
-			value = "Test Entry");
-
-		Navigator.openURL();
-
-		DisplayPageTemplatesAdmin.openDisplayPagesAdmin(siteURLKey = "guest");
-
-		DisplayPageTemplatesAdmin.addDisplayPage(
-			contentType = "Custom Object 116",
-			displayPageName = "Blank Display Page",
-			subtype = "Custom Object 116");
-
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Custom Field");
-
-		VisualizeObjectCollectionDisplay.viewMappedFragment(fieldLabel = "Custom Field");
-
-		PageEditor.selectItemToPreviewWithObject(entryValue = "Test Entry");
-
-		AssertElementPresent(
-			key_entry = "Test Entry",
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-	}
-
 	@description = "LPS-139803 - Verify it the Object Entry Title is displayed on the Relationship tab"
 	@priority = 4
 	test CanViewObjectEntryTitleOnRelationshipTab {

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectCollectionDisplay.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectCollectionDisplay.testcase
@@ -85,53 +85,6 @@ definition {
 			locator1 = "VisualizeObjectCollectionDisplay#ENTRIES_TABLE");
 	}
 
-	@description = "LPS-133865 - Verify if the fields from an Object are displayed to be mapped on a fragment"
-	@priority = 5
-	test FieldsFromObjectDisplayedToBeMapped {
-		property portal.acceptance = "true";
-
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 300",
-			objectName = "CustomObject300",
-			pluralLabelName = "Custom Objects 300");
-
-		ObjectAdmin.addObjectFieldViaAPI(
-			fieldBusinessType = "Integer",
-			fieldLabelName = "Number",
-			fieldName = "integer",
-			fieldType = "Integer",
-			isRequired = "false",
-			objectName = "CustomObject300");
-
-		ObjectAdmin.addObjectFieldViaAPI(
-			fieldBusinessType = "Text",
-			fieldLabelName = "Text",
-			fieldName = "text",
-			fieldType = "String",
-			isRequired = "false",
-			objectName = "CustomObject300");
-
-		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject300");
-
-		VisualizeObjectDisplayPage.createObjectPageTemplate(
-			contentType = "Custom Object 300",
-			pageTemplateName = "Blank Display Page");
-
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Number");
-
-		VisualizeObjectCollectionDisplay.viewMappedFragment(fieldLabel = "Number");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Text");
-
-		VisualizeObjectCollectionDisplay.viewMappedFragment(fieldLabel = "Text");
-	}
-
 	@description = "LPS-133865 - Verify if the Object is displayed to be selected as Collection Provider on the Collection Display fragment"
 	@priority = 5
 	test ObjectDisplayedToCollectionProdiver {

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
@@ -380,58 +380,6 @@ definition {
 			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
 	}
 
-	@description = "LPS-133867|LPS-135004 - Verify it is possible to display a specific entry of Double type for a specific Object"
-	@priority = 4
-	test DisplaySpecificEntryDouble {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 321",
-			objectName = "CustomObject321",
-			pluralLabelName = "Custom Objects 321");
-
-		ObjectAdmin.addObjectFieldViaAPI(
-			fieldBusinessType = "Decimal",
-			fieldLabelName = "Double",
-			fieldName = "customObjectField",
-			fieldType = "Double",
-			isRequired = "false",
-			objectName = "CustomObject321");
-
-		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject321");
-
-		ObjectAdmin.addObjectSingleFieldEntryViaAPI(
-			fieldName = "customObjectField",
-			objectName = "CustomObject321",
-			value = "1.54");
-
-		ContentPages.addPage(pageName = "Test Content Page Name");
-
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 321");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Double");
-
-		AssertElementPresent(
-			key_entry = "1.54",
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-
-		PageEditor.publish();
-
-		PagesAdmin.gotoPageEllipsisMenuItem(
-			menuItem = "View",
-			pageName = "Test Content Page Name");
-
-		AssertElementPresent(
-			key_entry = "1.54",
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-	}
-
 	@description = "LPS-137104 - Verify if Objects and its data are displayed as a Content Type and Subtype for a Page Template"
 	@priority = 5
 	test ObjectDisplayedForPageTemplate {

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
@@ -432,58 +432,6 @@ definition {
 			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
 	}
 
-	@description = "LPS-133867|LPS-135004 - Verify it is possible to display a specific entry of Integer type for a specific Object"
-	@priority = 4
-	test DisplaySpecificEntryInteger {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 322",
-			objectName = "CustomObject322",
-			pluralLabelName = "Custom Objects 322");
-
-		ObjectAdmin.addObjectFieldViaAPI(
-			fieldBusinessType = "Integer",
-			fieldLabelName = "Integer",
-			fieldName = "customObjectField",
-			fieldType = "Integer",
-			isRequired = "false",
-			objectName = "CustomObject322");
-
-		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject322");
-
-		ObjectAdmin.addObjectSingleFieldEntryViaAPI(
-			fieldName = "customObjectField",
-			objectName = "CustomObject322",
-			value = 123456789);
-
-		ContentPages.addPage(pageName = "Test Content Page Name");
-
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 322");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Integer");
-
-		AssertElementPresent(
-			key_entry = 123456789,
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-
-		PageEditor.publish();
-
-		PagesAdmin.gotoPageEllipsisMenuItem(
-			menuItem = "View",
-			pageName = "Test Content Page Name");
-
-		AssertElementPresent(
-			key_entry = 123456789,
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-	}
-
 	@description = "LPS-137104 - Verify if Objects and its data are displayed as a Content Type and Subtype for a Page Template"
 	@priority = 5
 	test ObjectDisplayedForPageTemplate {

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
@@ -536,58 +536,6 @@ definition {
 			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
 	}
 
-	@description = "LPS-133867|LPS-135004 - Verify it is possible to display a specific entry of String type for a specific Object"
-	@priority = 5
-	test DisplaySpecificEntryString {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 324",
-			objectName = "CustomObject324",
-			pluralLabelName = "Custom Objects 324");
-
-		ObjectAdmin.addObjectFieldViaAPI(
-			fieldBusinessType = "Text",
-			fieldLabelName = "String",
-			fieldName = "customObjectField",
-			fieldType = "String",
-			isRequired = "false",
-			objectName = "CustomObject324");
-
-		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject324");
-
-		ObjectAdmin.addObjectSingleFieldEntryViaAPI(
-			fieldName = "customObjectField",
-			objectName = "CustomObject324",
-			value = "Test text");
-
-		ContentPages.addPage(pageName = "Test Content Page Name");
-
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 324");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "String");
-
-		AssertElementPresent(
-			key_entry = "Test text",
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-
-		PageEditor.publish();
-
-		PagesAdmin.gotoPageEllipsisMenuItem(
-			menuItem = "View",
-			pageName = "Test Content Page Name");
-
-		AssertElementPresent(
-			key_entry = "Test text",
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-	}
-
 	@description = "LPS-137104 - Verify if Objects and its data are displayed as a Content Type and Subtype for a Page Template"
 	@priority = 5
 	test ObjectDisplayedForPageTemplate {

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
@@ -222,58 +222,6 @@ definition {
 		PageEditor.assertPaginationSimpleTypeIsDisplayed();
 	}
 
-	@description = "LPS-133867|LPS-135004 - Verify it is possible to display a specific entry of Big Decimal type for a specific Object"
-	@priority = 4
-	test DisplaySpecificEntryBigDecimal {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 318",
-			objectName = "CustomObject318",
-			pluralLabelName = "Custom Objects 318");
-
-		ObjectAdmin.addObjectFieldViaAPI(
-			fieldBusinessType = "PrecisionDecimal",
-			fieldLabelName = "BigDecimal",
-			fieldName = "customObjectField",
-			fieldType = "BigDecimal",
-			isRequired = "false",
-			objectName = "CustomObject318");
-
-		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject318");
-
-		ObjectAdmin.addObjectSingleFieldEntryViaAPI(
-			fieldName = "customObjectField",
-			objectName = "CustomObject318",
-			value = "123.123456");
-
-		ContentPages.addPage(pageName = "Test Content Page Name");
-
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 318");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "BigDecimal");
-
-		AssertElementPresent(
-			key_entry = "123.123456",
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-
-		PageEditor.publish();
-
-		PagesAdmin.gotoPageEllipsisMenuItem(
-			menuItem = "View",
-			pageName = "Test Content Page Name");
-
-		AssertElementPresent(
-			key_entry = "123.123456",
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-	}
-
 	@description = "LPS-133867|LPS-135004 - Verify it is possible to display a specific entry of Date type for a specific Object"
 	@priority = 4
 	test DisplaySpecificEntryDate {

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
@@ -311,69 +311,6 @@ definition {
 		VisualizeObjectDisplayPage.validateObjectContentType(contentType = "Custom Object 325");
 	}
 
-	@description = "LPS-137105 - Verify if the Object entries are rendered when previewing it"
-	@priority = 5
-	test ObjectEntriesAreRendered {
-		property portal.acceptance = "true";
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectAdmin.addNewObject(
-			fieldLabelName = "Custom Object 326",
-			pluralLabelName = "Custom Objects 326");
-
-		CreateObject.saveObject();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object 326");
-
-		ObjectAdmin.goToFieldsTab();
-
-		ObjectAdmin.addObjectFieldViaUI(
-			fieldLabel = "Field",
-			fieldType = "Text");
-
-		ObjectAdmin.openObjectAdmin();
-
-		ObjectPortlet.selectCustomObject(label = "Custom Object 326");
-
-		ObjectAdmin.selectDropdownItem(
-			labelName = "Panel Link",
-			optionName = "Object");
-
-		CreateObject.selectTitleField(fieldLabel = "Field");
-
-		CreateObject.saveObject();
-
-		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject326");
-
-		ObjectAdmin.goToCustomObject(objectName = "CustomObject326");
-
-		ObjectPortlet.addSingleFieldEntryViaUI(entry = "Test Entry");
-
-		Navigator.openURL();
-
-		DisplayPageTemplatesAdmin.openDisplayPagesAdmin(siteURLKey = "guest");
-
-		DisplayPageTemplatesAdmin.addDisplayPage(
-			contentType = "Custom Object 326",
-			displayPageName = "Blank Display Page",
-			subtype = "Custom Object 326");
-
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Field");
-
-		PageEditor.selectItemToPreviewWithObject(entryValue = "Test Entry");
-
-		AssertElementPresent(
-			key_entry = "Test Entry",
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-	}
-
 	@description = "LPS-137106 - Verify if it is possible to link a Mapped URL with the Objects Page Template"
 	@priority = 5
 	test ObjectMappedURL {

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
@@ -274,58 +274,6 @@ definition {
 			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
 	}
 
-	@description = "LPS-133867|LPS-135004 - Verify it is possible to display a specific entry of Boolean type for a specific Object"
-	@priority = 4
-	test DisplaySpecificEntryBoolean {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 319",
-			objectName = "CustomObject319",
-			pluralLabelName = "Custom Objects 319");
-
-		ObjectAdmin.addObjectFieldViaAPI(
-			fieldBusinessType = "Boolean",
-			fieldLabelName = "Boolean",
-			fieldName = "customObjectField",
-			fieldType = "Boolean",
-			isRequired = "false",
-			objectName = "CustomObject319");
-
-		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject319");
-
-		ObjectAdmin.addObjectSingleFieldEntryViaAPI(
-			fieldName = "customObjectField",
-			objectName = "CustomObject319",
-			value = "true");
-
-		ContentPages.addPage(pageName = "Test Content Page Name");
-
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 319");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Boolean");
-
-		AssertElementPresent(
-			key_entry = "true",
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-
-		PageEditor.publish();
-
-		PagesAdmin.gotoPageEllipsisMenuItem(
-			menuItem = "View",
-			pageName = "Test Content Page Name");
-
-		AssertElementPresent(
-			key_entry = "true",
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-	}
-
 	@description = "LPS-133867|LPS-135004 - Verify it is possible to display a specific entry of Date type for a specific Object"
 	@priority = 4
 	test DisplaySpecificEntryDate {

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
@@ -484,58 +484,6 @@ definition {
 			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
 	}
 
-	@description = "LPS-133867|LPS-135004 - Verify it is possible to display a specific entry of Long type for a specific Object"
-	@priority = 4
-	test DisplaySpecificEntryLong {
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 323",
-			objectName = "CustomObject323",
-			pluralLabelName = "Custom Objects 323");
-
-		ObjectAdmin.addObjectFieldViaAPI(
-			fieldBusinessType = "LongInteger",
-			fieldLabelName = "Long",
-			fieldName = "customObjectField",
-			fieldType = "Long",
-			isRequired = "false",
-			objectName = "CustomObject323");
-
-		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject323");
-
-		ObjectAdmin.addObjectSingleFieldEntryViaAPI(
-			fieldName = "customObjectField",
-			objectName = "CustomObject323",
-			value = 1234567891234567);
-
-		ContentPages.addPage(pageName = "Test Content Page Name");
-
-		PageEditor.addFragment(
-			collectionName = "Basic Components",
-			fragmentName = "Heading");
-
-		VisualizeObjectCollectionDisplay.openHeading();
-
-		VisualizeObjectDisplayPage.addItem(
-			frameTitle = "Select",
-			pluralLabelName = "Custom Objects 323");
-
-		VisualizeObjectCollectionDisplay.mapFragment(fieldLabel = "Long");
-
-		AssertElementPresent(
-			key_entry = 1234567891234567,
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-
-		PageEditor.publish();
-
-		PagesAdmin.gotoPageEllipsisMenuItem(
-			menuItem = "View",
-			pageName = "Test Content Page Name");
-
-		AssertElementPresent(
-			key_entry = 1234567891234567,
-			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
-	}
-
 	@description = "LPS-137104 - Verify if Objects and its data are displayed as a Content Type and Subtype for a Page Template"
 	@priority = 5
 	test ObjectDisplayedForPageTemplate {

--- a/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
+++ b/modules/apps/object/object-test/src/testFunctional/tests/VisualizeObjectDisplayPage.testcase
@@ -276,41 +276,6 @@ definition {
 			locator1 = "VisualizeObjectDisplayPage#DISPLAY_ENTRY");
 	}
 
-	@description = "LPS-137104 - Verify if Objects and its data are displayed as a Content Type and Subtype for a Page Template"
-	@priority = 5
-	test ObjectDisplayedForPageTemplate {
-		property portal.acceptance = "true";
-
-		ObjectAdmin.addObjectViaAPI(
-			labelName = "Custom Object 325",
-			objectName = "CustomObject325",
-			pluralLabelName = "Custom Objects 325");
-
-		ObjectAdmin.addObjectFieldViaAPI(
-			fieldBusinessType = "Text",
-			fieldLabelName = "Field",
-			fieldName = "customObjectField",
-			fieldType = "String",
-			isRequired = "false",
-			objectName = "CustomObject325");
-
-		ObjectAdmin.publishObjectViaAPI(objectName = "CustomObject325");
-
-		VisualizeObjectDisplayPage.openPageTemplate();
-
-		Click(locator1 = "VisualizeObjectDisplayPage#SELECT_BLANK_OBJECT_DISPLAY_PAGE_TEMPLATE");
-
-		Type(
-			locator1 = "VisualizeObjectDisplayPage#NAME_OBJECT_DISPLAY_PAGE_TEMPLATE",
-			value1 = "Object Display Page Template");
-
-		Select(
-			locator1 = "VisualizeObjectDisplayPage#OBJECT_CONTENT_TYPE",
-			value1 = "Custom Object 325");
-
-		VisualizeObjectDisplayPage.validateObjectContentType(contentType = "Custom Object 325");
-	}
-
 	@description = "LPS-137106 - Verify if it is possible to link a Mapped URL with the Objects Page Template"
 	@priority = 5
 	test ObjectMappedURL {

--- a/modules/test/playwright/helpers/ListTypeAdminApiHelper.ts
+++ b/modules/test/playwright/helpers/ListTypeAdminApiHelper.ts
@@ -27,7 +27,24 @@ export class ListTypeAdminApiHelper {
 		);
 	}
 
-	async postRandomListTypeDefinition() {
+	async postListTypeEntry(
+		listTypeDefinitionExternalReferenceCode: string,
+		listTypeEntryName: string
+	): Promise<PickList> {
+		const requestBody = {
+			key: listTypeEntryName.toLocaleLowerCase(),
+			name_i18n: {
+				en_US: listTypeEntryName,
+			},
+		};
+
+		return this.apiHelpers.post(
+			`${this.apiHelpers.baseUrl}${this.basePath}/list-type-definitions/by-external-reference-code/${listTypeDefinitionExternalReferenceCode}/list-type-entries`,
+			{data: requestBody}
+		);
+	}
+
+	async postRandomListTypeDefinition(): Promise<PickList> {
 		const listTypeDefinitionExternalReferenceCode =
 			'ListTypeDefinition' + getRandomInt();
 

--- a/modules/test/playwright/helpers/ListTypeAdminApiHelper.ts
+++ b/modules/test/playwright/helpers/ListTypeAdminApiHelper.ts
@@ -21,7 +21,7 @@ export class ListTypeAdminApiHelper {
 		);
 	}
 
-	async getListTypeDefinitions() {
+	async getListTypeDefinitions(): Promise<ListTypeDefinitions> {
 		return this.apiHelpers.get(
 			`${this.apiHelpers.baseUrl}${this.basePath}/list-type-definitions`
 		);
@@ -30,7 +30,7 @@ export class ListTypeAdminApiHelper {
 	async postListTypeEntry(
 		listTypeDefinitionExternalReferenceCode: string,
 		listTypeEntryName: string
-	): Promise<PickList> {
+	): Promise<ListTypeDefinition> {
 		const requestBody = {
 			key: listTypeEntryName.toLocaleLowerCase(),
 			name_i18n: {
@@ -44,7 +44,7 @@ export class ListTypeAdminApiHelper {
 		);
 	}
 
-	async postRandomListTypeDefinition(): Promise<PickList> {
+	async postRandomListTypeDefinition(): Promise<ListTypeDefinition> {
 		const listTypeDefinitionExternalReferenceCode =
 			'ListTypeDefinition' + getRandomInt();
 

--- a/modules/test/playwright/helpers/ObjectAdminApiHelper.ts
+++ b/modules/test/playwright/helpers/ObjectAdminApiHelper.ts
@@ -39,7 +39,7 @@ export class ObjectAdminApiHelper {
 		);
 	}
 
-	async postObjectDefinition(data: DataObject) {
+	async postObjectDefinition(data: DataObject): Promise<ObjectDefinition> {
 		return this.apiHelpers.post(
 			`${this.apiHelpers.baseUrl}${this.basePath}/object-definitions`,
 			{data}

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -20,6 +20,7 @@ export class PageEditorPage {
 	readonly redoButton: Locator;
 	readonly undoButton: Locator;
 	readonly undoHistory: Locator;
+	readonly selectItemMappingButton: Locator;
 
 	readonly segmentEditorPage: SegmentEditorPage;
 
@@ -33,6 +34,7 @@ export class PageEditorPage {
 		this.redoButton = page.getByTitle('Redo');
 		this.undoButton = page.getByTitle('Undo');
 		this.undoHistory = page.locator('.page-editor__undo-history');
+		this.selectItemMappingButton = page.getByLabel('Select Item');
 
 		this.segmentEditorPage = new SegmentEditorPage(page);
 	}
@@ -531,6 +533,50 @@ export class PageEditorPage {
 		await editable.click();
 
 		await expect(editable).toBeFocused();
+	}
+
+	async setMappingConfiguration({
+		entity,
+		entry,
+		field,
+		recentSelectedItem,
+		source,
+	}: {
+		entity: string;
+		entry: string;
+		field: string;
+		recentSelectedItem?: string;
+		source?: 'content' | 'structure';
+	}) {
+		if (source) {
+			await this.page.getByLabel('Source').selectOption(source);
+		}
+
+		await this.selectItemMappingButton.click();
+
+		if (recentSelectedItem) {
+			await this.page
+				.getByRole('menuitem', {name: recentSelectedItem})
+				.click();
+		}
+		else {
+			await this.page
+				.frameLocator('iframe[title="Select"]')
+				.getByRole('menuitem', {name: entity})
+				.click();
+
+			await this.page
+				.frameLocator('iframe[title="Select"]')
+				.getByText(entry)
+				.click();
+
+			await this.page
+				.frameLocator('iframe[title="Select"]')
+				.locator('modal-title')
+				.waitFor({state: 'hidden'});
+		}
+
+		await this.page.getByLabel('Field').selectOption(field);
 	}
 
 	async switchExperience(experience: string) {

--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -37,6 +37,21 @@ export class DisplayPageTemplatesPage {
 			.click();
 	}
 
+	async deleteAllDisplayPageTemplates() {
+		await this.goto();
+
+		await this.page
+			.getByLabel('Select All Items on the Page')
+			.setChecked(true);
+
+		await this.page.getByRole('button', {name: 'Delete'}).click();
+
+		await this.page
+			.getByLabel('Delete Entries- Loading')
+			.getByRole('button', {name: 'Delete'})
+			.click();
+	}
+
 	async markAsDefault(name: string) {
 		await this.clickMoreActions(name);
 
@@ -74,8 +89,8 @@ export class DisplayPageTemplatesPage {
 			.selectOption({label: contentType});
 
 		if (contentType === 'Web Content Article') {
-		await this.page
-			.getByLabel('Subtype')
+			await this.page
+				.getByLabel('Subtype')
 				.selectOption({label: subtype});
 		}
 

--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -54,18 +54,35 @@ export class DisplayPageTemplatesPage {
 		await waitForSuccessAlert(this.page);
 	}
 
-	async publishNewTemplate(name: string) {
+	async publishNewTemplate({
+		contentType,
+		name,
+		subtype,
+	}: {
+		contentType: string;
+		name: string;
+		subtype?: string;
+	}) {
 		await this.newButton.click();
+
 		await this.page.getByRole('button', {name: 'Blank'}).click();
+
 		await this.page.getByLabel('Name').fill(name);
+
 		await this.page
 			.getByLabel('Content Type')
-			.selectOption({label: 'Web Content Article'});
+			.selectOption({label: contentType});
+
+		if (contentType === 'Web Content Article') {
 		await this.page
 			.getByLabel('Subtype')
-			.selectOption({label: 'Basic Web Content'});
+				.selectOption({label: subtype});
+		}
+
 		await this.page.getByRole('button', {name: 'Save'}).click();
+
 		await this.publishButton.waitFor();
+
 		await this.publishButton.click();
 	}
 }

--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -27,21 +27,6 @@ export class DisplayPageTemplatesPage {
 		);
 	}
 
-	async publishNewTemplate(name: string) {
-		await this.newButton.click();
-		await this.page.getByRole('button', {name: 'Blank'}).click();
-		await this.page.getByLabel('Name').fill(name);
-		await this.page
-			.getByLabel('Content Type')
-			.selectOption({label: 'Web Content Article'});
-		await this.page
-			.getByLabel('Subtype')
-			.selectOption({label: 'Basic Web Content'});
-		await this.page.getByRole('button', {name: 'Save'}).click();
-		await this.publishButton.waitFor();
-		await this.publishButton.click();
-	}
-
 	async clickMoreActions(name: string) {
 		await this.page
 			.locator(
@@ -67,5 +52,20 @@ export class DisplayPageTemplatesPage {
 			.click();
 
 		await waitForSuccessAlert(this.page);
+	}
+
+	async publishNewTemplate(name: string) {
+		await this.newButton.click();
+		await this.page.getByRole('button', {name: 'Blank'}).click();
+		await this.page.getByLabel('Name').fill(name);
+		await this.page
+			.getByLabel('Content Type')
+			.selectOption({label: 'Web Content Article'});
+		await this.page
+			.getByLabel('Subtype')
+			.selectOption({label: 'Basic Web Content'});
+		await this.page.getByRole('button', {name: 'Save'}).click();
+		await this.publishButton.waitFor();
+		await this.publishButton.click();
 	}
 }

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -239,9 +239,11 @@ prefixUrlTest(
 
 		const displayPageTemplateName = getRandomString();
 
-		await displayPageTemplatesPage.publishNewTemplate(
-			displayPageTemplateName
-		);
+		await displayPageTemplatesPage.publishNewTemplate({
+			contentType: 'Web Content Article',
+			name: displayPageTemplateName,
+			subtype: 'Basic Web Content',
+		});
 
 		await displayPageTemplatesPage.markAsDefault(displayPageTemplateName);
 

--- a/modules/test/playwright/tests/object-web/env/portal-ext.properties
+++ b/modules/test/playwright/tests/object-web/env/portal-ext.properties
@@ -1,0 +1,2 @@
+object.encryption.algorithm=AES
+object.encryption.key=D9z5Rwxkn+8SctNWW/q/OA==

--- a/modules/test/playwright/tests/object-web/listTypeDefinitions.spec.ts
+++ b/modules/test/playwright/tests/object-web/listTypeDefinitions.spec.ts
@@ -37,7 +37,7 @@ test.afterEach(async ({apiHelpers, page, siteSettingsLocalizationPage}) => {
 			await apiHelpers.listTypeAdmin.getListTypeDefinitions();
 
 		const [createdListTypeDefinition] = listTypeDefinitions.items.filter(
-			(listTypeDefinition: PickList) =>
+			(listTypeDefinition: ListTypeDefinition) =>
 				listTypeDefinition.name === createdListTypeDefinitionName
 		);
 

--- a/modules/test/playwright/tests/object-web/objectEntries.spec.ts
+++ b/modules/test/playwright/tests/object-web/objectEntries.spec.ts
@@ -14,9 +14,11 @@ import {objectPagesTest} from '../../fixtures/objectPagesTest';
 import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
+import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 import getCollectionDefinition from '../layout-content-page-editor-web/utils/getCollectionDefinition';
 import getFragmentDefinition from '../layout-content-page-editor-web/utils/getFragmentDefinition';
 import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
+import {mockObjectFieldsObjectEntry} from './utils/mockObjectFieldsObjectEntry';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -25,6 +27,7 @@ export const test = mergeTests(
 	featureFlagsTest({
 		'LPS-178052': true,
 	}),
+	journalPagesTest,
 	loginTest(),
 	objectPagesTest,
 	pageEditorPagesTest
@@ -234,6 +237,146 @@ test.describe('Manage object entries through page templates', () => {
 		await apiHelpers.objectAdmin.deleteObjectDefinition(
 			objectDefinition.id
 		);
+	});
+
+	test('verify if the object entries are displayed when selecting to preview an object entry on a page template', async ({
+		apiHelpers,
+		displayPageTemplatesPage,
+		page,
+		pageEditorPage,
+	}) => {
+		const listTypeDefinition =
+			await apiHelpers.listTypeAdmin.postRandomListTypeDefinition();
+
+		const listTypeEntries = new Array(3)
+			.fill('')
+			.map(() => getRandomInt().toString());
+
+		for (const lisTypeEntry of listTypeEntries) {
+			await apiHelpers.listTypeAdmin.postListTypeEntry(
+				listTypeDefinition.externalReferenceCode,
+				lisTypeEntry
+			);
+		}
+
+		const objectDefinitionLabel =
+			'ObjectDefinitionLabel' + getRandomString();
+		const objectDefinitionName = 'ObjectDefinitionName' + getRandomInt();
+
+		const {objectEntry, objectFields} = mockObjectFieldsObjectEntry(
+			listTypeDefinition,
+			listTypeEntries
+		);
+
+		const objectFieldTextName = objectFields.find(
+			(objectField) => objectField.businessType === 'Text'
+		).name;
+
+		const objectDefinition =
+			await apiHelpers.objectAdmin.postObjectDefinition({
+				active: true,
+				label: {
+					en_US: objectDefinitionLabel,
+				},
+				name: objectDefinitionName,
+				objectFields,
+				pluralLabel: {
+					en_US: objectDefinitionLabel,
+				},
+				portlet: true,
+				scope: 'company',
+				status: {
+					code: 0,
+				},
+				titleObjectFieldName: objectFieldTextName,
+			});
+
+		const applicationName =
+			'c/' + objectDefinition.name.toLowerCase() + 's';
+
+		await apiHelpers.objectEntry.postObjectEntry(
+			objectEntry,
+			applicationName
+		);
+
+		await displayPageTemplatesPage.goto();
+
+		const displayPageTemplateName = getRandomString();
+
+		await displayPageTemplatesPage.publishNewTemplate({
+			contentType: objectDefinition.label['en_US'],
+			name: displayPageTemplateName,
+		});
+
+		await page.getByTitle(displayPageTemplateName).click();
+
+		for (const [index, objectField] of objectDefinition.objectFields
+			.filter((objectField) => !objectField.system)
+			.entries()) {
+			await pageEditorPage.addFragment('Basic Components', 'Heading');
+
+			await page.getByText('Heading Example', {exact: true}).click();
+
+			await page.getByLabel('Select element-text').click();
+
+			await pageEditorPage.setMappingConfiguration({
+				entity: objectDefinitionLabel,
+				entry: objectEntry[objectFieldTextName] as string,
+				field: objectField.label.en_US,
+				recentSelectedItem:
+					index >= 1
+						? (objectEntry[objectFieldTextName] as string)
+						: undefined,
+				source: 'content',
+			});
+
+			let matchString: string;
+
+			switch (objectField.businessType) {
+				case 'AutoIncrement': {
+					matchString = '1';
+
+					break;
+				}
+				case 'Picklist': {
+					matchString = (
+						objectEntry[objectField.name] as {key: string}
+					).key;
+
+					break;
+				}
+				case 'MultiselectPicklist': {
+					(objectEntry[objectField.name] as string[]).forEach(
+						(listTypeEntry, index) => {
+							index < 1
+								? (matchString = `${listTypeEntry}`)
+								: (matchString += `, ${listTypeEntry}`);
+						}
+					);
+
+					break;
+				}
+				default: {
+					matchString = objectEntry[objectField.name].toString();
+				}
+			}
+
+			await expect(
+				page.getByTitle('Edit Text').filter({hasText: matchString})
+			).toBeVisible();
+		}
+
+		// Clean up
+
+		await apiHelpers.objectAdmin.deleteObjectDefinition(
+			objectDefinition.id
+		);
+
+		await apiHelpers.listTypeAdmin.deleteListTypeDefinition(
+			listTypeDefinition.id
+		);
+
+		await displayPageTemplatesPage.deleteAllDisplayPageTemplates();
 	});
 });
 

--- a/modules/test/playwright/tests/object-web/objectEntries.spec.ts
+++ b/modules/test/playwright/tests/object-web/objectEntries.spec.ts
@@ -33,6 +33,27 @@ export const test = mergeTests(
 	pageEditorPagesTest
 );
 
+const customListTypeDefinitions: ListTypeDefinition[] = [];
+const customObjectDefinitions: ObjectDefinition[] = [];
+
+test.afterEach(async ({apiHelpers}) => {
+	if (customObjectDefinitions.length) {
+		for (const customObjectDefinition of customObjectDefinitions) {
+			await apiHelpers.objectAdmin.deleteObjectDefinition(
+				customObjectDefinition.id
+			);
+		}
+	}
+
+	if (customListTypeDefinitions.length) {
+		for (const customListTypeDefinition of customListTypeDefinitions) {
+			await apiHelpers.listTypeAdmin.deleteListTypeDefinition(
+				customListTypeDefinition.id
+			);
+		}
+	}
+});
+
 test.describe('Manage object entries through page templates', () => {
 	test('can view all entries related to an object in the relationship field', async ({
 		apiHelpers,
@@ -45,11 +66,15 @@ test.describe('Manage object entries through page templates', () => {
 				status: {code: 0},
 			});
 
+		customObjectDefinitions.push(objectDefinition1);
+
 		const objectDefinition2 =
 			await apiHelpers.objectAdmin.postRandomObjectDefinition({
 				objectFolderExternalReferenceCode: 'default',
 				status: {code: 0},
 			});
+
+		customObjectDefinitions.push(objectDefinition2);
 
 		const objectRelationshipLabel =
 			'objectRelationshipLabel' + getRandomInt();
@@ -154,6 +179,8 @@ test.describe('Manage object entries through page templates', () => {
 				},
 			});
 
+		customObjectDefinitions.push(objectDefinition);
+
 		const trueObjectEntry = {
 			customBoolean: true,
 		};
@@ -248,6 +275,8 @@ test.describe('Manage object entries through page templates', () => {
 		const listTypeDefinition =
 			await apiHelpers.listTypeAdmin.postRandomListTypeDefinition();
 
+		customListTypeDefinitions.push(listTypeDefinition);
+
 		const listTypeEntries = new Array(3)
 			.fill('')
 			.map(() => getRandomInt().toString());
@@ -290,6 +319,8 @@ test.describe('Manage object entries through page templates', () => {
 				},
 				titleObjectFieldName: objectFieldTextName,
 			});
+
+		customObjectDefinitions.push(objectDefinition);
 
 		const applicationName =
 			'c/' + objectDefinition.name.toLowerCase() + 's';
@@ -368,14 +399,6 @@ test.describe('Manage object entries through page templates', () => {
 
 		// Clean up
 
-		await apiHelpers.objectAdmin.deleteObjectDefinition(
-			objectDefinition.id
-		);
-
-		await apiHelpers.listTypeAdmin.deleteListTypeDefinition(
-			listTypeDefinition.id
-		);
-
 		await displayPageTemplatesPage.deleteAllDisplayPageTemplates();
 	});
 });
@@ -386,40 +409,24 @@ test.describe('Manage object entries through View Object Entries', () => {
 		page,
 		viewObjectEntriesPage,
 	}) => {
-		const picklist = await apiHelpers.post(
-			'/o/headless-admin-list-type/v1.0/list-type-definitions',
-			{
-				data: {
-					externalReferenceCode: 'picklistERC',
-					name: 'picklist',
-					name_i18n: {
-						en_US: 'picklist',
-					},
-				},
-			}
-		);
+		const listTypeDefinition =
+			await apiHelpers.listTypeAdmin.postRandomListTypeDefinition();
 
-		await apiHelpers.post(
-			`/o/headless-admin-list-type/v1.0/list-type-definitions/${picklist.id}/list-type-entries`,
-			{
-				data: {
-					key: 'item1',
-					name: 'item1',
-					name_i18n: {
-						en_US: 'item1',
-					},
-				},
-			}
+		customListTypeDefinitions.push(listTypeDefinition);
+
+		await apiHelpers.listTypeAdmin.postListTypeEntry(
+			listTypeDefinition.externalReferenceCode,
+			'item1'
 		);
 
 		const objectDefinition =
 			await apiHelpers.objectAdmin.postObjectDefinition({
 				active: true,
-				externalReferenceCode: 'NewObjectERC',
+				externalReferenceCode: getRandomString(),
 				label: {
-					en_US: 'NewObject',
+					en_US: getRandomString(),
 				},
-				name: 'NewObject',
+				name: 'ObjectDefinitionName' + getRandomInt(),
 				objectFields: [
 					{
 						DBType: 'String',
@@ -446,7 +453,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 						label: {
 							en_US: 'longInteger',
 						},
-						listTypeDefinitionId: 0,
 						localized: false,
 						name: 'longInteger',
 						required: false,
@@ -463,7 +469,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 						label: {
 							en_US: 'date',
 						},
-						listTypeDefinitionId: 0,
 						localized: false,
 						name: 'date',
 						required: false,
@@ -480,7 +485,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 						label: {
 							en_US: 'integer',
 						},
-						listTypeDefinitionId: 0,
 						localized: false,
 						name: 'integer',
 						required: false,
@@ -497,7 +501,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 						label: {
 							en_US: 'decimal',
 						},
-						listTypeDefinitionId: 0,
 						localized: false,
 						name: 'decimal',
 						required: false,
@@ -514,7 +517,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 						label: {
 							en_US: 'richText',
 						},
-						listTypeDefinitionId: 0,
 						localized: false,
 						name: 'richText',
 						required: false,
@@ -529,7 +531,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 						indexedAsKeyword: false,
 						indexedLanguageId: '',
 						label: {en_US: 'boolean'},
-						listTypeDefinitionId: 0,
 						name: 'boolean',
 						required: false,
 						system: false,
@@ -543,7 +544,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 						indexedAsKeyword: false,
 						indexedLanguageId: '',
 						label: {en_US: 'longText'},
-						listTypeDefinitionId: 0,
 						name: 'longText',
 						required: false,
 						system: false,
@@ -557,7 +557,6 @@ test.describe('Manage object entries through View Object Entries', () => {
 						indexedAsKeyword: false,
 						indexedLanguageId: '',
 						label: {en_US: 'precisionDecimal'},
-						listTypeDefinitionId: 0,
 						name: 'precisionDecimal',
 						required: false,
 						system: false,
@@ -573,7 +572,8 @@ test.describe('Manage object entries through View Object Entries', () => {
 						label: {
 							en_US: 'picklist',
 						},
-						listTypeDefinitionExternalReferenceCode: 'picklistERC',
+						listTypeDefinitionExternalReferenceCode:
+							listTypeDefinition.externalReferenceCode,
 						name: 'picklist',
 						required: false,
 						state: false,
@@ -615,6 +615,8 @@ test.describe('Manage object entries through View Object Entries', () => {
 					code: 0,
 				},
 			});
+
+		customObjectDefinitions.push(objectDefinition);
 
 		await viewObjectEntriesPage.goto(objectDefinition.id);
 
@@ -690,13 +692,5 @@ test.describe('Manage object entries through View Object Entries', () => {
 
 			await expect(page.getByText(entry)).toBeVisible();
 		}
-
-		// Clean up
-
-		await apiHelpers.objectAdmin.deleteObjectDefinition(
-			objectDefinition.id
-		);
-
-		await apiHelpers.listTypeAdmin.deleteListTypeDefinition(picklist.id);
 	});
 });

--- a/modules/test/playwright/tests/object-web/utils/mockObjectFieldsObjectEntry.ts
+++ b/modules/test/playwright/tests/object-web/utils/mockObjectFieldsObjectEntry.ts
@@ -1,0 +1,362 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {getRandomInt} from '../../../utils/getRandomInt';
+import getRandomString from '../../../utils/getRandomString';
+
+type objectFieldBusinessType = (typeof objectFieldBusinessTypes)[number];
+
+type objectFieldBusinessTypesLabelName = {
+	[K in objectFieldBusinessType]: objectFieldLabelName;
+};
+
+type objectFieldLabelName = {
+	label: string;
+	name: string;
+};
+
+const objectFieldBusinessTypes = [
+	'autoIncrement',
+	'boolean',
+	'decimal',
+	'encrypted',
+	'integer',
+	'longInteger',
+	'longText',
+	'multiselectPicklist',
+	'picklist',
+	'precisionDecimal',
+	'richText',
+	'text',
+] as const;
+
+function mockObjectEntry(
+	objectFieldBusinessTypesInfo: objectFieldBusinessTypesLabelName,
+	listTypeEntries: string[]
+) {
+	return {
+		[objectFieldBusinessTypesInfo.boolean.name]: Math.random() < 0.5,
+		[objectFieldBusinessTypesInfo.decimal.name]: parseFloat(
+			Math.random().toFixed(10)
+		).toString(),
+		[objectFieldBusinessTypesInfo.encrypted.name]: getRandomString(),
+		[objectFieldBusinessTypesInfo.integer.name]: Math.floor(
+			Math.random() * 100
+		),
+		[objectFieldBusinessTypesInfo.longInteger.name]: getRandomInt(),
+		[objectFieldBusinessTypesInfo.longText.name]: getRandomString(),
+		[objectFieldBusinessTypesInfo.multiselectPicklist.name]: [
+			listTypeEntries[0],
+			listTypeEntries[1],
+		],
+		[objectFieldBusinessTypesInfo.picklist.name]: {
+			key: listTypeEntries[0],
+		},
+		[objectFieldBusinessTypesInfo.precisionDecimal.name]: parseFloat(
+			Math.random().toFixed(15)
+		).toString(),
+		[objectFieldBusinessTypesInfo.richText.name]: getRandomString(),
+		[objectFieldBusinessTypesInfo.text.name]: getRandomString(),
+	};
+}
+
+function mockObjectFields(
+	objectFieldBusinessTypesInfo: objectFieldBusinessTypesLabelName,
+	listTypeDefinition: PickList
+) {
+	return [
+		{
+			DBType: 'String',
+			businessType: 'AutoIncrement',
+			indexed: true,
+			indexedAsKeyword: false,
+			indexedLanguageId: 'en_US',
+			label: {
+				en_US: objectFieldBusinessTypesInfo.autoIncrement.label,
+			},
+			localized: false,
+			name: objectFieldBusinessTypesInfo.autoIncrement.name,
+			objectFieldSettings: [
+				{
+					name: 'initialValue',
+					value: '1',
+				},
+			],
+			readOnly: 'false',
+			readOnlyConditionExpression: '',
+			required: false,
+			state: false,
+			system: false,
+			type: 'String',
+			unique: false,
+		},
+		{
+			DBType: 'Boolean',
+			businessType: 'Boolean',
+			indexed: true,
+			indexedAsKeyword: false,
+			indexedLanguageId: '',
+			label: {
+				en_US: objectFieldBusinessTypesInfo.boolean.label,
+			},
+			localized: false,
+			name: objectFieldBusinessTypesInfo.boolean.name,
+			objectFieldSettings: [],
+			readOnly: 'false',
+			readOnlyConditionExpression: '',
+			required: false,
+			state: false,
+			system: false,
+			type: 'Boolean',
+			unique: false,
+		},
+		{
+			DBType: 'Double',
+			businessType: 'Decimal',
+			indexed: true,
+			indexedAsKeyword: false,
+			indexedLanguageId: '',
+			label: {
+				en_US: objectFieldBusinessTypesInfo.decimal.label,
+			},
+			listTypeDefinitionExternalReferenceCode: '',
+			localized: false,
+			name: objectFieldBusinessTypesInfo.decimal.name,
+			objectFieldSettings: [],
+			readOnly: 'false',
+			readOnlyConditionExpression: '',
+			required: false,
+			state: false,
+		},
+		{
+			DBType: 'Clob',
+			businessType: 'Encrypted',
+			indexed: false,
+			indexedAsKeyword: false,
+			indexedLanguageId: '',
+			label: {
+				en_US: objectFieldBusinessTypesInfo.encrypted.label,
+			},
+			localized: false,
+			name: objectFieldBusinessTypesInfo.encrypted.name,
+			objectFieldSettings: [],
+			readOnly: 'false',
+			readOnlyConditionExpression: '',
+			required: false,
+			state: false,
+			system: false,
+			type: 'Clob',
+			unique: false,
+		},
+		{
+			DBType: 'Integer',
+			businessType: 'Integer',
+			indexed: true,
+			indexedAsKeyword: false,
+			indexedLanguageId: '',
+			label: {
+				en_US: objectFieldBusinessTypesInfo.integer.label,
+			},
+			localized: false,
+			name: objectFieldBusinessTypesInfo.integer.name,
+			objectFieldSettings: [],
+			readOnly: 'false',
+			readOnlyConditionExpression: '',
+			required: false,
+			state: false,
+			system: false,
+			type: 'Integer',
+			unique: false,
+		},
+		{
+			DBType: 'Long',
+			businessType: 'LongInteger',
+			indexed: true,
+			indexedAsKeyword: false,
+			indexedLanguageId: '',
+			label: {
+				en_US: objectFieldBusinessTypesInfo.longInteger.label,
+			},
+			localized: false,
+			name: objectFieldBusinessTypesInfo.longInteger.name,
+			objectFieldSettings: [],
+			readOnly: 'false',
+			readOnlyConditionExpression: '',
+			required: false,
+			state: false,
+			system: false,
+			type: 'Long',
+			unique: false,
+		},
+		{
+			DBType: 'Clob',
+			businessType: 'LongText',
+			indexed: true,
+			indexedAsKeyword: false,
+			indexedLanguageId: 'en_US',
+			label: {
+				en_US: objectFieldBusinessTypesInfo.longText.label,
+			},
+			localized: false,
+			name: objectFieldBusinessTypesInfo.longText.name,
+			objectFieldSettings: [
+				{
+					name: 'showCounter',
+					value: false,
+				},
+			],
+			readOnly: 'false',
+			readOnlyConditionExpression: '',
+			required: false,
+			state: false,
+			system: false,
+			type: 'Clob',
+			unique: false,
+		},
+		{
+			DBType: 'String',
+			businessType: 'MultiselectPicklist',
+			indexed: true,
+			indexedAsKeyword: false,
+			indexedLanguageId: 'en_US',
+			label: {
+				en_US: objectFieldBusinessTypesInfo.multiselectPicklist.label,
+			},
+			listTypeDefinitionExternalReferenceCode:
+				listTypeDefinition.externalReferenceCode,
+			listTypeDefinitionId: listTypeDefinition.id,
+			localized: false,
+			name: objectFieldBusinessTypesInfo.multiselectPicklist.name,
+			objectFieldSettings: [],
+			readOnly: 'false',
+			readOnlyConditionExpression: '',
+			required: false,
+			state: false,
+			system: false,
+			type: 'String',
+			unique: false,
+		},
+		{
+			DBType: 'String',
+			businessType: 'Picklist',
+			indexed: true,
+			indexedAsKeyword: false,
+			indexedLanguageId: 'en_US',
+			label: {
+				en_US: objectFieldBusinessTypesInfo.picklist.label,
+			},
+			listTypeDefinitionExternalReferenceCode:
+				listTypeDefinition.externalReferenceCode,
+			localized: false,
+			name: objectFieldBusinessTypesInfo.picklist.name,
+			objectFieldSettings: [],
+			readOnly: 'false',
+			readOnlyConditionExpression: '',
+			required: false,
+			state: false,
+			system: false,
+			type: 'String',
+			unique: false,
+		},
+		{
+			DBType: 'BigDecimal',
+			businessType: 'PrecisionDecimal',
+			indexed: true,
+			indexedAsKeyword: false,
+			indexedLanguageId: '',
+			label: {
+				en_US: objectFieldBusinessTypesInfo.precisionDecimal.label,
+			},
+			localized: false,
+			name: objectFieldBusinessTypesInfo.precisionDecimal.name,
+			objectFieldSettings: [],
+			readOnly: 'false',
+			readOnlyConditionExpression: '',
+			required: false,
+			state: false,
+			system: false,
+			type: 'BigDecimal',
+			unique: false,
+		},
+		{
+			DBType: 'Clob',
+			businessType: 'RichText',
+			indexed: true,
+			indexedAsKeyword: false,
+			indexedLanguageId: 'en_US',
+			label: {
+				en_US: objectFieldBusinessTypesInfo.richText.label,
+			},
+			localized: false,
+			name: objectFieldBusinessTypesInfo.richText.name,
+			objectFieldSettings: [],
+			readOnly: 'false',
+			readOnlyConditionExpression: '',
+			required: false,
+			state: false,
+			system: false,
+			type: 'Clob',
+			unique: false,
+		},
+		{
+			DBType: 'String',
+			businessType: 'Text',
+			indexed: true,
+			indexedAsKeyword: false,
+			indexedLanguageId: 'en_US',
+			label: {
+				en_US: objectFieldBusinessTypesInfo.text.label,
+			},
+			localized: false,
+			name: objectFieldBusinessTypesInfo.text.name,
+			objectFieldSettings: [],
+			readOnly: 'false',
+			readOnlyConditionExpression: '',
+			required: false,
+			state: false,
+			system: false,
+			type: 'String',
+			unique: false,
+		},
+	];
+}
+
+export function mockObjectFieldsObjectEntry(
+	listTypeDefinition: PickList,
+	listTypeDefinitionItems: string[]
+) {
+	const objectFieldBusinessTypeLabelName =
+		{} as objectFieldBusinessTypesLabelName;
+
+	const setLabelName = (
+		target: objectFieldBusinessTypesLabelName,
+		businessType: string,
+		{label, name}
+	) => {
+		Object.defineProperty(target, businessType, {value: {label, name}});
+	};
+
+	objectFieldBusinessTypes.forEach((objectFieldBusinessType) => {
+		setLabelName(
+			objectFieldBusinessTypeLabelName,
+			objectFieldBusinessType,
+			{
+				label: `${objectFieldBusinessType}ObjectFieldLabel`,
+				name: `${objectFieldBusinessType}ObjectFieldName`,
+			}
+		);
+	});
+
+	return {
+		objectEntry: mockObjectEntry(
+			objectFieldBusinessTypeLabelName,
+			listTypeDefinitionItems
+		),
+		objectFields: mockObjectFields(
+			objectFieldBusinessTypeLabelName,
+			listTypeDefinition
+		),
+	};
+}

--- a/modules/test/playwright/tests/object-web/utils/mockObjectFieldsObjectEntry.ts
+++ b/modules/test/playwright/tests/object-web/utils/mockObjectFieldsObjectEntry.ts
@@ -64,7 +64,7 @@ function mockObjectEntry(
 
 function mockObjectFields(
 	objectFieldBusinessTypesInfo: objectFieldBusinessTypesLabelName,
-	listTypeDefinition: PickList
+	listTypeDefinition: ListTypeDefinition
 ) {
 	return [
 		{
@@ -324,7 +324,7 @@ function mockObjectFields(
 }
 
 export function mockObjectFieldsObjectEntry(
-	listTypeDefinition: PickList,
+	listTypeDefinition: ListTypeDefinition,
 	listTypeDefinitionItems: string[]
 ) {
 	const objectFieldBusinessTypeLabelName =

--- a/modules/test/playwright/tsconfig.json
+++ b/modules/test/playwright/tsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"downlevelIteration": true,
 		"esModuleInterop": true,
 		"noEmit": true,
 		"types": [

--- a/modules/test/playwright/types/object.d.ts
+++ b/modules/test/playwright/types/object.d.ts
@@ -39,6 +39,30 @@ type IncludesFilterOperator = {
 	in: string[] | number[];
 };
 
+interface ListTypeDefinition {
+	actions: Actions;
+	externalReferenceCode: string;
+	id: number;
+	key: string;
+	listTypeEntries: ListTypeEntry[];
+	name: string;
+	name_i18n: LocalizedValue<string>;
+	system: boolean;
+}
+
+interface ListTypeDefinitions {
+	actions: Actions;
+	items: ListTypeDefinition[];
+}
+
+interface ListTypeEntry {
+	externalReferenceCode: string;
+	id: number;
+	key: string;
+	name: string;
+	name_i18n: LocalizedValue<string>;
+}
+
 type LocalizedValue<T> = Liferay.Language.LocalizedValue<T>;
 
 interface NameValueObject {
@@ -345,24 +369,6 @@ interface ObjectValidationRuleSetting {
 		| 'compositeKeyObjectFieldExternalReferenceCode'
 		| 'outputObjectFieldExternalReferenceCode';
 	value: string;
-}
-
-interface PickListItem {
-	externalReferenceCode: string;
-	id: number;
-	key: string;
-	name: string;
-	name_i18n: LocalizedValue<string>;
-}
-
-interface PickList {
-	actions: Actions;
-	externalReferenceCode: string;
-	id: number;
-	key: string;
-	listTypeEntries: PickListItem[];
-	name: string;
-	name_i18n: LocalizedValue<string>;
 }
 
 type ReadOnlyFieldValue = '' | 'conditional' | 'false' | 'true';


### PR DESCRIPTION
Hey team, I'm opening this PR here to request a review of the changes made to the files that are maintained by you.

This PR aims to guarantee the functionality of the visualization of object definitions entries in the page editor.

There are some poshi tests that aimed to guarantee that this behavior would continue to work, but they were failing due to time out.

Instead of creating a test for each business type, as poshi did, I decided to create an object definition with a list of business types and check them all at once.

I have the https://github.com/liferay-objects/liferay-portal/pull/3348 awaiting review in the objects repository. However, I will wait for your approval on this PR so I can go ahead with the objects PR.

https://github.com/liferay-echo/liferay-portal/assets/61854510/39321924-f741-4994-b766-90b726be13da

