### PR TITLE
LPD-26865 Add a performance test for GetDuplicatedFriendlyURLLayouts with a LayoutSetPrototype's layout

### DIFF
--- a/modules/apps/layout/layout-set-prototype-test/src/testIntegration/java/com/liferay/layout/set/prototype/internal/helper/test/LayoutSetPrototypeHelperPerformanceTest.java
+++ b/modules/apps/layout/layout-set-prototype-test/src/testIntegration/java/com/liferay/layout/set/prototype/internal/helper/test/LayoutSetPrototypeHelperPerformanceTest.java
@@ -1,0 +1,128 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.set.prototype.internal.helper.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
+import com.liferay.layout.set.prototype.helper.LayoutSetPrototypeHelper;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.function.transform.TransformUtil;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.dao.orm.EntityCache;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSetPrototype;
+import com.liferay.portal.kernel.test.performance.PerformanceTimer;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.sites.kernel.util.Sites;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@RunWith(Arquillian.class)
+public class LayoutSetPrototypeHelperPerformanceTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_layoutSetPrototype = LayoutTestUtil.addLayoutSetPrototype(
+			RandomTestUtil.randomString());
+
+		for (int i = 0; i < _NUMBER_GROUPS; i++) {
+			Group group = GroupTestUtil.addGroup();
+
+			setLinkEnabled(group);
+
+			_groups.add(group);
+		}
+	}
+
+	@Test
+	public void testGetDuplicatedFriendlyURLLayoutsWithLayoutSetPrototypeLayout()
+		throws Exception {
+
+		List<Layout> layouts = new ArrayList<>();
+
+		for (Group group : _groups) {
+			layouts.add(
+				LayoutTestUtil.addTypePortletLayout(
+					group.getGroupId(), "test", false));
+		}
+
+		Layout layoutSetPrototypeLayout = LayoutTestUtil.addTypePortletLayout(
+			_layoutSetPrototype.getGroupId(), "test", true);
+
+		_entityCache.clearCache();
+		_multiVMPool.clear();
+
+		List<Layout> conflictLayouts = null;
+
+		try (PerformanceTimer performanceTimer = new PerformanceTimer(1000)) {
+			conflictLayouts =
+				_layoutSetPrototypeHelper.getDuplicatedFriendlyURLLayouts(
+					layoutSetPrototypeLayout);
+		}
+
+		Assert.assertEquals(
+			conflictLayouts.toString(), layouts.size(), conflictLayouts.size());
+		Assert.assertArrayEquals(
+			TransformUtil.transformToLongArray(
+				layouts, layout -> layout.getPlid()),
+			TransformUtil.transformToLongArray(
+				conflictLayouts, layout -> layout.getPlid()));
+	}
+
+	protected void setLinkEnabled(Group group) throws Exception {
+		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+
+		_sites.updateLayoutSetPrototypesLinks(
+			group, _layoutSetPrototype.getLayoutSetPrototypeId(), 0, true,
+			false);
+	}
+
+	private static final int _NUMBER_GROUPS = 5;
+
+	@Inject
+	private EntityCache _entityCache;
+
+	@DeleteAfterTestRun
+	private List<Group> _groups = new ArrayList<>();
+
+	@DeleteAfterTestRun
+	private LayoutSetPrototype _layoutSetPrototype;
+
+	@Inject
+	private LayoutSetPrototypeHelper _layoutSetPrototypeHelper;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	@Inject
+	private Sites _sites;
+
+}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-26865

The reason for this PR is that we feared that we were worsening performance for all DB types when we incorporated the LPD-20883 fix for DBs that do not support the distinct clause on CLOB columns.

These have led us to add this test so that, in addition to asserting the functionality, it allows us to use it to test performance. I have tested the performance on MySQL and I have verified that:

- The performance of the previous implementation is similar to the current one if there are few sites linked to the site template.
- Increasing the number of linked sites, a certain worsening of performance is already beginning to be noticed, although it does not seem notable. For example, those are the execution times with 100 sites linked to the site template.


**Before LPD-20883**
![image](https://github.com/liferay-echo/liferay-portal/assets/84471361/3ccfc373-a0ed-4102-a32a-0cac33209efc)


**After LPD-20883**
![image](https://github.com/liferay-echo/liferay-portal/assets/84471361/c938bbd0-d519-48af-a9a2-a35a125f8882)

It is pending to decide whether this justifies maintaining the old implementation for the DBs that support it.