### PR TITLE
LPD-26865 Adds performance tests to evaluate the LPD-20883 fix against the previous solution

### DIFF
--- a/modules/apps/layout/layout-set-prototype-test/src/testIntegration/java/com/liferay/layout/set/prototype/internal/helper/test/LayoutSetPrototypeHelperTest.java
+++ b/modules/apps/layout/layout-set-prototype-test/src/testIntegration/java/com/liferay/layout/set/prototype/internal/helper/test/LayoutSetPrototypeHelperTest.java
@@ -10,6 +10,8 @@ import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.layout.set.prototype.helper.LayoutSetPrototypeHelper;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
@@ -22,6 +24,7 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.LoggingTimer;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.sites.kernel.util.Sites;
@@ -193,9 +196,16 @@ public class LayoutSetPrototypeHelperTest {
 		Layout layoutSetPrototypeLayout = LayoutTestUtil.addTypePortletLayout(
 			_layoutSetPrototypeGroup.getGroupId(), "test", true);
 
-		List<Layout> conflictLayouts =
-			_layoutSetPrototypeHelper.getDuplicatedFriendlyURLLayouts(
-				layoutSetPrototypeLayout);
+		_entityCache.clearCache();
+		_multiVMPool.clear();
+
+		List<Layout> conflictLayouts = null;
+
+		try (LoggingTimer loggingTimer = new LoggingTimer()) {
+			conflictLayouts =
+				_layoutSetPrototypeHelper.getDuplicatedFriendlyURLLayouts(
+					layoutSetPrototypeLayout);
+		}
 
 		Assert.assertEquals(
 			conflictLayouts.toString(), expectedConflictLayouts.size(),
@@ -296,6 +306,9 @@ public class LayoutSetPrototypeHelperTest {
 
 	private static final int _NUMBER_ENABLED_LINKS = 5;
 
+	@Inject
+	private EntityCache _entityCache;
+
 	@DeleteAfterTestRun
 	private Group _group;
 
@@ -310,6 +323,9 @@ public class LayoutSetPrototypeHelperTest {
 
 	@Inject
 	private LayoutSetPrototypeHelper _layoutSetPrototypeHelper;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
 
 	private Layout _prototypeLayout;
 	private Layout _siteLayout;

--- a/modules/apps/layout/layout-set-prototype-test/src/testIntegration/java/com/liferay/layout/set/prototype/internal/helper/test/LayoutSetPrototypeHelperTest.java
+++ b/modules/apps/layout/layout-set-prototype-test/src/testIntegration/java/com/liferay/layout/set/prototype/internal/helper/test/LayoutSetPrototypeHelperTest.java
@@ -9,6 +9,7 @@ import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.layout.set.prototype.helper.LayoutSetPrototypeHelper;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutSetPrototype;
@@ -63,7 +64,7 @@ public class LayoutSetPrototypeHelperTest {
 		_prototypeLayout = LayoutTestUtil.addTypePortletLayout(
 			_layoutSetPrototypeGroup, true);
 
-		setLinkEnabled();
+		setLinkEnabled(_group);
 
 		_siteLayout = LayoutLocalServiceUtil.getFriendlyURLLayout(
 			_group.getGroupId(), false, _prototypeLayout.getFriendlyURL());
@@ -171,8 +172,23 @@ public class LayoutSetPrototypeHelperTest {
 	public void testLayoutSetPrototypeLayoutFriendlyURLConflictDetectionBeforePropagate()
 		throws Exception {
 
-		Layout siteLayout = LayoutTestUtil.addTypePortletLayout(
-			_group.getGroupId(), "test", false);
+		List<Layout> expectedConflictLayouts = new ArrayList<>();
+
+		expectedConflictLayouts.add(
+			LayoutTestUtil.addTypePortletLayout(
+				_group.getGroupId(), "test", false));
+
+		for (int i = 1; i < _NUMBER_ENABLED_LINKS; i++) {
+			Group group = GroupTestUtil.addGroup();
+
+			setLinkEnabled(group);
+
+			_groups.add(group);
+
+			expectedConflictLayouts.add(
+				LayoutTestUtil.addTypePortletLayout(
+					group.getGroupId(), "test", false));
+		}
 
 		Layout layoutSetPrototypeLayout = LayoutTestUtil.addTypePortletLayout(
 			_layoutSetPrototypeGroup.getGroupId(), "test", true);
@@ -182,11 +198,13 @@ public class LayoutSetPrototypeHelperTest {
 				layoutSetPrototypeLayout);
 
 		Assert.assertEquals(
-			conflictLayouts.toString(), 1, conflictLayouts.size());
-
-		Layout conflictLayout = conflictLayouts.get(0);
-
-		Assert.assertEquals(conflictLayout.getPlid(), siteLayout.getPlid());
+			conflictLayouts.toString(), expectedConflictLayouts.size(),
+			conflictLayouts.size());
+		Assert.assertArrayEquals(
+			TransformUtil.transformToLongArray(
+				expectedConflictLayouts, layout -> layout.getPlid()),
+			TransformUtil.transformToLongArray(
+				conflictLayouts, layout -> layout.getPlid()));
 	}
 
 	@Test
@@ -268,16 +286,21 @@ public class LayoutSetPrototypeHelperTest {
 		Assert.assertFalse(hasConflicts);
 	}
 
-	protected void setLinkEnabled() throws Exception {
+	protected void setLinkEnabled(Group group) throws Exception {
 		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
 
 		_sites.updateLayoutSetPrototypesLinks(
-			_group, _layoutSetPrototype.getLayoutSetPrototypeId(), 0, true,
+			group, _layoutSetPrototype.getLayoutSetPrototypeId(), 0, true,
 			false);
 	}
 
+	private static final int _NUMBER_ENABLED_LINKS = 5;
+
 	@DeleteAfterTestRun
 	private Group _group;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups = new ArrayList<>();
 
 	@DeleteAfterTestRun
 	private LayoutSetPrototype _layoutSetPrototype;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-26865

The reason for this PR is that we feared that we were worsening performance for all DB types when we incorporated the LPD-20883 fix for DBs that do not support the distinct clause on CLOB columns.

These have led us to modify this test so that, in addition to asserting the functionality, it allows us to use it to test performance.

With the changes incorporated here I have tested the performance on MySQL and I have verified that:

- The performance of the previous implementation is similar to the current one if there are few sites linked to the site template
- Increasing the number of linked sites, a certain worsening of performance is already beginning to be noticed, although it does not seem notable. For example, those are the execution times with 100 sites linked to the site template.

***Before LPD-20883***
![image](https://github.com/liferay-echo/liferay-portal/assets/84471361/891ab93a-a90f-4121-8dfe-2bdc8165e9c3)

***After LPD-20883***
![image](https://github.com/liferay-echo/liferay-portal/assets/84471361/327216d3-b958-4b66-9ddf-719ef4e717be)

It is pending to decide whether this justifies maintaining the old implementation for the DBs that support it.