### PR TITLE
LPD-28157 Avoid breaking index IX_502B1A93 in v1_4_2.LayoutUpgradeProcess

### DIFF
--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_2/LayoutUpgradeProcess.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/v1_4_2/LayoutUpgradeProcess.java
@@ -7,8 +7,10 @@ package com.liferay.layout.internal.upgrade.v1_4_2;
 
 import com.liferay.layout.page.template.constants.LayoutPageTemplateEntryTypeConstants;
 import com.liferay.petra.string.StringBundler;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.dao.jdbc.AutoBatchPreparedStatementUtil;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.security.SecureRandomUtil;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.LoggingTimer;
@@ -16,6 +18,8 @@ import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+
+import java.util.UUID;
 
 /**
  * @author Jonathan McCann
@@ -31,17 +35,30 @@ public class LayoutUpgradeProcess extends UpgradeProcess {
 		try (LoggingTimer loggingTimer = new LoggingTimer();
 			PreparedStatement preparedStatement1 = connection.prepareStatement(
 				StringBundler.concat(
-					"select groupId, plid from Layout where privateLayout = ? ",
-					"and (plid IN (select plid from LayoutPageTemplateEntry ",
-					"where type_ = ?) OR (classPK IN (select plid from ",
-					"LayoutPageTemplateEntry where type_ = ?) and classNameId ",
-					"= ?))"));
-			PreparedStatement preparedStatement2 =
+					"select groupId, plid, friendlyUrl from Layout where ",
+					"privateLayout = ? and (plid IN (select plid from ",
+					"LayoutPageTemplateEntry where type_ = ?) OR (classPK IN (",
+					"select plid from LayoutPageTemplateEntry where type_ = ?",
+					") and classNameId = ?))"));
+			PreparedStatement preparedStatement2 = connection.prepareStatement(
+				"select plid from Layout where privateLayout = ? and groupId " +
+					"= ? and friendlyUrl = ? and plid != ?");
+			PreparedStatement preparedStatement3 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update Layout set uuid_ = ?, friendlyUrl = ? where plid " +
+						"= ?");
+			PreparedStatement preparedStatement4 =
+				AutoBatchPreparedStatementUtil.autoBatch(
+					connection,
+					"update LayoutFriendlyURL set friendlyUrl = ? where plid " +
+						"= ?");
+			PreparedStatement preparedStatement5 =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
 					"update Layout set privateLayout = ?, layoutId = ? where " +
 						"plid = ?");
-			PreparedStatement preparedStatement3 =
+			PreparedStatement preparedStatement6 =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
 					"update LayoutFriendlyURL set privateLayout = ? where " +
@@ -59,25 +76,68 @@ public class LayoutUpgradeProcess extends UpgradeProcess {
 				while (resultSet.next()) {
 					long groupId = resultSet.getLong("groupId");
 					long plid = resultSet.getLong("plid");
+					String friendlyUrl = resultSet.getString("friendlyUrl");
 
 					preparedStatement2.setBoolean(1, true);
-					preparedStatement2.setLong(
+					preparedStatement2.setLong(2, groupId);
+					preparedStatement2.setString(3, friendlyUrl);
+					preparedStatement2.setLong(4, plid);
+
+					try (ResultSet resultSet1 =
+							preparedStatement2.executeQuery()) {
+
+						while (resultSet1.next()) {
+							long duplicationPlid = resultSet1.getLong("plid");
+							String newFriendlyUrl = _generateFriendlyURLUUID();
+
+							preparedStatement3.setString(1, _generateUUID());
+							preparedStatement3.setString(2, newFriendlyUrl);
+							preparedStatement3.setLong(3, duplicationPlid);
+
+							preparedStatement3.addBatch();
+
+							preparedStatement4.setString(1, newFriendlyUrl);
+							preparedStatement4.setLong(2, duplicationPlid);
+
+							preparedStatement4.addBatch();
+						}
+					}
+
+					preparedStatement5.setBoolean(1, true);
+					preparedStatement5.setLong(
 						2, _layoutLocalService.getNextLayoutId(groupId, true));
-					preparedStatement2.setLong(3, plid);
+					preparedStatement5.setLong(3, plid);
 
-					preparedStatement2.addBatch();
+					preparedStatement5.addBatch();
 
-					preparedStatement3.setBoolean(1, true);
-					preparedStatement3.setLong(2, plid);
+					preparedStatement6.setBoolean(1, true);
+					preparedStatement6.setLong(2, plid);
 
-					preparedStatement3.addBatch();
+					preparedStatement6.addBatch();
 				}
 			}
 
-			preparedStatement2.executeBatch();
-
 			preparedStatement3.executeBatch();
+
+			preparedStatement4.executeBatch();
+
+			preparedStatement5.executeBatch();
+
+			preparedStatement6.executeBatch();
 		}
+	}
+
+	private String _generateFriendlyURLUUID() {
+		UUID uuid = new UUID(
+			SecureRandomUtil.nextLong(), SecureRandomUtil.nextLong());
+
+		return StringPool.SLASH + uuid.toString();
+	}
+
+	private String _generateUUID() {
+		return new UUID(
+			SecureRandomUtil.nextLong(), SecureRandomUtil.nextLong()
+		).toString();
 	}
 
 	private final LayoutLocalService _layoutLocalService;

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/upgrade/v1_4_2/test/LayoutUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/upgrade/v1_4_2/test/LayoutUpgradeProcessTest.java
@@ -135,6 +135,73 @@ public class LayoutUpgradeProcessTest {
 		Assert.assertTrue(updatedLayoutFriendlyURL.isPrivateLayout());
 	}
 
+	@Test
+	public void testUpgradeProcessWithDuplicatedEntry() throws Exception {
+		LayoutPageTemplateEntry layoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+				null, TestPropsValues.getUserId(), _group.getGroupId(), 0,
+				RandomTestUtil.randomString(),
+				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT, 0,
+				WorkflowConstants.STATUS_DRAFT, _serviceContext);
+
+		Layout draftLayout = _layoutLocalService.fetchLayout(
+			_classNameLocalService.getClassNameId(Layout.class),
+			layoutPageTemplateEntry.getPlid());
+
+		Layout layout = _layoutLocalService.getLayout(draftLayout.getClassPK());
+
+		Assert.assertTrue(layout.isPrivateLayout());
+
+		LayoutPageTemplateEntry duplicatedLayoutPageTemplateEntry =
+			_layoutPageTemplateEntryLocalService.addLayoutPageTemplateEntry(
+				null, TestPropsValues.getUserId(), _group.getGroupId(), 0,
+				RandomTestUtil.randomString(),
+				LayoutPageTemplateEntryTypeConstants.MASTER_LAYOUT, 0,
+				WorkflowConstants.STATUS_DRAFT, _serviceContext);
+
+		Layout duplicatedDraftLayout = _layoutLocalService.fetchLayout(
+			_classNameLocalService.getClassNameId(Layout.class),
+			duplicatedLayoutPageTemplateEntry.getPlid());
+
+		Layout duplicatedLayout = _layoutLocalService.getLayout(
+			duplicatedDraftLayout.getClassPK());
+
+		duplicatedLayout.setUuid(layout.getUuid());
+		duplicatedLayout.setPrivateLayout(false);
+		duplicatedLayout.setFriendlyURL(layout.getFriendlyURL());
+
+		duplicatedLayout = _layoutLocalService.updateLayout(duplicatedLayout);
+
+		LayoutFriendlyURL layoutFriendlyURL =
+			_layoutFriendlyURLLocalService.fetchLayoutFriendlyURL(
+				layout.getPlid(), layout.getDefaultLanguageId());
+
+		LayoutFriendlyURL duplicatedLayoutFriendlyURL =
+			_layoutFriendlyURLLocalService.fetchLayoutFriendlyURL(
+				duplicatedLayout.getPlid(),
+				duplicatedDraftLayout.getDefaultLanguageId());
+
+		duplicatedLayoutFriendlyURL.setPrivateLayout(false);
+		duplicatedLayoutFriendlyURL.setFriendlyURL(
+			layoutFriendlyURL.getFriendlyURL());
+
+		_layoutFriendlyURLLocalService.updateLayoutFriendlyURL(
+			duplicatedLayoutFriendlyURL);
+
+		_runUpgrade();
+
+		Layout updatedLayout = _layoutLocalService.getLayout(
+			duplicatedLayout.getPlid());
+
+		Assert.assertTrue(updatedLayout.isPrivateLayout());
+
+		LayoutFriendlyURL updatedLayoutFriendlyURL =
+			_layoutFriendlyURLLocalService.fetchLayoutFriendlyURL(
+				updatedLayout.getPlid(), updatedLayout.getDefaultLanguageId());
+
+		Assert.assertTrue(updatedLayoutFriendlyURL.isPrivateLayout());
+	}
+
 	private void _runUpgrade() throws Exception {
 		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
 			_upgradeStepRegistrator, _CLASS_NAME);


### PR DESCRIPTION
Motivation
=======
Fix https://liferay.atlassian.net/browse/LPD-28157

Proposed Solution
========
The reproduction steps described in https://liferay.atlassian.net/browse/LPD-28157 are one way of producing this error but there may be others. The reproduction steps generate pairs of rows in table Layout with same groupId and friendlyURL but one with `privateLayout=true` and another one (created by the import of the LAR) with `privateLayout=false`. Both rows are related to master pages. 

When upgrade process v1_4_2.LayoutUpgradeProcess is run, both of those rows end up with the same groupId, friendlyURL and privateLayout breaking index [IX_502B1A93](https://github.com/liferay/liferay-portal/blob/91fa9a063722ac861c5c84cc5b96d74331c66efa/sql/indexes.sql#L194).

As solution alternatives I considered deleting the duplicated row but I was not sure that I could delete all the associated entities and I was not sure if that row is useless. Maybe there are other use cases that produce this data so just changing the conflicting data seemed safer.