### PR TITLE
LPD-32174 Shorten table name to less than 30 characters. 

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryServiceImpl.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/service/impl/FragmentEntryServiceImpl.java
@@ -195,7 +195,7 @@ public class FragmentEntryServiceImpl extends FragmentEntryServiceBaseImpl {
 				_getFragmentEntryGroupByStep(
 					groupId, fragmentCollectionId, name, status)
 			).as(
-				"fragmentCompositionsAndFragmentEntriesTable",
+				"TEMP_TABLE",
 				FragmentCompositionsAndFragmentEntriesTable.INSTANCE
 			);
 
@@ -260,7 +260,7 @@ public class FragmentEntryServiceImpl extends FragmentEntryServiceBaseImpl {
 						groupId, fragmentCollectionId, name, status)
 				)
 			).as(
-				"fragmentCompositionsAndFragmentEntriesTable"
+				"TEMP_TABLE"
 			);
 
 		DSLQuery dslQuery = DSLQueryFactoryUtil.select(
@@ -742,8 +742,7 @@ public class FragmentEntryServiceImpl extends FragmentEntryServiceBaseImpl {
 
 		private FragmentCompositionsAndFragmentEntriesTable() {
 			super(
-				"FragmentCompositionsAndFragmentEntriesTable",
-				FragmentCompositionsAndFragmentEntriesTable::new);
+				"TEMP_TABLE", FragmentCompositionsAndFragmentEntriesTable::new);
 		}
 
 	}


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-32174

This should be done to prevent the error "ORA-00972: identifier is too long" in case Oracle with the 'compatible' parameter set to a version lower than '19.0.0.0'.

This functionality is already covered by the integration tests:

com.liferay.fragment.service.test.FragmentEntryServiceTest.testGetFragmentCompositionsAndFragmentEntriesOrderByModifiedDate
com.liferay.fragment.service.test.FragmentEntryServiceTest.testGetFragmentCompositionsAndFragmentEntriesOrderByName
The specific issue that this commit resolves cannot be tested given that it requires a specific Oracle configuration.

Previous PR: https://github.com/brianchandotcom/liferay-portal/pull/152624
I am resending because of https://github.com/brianchandotcom/liferay-portal/pull/152624#issuecomment-2248309292