### PR TITLE
LPD-27480 Fix resetting client extensions after stage on LayoutSet

### DIFF
--- a/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/exportimport/data/handler/ClientExtensionEntryRelStagedModelDataHandler.java
+++ b/modules/apps/client-extension/client-extension-web/src/main/java/com/liferay/client/extension/web/internal/exportimport/data/handler/ClientExtensionEntryRelStagedModelDataHandler.java
@@ -11,11 +11,14 @@ import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.staged.model.repository.StagedModelRepository;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.xml.Element;
 
 import java.util.Map;
+import java.util.Objects;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -89,6 +92,22 @@ public class ClientExtensionEntryRelStagedModelDataHandler
 			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
 				clientExtensionEntryRel.getClassName());
 
+		if (Objects.equals(
+				clientExtensionEntryRel.getClassName(),
+				LayoutSet.class.getName())) {
+
+			LayoutSet existingImportedLayoutSet =
+				_layoutSetLocalService.fetchLayoutSet(
+					portletDataContext.getScopeGroupId(),
+					portletDataContext.isPrivateLayout());
+
+			if (existingImportedLayoutSet != null) {
+				classPKs.put(
+					clientExtensionEntryRel.getClassPK(),
+					existingImportedLayoutSet.getLayoutSetId());
+			}
+		}
+
 		importedClientExtensionEntryRel.setClassPK(
 			MapUtil.getLong(
 				classPKs, clientExtensionEntryRel.getClassPK(),
@@ -125,6 +144,9 @@ public class ClientExtensionEntryRelStagedModelDataHandler
 
 		return _stagedModelRepository;
 	}
+
+	@Reference
+	private LayoutSetLocalService _layoutSetLocalService;
 
 	@Reference
 	private Portal _portal;

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/test/LayoutStagedModelDataHandlerTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/test/LayoutStagedModelDataHandlerTest.java
@@ -99,119 +99,12 @@ public class LayoutStagedModelDataHandlerTest
 
 	@Test
 	public void testClientExtensionEntries() throws Exception {
-		initExport();
-
-		ClientExtensionEntry clientExtensionEntry =
-			_clientExtensionEntryLocalService.addClientExtensionEntry(
-				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
-				StringPool.BLANK,
-				Collections.singletonMap(
-					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
-				StringPool.BLANK, StringPool.BLANK,
-				ClientExtensionEntryConstants.TYPE_GLOBAL_CSS,
-				UnicodePropertiesBuilder.create(
-					true
-				).put(
-					"url", "http://css.css"
-				).buildString());
-
-		Layout layout = LayoutTestUtil.addTypePortletLayout(stagingGroup);
-
-		_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
-			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
-			_portal.getClassNameId(Layout.class), layout.getPlid(),
-			clientExtensionEntry.getExternalReferenceCode(),
-			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS, StringPool.BLANK,
-			ServiceContextTestUtil.getServiceContext(
-				stagingGroup.getGroupId()));
-
-		StagedModelDataHandlerUtil.exportStagedModel(
-			portletDataContext, layout);
-
-		initImport();
-
-		ExportImportLifecycleManagerUtil.fireExportImportLifecycleEvent(
-			ExportImportLifecycleConstants.EVENT_LAYOUT_IMPORT_STARTED,
-			ExportImportLifecycleConstants.
-				PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS,
-			portletDataContext.getExportImportProcessId(),
-			PortletDataContextFactoryUtil.clonePortletDataContext(
-				portletDataContext));
-
-		Layout exportedLayout = (Layout)readExportedStagedModel(layout);
-
-		StagedModelDataHandlerUtil.importStagedModel(
-			portletDataContext, exportedLayout);
-
-		ExportImportLifecycleManagerUtil.fireExportImportLifecycleEvent(
-			ExportImportLifecycleConstants.EVENT_LAYOUT_IMPORT_SUCCEEDED,
-			ExportImportLifecycleConstants.
-				PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS,
-			portletDataContext.getExportImportProcessId(),
-			PortletDataContextFactoryUtil.clonePortletDataContext(
-				portletDataContext));
-
-		Layout importedLayout = _layoutLocalService.getLayoutByUuidAndGroupId(
-			layout.getUuid(), liveGroup.getGroupId(), layout.isPrivateLayout());
-
-		Assert.assertEquals(
-			1,
-			_clientExtensionEntryRelLocalService.
-				getClientExtensionEntryRelsCount(
-					_portal.getClassNameId(Layout.class),
-					importedLayout.getPlid(),
-					ClientExtensionEntryConstants.TYPE_GLOBAL_CSS));
-
-		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
-			_portal.getClassNameId(Layout.class), layout.getPlid(),
-			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS);
-
-		_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
-			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
-			_portal.getClassNameId(Layout.class), layout.getPlid(),
-			clientExtensionEntry.getExternalReferenceCode(),
-			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS, StringPool.BLANK,
-			ServiceContextTestUtil.getServiceContext(
-				stagingGroup.getGroupId()));
-
-		initExport();
-
-		StagedModelDataHandlerUtil.exportStagedModel(
-			portletDataContext, layout);
-
-		initImport();
-
-		ExportImportLifecycleManagerUtil.fireExportImportLifecycleEvent(
-			ExportImportLifecycleConstants.EVENT_LAYOUT_IMPORT_STARTED,
-			ExportImportLifecycleConstants.
-				PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS,
-			portletDataContext.getExportImportProcessId(),
-			PortletDataContextFactoryUtil.clonePortletDataContext(
-				portletDataContext));
-
-		exportedLayout = (Layout)readExportedStagedModel(layout);
-
-		StagedModelDataHandlerUtil.importStagedModel(
-			portletDataContext, exportedLayout);
-
-		ExportImportLifecycleManagerUtil.fireExportImportLifecycleEvent(
-			ExportImportLifecycleConstants.EVENT_LAYOUT_IMPORT_SUCCEEDED,
-			ExportImportLifecycleConstants.
-				PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS,
-			portletDataContext.getExportImportProcessId(),
-			PortletDataContextFactoryUtil.clonePortletDataContext(
-				portletDataContext));
-
-		importedLayout = _layoutLocalService.getLayoutByUuidAndGroupId(
-			layout.getUuid(), liveGroup.getGroupId(), layout.isPrivateLayout());
-
-		Assert.assertEquals(
-			1,
-			_clientExtensionEntryRelLocalService.
-				getClientExtensionEntryRelsCount(
-					_portal.getClassNameId(Layout.class),
-					importedLayout.getPlid(),
-					ClientExtensionEntryConstants.TYPE_GLOBAL_CSS));
+		_testClientExtensionByType(
+			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS, "http://css.css");
+		_testClientExtensionByType(
+			ClientExtensionEntryConstants.TYPE_THEME_CSS, "http://css.css");
+		_testClientExtensionByType(
+			ClientExtensionEntryConstants.TYPE_GLOBAL_JS, "http://js.js");
 	}
 
 	@Test
@@ -758,6 +651,120 @@ public class LayoutStagedModelDataHandlerTest
 			).put(
 				"javax.portlet.name", _TEST_PORTLET_NAME
 			).build());
+	}
+
+	private void _testClientExtensionByType(String type, String url)
+		throws Exception {
+
+		initExport();
+
+		ClientExtensionEntry clientExtensionEntry =
+			_clientExtensionEntryLocalService.addClientExtensionEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				StringPool.BLANK,
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				StringPool.BLANK, StringPool.BLANK, type,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"url", url
+				).buildString());
+
+		Layout layout = LayoutTestUtil.addTypePortletLayout(stagingGroup);
+
+		_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
+			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+			_portal.getClassNameId(Layout.class), layout.getPlid(),
+			clientExtensionEntry.getExternalReferenceCode(), type,
+			StringPool.BLANK,
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup.getGroupId()));
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, layout);
+
+		initImport();
+
+		ExportImportLifecycleManagerUtil.fireExportImportLifecycleEvent(
+			ExportImportLifecycleConstants.EVENT_LAYOUT_IMPORT_STARTED,
+			ExportImportLifecycleConstants.
+				PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS,
+			portletDataContext.getExportImportProcessId(),
+			PortletDataContextFactoryUtil.clonePortletDataContext(
+				portletDataContext));
+
+		Layout exportedLayout = (Layout)readExportedStagedModel(layout);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedLayout);
+
+		ExportImportLifecycleManagerUtil.fireExportImportLifecycleEvent(
+			ExportImportLifecycleConstants.EVENT_LAYOUT_IMPORT_SUCCEEDED,
+			ExportImportLifecycleConstants.
+				PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS,
+			portletDataContext.getExportImportProcessId(),
+			PortletDataContextFactoryUtil.clonePortletDataContext(
+				portletDataContext));
+
+		Layout importedLayout = _layoutLocalService.getLayoutByUuidAndGroupId(
+			layout.getUuid(), liveGroup.getGroupId(), layout.isPrivateLayout());
+
+		Assert.assertEquals(
+			1,
+			_clientExtensionEntryRelLocalService.
+				getClientExtensionEntryRelsCount(
+					_portal.getClassNameId(Layout.class),
+					importedLayout.getPlid(), type));
+
+		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
+			_portal.getClassNameId(Layout.class), layout.getPlid(), type);
+
+		_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
+			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+			_portal.getClassNameId(Layout.class), layout.getPlid(),
+			clientExtensionEntry.getExternalReferenceCode(), type,
+			StringPool.BLANK,
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup.getGroupId()));
+
+		initExport();
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, layout);
+
+		initImport();
+
+		ExportImportLifecycleManagerUtil.fireExportImportLifecycleEvent(
+			ExportImportLifecycleConstants.EVENT_LAYOUT_IMPORT_STARTED,
+			ExportImportLifecycleConstants.
+				PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS,
+			portletDataContext.getExportImportProcessId(),
+			PortletDataContextFactoryUtil.clonePortletDataContext(
+				portletDataContext));
+
+		exportedLayout = (Layout)readExportedStagedModel(layout);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedLayout);
+
+		ExportImportLifecycleManagerUtil.fireExportImportLifecycleEvent(
+			ExportImportLifecycleConstants.EVENT_LAYOUT_IMPORT_SUCCEEDED,
+			ExportImportLifecycleConstants.
+				PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS,
+			portletDataContext.getExportImportProcessId(),
+			PortletDataContextFactoryUtil.clonePortletDataContext(
+				portletDataContext));
+
+		importedLayout = _layoutLocalService.getLayoutByUuidAndGroupId(
+			layout.getUuid(), liveGroup.getGroupId(), layout.isPrivateLayout());
+
+		Assert.assertEquals(
+			1,
+			_clientExtensionEntryRelLocalService.
+				getClientExtensionEntryRelsCount(
+					_portal.getClassNameId(Layout.class),
+					importedLayout.getPlid(), type));
 	}
 
 	private static final String _TEST_PORTLET_NAME =

--- a/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/test/StagedLayoutSetStagedModelDataHandlerTest.java
+++ b/modules/apps/layout/layout-admin-web-test/src/testIntegration/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/test/StagedLayoutSetStagedModelDataHandlerTest.java
@@ -1,0 +1,242 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.admin.web.internal.exportimport.data.handler.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
+import com.liferay.client.extension.model.ClientExtensionEntry;
+import com.liferay.client.extension.service.ClientExtensionEntryLocalService;
+import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
+import com.liferay.exportimport.kernel.lar.PortletDataContextFactoryUtil;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
+import com.liferay.exportimport.kernel.lifecycle.ExportImportLifecycleManagerUtil;
+import com.liferay.exportimport.kernel.lifecycle.constants.ExportImportLifecycleConstants;
+import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
+import com.liferay.layout.set.model.adapter.StagedLayoutSet;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.LayoutSet;
+import com.liferay.portal.kernel.model.StagedModel;
+import com.liferay.portal.kernel.service.LayoutSetLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.UnicodePropertiesBuilder;
+import com.liferay.portal.model.adapter.util.ModelAdapterUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Georgel Pop
+ */
+@RunWith(Arquillian.class)
+public class StagedLayoutSetStagedModelDataHandlerTest
+	extends BaseStagedModelDataHandlerTestCase {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new LiferayIntegrationTestRule();
+
+	@Test
+	public void testClientExtensionEntries() throws Exception {
+		_testClientExtensionEntriesByType(
+			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS, "http://css.css");
+		_testClientExtensionEntriesByType(
+			ClientExtensionEntryConstants.TYPE_THEME_CSS, "http://css.css");
+		_testClientExtensionEntriesByType(
+			ClientExtensionEntryConstants.TYPE_GLOBAL_JS, "http://js.js");
+	}
+
+	@Override
+	protected StagedModel addStagedModel(
+			Group group,
+			Map<String, List<StagedModel>> dependentStagedModelsMap)
+		throws Exception {
+
+		List<StagedModel> dependentStagedModels = dependentStagedModelsMap.get(
+			LayoutSet.class.getSimpleName());
+
+		LayoutSet parentLayoutSet = (LayoutSet)dependentStagedModels.get(0); //check this
+
+		return ModelAdapterUtil.adapt(
+			_layoutSetLocalService.getLayoutSet(
+				group.getGroupId(), parentLayoutSet.isPrivateLayout()),
+			LayoutSet.class, StagedLayoutSet.class);
+	}
+
+	@Override
+	protected StagedModel getStagedModel(String uuid, Group group)
+		throws PortalException {
+
+		return ModelAdapterUtil.adapt(
+			_layoutSetLocalService.getLayoutSet(group.getGroupId(), false),
+			LayoutSet.class, StagedLayoutSet.class);
+	}
+
+	@Override
+	protected Class<? extends StagedModel> getStagedModelClass() {
+		return StagedLayoutSet.class;
+	}
+
+	private void _testClientExtensionEntriesByType(String type, String url)
+		throws Exception {
+
+		initExport();
+
+		ClientExtensionEntry clientExtensionEntry =
+			_clientExtensionEntryLocalService.addClientExtensionEntry(
+				RandomTestUtil.randomString(), TestPropsValues.getUserId(),
+				StringPool.BLANK,
+				Collections.singletonMap(
+					LocaleUtil.getDefault(), RandomTestUtil.randomString()),
+				StringPool.BLANK, StringPool.BLANK, type,
+				UnicodePropertiesBuilder.create(
+					true
+				).put(
+					"url", url
+				).buildString());
+
+		StagedLayoutSet stagedLayoutSet = ModelAdapterUtil.adapt(
+			_layoutSetLocalService.getLayoutSet(
+				stagingGroup.getGroupId(), false),
+			LayoutSet.class, StagedLayoutSet.class);
+
+		LayoutSet stagingLayoutSet = stagedLayoutSet.getLayoutSet();
+
+		_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
+			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+			_portal.getClassNameId(LayoutSet.class),
+			stagingLayoutSet.getLayoutSetId(),
+			clientExtensionEntry.getExternalReferenceCode(), type,
+			StringPool.BLANK,
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup.getGroupId()));
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, stagedLayoutSet);
+
+		initImport();
+
+		ExportImportLifecycleManagerUtil.fireExportImportLifecycleEvent(
+			ExportImportLifecycleConstants.EVENT_LAYOUT_IMPORT_STARTED,
+			ExportImportLifecycleConstants.
+				PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS,
+			portletDataContext.getExportImportProcessId(),
+			PortletDataContextFactoryUtil.clonePortletDataContext(
+				portletDataContext));
+
+		StagedLayoutSet exportedStagedLayoutSet =
+			(StagedLayoutSet)readExportedStagedModel(stagedLayoutSet);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedStagedLayoutSet);
+
+		ExportImportLifecycleManagerUtil.fireExportImportLifecycleEvent(
+			ExportImportLifecycleConstants.EVENT_LAYOUT_IMPORT_SUCCEEDED,
+			ExportImportLifecycleConstants.
+				PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS,
+			portletDataContext.getExportImportProcessId(),
+			PortletDataContextFactoryUtil.clonePortletDataContext(
+				portletDataContext));
+
+		StagedLayoutSet importedStagedLayoutSet = ModelAdapterUtil.adapt(
+			_layoutSetLocalService.getLayoutSet(liveGroup.getGroupId(), false),
+			LayoutSet.class, StagedLayoutSet.class);
+
+		LayoutSet importedLayoutSet = importedStagedLayoutSet.getLayoutSet();
+
+		Assert.assertEquals(
+			1,
+			_clientExtensionEntryRelLocalService.
+				getClientExtensionEntryRelsCount(
+					_portal.getClassNameId(LayoutSet.class),
+					importedLayoutSet.getLayoutSetId(), type));
+
+		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
+			_portal.getClassNameId(LayoutSet.class),
+			stagingLayoutSet.getLayoutSetId(), type);
+
+		_clientExtensionEntryRelLocalService.addClientExtensionEntryRel(
+			TestPropsValues.getUserId(), stagingGroup.getGroupId(),
+			_portal.getClassNameId(LayoutSet.class),
+			stagingLayoutSet.getLayoutSetId(),
+			clientExtensionEntry.getExternalReferenceCode(), type,
+			StringPool.BLANK,
+			ServiceContextTestUtil.getServiceContext(
+				stagingGroup.getGroupId()));
+
+		initExport();
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, stagedLayoutSet);
+
+		initImport();
+
+		ExportImportLifecycleManagerUtil.fireExportImportLifecycleEvent(
+			ExportImportLifecycleConstants.EVENT_LAYOUT_IMPORT_STARTED,
+			ExportImportLifecycleConstants.
+				PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS,
+			portletDataContext.getExportImportProcessId(),
+			PortletDataContextFactoryUtil.clonePortletDataContext(
+				portletDataContext));
+
+		exportedStagedLayoutSet = (StagedLayoutSet)readExportedStagedModel(
+			stagedLayoutSet);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedStagedLayoutSet);
+
+		ExportImportLifecycleManagerUtil.fireExportImportLifecycleEvent(
+			ExportImportLifecycleConstants.EVENT_LAYOUT_IMPORT_SUCCEEDED,
+			ExportImportLifecycleConstants.
+				PROCESS_FLAG_LAYOUT_IMPORT_IN_PROCESS,
+			portletDataContext.getExportImportProcessId(),
+			PortletDataContextFactoryUtil.clonePortletDataContext(
+				portletDataContext));
+
+		importedStagedLayoutSet = ModelAdapterUtil.adapt(
+			_layoutSetLocalService.getLayoutSet(liveGroup.getGroupId(), false),
+			LayoutSet.class, StagedLayoutSet.class);
+
+		importedLayoutSet = importedStagedLayoutSet.getLayoutSet();
+
+		Assert.assertEquals(
+			1,
+			_clientExtensionEntryRelLocalService.
+				getClientExtensionEntryRelsCount(
+					_portal.getClassNameId(LayoutSet.class),
+					importedLayoutSet.getLayoutSetId(), type));
+	}
+
+	@Inject
+	private ClientExtensionEntryLocalService _clientExtensionEntryLocalService;
+
+	@Inject
+	private ClientExtensionEntryRelLocalService
+		_clientExtensionEntryRelLocalService;
+
+	@Inject
+	private LayoutSetLocalService _layoutSetLocalService;
+
+	@Inject
+	private Portal _portal;
+
+}

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -2049,6 +2049,9 @@ public class LayoutStagedModelDataHandler
 		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
 			_portal.getClassNameId(Layout.class), importedLayout.getPlid(),
 			ClientExtensionEntryConstants.TYPE_GLOBAL_JS);
+		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
+			_portal.getClassNameId(Layout.class), importedLayout.getPlid(),
+			ClientExtensionEntryConstants.TYPE_THEME_CSS);
 
 		List<Element> clientExtensionEntryRelsElements =
 			portletDataContext.getReferenceDataElements(

--- a/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java
@@ -5,7 +5,6 @@
 
 package com.liferay.layout.internal.exportimport.data.handler;
 
-import com.liferay.client.extension.constants.ClientExtensionEntryConstants;
 import com.liferay.client.extension.model.ClientExtensionEntryRel;
 import com.liferay.client.extension.service.ClientExtensionEntryRelLocalService;
 import com.liferay.document.library.kernel.model.DLFileEntry;
@@ -219,7 +218,8 @@ public class StagedLayoutSetStagedModelDataHandler
 					portletDataContext, importedStagedLayoutSet);
 		}
 
-		_importClientExtensionEntryRels(portletDataContext, stagedLayoutSet);
+		_importClientExtensionEntryRels(
+			portletDataContext, stagedLayoutSet, importedStagedLayoutSet);
 		_importLogo(portletDataContext);
 		_importTheme(portletDataContext, stagedLayoutSet);
 
@@ -388,6 +388,34 @@ public class StagedLayoutSetStagedModelDataHandler
 							exception);
 					}
 				}
+			}
+		}
+	}
+
+	private void _deleteUnnecessaryClientExtensions(
+		StagedLayoutSet stagedLayoutSet,
+		StagedLayoutSet importedStagedLayoutSet) {
+
+		LayoutSet importedLayoutSet = importedStagedLayoutSet.getLayoutSet();
+
+		List<ClientExtensionEntryRel> importedClientExtensionEntryRels =
+			_clientExtensionEntryRelLocalService.getClientExtensionEntryRels(
+				_portal.getClassNameId(LayoutSet.class),
+				importedLayoutSet.getLayoutSetId());
+
+		for (ClientExtensionEntryRel importedClientExtensionEntryRel :
+				importedClientExtensionEntryRels) {
+
+			ClientExtensionEntryRel stagedClientExtensionEntryRel =
+				_clientExtensionEntryRelLocalService.
+					fetchClientExtensionEntryRelByUuidAndGroupId(
+						importedClientExtensionEntryRel.getUuid(),
+						stagedLayoutSet.getGroupId());
+
+			if (stagedClientExtensionEntryRel == null) {
+				_clientExtensionEntryRelLocalService.
+					deleteClientExtensionEntryRel(
+						importedClientExtensionEntryRel);
 			}
 		}
 	}
@@ -686,17 +714,12 @@ public class StagedLayoutSetStagedModelDataHandler
 
 	private void _importClientExtensionEntryRels(
 			PortletDataContext portletDataContext,
-			StagedLayoutSet stagedLayoutSet)
+			StagedLayoutSet stagedLayoutSet,
+			StagedLayoutSet importedStagedLayoutSet)
 		throws Exception {
 
-		LayoutSet layoutSet = stagedLayoutSet.getLayoutSet();
-
-		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
-			_portal.getClassNameId(LayoutSet.class), layoutSet.getLayoutSetId(),
-			ClientExtensionEntryConstants.TYPE_GLOBAL_CSS);
-		_clientExtensionEntryRelLocalService.deleteClientExtensionEntryRels(
-			_portal.getClassNameId(LayoutSet.class), layoutSet.getLayoutSetId(),
-			ClientExtensionEntryConstants.TYPE_GLOBAL_JS);
+		_deleteUnnecessaryClientExtensions(
+			stagedLayoutSet, importedStagedLayoutSet);
 
 		List<Element> clientExtensionEntryRelsElements =
 			portletDataContext.getReferenceDataElements(


### PR DESCRIPTION
Working on test cases... please review first.

The first issue was that we did not have the corresponding classPks (LayoutSetIds) in newPrimaryKeysMap, this resulted in duplicated client extensions.

Secondly, we deleted everything with the staged classPk and never used the imported one, also we deleted everything on import as StagedLayoutSetStagedModelDataHandler.java is executed after the importing of layoutset (same time with groups).

So I had to do it like this as we always reset uuid when saving the page configuration https://github.com/liferay/liferay-portal/blob/a6c2fc64092074547164f2958cadcc85c8a05932/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/portlet/action/EditLayoutSetMVCActionCommand.java#L189 

Also when importing the layoutset is imported with the groups see https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/data/handler/StagedGroupStagedModelDataHandler.java#L283 before https://github.com/liferay/liferay-portal/blob/6ce0b9eb049e99a50285a324a3bd4afd76d340ab/modules/apps/layout/layout-impl/src/main/java/com/liferay/layout/internal/exportimport/data/handler/StagedLayoutSetStagedModelDataHandler.java (so we can't delete all here as we remove them completely, and we need to check them by uuid).