### PR TITLE
LPD-33573 Updating the sites Friendly URL doesn't update the background image url

### DIFF
--- a/modules/apps/layout/layout-taglib/build.gradle
+++ b/modules/apps/layout/layout-taglib/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly project(":apps:adaptive-media:adaptive-media-content-transformer-api")
 	compileOnly project(":apps:asset:asset-display-page-api")
 	compileOnly project(":apps:asset:asset-info-display-api")
+	compileOnly project(":apps:document-library:document-library-api")
 	compileOnly project(":apps:fragment:fragment-api")
 	compileOnly project(":apps:fragment:fragment-collection-filter-api")
 	compileOnly project(":apps:fragment:fragment-entry-processor:fragment-entry-processor-api")

--- a/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
+++ b/modules/apps/layout/layout-taglib/src/main/java/com/liferay/layout/taglib/internal/display/context/RenderLayoutStructureDisplayContext.java
@@ -5,6 +5,8 @@
 
 package com.liferay.layout.taglib.internal.display.context;
 
+import com.liferay.document.library.kernel.service.DLAppLocalServiceUtil;
+import com.liferay.document.library.util.DLURLHelperUtil;
 import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
 import com.liferay.fragment.entry.processor.helper.FragmentEntryProcessorHelper;
 import com.liferay.fragment.model.FragmentEntryLink;
@@ -57,6 +59,7 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.Theme;
+import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
@@ -569,14 +572,23 @@ public class RenderLayoutStructureDisplayContext {
 				backgroundImageJSONObject.getString("mappedField"));
 		}
 
+		String backgroundImageURL = null;
+
 		if (fileEntryId != 0) {
 			sb.append("--background-image-file-entry-id:");
 			sb.append(fileEntryId);
 			sb.append(StringPool.SEMICOLON);
-		}
 
-		String backgroundImageURL = _getBackgroundImage(
-			backgroundImageJSONObject);
+			FileEntry fileEntry = _dlAppLocalServiceUtil.getFileEntry(
+				fileEntryId);
+
+			backgroundImageURL = _dlURLHelperUtil.getPreviewURL(
+				fileEntry, fileEntry.getFileVersion(), _themeDisplay,
+				StringPool.BLANK, false, false);
+		}
+		else {
+			backgroundImageURL = _getBackgroundImage(backgroundImageJSONObject);
+		}
 
 		if (Validator.isNotNull(backgroundImageURL)) {
 			sb.append("--lfr-background-image-");
@@ -1133,6 +1145,8 @@ public class RenderLayoutStructureDisplayContext {
 	private static final Log _log = LogFactoryUtil.getLog(
 		RenderLayoutStructureDisplayContext.class);
 
+	private DLAppLocalServiceUtil _dlAppLocalServiceUtil;
+	private DLURLHelperUtil _dlURLHelperUtil;
 	private final HttpServletRequest _httpServletRequest;
 	private final LayoutStructure _layoutStructure;
 	private LayoutStructureRulesHelper.LayoutStructureRulesResult

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
@@ -62,6 +62,8 @@ import com.liferay.layout.provider.LayoutStructureProvider;
 import com.liferay.layout.taglib.servlet.taglib.RenderLayoutStructureTag;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.layout.util.LayoutServiceContextHelper;
+import com.liferay.layout.util.constants.LayoutDataItemTypeConstants;
 import com.liferay.layout.util.structure.CollectionStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.ContainerStyledLayoutStructureItem;
 import com.liferay.layout.util.structure.LayoutStructure;
@@ -83,6 +85,7 @@ import com.liferay.portal.kernel.model.LayoutTypePortlet;
 import com.liferay.portal.kernel.model.LayoutTypePortletConstants;
 import com.liferay.portal.kernel.repository.model.FileEntry;
 import com.liferay.portal.kernel.service.CompanyLocalService;
+import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
@@ -166,6 +169,82 @@ public class RenderLayoutStructureTagTest {
 	@After
 	public void tearDown() {
 		ServiceContextThreadLocal.popServiceContext();
+	}
+
+	@Test
+	public void testEnsureFileURLWhenChangingGroupFriendlyURL()
+		throws Exception {
+
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
+		FileEntry fileEntry = _dlAppLocalService.addFileEntry(
+			null, TestPropsValues.getUserId(), _group.getGroupId(),
+			DLFolderConstants.DEFAULT_PARENT_FOLDER_ID,
+			RandomTestUtil.randomString() + ".jpg", ContentTypes.IMAGE_JPEG,
+			FileUtil.getBytes(
+				RenderLayoutStructureTagTest.class, "dependencies/liferay.jpg"),
+			null, null, null,
+			ServiceContextTestUtil.getServiceContext(
+				_group, TestPropsValues.getUserId()));
+
+		String url = _dlURLHelper.getPreviewURL(
+			fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+			false, false);
+
+		Assert.assertTrue(
+			StringUtil.contains(
+				url, _group.getFriendlyURL(), StringPool.BLANK));
+
+		long segmentExperienceId =
+			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
+				layout.getPlid());
+
+		ContentLayoutTestUtil.addItemToLayout(
+			JSONUtil.put(
+				"styles",
+				JSONUtil.put(
+					"backgroundImage",
+					JSONUtil.put(
+						"classNameId", _portal.getClassNameId(FileEntry.class)
+					).put(
+						"classPK", fileEntry.getFileEntryId()
+					).put(
+						"fileEntryId", fileEntry.getFileEntryId()
+					).put(
+						"url", url
+					))
+			).toString(),
+			LayoutDataItemTypeConstants.TYPE_CONTAINER,
+			layout.fetchDraftLayout(), _layoutStructureProvider,
+			segmentExperienceId);
+
+		ContentLayoutTestUtil.publishLayout(layout.fetchDraftLayout(), layout);
+
+		MockHttpServletResponse mockHttpServletResponse = _renderLayout(
+			layout, _getMockHttpServletRequest(layout));
+
+		String content = mockHttpServletResponse.getContentAsString();
+
+		Assert.assertTrue(
+			content, StringUtil.contains(content, url, StringPool.BLANK));
+
+		_groupLocalService.updateFriendlyURL(
+			_group.getGroupId(), "/new-friendly-url");
+
+		url = _dlURLHelper.getPreviewURL(
+			fileEntry, fileEntry.getFileVersion(), null, StringPool.BLANK,
+			false, false);
+
+		Assert.assertTrue(
+			StringUtil.contains(url, "/new-friendly-url", StringPool.BLANK));
+
+		mockHttpServletResponse = _renderLayout(
+			layout, _getMockHttpServletRequest(layout));
+
+		content = mockHttpServletResponse.getContentAsString();
+
+		Assert.assertTrue(
+			content, StringUtil.contains(content, url, StringPool.BLANK));
 	}
 
 	@Test
@@ -1494,6 +1573,9 @@ public class RenderLayoutStructureTagTest {
 	@DeleteAfterTestRun
 	private Group _group;
 
+	@Inject
+	private GroupLocalService _groupLocalService;
+
 	@Inject(
 		filter = "component.name=com.liferay.journal.web.internal.layout.display.page.JournalArticleLayoutDisplayPageProvider"
 	)
@@ -1512,6 +1594,9 @@ public class RenderLayoutStructureTagTest {
 	@Inject
 	private LayoutPageTemplateStructureLocalService
 		_layoutPageTemplateStructureLocalService;
+
+	@Inject
+	private LayoutServiceContextHelper _layoutServiceContextHelper;
 
 	@Inject
 	private LayoutStructureProvider _layoutStructureProvider;

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/taglib/test/RenderLayoutStructureTagTest.java
@@ -389,15 +389,8 @@ public class RenderLayoutStructureTagTest {
 			fragmentEntry.getType(), childrenItemIds.get(0), 0,
 			segmentsExperienceId);
 
-		MockHttpServletResponse mockHttpServletResponse =
-			new MockHttpServletResponse();
-
-		RenderLayoutStructureTag renderLayoutStructureTag =
-			_getRenderLayoutStructureTagDefaultSegmentsExperience(
-				layout, mockHttpServletRequest, mockHttpServletResponse);
-
-		renderLayoutStructureTag.doTag(
-			mockHttpServletRequest, mockHttpServletResponse);
+		MockHttpServletResponse mockHttpServletResponse = _renderLayout(
+			layout, mockHttpServletRequest);
 
 		String content = mockHttpServletResponse.getContentAsString();
 
@@ -643,15 +636,7 @@ public class RenderLayoutStructureTagTest {
 		MockHttpServletRequest mockHttpServletRequest =
 			_getMockHttpServletRequest(layout);
 
-		MockHttpServletResponse mockHttpServletResponse =
-			new MockHttpServletResponse();
-
-		RenderLayoutStructureTag renderLayoutStructureTag =
-			_getRenderLayoutStructureTagDefaultSegmentsExperience(
-				layout, mockHttpServletRequest, mockHttpServletResponse);
-
-		renderLayoutStructureTag.doTag(
-			mockHttpServletRequest, mockHttpServletResponse);
+		_renderLayout(layout, mockHttpServletRequest);
 
 		List<JournalArticle> actualJournalArticles =
 			(List<JournalArticle>)mockHttpServletRequest.getAttribute(
@@ -740,17 +725,8 @@ public class RenderLayoutStructureTagTest {
 						fetchDefaultSegmentsExperienceId(layout.getPlid()),
 					layoutStructure.toString());
 
-			MockHttpServletRequest mockHttpServletRequest =
-				_getMockHttpServletRequest(layout);
-			MockHttpServletResponse mockHttpServletResponse =
-				new MockHttpServletResponse();
-
-			RenderLayoutStructureTag renderLayoutStructureTag =
-				_getRenderLayoutStructureTagDefaultSegmentsExperience(
-					layout, mockHttpServletRequest, mockHttpServletResponse);
-
-			renderLayoutStructureTag.doTag(
-				mockHttpServletRequest, mockHttpServletResponse);
+			MockHttpServletResponse mockHttpServletResponse = _renderLayout(
+				layout, _getMockHttpServletRequest(layout));
 
 			String content = mockHttpServletResponse.getContentAsString();
 
@@ -791,21 +767,12 @@ public class RenderLayoutStructureTagTest {
 			Layout layout = _addDisplayPageWithFormAndGetLayout(
 				infoField1, infoField2);
 
-			MockHttpServletRequest mockHttpServletRequest =
+			MockHttpServletResponse mockHttpServletResponse = _renderLayout(
+				layout,
 				_getMockHttpServletRequest(
 					layout,
 					mockInfoServiceRegistrationHolder.
-						getMockObjectLayoutDisplayPageObjectProvider());
-
-			MockHttpServletResponse mockHttpServletResponse =
-				new MockHttpServletResponse();
-
-			RenderLayoutStructureTag renderLayoutStructureTag =
-				_getRenderLayoutStructureTagDefaultSegmentsExperience(
-					layout, mockHttpServletRequest, mockHttpServletResponse);
-
-			renderLayoutStructureTag.doTag(
-				mockHttpServletRequest, mockHttpServletResponse);
+						getMockObjectLayoutDisplayPageObjectProvider()));
 
 			String content = mockHttpServletResponse.getContentAsString();
 
@@ -851,21 +818,12 @@ public class RenderLayoutStructureTagTest {
 			Layout layout = _addDisplayPageWithFormAndGetLayout(
 				infoField1, infoField2);
 
-			MockHttpServletRequest mockHttpServletRequest =
+			MockHttpServletResponse mockHttpServletResponse = _renderLayout(
+				layout,
 				_getMockHttpServletRequest(
 					layout,
 					mockInfoServiceRegistrationHolder.
-						getMockObjectLayoutDisplayPageObjectProvider());
-
-			MockHttpServletResponse mockHttpServletResponse =
-				new MockHttpServletResponse();
-
-			RenderLayoutStructureTag renderLayoutStructureTag =
-				_getRenderLayoutStructureTagDefaultSegmentsExperience(
-					layout, mockHttpServletRequest, mockHttpServletResponse);
-
-			renderLayoutStructureTag.doTag(
-				mockHttpServletRequest, mockHttpServletResponse);
+						getMockObjectLayoutDisplayPageObjectProvider()));
 
 			String content = mockHttpServletResponse.getContentAsString();
 
@@ -908,15 +866,8 @@ public class RenderLayoutStructureTagTest {
 			SessionErrors.add(
 				mockHttpServletRequest, formItemId, infoFormException);
 
-			MockHttpServletResponse mockHttpServletResponse =
-				new MockHttpServletResponse();
-
-			RenderLayoutStructureTag renderLayoutStructureTag =
-				_getRenderLayoutStructureTagDefaultSegmentsExperience(
-					layout, mockHttpServletRequest, mockHttpServletResponse);
-
-			renderLayoutStructureTag.doTag(
-				mockHttpServletRequest, mockHttpServletResponse);
+			MockHttpServletResponse mockHttpServletResponse = _renderLayout(
+				layout, mockHttpServletRequest);
 
 			Assert.assertFalse(
 				SessionErrors.contains(mockHttpServletRequest, formItemId));
@@ -968,15 +919,8 @@ public class RenderLayoutStructureTagTest {
 				mockHttpServletRequest, infoField.getUniqueId(),
 				infoFormValidationException);
 
-			MockHttpServletResponse mockHttpServletResponse =
-				new MockHttpServletResponse();
-
-			RenderLayoutStructureTag renderLayoutStructureTag =
-				_getRenderLayoutStructureTagDefaultSegmentsExperience(
-					layout, mockHttpServletRequest, mockHttpServletResponse);
-
-			renderLayoutStructureTag.doTag(
-				mockHttpServletRequest, mockHttpServletResponse);
+			MockHttpServletResponse mockHttpServletResponse = _renderLayout(
+				layout, mockHttpServletRequest);
 
 			Assert.assertFalse(
 				SessionErrors.contains(mockHttpServletRequest, formItemId));
@@ -1020,18 +964,8 @@ public class RenderLayoutStructureTagTest {
 				"0", layout, _layoutStructureProvider, infoField,
 				readOnlyInfoField);
 
-			MockHttpServletRequest mockHttpServletRequest =
-				_getMockHttpServletRequest(layout);
-
-			MockHttpServletResponse mockHttpServletResponse =
-				new MockHttpServletResponse();
-
-			RenderLayoutStructureTag renderLayoutStructureTag =
-				_getRenderLayoutStructureTagDefaultSegmentsExperience(
-					layout, mockHttpServletRequest, mockHttpServletResponse);
-
-			renderLayoutStructureTag.doTag(
-				mockHttpServletRequest, mockHttpServletResponse);
+			MockHttpServletResponse mockHttpServletResponse = _renderLayout(
+				layout, _getMockHttpServletRequest(layout));
 
 			String content = mockHttpServletResponse.getContentAsString();
 
@@ -1072,15 +1006,8 @@ public class RenderLayoutStructureTagTest {
 
 			SessionMessages.add(mockHttpServletRequest, formItemId);
 
-			MockHttpServletResponse mockHttpServletResponse =
-				new MockHttpServletResponse();
-
-			RenderLayoutStructureTag renderLayoutStructureTag =
-				_getRenderLayoutStructureTagDefaultSegmentsExperience(
-					layout, mockHttpServletRequest, mockHttpServletResponse);
-
-			renderLayoutStructureTag.doTag(
-				mockHttpServletRequest, mockHttpServletResponse);
+			MockHttpServletResponse mockHttpServletResponse = _renderLayout(
+				layout, mockHttpServletRequest);
 
 			String content = mockHttpServletResponse.getContentAsString();
 
@@ -1497,6 +1424,23 @@ public class RenderLayoutStructureTagTest {
 
 		return StringUtil.read(
 			clazz.getResourceAsStream("dependencies/" + fileName));
+	}
+
+	private MockHttpServletResponse _renderLayout(
+			Layout layout, MockHttpServletRequest mockHttpServletRequest)
+		throws Exception {
+
+		MockHttpServletResponse mockHttpServletResponse =
+			new MockHttpServletResponse();
+
+		RenderLayoutStructureTag renderLayoutStructureTag =
+			_getRenderLayoutStructureTagDefaultSegmentsExperience(
+				layout, mockHttpServletRequest, mockHttpServletResponse);
+
+		renderLayoutStructureTag.doTag(
+			mockHttpServletRequest, mockHttpServletResponse);
+
+		return mockHttpServletResponse;
 	}
 
 	private static final int _COUNT_FRAGMENT_ENTRY_LINKS = 5;


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPD-33573)

## Changes

Use the correct url for the document library files

## Test Scenario

1. Create a Site
2. Create a content page
3. Edit the content page and add a banner fragment
4. Click on the Banner container
5. Go to the Styles tab in the right column panel
6. Under Background select Image Source choose Direct
7. Click in Background Image field and select an image from Documents and Media
8. Publish and Navigate to Configuration > Site Settings in the Product Menu
9. Go to Platform > Site Configuration
10. Edit the Friendly URL to a new one in Site URL
11. Save and go back to the created page

[Screencast from 2024-08-13 18-01-35.webm](https://github.com/user-attachments/assets/a5ff593b-3a07-474d-bd3b-16fab8446638)
