### PR TITLE
LPD-32101 Move com.liferay.layout.internal.upgrade.v1_0_0.LayoutPermissionsUpgradeProcess to Core upgrades

### DIFF
--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/registry/LayoutServiceUpgradeStepRegistrator.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/upgrade/registry/LayoutServiceUpgradeStepRegistrator.java
@@ -11,7 +11,6 @@ import com.liferay.asset.kernel.service.AssetTagLocalService;
 import com.liferay.change.tracking.service.CTCollectionLocalService;
 import com.liferay.change.tracking.service.CTEntryLocalService;
 import com.liferay.layout.internal.upgrade.v1_0_0.LayoutClassedModelUsageUpgradeProcess;
-import com.liferay.layout.internal.upgrade.v1_0_0.LayoutPermissionsUpgradeProcess;
 import com.liferay.layout.internal.upgrade.v1_0_0.LayoutUpgradeProcess;
 import com.liferay.layout.internal.upgrade.v1_1_0.UpgradeCompanyId;
 import com.liferay.layout.internal.upgrade.v1_2_1.LayoutAssetUpgradeProcess;
@@ -46,8 +45,7 @@ public class LayoutServiceUpgradeStepRegistrator
 	public void register(Registry registry) {
 		registry.register(
 			"0.0.1", "1.0.0",
-			new LayoutClassedModelUsageUpgradeProcess(_assetEntryLocalService),
-			new LayoutPermissionsUpgradeProcess());
+			new LayoutClassedModelUsageUpgradeProcess(_assetEntryLocalService));
 
 		registry.register("1.0.0", "1.0.1", new LayoutUpgradeProcess());
 

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/upgrade/v1_0_0/test/LayoutPermissionsUpgradeProcessTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/internal/upgrade/v1_0_0/test/LayoutPermissionsUpgradeProcessTest.java
@@ -1,0 +1,218 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.layout.internal.upgrade.v1_0_0.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.portal.kernel.cache.MultiVMPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.ResourceConstants;
+import com.liferay.portal.kernel.model.Role;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.role.RoleConstants;
+import com.liferay.portal.kernel.security.permission.ResourceActions;
+import com.liferay.portal.kernel.service.ResourcePermissionLocalService;
+import com.liferay.portal.kernel.service.RoleLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
+import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Lourdes Fernández Besada
+ */
+@RunWith(Arquillian.class)
+public class LayoutPermissionsUpgradeProcessTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_group = GroupTestUtil.addGroup();
+
+		_groupActions = _resourceActions.getModelResourceGroupDefaultActions(
+			Layout.class.getName());
+		_groupRole = _roleLocalService.getDefaultGroupRole(_group.getGroupId());
+
+		_guestActions = _resourceActions.getModelResourceGuestDefaultActions(
+			Layout.class.getName());
+		_guestRole = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), RoleConstants.GUEST);
+
+		_ownerActions = _resourceActions.getModelResourceActions(
+			Layout.class.getName());
+
+		List<String> defaultOwnerActions =
+			_resourceActions.getModelResourceOwnerDefaultActions(
+				Layout.class.getName());
+
+		if (!defaultOwnerActions.isEmpty()) {
+			_ownerActions.retainAll(defaultOwnerActions);
+		}
+
+		_ownerRole = _roleLocalService.getRole(
+			TestPropsValues.getCompanyId(), RoleConstants.OWNER);
+
+		_user = UserTestUtil.addUser();
+	}
+
+	@Test
+	public void testUpgrade() throws Exception {
+		Layout publicLayout1 = LayoutTestUtil.addTypePortletLayout(_group);
+		Layout publicLayout2 = LayoutTestUtil.addTypePortletLayout(_group);
+
+		_assertResourcePermission(
+			_guestActions, _guestRole, publicLayout1, publicLayout2);
+
+		Layout privateLayout1 = LayoutTestUtil.addTypePortletLayout(
+			_group, true);
+		Layout privateLayout2 = LayoutTestUtil.addTypePortletLayout(
+			_group, true);
+
+		_assertResourcePermission(
+			_groupActions, _groupRole, publicLayout1, publicLayout2,
+			privateLayout1, privateLayout2);
+
+		Layout userGroupLayout1 = LayoutTestUtil.addTypePortletLayout(
+			_user.getGroup());
+		Layout userGroupLayout2 = LayoutTestUtil.addTypePortletLayout(
+			_user.getGroup());
+
+		_assertResourcePermission(
+			_ownerActions, _ownerRole, publicLayout1, publicLayout2,
+			privateLayout1, privateLayout2, userGroupLayout1, userGroupLayout2);
+
+		_deleteResourcePermissions(
+			privateLayout1, publicLayout1, userGroupLayout1);
+
+		_runUpgrade();
+
+		_assertResourcePermission(
+			_guestActions, _guestRole, publicLayout1, publicLayout2);
+		_assertResourcePermission(
+			_groupActions, _groupRole, publicLayout1, publicLayout2,
+			privateLayout1, privateLayout2);
+		_assertResourcePermission(
+			_ownerActions, _ownerRole, publicLayout1, publicLayout2,
+			privateLayout1, privateLayout2, userGroupLayout1, userGroupLayout2);
+	}
+
+	private void _assertResourcePermission(
+			List<String> actions, Role role, Layout... layouts)
+		throws Exception {
+
+		for (String action : actions) {
+			for (Layout layout : layouts) {
+				Assert.assertTrue(
+					action,
+					_resourcePermissionLocalService.hasResourcePermission(
+						layout.getCompanyId(), Layout.class.getName(),
+						ResourceConstants.SCOPE_INDIVIDUAL,
+						String.valueOf(layout.getPlid()),
+						new long[] {role.getRoleId()}, action));
+			}
+		}
+	}
+
+	private void _deleteResourcePermissions(Layout... layouts)
+		throws Exception {
+
+		for (Layout layout : layouts) {
+			Assert.assertTrue(
+				ListUtil.isNotEmpty(
+					_resourcePermissionLocalService.getResourcePermissions(
+						layout.getCompanyId(), Layout.class.getName(),
+						ResourceConstants.SCOPE_INDIVIDUAL,
+						String.valueOf(layout.getPlid()))));
+
+			_resourcePermissionLocalService.deleteResourcePermissions(
+				layout.getCompanyId(), Layout.class.getName(),
+				ResourceConstants.SCOPE_INDIVIDUAL,
+				String.valueOf(layout.getPlid()));
+
+			Assert.assertTrue(
+				ListUtil.isEmpty(
+					_resourcePermissionLocalService.getResourcePermissions(
+						layout.getCompanyId(), Layout.class.getName(),
+						ResourceConstants.SCOPE_INDIVIDUAL,
+						String.valueOf(layout.getPlid()))));
+		}
+	}
+
+	private void _runUpgrade() throws Exception {
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_CLASS_NAME, LoggerTestUtil.OFF)) {
+
+			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
+				_upgradeStepRegistrator, _CLASS_NAME);
+
+			upgradeProcess.upgrade();
+
+			_multiVMPool.clear();
+		}
+	}
+
+	private static final String _CLASS_NAME =
+		"com.liferay.layout.internal.upgrade.v1_0_0." +
+		"LayoutPermissionsUpgradeProcess";
+
+	@Inject(
+		filter = "(&(component.name=com.liferay.layout.internal.upgrade.registry.LayoutServiceUpgradeStepRegistrator))"
+	)
+	private static UpgradeStepRegistrator _upgradeStepRegistrator;
+
+	@DeleteAfterTestRun
+	private Group _group;
+
+	private List<String> _groupActions;
+	private Role _groupRole;
+	private List<String> _guestActions;
+	private Role _guestRole;
+
+	@Inject
+	private MultiVMPool _multiVMPool;
+
+	private List<String> _ownerActions;
+	private Role _ownerRole;
+
+	@Inject
+	private ResourceActions _resourceActions;
+
+	@Inject
+	private ResourcePermissionLocalService _resourcePermissionLocalService;
+
+	@Inject
+	private RoleLocalService _roleLocalService;
+
+	@DeleteAfterTestRun
+	private User _user;
+
+}

--- a/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_1_x/test/UpgradeLayoutPermissionTest.java
+++ b/modules/apps/portal/portal-upgrade-test/src/testIntegration/java/com/liferay/portal/upgrade/v7_1_x/test/UpgradeLayoutPermissionTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.layout.internal.upgrade.v1_0_0.test;
+package com.liferay.portal.upgrade.v7_1_x.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.layout.test.util.LayoutTestUtil;
@@ -24,13 +24,10 @@ import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.test.util.UserTestUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.ListUtil;
-import com.liferay.portal.test.log.LogCapture;
-import com.liferay.portal.test.log.LoggerTestUtil;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
-import com.liferay.portal.upgrade.registry.UpgradeStepRegistrator;
-import com.liferay.portal.upgrade.test.util.UpgradeTestUtil;
+import com.liferay.portal.upgrade.v7_1_x.UpgradeLayoutPermission;
 
 import java.util.List;
 
@@ -45,7 +42,7 @@ import org.junit.runner.RunWith;
  * @author Lourdes Fernández Besada
  */
 @RunWith(Arquillian.class)
-public class LayoutPermissionsUpgradeProcessTest {
+public class UpgradeLayoutPermissionTest {
 
 	@ClassRule
 	@Rule
@@ -168,26 +165,12 @@ public class LayoutPermissionsUpgradeProcessTest {
 	}
 
 	private void _runUpgrade() throws Exception {
-		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
-				_CLASS_NAME, LoggerTestUtil.OFF)) {
+		UpgradeProcess upgradeProcess = new UpgradeLayoutPermission();
 
-			UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
-				_upgradeStepRegistrator, _CLASS_NAME);
+		upgradeProcess.upgrade();
 
-			upgradeProcess.upgrade();
-
-			_multiVMPool.clear();
-		}
+		_multiVMPool.clear();
 	}
-
-	private static final String _CLASS_NAME =
-		"com.liferay.layout.internal.upgrade.v1_0_0." +
-		"LayoutPermissionsUpgradeProcess";
-
-	@Inject(
-		filter = "(&(component.name=com.liferay.layout.internal.upgrade.registry.LayoutServiceUpgradeStepRegistrator))"
-	)
-	private static UpgradeStepRegistrator _upgradeStepRegistrator;
 
 	@DeleteAfterTestRun
 	private Group _group;

--- a/portal-impl/bnd.bnd
+++ b/portal-impl/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: ${manifest.bundle.name}
 Bundle-SymbolicName: ${manifest.bundle.symbolic.name}
-Bundle-Version: 104.0.5
+Bundle-Version: 104.1.0
 Export-Package:\
 	com.liferay.portal.bean,\
 	com.liferay.portal.dao.orm.hibernate,\

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/PortalUpgradeProcessRegistryImpl.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/PortalUpgradeProcessRegistryImpl.java
@@ -50,6 +50,9 @@ public class PortalUpgradeProcessRegistryImpl
 		upgradeVersionTreeMap.put(new Version(1, 1, 2), new UpgradeDB2());
 
 		upgradeVersionTreeMap.put(
+			new Version(1, 1, 3), new UpgradeLayoutPermission());
+
+		upgradeVersionTreeMap.put(
 			new Version(2, 0, 0), new UpgradeAssetTagsPermission());
 
 		upgradeVersionTreeMap.put(

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/UpgradeLayoutPermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/UpgradeLayoutPermission.java
@@ -7,13 +7,14 @@ package com.liferay.portal.upgrade.v7_1_x;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
-import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.ResourceConstants;
-import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.model.UserGroup;
 import com.liferay.portal.kernel.service.ResourceLocalServiceUtil;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
 import com.liferay.portal.kernel.util.LoggingTimer;
+import com.liferay.portal.kernel.util.PortalUtil;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
@@ -28,13 +29,18 @@ public class UpgradeLayoutPermission extends UpgradeProcess {
 		String sql = SQLTransformer.transform(
 			StringBundler.concat(
 				"select Layout.companyId, Layout.plid, Layout.privateLayout",
-				", Layout.groupId, Layout.userId from Layout left join ",
-				"ResourcePermission on (ResourcePermission.companyId = ",
-				"Layout.companyId and ResourcePermission.name = '",
-				Layout.class.getName(), "' and ResourcePermission.scope = ",
+				", Layout.groupId, Layout.userId, Group_.classNameId from ",
+				"Layout left join ResourcePermission on ",
+				"(ResourcePermission.companyId = Layout.companyId and ",
+				"ResourcePermission.name = '", Layout.class.getName(),
+				"' and ResourcePermission.scope = ",
 				ResourceConstants.SCOPE_INDIVIDUAL,
-				" and ResourcePermission.primKeyId = Layout.plid) where ",
+				" and ResourcePermission.primKeyId = Layout.plid) inner join ",
+				"Group_ on Group_.groupId = Layout.groupId where ",
 				"ResourcePermission.resourcePermissionId is null"));
+
+		long userGroupClassNameId = PortalUtil.getClassNameId(UserGroup.class);
+		long userClassNameId = PortalUtil.getClassNameId(User.class);
 
 		try (LoggingTimer loggingTimer = new LoggingTimer();
 			PreparedStatement preparedStatement = connection.prepareStatement(
@@ -54,9 +60,11 @@ public class UpgradeLayoutPermission extends UpgradeProcess {
 				if (privateLayout) {
 					addGuestPermission = false;
 
-					Group group = GroupLocalServiceUtil.getGroup(groupId);
+					long classNameId = resultSet.getLong("classNameId");
 
-					if (group.isUser() || group.isUserGroup()) {
+					if ((classNameId == userGroupClassNameId) ||
+						(classNameId == userClassNameId)) {
+
 						addGroupPermission = false;
 					}
 				}

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/UpgradeLayoutPermission.java
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/UpgradeLayoutPermission.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-package com.liferay.layout.internal.upgrade.v1_0_0;
+package com.liferay.portal.upgrade.v7_1_x;
 
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.dao.orm.common.SQLTransformer;
@@ -21,7 +21,7 @@ import java.sql.ResultSet;
 /**
  * @author Michael Bowerman
  */
-public class LayoutPermissionsUpgradeProcess extends UpgradeProcess {
+public class UpgradeLayoutPermission extends UpgradeProcess {
 
 	@Override
 	protected void doUpgrade() throws Exception {

--- a/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/packageinfo
+++ b/portal-impl/src/com/liferay/portal/upgrade/v7_1_x/packageinfo
@@ -1,1 +1,1 @@
-version 5.0.0
+version 5.1.0


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-32101

@achaparro I'm sending this PR for your review to see if the approach is correct, even though it doesn't pass the source formatter due to the use of ServiceUtil in an Upgrade class.

With the last commit, I have removed the use of GroupLocalServiceUtil, but removing the use of ResourceLocalServiceUtil will be much more complicated as it would require replicating all the internal logic of the service.

The test I added works correctly after moving the Upgrade and with the DB we have to test I think it will also work because the query does not return any results so it will never be executed.

But I don't see any use of services in the core upgrades, so I suspect that it's not just a matter of making an exception to the SF rule and that I need to replicate all this logic. Since this will not be trivial, before trying to make these changes, I wanted to ask for your first assessment of the approach and whether it will solve the query performance problem that originated this ticket.

Thanks in advance!

I'm leaving this PR on hold.

cc: @ealonso 