### PR TITLE
LPD-29536 - Technical Task | Fix test FormContainer#ViewCreatedObjectEntryAfterSubmitForm to account for the fact that dates now follow the follow the ISO8601 pattern

### DIFF
--- a/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/outoftheboxfragments/formcomponents/FormContainer.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/enduser/wem/fragment/outoftheboxfragments/formcomponents/FormContainer.testcase
@@ -1442,7 +1442,7 @@ definition {
 			ObjectAdmin.assertObjectEntryFieldValueViaAPI(
 				attribute = "address",
 				attributeValue = "Dalian",
-				expectedValue = "2020-08-08T00:00:00Z",
+				expectedValue = "2020-08-08T00:00:00.000Z",
 				fieldName = "purchaseDate",
 				objectName = "PurchaseOrder");
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-29536 - Technical Task | Fix test FormContainer#ViewCreatedObjectEntryAfterSubmitForm to account for the fact that dates now follow the follow the ISO8601 pattern