### PR TITLE
LPD-31288 Adapt collections for multi-selection

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/keyboard_movement/KeyboardMovementManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/keyboard_movement/KeyboardMovementManager.js
@@ -36,6 +36,7 @@ import {TARGET_POSITIONS} from '../../utils/drag_and_drop/constants/targetPositi
 import getDropData from '../../utils/drag_and_drop/getDropData';
 import itemIsAncestor from '../../utils/drag_and_drop/itemIsAncestor';
 import {isUnmappedCollection} from '../../utils/isUnmappedCollection';
+import useSelectFirstControlsItem from '../useSelectFirstControlsItem';
 
 const DIRECTIONS = {
 	down: 'down',
@@ -60,6 +61,7 @@ export default function KeyboardMovementManager() {
 	const disableMovement = useDisableKeyboardMovement();
 	const setTarget = useSetMovementTarget();
 	const setText = useSetMovementText();
+	const selectFirstControlsItem = useSelectFirstControlsItem();
 	const selectItem = useSelectItem();
 	const dispatch = useDispatch();
 
@@ -110,7 +112,7 @@ export default function KeyboardMovementManager() {
 								portletId: source.portletId,
 								portletItemId: source.portletItemId,
 								position,
-								selectItem,
+								selectItem: selectFirstControlsItem,
 							});
 						}
 						else {
@@ -119,7 +121,7 @@ export default function KeyboardMovementManager() {
 								groupId: source.groupId,
 								parentItemId: dropItemId,
 								position,
-								selectItem,
+								selectItem: selectFirstControlsItem,
 								type: source.type,
 							});
 						}
@@ -129,7 +131,7 @@ export default function KeyboardMovementManager() {
 							itemType: source.type,
 							parentItemId: dropItemId,
 							position,
-							selectItem,
+							selectItem: selectFirstControlsItem,
 						});
 					}
 				}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/Collection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/Collection.js
@@ -55,6 +55,14 @@ export function getToControlsId(collectionId, index, toControlsId) {
 	};
 }
 
+function getFromControlsId(id) {
+	const splits = id.split(COLLECTION_ID_DIVIDER);
+
+	const itemId = splits.pop();
+
+	return itemId || id;
+}
+
 export function fromControlsId(controlsItemId) {
 	if (!controlsItemId) {
 		return null;
@@ -63,17 +71,10 @@ export function fromControlsId(controlsItemId) {
 		Liferay.FeatureFlags['LPD-18221'] &&
 		Array.isArray(controlsItemId)
 	) {
-
-		// todo: adapt collections for multiselect
-
-		return controlsItemId;
+		return controlsItemId.map(getFromControlsId);
 	}
 	else {
-		const splits = controlsItemId.split(COLLECTION_ID_DIVIDER);
-
-		const itemId = splits.pop();
-
-		return itemId || controlsItemId;
+		return getFromControlsId(controlsItemId);
 	}
 }
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/Collection.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/layout_data_items/Collection.js
@@ -49,6 +49,10 @@ export function getToControlsId(collectionId, index, toControlsId) {
 			return null;
 		}
 
+		if (collectionId === itemId) {
+			return itemId;
+		}
+
 		return toControlsId(
 			`${getCollectionPrefix(collectionId, index)}${itemId}`
 		);
@@ -252,6 +256,7 @@ const ItemContext = ({
 	const contextValue = useMemo(
 		() => ({
 			collectionConfig,
+			collectionId,
 			collectionItem,
 			collectionItemIndex: index,
 			customCollectionSelectorURL,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/Topper.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/Topper.js
@@ -293,7 +293,9 @@ function TopperContent({
 								>
 									<ClayIcon
 										className="page-editor__topper__icon"
-										onClick={() => {
+										onClick={(event) => {
+											event.stopPropagation();
+
 											dispatch(
 												switchSidebarPanel({
 													sidebarOpen: true,

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/TopperItemActions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/TopperItemActions.js
@@ -158,6 +158,7 @@ export default function TopperItemActions({disabled, item}) {
 						aria-label={Liferay.Language.get('options')}
 						disabled={disabled}
 						displayType="unstyled"
+						onClick={(event) => event.stopPropagation()}
 						size="sm"
 						title={Liferay.Language.get('options')}
 					>
@@ -177,7 +178,9 @@ export default function TopperItemActions({disabled, item}) {
 						) : (
 							<React.Fragment key={index}>
 								<ClayDropDown.Item
-									onClick={() => {
+									onClick={(event) => {
+										event.stopPropagation();
+
 										setActive(false);
 
 										dropdownItem.action();

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/useSelectFirstControlsItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/useSelectFirstControlsItem.js
@@ -1,0 +1,26 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {useSelectItem} from '../contexts/ControlsContext';
+import getFirstControlsId from '../utils/getFirstControlsId';
+
+export default function useSelectFirstControlsItem() {
+	const selectItem = useSelectItem();
+
+	return (itemId, layoutData) => {
+		const {itemId: id, itemType, parentId} = layoutData.items[itemId];
+
+		selectItem(
+			getFirstControlsId({
+				item: {
+					id,
+					itemType,
+					parentId,
+				},
+				layoutData,
+			})
+		);
+	};
+}

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addFragment.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addFragment.js
@@ -35,7 +35,7 @@ export default function addFragment({
 				})
 			);
 
-			selectItem(itemId);
+			selectItem(itemId, layoutData);
 		};
 
 		if (type === FRAGMENT_ENTRY_TYPES.composition) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addItem.js
@@ -28,7 +28,7 @@ export default function addItem({
 			clearPageContents();
 
 			if (addedItemId) {
-				selectItem(addedItemId);
+				selectItem(addedItemId, layoutData);
 			}
 		});
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addWidget.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/addWidget.js
@@ -31,7 +31,7 @@ export default function addWidget({
 			);
 
 			if (addedItemId) {
-				selectItem(addedItemId);
+				selectItem(addedItemId, layoutData);
 			}
 		});
 	};

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/deleteItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/deleteItem.js
@@ -24,6 +24,33 @@ import {hasFormParent} from '../utils/hasFormParent';
 import {isRequiredFormInput} from '../utils/isRequiredFormInput';
 import {clearPageContents} from '../utils/usePageContents';
 
+function getPreviousItemId(itemId, layoutData, nextLayoutData) {
+	const {items} = layoutData;
+	const {items: nextItems} = nextLayoutData;
+	const parentId = items[itemId].parentId;
+
+	const parent = items[parentId];
+
+	let nextItemId = parentId;
+
+	if (nextItems[parentId].children.length) {
+		const index = parent.children.indexOf(itemId);
+
+		nextItemId = nextItems[parentId].children[index ? index - 1 : index];
+	}
+	else if (
+		parent.type === LAYOUT_DATA_ITEM_TYPES.collectionItem ||
+		parent.type === LAYOUT_DATA_ITEM_TYPES.column
+	) {
+		nextItemId = nextItems[parent.parentId].itemId;
+	}
+	else if (parent.type === LAYOUT_DATA_ITEM_TYPES.root) {
+		document.querySelector('button[data-panel-id="browser"]').focus();
+	}
+
+	return nextItemId;
+}
+
 export default function deleteItem({itemId, selectItem = () => {}}) {
 	return (dispatch, getState) => {
 		const {fragmentEntryLinks, layoutData, segmentsExperienceId} =
@@ -36,10 +63,7 @@ export default function deleteItem({itemId, selectItem = () => {}}) {
 			onNetworkStatus: dispatch,
 			segmentsExperienceId,
 		}).then(({portletIds = [], layoutData: nextLayoutData}) => {
-			const [firstChild] =
-				nextLayoutData.items[nextLayoutData.rootItems.main].children;
-
-			selectItem(firstChild, {
+			selectItem(getPreviousItemId(itemId, layoutData, nextLayoutData), {
 				origin: ITEM_ACTIVATION_ORIGINS.itemActions,
 			});
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTree.js
@@ -48,6 +48,7 @@ import selectCanUpdateItemConfiguration from '../../../../../app/selectors/selec
 import selectCanUpdatePageStructure from '../../../../../app/selectors/selectCanUpdatePageStructure';
 import selectLayoutDataItemLabel from '../../../../../app/selectors/selectLayoutDataItemLabel';
 import canActivateEditable from '../../../../../app/utils/canActivateEditable';
+import {deepEqual} from '../../../../../app/utils/checkDeepEqual';
 import {DragAndDropContextProvider} from '../../../../../app/utils/drag_and_drop/useDragAndDrop';
 import isMapped from '../../../../../app/utils/editable_value/isMapped';
 import isMappedToCollection from '../../../../../app/utils/editable_value/isMappedToCollection';
@@ -166,10 +167,6 @@ export default function PageStructureSidebar() {
 			selectedViewportSize,
 		]
 	);
-
-	const setExpandedNodes = (expandedNodes) => {
-		setExpandedKeys(Array.from(expandedNodes));
-	};
 
 	const handleNodeFocus = () => {
 		const focusedItem =
@@ -294,8 +291,9 @@ export default function PageStructureSidebar() {
 	);
 
 	useEffect(() => {
-		if (Liferay.FeatureFlags['LPD-18221']) {
-			if (activeItemIds.length) {
+		if (Liferay.FeatureFlags['LPD-18221'] && activeItemIds.length) {
+			const getExpandedKeys = () => {
+				const expandedKeys = [];
 				let layoutDataActiveItem = null;
 
 				activeItemIds.forEach((itemId) => {
@@ -307,17 +305,25 @@ export default function PageStructureSidebar() {
 						return;
 					}
 
-					setExpandedKeys((previousExpanedKeys) => [
-						...new Set([
-							...previousExpanedKeys,
-							...getAncestorsIds(
-								layoutDataActiveItem,
-								layoutData
-							),
-						]),
-					]);
+					expandedKeys.push(
+						...getAncestorsIds(layoutDataActiveItem, layoutData)
+					);
 				});
-			}
+
+				return expandedKeys;
+			};
+
+			setExpandedKeys((prevState) => {
+				const nextState = [
+					...new Set([...prevState, ...getExpandedKeys()]),
+				];
+
+				if (deepEqual(prevState, nextState)) {
+					return prevState;
+				}
+
+				return nextState;
+			});
 		}
 		else {
 			if (activeItemIds) {
@@ -413,7 +419,9 @@ export default function PageStructureSidebar() {
 						open: <ClayIcon symbol="plus" />,
 					}}
 					items={nodes}
-					onExpandedChange={setExpandedNodes}
+					onExpandedChange={(expandedNodes) => {
+						setExpandedKeys(Array.from(expandedNodes));
+					}}
 					onItemsChange={() => {}}
 					showExpanderOnHover={false}
 				>

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/fragments_and_widgets/components/TabItem.js
@@ -11,10 +11,10 @@ import {sub} from 'frontend-js-web';
 import PropTypes from 'prop-types';
 import React, {useCallback, useState} from 'react';
 
+import useSelectFirstControlsItem from '../../../app/components/useSelectFirstControlsItem';
 import {FRAGMENTS_DISPLAY_STYLES} from '../../../app/config/constants/fragmentsDisplayStyles';
 import {LAYOUT_DATA_ITEM_TYPES} from '../../../app/config/constants/layoutDataItemTypes';
 import {LIST_ITEM_TYPES} from '../../../app/config/constants/listItemTypes';
-import {useSelectItem} from '../../../app/contexts/ControlsContext';
 import {
 	useDisableKeyboardMovement,
 	useSetMovementSource,
@@ -41,7 +41,7 @@ export default function TabItem({displayStyle, item, onRemoveHighlighted}) {
 	const dispatch = useDispatch();
 	const [disabled, setDisabled] = useState(item.disabled);
 	const setMovementSource = useSetMovementSource();
-	const selectItem = useSelectItem();
+	const selectFirstControlsItem = useSelectFirstControlsItem();
 
 	const onMovementSource = (event) => {
 		if (event.key === 'Enter' || event.key === ' ') {
@@ -114,7 +114,7 @@ export default function TabItem({displayStyle, item, onRemoveHighlighted}) {
 					itemType: item.type,
 					parentItemId: parentId,
 					position,
-					selectItem,
+					selectItem: selectFirstControlsItem,
 				})
 			)
 				.then(() => {


### PR DESCRIPTION
Collections have been adapted to have several active elements.

The following has also been fixed:
- When deleting an item, its previous sibling is selected, if it doesn't have one, its parent is selected.
- When adding an item to a collection, the first item is always selected
- When deleting the last item within a collection, the content display is selected
- Avoid calling `selectItem()` when clicking on any button on the topper