### PR TITLE
LPD-27167 Check if the segmentsExperienceId belongs to the actual page

### DIFF
--- a/modules/dxp/apps/segments/segments-experiment-test/src/testIntegration/java/com/liferay/segments/experiment/web/internal/processor/test/SegmentsExperimentSegmentsExperienceRequestProcessorTest.java
+++ b/modules/dxp/apps/segments/segments-experiment-test/src/testIntegration/java/com/liferay/segments/experiment/web/internal/processor/test/SegmentsExperimentSegmentsExperienceRequestProcessorTest.java
@@ -129,6 +129,152 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessorTest {
 	}
 
 	@Test
+	public void testGetSegmentsExperienceIdsFromAnotherPage() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.addSegmentsExperience(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				segmentsEntry.getSegmentsEntryId(), _layout.getPlid(),
+				RandomTestUtil.randomLocaleStringMap(), true,
+				new UnicodeProperties(true),
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		SegmentsExperiment segmentsExperiment =
+			_segmentsExperimentLocalService.addSegmentsExperiment(
+				segmentsExperience.getSegmentsExperienceId(),
+				segmentsExperience.getPlid(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(),
+				SegmentsExperimentConstants.Goal.BOUNCE_RATE.getLabel(),
+				StringPool.BLANK,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		_segmentsExperimentLocalService.updateSegmentsExperimentStatus(
+			segmentsExperiment.getSegmentsExperimentId(),
+			SegmentsExperimentConstants.STATUS_RUNNING);
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						AnalyticsConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsDataSourceId",
+							RandomTestUtil.randomLong()
+						).put(
+							"liferayAnalyticsEnableAllGroupIds", true
+						).put(
+							"liferayAnalyticsFaroBackendSecuritySignature",
+							RandomTestUtil.randomString()
+						).put(
+							"liferayAnalyticsFaroBackendURL",
+							RandomTestUtil.randomString()
+						).build())) {
+
+			MockHttpServletRequest mockHttpServletRequest =
+				_getMockHttpServletRequest();
+
+			mockHttpServletRequest.setParameter(
+				"segmentsExperienceId",
+				String.valueOf(
+					_segmentsExperienceLocalService.
+						fetchDefaultSegmentsExperienceId(layout.getPlid())));
+
+			long defaultSegmentsExperienceId =
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(
+						segmentsExperience.getPlid());
+
+			long[] segmentsExperienceIds =
+				_segmentsExperienceRequestProcessor.getSegmentsExperienceIds(
+					mockHttpServletRequest, new MockHttpServletResponse(),
+					_group.getGroupId(), _layout.getPlid(),
+					new long[] {defaultSegmentsExperienceId});
+
+			Assert.assertEquals(
+				Arrays.toString(segmentsExperienceIds), 1,
+				segmentsExperienceIds.length);
+
+			Assert.assertEquals(
+				defaultSegmentsExperienceId, segmentsExperienceIds[0]);
+		}
+	}
+
+	@Test
+	public void testGetSegmentsExperienceIdsThatIsNull() throws Exception {
+		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
+			_group.getGroupId());
+
+		SegmentsExperience segmentsExperience =
+			_segmentsExperienceLocalService.addSegmentsExperience(
+				null, TestPropsValues.getUserId(), _group.getGroupId(),
+				segmentsEntry.getSegmentsEntryId(), _layout.getPlid(),
+				RandomTestUtil.randomLocaleStringMap(), true,
+				new UnicodeProperties(true),
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		SegmentsExperiment segmentsExperiment =
+			_segmentsExperimentLocalService.addSegmentsExperiment(
+				segmentsExperience.getSegmentsExperienceId(),
+				segmentsExperience.getPlid(), RandomTestUtil.randomString(),
+				RandomTestUtil.randomString(),
+				SegmentsExperimentConstants.Goal.BOUNCE_RATE.getLabel(),
+				StringPool.BLANK,
+				ServiceContextTestUtil.getServiceContext(_group.getGroupId()));
+
+		_segmentsExperimentLocalService.updateSegmentsExperimentStatus(
+			segmentsExperiment.getSegmentsExperimentId(),
+			SegmentsExperimentConstants.STATUS_RUNNING);
+
+		try (CompanyConfigurationTemporarySwapper
+				companyConfigurationTemporarySwapper =
+					new CompanyConfigurationTemporarySwapper(
+						TestPropsValues.getCompanyId(),
+						AnalyticsConfiguration.class.getName(),
+						HashMapDictionaryBuilder.<String, Object>put(
+							"liferayAnalyticsDataSourceId",
+							RandomTestUtil.randomLong()
+						).put(
+							"liferayAnalyticsEnableAllGroupIds", true
+						).put(
+							"liferayAnalyticsFaroBackendSecuritySignature",
+							RandomTestUtil.randomString()
+						).put(
+							"liferayAnalyticsFaroBackendURL",
+							RandomTestUtil.randomString()
+						).build())) {
+
+			MockHttpServletRequest mockHttpServletRequest =
+				_getMockHttpServletRequest();
+
+			mockHttpServletRequest.setParameter(
+				"segmentsExperienceId",
+				String.valueOf(RandomTestUtil.randomLong()));
+
+			long defaultSegmentsExperienceId =
+				_segmentsExperienceLocalService.
+					fetchDefaultSegmentsExperienceId(
+						segmentsExperience.getPlid());
+
+			long[] segmentsExperienceIds =
+				_segmentsExperienceRequestProcessor.getSegmentsExperienceIds(
+					_getMockHttpServletRequest(), new MockHttpServletResponse(),
+					_group.getGroupId(), _layout.getPlid(),
+					new long[] {defaultSegmentsExperienceId});
+
+			Assert.assertEquals(
+				Arrays.toString(segmentsExperienceIds), 1,
+				segmentsExperienceIds.length);
+
+			Assert.assertEquals(
+				defaultSegmentsExperienceId, segmentsExperienceIds[0]);
+		}
+	}
+
+	@Test
 	public void testGetSegmentsExperienceIdsWithCookie() throws Exception {
 		SegmentsEntry segmentsEntry = SegmentsTestUtil.addSegmentsEntry(
 			_group.getGroupId());

--- a/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/processor/SegmentsExperimentSegmentsExperienceRequestProcessor.java
+++ b/modules/dxp/apps/segments/segments-experiment-web/src/main/java/com/liferay/segments/experiment/web/internal/processor/SegmentsExperimentSegmentsExperienceRequestProcessor.java
@@ -87,7 +87,9 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 				_segmentsExperimentLocalService.fetchSegmentsExperiment(
 					themeDisplay.getScopeGroupId(), segmentsExperimentKey);
 
-			if (segmentsExperiment != null) {
+			if ((segmentsExperiment != null) &&
+				(segmentsExperiment.getPlid() == themeDisplay.getPlid())) {
+
 				return new long[] {
 					segmentsExperiment.getSegmentsExperienceId()
 				};
@@ -259,7 +261,9 @@ public class SegmentsExperimentSegmentsExperienceRequestProcessor
 				_segmentsExperienceLocalService.fetchSegmentsExperience(
 					selectedSegmentsExperienceId);
 
-			if (segmentsExperience != null) {
+			if ((segmentsExperience != null) &&
+				(segmentsExperience.getPlid() == themeDisplay.getPlid())) {
+
 				return selectedSegmentsExperienceId;
 			}
 		}


### PR DESCRIPTION
Not sure how to add automatic tests as I need to have analytics cloud activated to reproduce this case, and it seems that we don't have a testing environment available for it https://liferay.slack.com/archives/C014BCDN8MU/p1717059479015849?thread_ts=1716998783.794319&cid=C014BCDN8MU