### PR TITLE
LPD-26211 It's not possible to create Utility Pages or edit the SEO

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutUtilityPageEntryManagementToolbarDisplayContext.java
@@ -184,7 +184,7 @@ public class LayoutUtilityPageEntryManagementToolbarDisplayContext
 	private String _getSelectMasterLayoutURL(String type) {
 		return PortletURLBuilder.createRenderURL(
 			liferayPortletResponse
-		).setMVCPath(
+		).setMVCRenderCommandName(
 			"/layout_admin/select_layout_utility_page_entry_master_layout"
 		).setRedirect(
 			_themeDisplay.getURLCurrent()

--- a/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/portlet/action/EditSEOMVCActionCommand.java
+++ b/modules/apps/layout/layout-seo-web/src/main/java/com/liferay/layout/seo/web/internal/portlet/action/EditSEOMVCActionCommand.java
@@ -131,7 +131,7 @@ public class EditSEOMVCActionCommand extends BaseMVCActionCommand {
 		serviceContext.setAssetCategoryIds(assetEntry.getCategoryIds());
 		serviceContext.setAssetTagNames(assetEntry.getTagNames());
 
-		if (layout.isTypeAssetDisplay()) {
+		if (layout.isTypeAssetDisplay() || layout.isTypeUtility()) {
 			serviceContext.setAttribute(
 				"layout.instanceable.allowed", Boolean.TRUE);
 		}


### PR DESCRIPTION
## Motivation

Due this test failure: [Link to test failure](https://liferay.atlassian.net/browse/LPD-26212)
We create the bug to fix the problem. No test should be needed since we are fixing it after a test failure.
 Bug ticket: [Link to ticket](https://liferay.atlassian.net/browse/LPD-26211)

## Test scenario 

Case1:
1. Go to Site Builder > Pages > Utility Pages
2. Try to create a 404 page for example

Case 2:
1. Go to Site Builder > Pages > Utility Pages
2. Try to modify the SEO from “configure” for any Utility Page

[Screencast from 2024-05-20 14-25-41.webm](https://github.com/liferay-echo/liferay-portal/assets/93203423/a9168276-1e11-4464-9f7f-1e1e350bc4a0)
