### PR TITLE
LPD-32724 Asset Publisher using site's theme instead of default styles

### DIFF
--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/create_asset_list.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/create_asset_list.jsp
@@ -22,8 +22,6 @@ String portletResource = ParamUtil.getString(request, "portletResource");
 			HashMapBuilder.<String, Object>put(
 				"portletNamespace", PortalUtil.getPortletNamespace(HtmlUtil.escape(portletResource))
 			).put(
-				"spritemap", themeDisplay.getPathThemeSpritemap()
-			).put(
 				"url", addAssetListURL
 			).build()
 		%>'

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/create_asset_list.jsp
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/configuration/create_asset_list.jsp
@@ -12,40 +12,25 @@ String portletResource = ParamUtil.getString(request, "portletResource");
 %>
 
 <div class="mb-2">
-	<aui:a cssClass="create-collection-link" href="javascript:void(0);">
-		<liferay-ui:message key="create-a-collection-from-this-configuration" />
-	</aui:a>
+	<liferay-portlet:actionURL name="/asset_publisher/add_asset_list" portletName="<%= portletResource %>" var="addAssetListURL">
+		<portlet:param name="portletResource" value="<%= portletResource %>" />
+		<portlet:param name="redirect" value="<%= currentURL %>" />
+	</liferay-portlet:actionURL>
+
+	<clay:button
+		additionalProps='<%=
+			HashMapBuilder.<String, Object>put(
+				"portletNamespace", PortalUtil.getPortletNamespace(HtmlUtil.escape(portletResource))
+			).put(
+				"spritemap", themeDisplay.getPathThemeSpritemap()
+			).put(
+				"url", addAssetListURL
+			).build()
+		%>'
+		cssClass="c-pl-0 create-collection-link"
+		displayType="link"
+		id='<%= liferayPortletResponse.getNamespace() + "collectionButton" %>'
+		label="create-a-collection-from-this-configuration"
+		propsTransformer="{CreateAssetListActionButtonPropsTransformer} from asset-publisher-web"
+	/>
 </div>
-
-<aui:script sandbox="<%= true %>">
-	function handleCreateAssetListLinkClick(event) {
-		event.preventDefault();
-
-		Liferay.Util.openSimpleInputModal({
-			dialogTitle: '<liferay-ui:message key="collection-title" />',
-			formSubmitURL:
-				'<liferay-portlet:actionURL name="/asset_publisher/add_asset_list" portletName="<%= portletResource %>"><portlet:param name="portletResource" value="<%= portletResource %>" /><portlet:param name="redirect" value="<%= currentURL %>" /></liferay-portlet:actionURL>',
-			mainFieldLabel: '<liferay-ui:message key="title" />',
-			mainFieldName: 'title',
-			mainFieldPlaceholder: '<liferay-ui:message key="title" />',
-			namespace:
-				'<%= PortalUtil.getPortletNamespace(HtmlUtil.escape(portletResource)) %>',
-			spritemap: '<%= themeDisplay.getPathThemeSpritemap() %>',
-		});
-	}
-
-	var createAssetListLinkClickHandler = Liferay.Util.delegate(
-		document.body,
-		'click',
-		'a.create-collection-link',
-		handleCreateAssetListLinkClick
-	);
-
-	function handleDestroyPortlet() {
-		createAssetListLinkClickHandler.dispose();
-
-		Liferay.detach('destroyPortlet', handleDestroyPortlet);
-	}
-
-	Liferay.on('destroyPortlet', handleDestroyPortlet);
-</aui:script>

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/CreateAssetListActionButtonPropsTransformer.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/CreateAssetListActionButtonPropsTransformer.js
@@ -16,7 +16,6 @@ export default function propsTransformer({additionalProps, ...props}) {
 				mainFieldName: 'title',
 				mainFieldPlaceholder: Liferay.Language.get('title'),
 				namespace: additionalProps.portletNamespace,
-				spritemap: additionalProps.spritemap,
 			});
 		},
 	};

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/CreateAssetListActionButtonPropsTransformer.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/CreateAssetListActionButtonPropsTransformer.js
@@ -1,0 +1,23 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {openSimpleInputModal} from 'frontend-js-web';
+
+export default function propsTransformer({additionalProps, ...props}) {
+	return {
+		...props,
+		onClick() {
+			openSimpleInputModal({
+				dialogTitle: Liferay.Language.get('collection-title'),
+				formSubmitURL: additionalProps.url,
+				mainFieldLabel: Liferay.Language.get('title'),
+				mainFieldName: 'title',
+				mainFieldPlaceholder: Liferay.Language.get('title'),
+				namespace: additionalProps.portletNamespace,
+				spritemap: additionalProps.spritemap,
+			});
+		},
+	};
+}

--- a/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/index.js
+++ b/modules/apps/asset/asset-publisher-web/src/main/resources/META-INF/resources/js/index.js
@@ -6,6 +6,7 @@
 export {default as AssetEntryActionButtonPropsTransformer} from './AssetEntryActionButtonPropsTransformer';
 export {default as AssetEntryActionDropdownPropsTransformer} from './AssetEntryActionDropdownPropsTransformer';
 export {default as AssetEntrySelectionDropdownPropsTransformer} from './AssetEntrySelectionDropdownPropsTransformer';
+export {default as CreateAssetListActionButtonPropsTransformer} from './CreateAssetListActionButtonPropsTransformer';
 export {default as DisplaySettings} from './DisplaySettings';
 export {default as Ordering} from './Ordering';
 export {default as printPageButtonPropsTransformer} from './printPageButtonPropsTransformer';

--- a/modules/apps/asset/asset-publisher-web/test.properties
+++ b/modules/apps/asset/asset-publisher-web/test.properties
@@ -9,7 +9,8 @@
 
     test.batch.names[relevant][asset-publisher-web-rule]=\
         modules-integration-mysql57-jdk8,\
-        modules-unit-jdk8
+        modules-unit-jdk8,\
+        playwright-js-tomcat90-mysql57-jdk8
 
     #
     # Relevant
@@ -20,6 +21,8 @@
 
     modules.includes.required.test.batch.class.names.includes[modules-unit-jdk8][relevant][asset-publisher-web-rule]=\
         **/asset-publisher-test/**/*Test.java
+
+    playwright.test.project[playwright-js-tomcat90-mysql57-jdk8][relevant][asset-publisher-web-rule]=asset-publisher-web
 
 ##
 ## Testray

--- a/modules/test/playwright/fixtures/assetPublisherPagesTest.ts
+++ b/modules/test/playwright/fixtures/assetPublisherPagesTest.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {test} from '@playwright/test';
+
+import {AssetPublisherPage} from '../pages/asset-publisher-web/AssetPublisherPage';
+
+const assetPublisherPagesTest = test.extend<{
+	assetPublisherPage: AssetPublisherPage;
+}>({
+	assetPublisherPage: async ({page}, use) => {
+		await use(new AssetPublisherPage(page));
+	},
+});
+
+export {assetPublisherPagesTest};

--- a/modules/test/playwright/pages/asset-publisher-web/AssetPublisherPage.ts
+++ b/modules/test/playwright/pages/asset-publisher-web/AssetPublisherPage.ts
@@ -1,0 +1,49 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {Page} from '@playwright/test';
+
+import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {PageEditorPage} from '../layout-content-page-editor-web/PageEditorPage';
+
+export class AssetPublisherPage {
+	readonly page: Page;
+	readonly pageEditorPage: PageEditorPage;
+
+	constructor(page: Page) {
+		this.page = page;
+		this.pageEditorPage = new PageEditorPage(this.page);
+	}
+
+	async createCollectionFromAssetPublisher(
+		collectionName: string,
+		type: string
+	) {
+		const iframe = this.pageEditorPage.page.frameLocator('iframe');
+
+		await iframe.getByLabel(type, {exact: true}).click();
+
+		await waitForSuccessAlert(
+			iframe,
+			'Success:You have successfully updated the setup.'
+		);
+
+		await iframe
+			.getByRole('button', {name: 'Create a collection from this'})
+			.click();
+
+		await iframe.getByPlaceholder('Title').fill(collectionName);
+
+		await iframe
+			.getByLabel('Collection Title')
+			.getByRole('button', {name: 'Save'})
+			.click();
+
+		await waitForSuccessAlert(
+			iframe,
+			'Success:The collection was created successfully.'
+		);
+	}
+}

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -698,6 +698,26 @@ export class PageEditorPage {
 		await this.page.getByLabel(spacingType, {exact: true}).click();
 	}
 
+	async goToWidgetConfiguration(
+		layout: Layout,
+		site: Site,
+		widgetId: string
+	) {
+		await this.goto(layout, site.friendlyUrlPath);
+
+		const topper = this.getTopper(widgetId);
+
+		await topper.hover();
+
+		await expect(topper.locator('.portlet-options')).toBeVisible();
+
+		await topper.locator('.portlet-options').click();
+
+		await this.page
+			.getByRole('menuitem', {exact: true, name: 'Configuration'})
+			.click();
+	}
+
 	async publishPage() {
 		const isMaster = await this.isMaster();
 

--- a/modules/test/playwright/playwright.config.ts
+++ b/modules/test/playwright/playwright.config.ts
@@ -9,6 +9,7 @@ import {config as accountAdminWebConfig} from './tests/account-admin-web/config'
 import {config as analyticsSettingsWebConfig} from './tests/analytics-settings-web/config';
 import {config as analyticsWebConfig} from './tests/analytics-web/config';
 import {config as announcementsWebConfig} from './tests/announcements-web/config';
+import {config as assetPublisherWebConfig} from './tests/asset-publisher-web/config';
 import {config as batchPlannerConfig} from './tests/batch-planner/config';
 import {config as blogsWebConfig} from './tests/blogs-web/config';
 import {config as calendarWebConfig} from './tests/calendar-web/config';
@@ -90,6 +91,7 @@ export default defineConfig({
 		analyticsSettingsWebConfig,
 		analyticsWebConfig,
 		announcementsWebConfig,
+		assetPublisherWebConfig,
 		batchPlannerConfig,
 		blogsWebConfig,
 		calendarWebConfig,

--- a/modules/test/playwright/tests/asset-publisher-web/assetPublisherConfiguration.spec.ts
+++ b/modules/test/playwright/tests/asset-publisher-web/assetPublisherConfiguration.spec.ts
@@ -1,0 +1,131 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import {expect, mergeTests} from '@playwright/test';
+
+import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
+import {assetPublisherPagesTest} from '../../fixtures/assetPublisherPagesTest';
+import {collectionsPagesTest} from '../../fixtures/collectionsPagesTest';
+import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
+import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
+import {loginTest} from '../../fixtures/loginTest';
+import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
+import getRandomString from '../../utils/getRandomString';
+import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
+import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidgetDefinition';
+
+const test = mergeTests(
+	assetPublisherPagesTest,
+	apiHelpersTest,
+	collectionsPagesTest,
+	featureFlagsTest({
+		'LPS-178052': true,
+	}),
+	isolatedSiteTest,
+	loginTest(),
+	pageEditorPagesTest
+);
+
+test(
+	'Create manual collection from asset publisher configuration',
+	{
+		tag: '@LPD-32724',
+	},
+	async ({
+		apiHelpers,
+		assetPublisherPage,
+		collectionsPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create a page with an Asset Publisher Widget
+
+		const widgetId = getRandomString();
+
+		const widgetDefinition = getWidgetDefinition({
+			id: widgetId,
+			widgetName:
+				'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet',
+		});
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([widgetDefinition]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Access to the configuration of the widget from the page editor
+
+		await pageEditorPage.goToWidgetConfiguration(layout, site, widgetId);
+
+		// Create a manual collection
+
+		const collectionName = getRandomString();
+
+		await assetPublisherPage.createCollectionFromAssetPublisher(
+			collectionName,
+			'Manual'
+		);
+
+		// Check that the collection has been created correctly
+
+		await collectionsPage.goto(site.friendlyUrlPath);
+
+		await expect(page.getByText(collectionName)).toBeVisible();
+	}
+);
+
+test(
+	'Create dynamic collection from asset publisher configuration',
+	{
+		tag: '@LPD-32724',
+	},
+	async ({
+		apiHelpers,
+		assetPublisherPage,
+		collectionsPage,
+		page,
+		pageEditorPage,
+		site,
+	}) => {
+
+		// Create a page with an Asset Publisher Widget
+
+		const widgetId = getRandomString();
+
+		const widgetDefinition = getWidgetDefinition({
+			id: widgetId,
+			widgetName:
+				'com_liferay_asset_publisher_web_portlet_AssetPublisherPortlet',
+		});
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([widgetDefinition]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		// Access to the configuration of the widget from the page editor
+
+		await pageEditorPage.goToWidgetConfiguration(layout, site, widgetId);
+
+		// Create a dynamic collection
+
+		const collectionName = getRandomString();
+
+		await assetPublisherPage.createCollectionFromAssetPublisher(
+			collectionName,
+			'Dynamic'
+		);
+
+		// Check that the collection has been created correctly
+
+		await collectionsPage.goto(site.friendlyUrlPath);
+
+		await expect(page.getByText(collectionName)).toBeVisible();
+	}
+);

--- a/modules/test/playwright/tests/asset-publisher-web/config.ts
+++ b/modules/test/playwright/tests/asset-publisher-web/config.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+export const config = {
+	name: 'asset-publisher-web',
+	testDir: 'tests/asset-publisher-web',
+};

--- a/modules/test/playwright/tests/asset-publisher-web/test.properties
+++ b/modules/test/playwright/tests/asset-publisher-web/test.properties
@@ -1,0 +1,5 @@
+##
+## Testray
+##
+
+    testray.main.component.name=Asset Publisher Widget

--- a/test.properties
+++ b/test.properties
@@ -6795,6 +6795,7 @@ test.batch.run.property.query[functional-orcllinux9-tomcat90-mysql57-jdk8]=\
     #
 
     page-management-playwright-projects=\
+        asset-publisher-web,\
         fragment-web,\
         layout-admin-web,\
         layout-content-page-editor-web,\


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPD-32724)

## Changes

Migrate element to a clay component and remove th spritemap to don't use the site's theme

## Test Scenario

1. Create a Page
2. Add an Asset Publisher widget
3. Go to the configuration of the widget and select dynamic or manual collection
4. Click on the new link "Create a collection from this configuration."
5. Create a collection
6. Verify that it has been created.

[Screencast from 2024-08-13 18-27-49.webm](https://github.com/user-attachments/assets/bebcb882-3fc3-463c-a1b0-aea6f71c2c00)


