### PR TITLE
LPD-34450

### DIFF
--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/SiteNavigationMenuExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/SiteNavigationMenuExportImportPortletPreferencesProcessor.java
@@ -13,12 +13,15 @@ import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
 import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.service.PortletPreferenceValueLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.xml.Element;
 import com.liferay.site.navigation.constants.SiteNavigationConstants;
 import com.liferay.site.navigation.constants.SiteNavigationMenuPortletKeys;
 import com.liferay.site.navigation.model.SiteNavigationMenu;
@@ -45,12 +48,20 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 
 	@Override
 	public List<Capability> getExportCapabilities() {
-		return ListUtil.fromArray(_exportCapability);
+		if (FeatureFlagManagerUtil.isEnabled("LPD-23048")) {
+			return ListUtil.fromArray(_exportCapability);
+		}
+
+		return ListUtil.fromArray(_legacyExportCapability);
 	}
 
 	@Override
 	public List<Capability> getImportCapabilities() {
-		return ListUtil.fromArray(_importCapability);
+		if (FeatureFlagManagerUtil.isEnabled("LPD-23048")) {
+			return ListUtil.fromArray(_importCapability);
+		}
+
+		return ListUtil.fromArray(_legacyImportCapability);
 	}
 
 	@Override
@@ -75,6 +86,93 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 			throw new PortletDataException(
 				"Unable to export portlet permissions", portalException);
 		}
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-23048")) {
+			return _processExportPortletPreferencesBySiteNavigationId(
+				portletDataContext, portletPreferences);
+		}
+
+		String siteNavigationMenuExternalReferenceCode =
+			portletPreferences.getValue(
+				"siteNavigationMenuExternalReferenceCode", null);
+
+		if (Validator.isNotNull(siteNavigationMenuExternalReferenceCode)) {
+			SiteNavigationMenu siteNavigationMenu =
+				_siteNavigationMenuLocalService.
+					fetchSiteNavigationMenuByExternalReferenceCode(
+						siteNavigationMenuExternalReferenceCode,
+						portletDataContext.getScopeGroupId());
+
+			if (siteNavigationMenu != null) {
+				StagedModelDataHandlerUtil.exportReferenceStagedModel(
+					portletDataContext, portletDataContext.getPortletId(),
+					siteNavigationMenu);
+			}
+		}
+
+		return portletPreferences;
+	}
+
+	@Override
+	public PortletPreferences processImportPortletPreferences(
+			PortletDataContext portletDataContext,
+			PortletPreferences portletPreferences)
+		throws PortletDataException {
+
+		try {
+			portletDataContext.importPortletPermissions(
+				SiteNavigationConstants.RESOURCE_NAME);
+		}
+		catch (PortalException portalException) {
+			throw new PortletDataException(
+				"Unable to import portlet permissions", portalException);
+		}
+
+		if (!FeatureFlagManagerUtil.isEnabled("LPD-23048")) {
+			return _processImportPortletPreferencesBySiteNavigationId(
+				portletDataContext, portletPreferences);
+		}
+
+		_importSiteNavigationMenuReference(portletDataContext);
+
+		return portletPreferences;
+	}
+
+	private void _importSiteNavigationMenuReference(
+			PortletDataContext portletDataContext)
+		throws PortletDataException {
+
+		Element importDataRootElement =
+			portletDataContext.getImportDataRootElement();
+
+		Element referencesElement = importDataRootElement.element("references");
+
+		if (referencesElement == null) {
+			return;
+		}
+
+		List<Element> referenceElements = referencesElement.elements();
+
+		for (Element referenceElement : referenceElements) {
+			String className = referenceElement.attributeValue("class-name");
+
+			if (!className.equals(SiteNavigationMenu.class.getName())) {
+				continue;
+			}
+
+			long classPK = GetterUtil.getLong(
+				referenceElement.attributeValue("class-pk"));
+
+			StagedModelDataHandlerUtil.importReferenceStagedModel(
+				portletDataContext, className, Long.valueOf(classPK));
+		}
+	}
+
+	private PortletPreferences
+			_processExportPortletPreferencesBySiteNavigationId(
+				PortletDataContext portletDataContext,
+				PortletPreferences portletPreferences)
+		throws PortletDataException {
 
 		long siteNavigationMenuId = GetterUtil.getLong(
 			portletPreferences.getValue("siteNavigationMenuId", null));
@@ -104,20 +202,11 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 		return portletPreferences;
 	}
 
-	@Override
-	public PortletPreferences processImportPortletPreferences(
-			PortletDataContext portletDataContext,
-			PortletPreferences portletPreferences)
+	private PortletPreferences
+			_processImportPortletPreferencesBySiteNavigationId(
+				PortletDataContext portletDataContext,
+				PortletPreferences portletPreferences)
 		throws PortletDataException {
-
-		try {
-			portletDataContext.importPortletPermissions(
-				SiteNavigationConstants.RESOURCE_NAME);
-		}
-		catch (PortalException portalException) {
-			throw new PortletDataException(
-				"Unable to import portlet permissions", portalException);
-		}
 
 		if (!MapUtil.getBoolean(
 				portletDataContext.getParameterMap(),
@@ -215,11 +304,17 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 		return portletPreferences;
 	}
 
-	@Reference(target = "(name=PortletDisplayTemplateExporter)")
+	@Reference(target = "(name=CommonPortletDisplayTemplateExportCapability)")
 	private Capability _exportCapability;
 
-	@Reference(target = "(name=PortletDisplayTemplateImporter)")
+	@Reference(target = "(name=CommonPortletDisplayTemplateImportCapability)")
 	private Capability _importCapability;
+
+	@Reference(target = "(name=PortletDisplayTemplateExporter)")
+	private Capability _legacyExportCapability;
+
+	@Reference(target = "(name=PortletDisplayTemplateImporter)")
+	private Capability _legacyImportCapability;
 
 	@Reference(unbind = "-")
 	private PortletPreferencesLocalService _portletPreferencesLocalService;

--- a/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/SiteNavigationMenuExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/site-navigation/site-navigation-menu-web/src/main/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/SiteNavigationMenuExportImportPortletPreferencesProcessor.java
@@ -12,6 +12,7 @@ import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.exportimport.portlet.preferences.processor.Capability;
 import com.liferay.exportimport.portlet.preferences.processor.ExportImportPortletPreferencesProcessor;
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.feature.flag.FeatureFlagManagerUtil;
 import com.liferay.portal.kernel.service.PortletPreferenceValueLocalService;
@@ -131,6 +132,69 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessor
 		if (!FeatureFlagManagerUtil.isEnabled("LPD-23048")) {
 			return _processImportPortletPreferencesBySiteNavigationId(
 				portletDataContext, portletPreferences);
+		}
+
+		if (!MapUtil.getBoolean(
+				portletDataContext.getParameterMap(),
+				PortletDataHandlerKeys.PORTLET_DATA) &&
+			MergeLayoutPrototypesThreadLocal.isInProgress()) {
+
+			String siteNavigationMenuExternalReferenceCode = StringPool.BLANK;
+
+			long originalPlid = MapUtil.getLong(
+				portletDataContext.getParameterMap(), "portletPreferencePlid");
+
+			List<com.liferay.portal.kernel.model.PortletPreferences>
+				serviceBuilderPortletPreferencesList = null;
+
+			if (originalPlid == PortletKeys.PREFS_PLID_SHARED) {
+				serviceBuilderPortletPreferencesList =
+					_portletPreferencesLocalService.getPortletPreferences(
+						PortletKeys.PREFS_PLID_SHARED,
+						portletDataContext.getPortletId());
+			}
+			else {
+				serviceBuilderPortletPreferencesList =
+					_portletPreferencesLocalService.getPortletPreferences(
+						portletDataContext.getPlid(),
+						portletDataContext.getPortletId());
+			}
+
+			if (!serviceBuilderPortletPreferencesList.isEmpty()) {
+				for (com.liferay.portal.kernel.model.PortletPreferences
+						serviceBuilderPortletPreferences :
+							serviceBuilderPortletPreferencesList) {
+
+					if (serviceBuilderPortletPreferences.getCompanyId() !=
+							portletDataContext.getCompanyId()) {
+
+						continue;
+					}
+
+					PortletPreferences originalPortletPreferences =
+						_portletPreferenceValueLocalService.getPreferences(
+							serviceBuilderPortletPreferences);
+
+					siteNavigationMenuExternalReferenceCode =
+						originalPortletPreferences.getValue(
+							"siteNavigationMenuExternalReferenceCode",
+							StringPool.BLANK);
+				}
+			}
+
+			try {
+				portletPreferences.setValue(
+					"siteNavigationMenuExternalReferenceCode",
+					String.valueOf(siteNavigationMenuExternalReferenceCode));
+			}
+			catch (ReadOnlyException readOnlyException) {
+				PortletDataException portletDataException =
+					new PortletDataException(readOnlyException);
+
+				throw portletDataException;
+			}
+
+			return portletPreferences;
 		}
 
 		_importSiteNavigationMenuReference(portletDataContext);

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/test/SiteNavigationMenuExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/test/SiteNavigationMenuExportImportPortletPreferencesProcessorTest.java
@@ -8,19 +8,24 @@ package com.liferay.site.navigation.menu.web.internal.exportimport.portlet.prefe
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationParameterMapFactoryUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.exportimport.kernel.staging.MergeLayoutPrototypesThreadLocal;
 import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.model.LayoutSetPrototype;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HashMapBuilder;
 import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.FeatureFlags;
 import com.liferay.portal.test.rule.Inject;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -31,6 +36,7 @@ import com.liferay.site.navigation.model.SiteNavigationMenuItem;
 import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
 import com.liferay.site.navigation.test.util.SiteNavigationMenuItemTestUtil;
 import com.liferay.site.navigation.test.util.SiteNavigationMenuTestUtil;
+import com.liferay.sites.kernel.util.Sites;
 
 import java.util.Map;
 
@@ -141,6 +147,66 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessorTest {
 			).size());
 	}
 
+	@FeatureFlags("LPS-173790")
+	@Test
+	public void testSiteTemplatePropagationWhenDuplicateSiteNavigationMenusExist()
+		throws Exception {
+
+		_group = GroupTestUtil.addGroup();
+
+		LayoutSetPrototype layoutSetPrototype =
+			LayoutTestUtil.addLayoutSetPrototype(RandomTestUtil.randomString());
+
+		Layout prototypeLayout = LayoutTestUtil.addTypePortletLayout(
+			layoutSetPrototype.getGroup(), true);
+
+		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+
+		_sites.updateLayoutSetPrototypesLinks(
+			_group, layoutSetPrototype.getLayoutSetPrototypeId(), 0, true,
+			true);
+
+		Layout layout = _layoutLocalService.getFriendlyURLLayout(
+			_group.getGroupId(), false, prototypeLayout.getFriendlyURL());
+
+		layout.setLayoutPrototypeUuid(prototypeLayout.getUuid());
+		layout.setLayoutPrototypeLinkEnabled(true);
+
+		_layoutLocalService.updateLayout(layout);
+
+		String name = RandomTestUtil.randomString();
+
+		SiteNavigationMenuTestUtil.addSiteNavigationMenu(_group, name);
+
+		LayoutTestUtil.addPortletToLayout(
+			prototypeLayout, SiteNavigationMenuPortletKeys.SITE_NAVIGATION_MENU,
+			HashMapBuilder.put(
+				"siteNavigationMenuExternalReferenceCode",
+				new String[] {
+					SiteNavigationMenuTestUtil.addSiteNavigationMenu(
+						layoutSetPrototype.getGroup(), name
+					).getExternalReferenceCode()
+				}
+			).build());
+
+		MergeLayoutPrototypesThreadLocal.clearMergeComplete();
+
+		MergeLayoutPrototypesThreadLocal.setSkipMerge(false);
+
+		_sites.mergeLayoutSetPrototypeLayouts(
+			_group, _group.getPublicLayoutSet());
+
+		UnicodeProperties layoutSetPrototypeSettingsUnicodeProperties =
+			layoutSetPrototype.getLayoutSet(
+			).getSettingsProperties();
+
+		Assert.assertEquals(
+			0,
+			GetterUtil.getInteger(
+				layoutSetPrototypeSettingsUnicodeProperties.getProperty(
+					Sites.MERGE_FAIL_COUNT)));
+	}
+
 	private void _publishLayouts() throws Exception {
 		Map<String, String[]> parameterMap =
 			ExportImportConfigurationParameterMapFactoryUtil.
@@ -159,6 +225,9 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessorTest {
 			_liveGroup.getGroupId(), false, parameterMap);
 	}
 
+	@DeleteAfterTestRun
+	private Group _group;
+
 	private Layout _layout;
 
 	@Inject
@@ -175,6 +244,9 @@ public class SiteNavigationMenuExportImportPortletPreferencesProcessorTest {
 
 	@Inject
 	private SiteNavigationMenuLocalService _siteNavigationMenuLocalService;
+
+	@Inject
+	private Sites _sites;
 
 	private Group _stagingGroup;
 

--- a/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/test/SiteNavigationMenuExportImportPortletPreferencesProcessorTest.java
+++ b/modules/apps/site-navigation/site-navigation-test/src/testIntegration/java/com/liferay/site/navigation/menu/web/internal/exportimport/portlet/preferences/processor/test/SiteNavigationMenuExportImportPortletPreferencesProcessorTest.java
@@ -1,0 +1,181 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.site.navigation.menu.web.internal.exportimport.portlet.preferences.processor.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.exportimport.kernel.configuration.ExportImportConfigurationParameterMapFactoryUtil;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.exportimport.kernel.staging.StagingUtil;
+import com.liferay.layout.test.util.LayoutTestUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.service.LayoutLocalService;
+import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
+import com.liferay.portal.kernel.test.rule.AggregateTestRule;
+import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
+import com.liferay.portal.kernel.test.util.GroupTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.util.HashMapBuilder;
+import com.liferay.portal.kernel.util.PortletKeys;
+import com.liferay.portal.test.rule.FeatureFlags;
+import com.liferay.portal.test.rule.Inject;
+import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
+import com.liferay.portal.test.rule.PermissionCheckerMethodTestRule;
+import com.liferay.site.navigation.constants.SiteNavigationMenuPortletKeys;
+import com.liferay.site.navigation.model.SiteNavigationMenu;
+import com.liferay.site.navigation.model.SiteNavigationMenuItem;
+import com.liferay.site.navigation.service.SiteNavigationMenuLocalService;
+import com.liferay.site.navigation.test.util.SiteNavigationMenuItemTestUtil;
+import com.liferay.site.navigation.test.util.SiteNavigationMenuTestUtil;
+
+import java.util.Map;
+
+import javax.portlet.PortletPreferences;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * @author Javier Moral
+ */
+@RunWith(Arquillian.class)
+public class SiteNavigationMenuExportImportPortletPreferencesProcessorTest {
+
+	@ClassRule
+	@Rule
+	public static final AggregateTestRule aggregateTestRule =
+		new AggregateTestRule(
+			new LiferayIntegrationTestRule(),
+			PermissionCheckerMethodTestRule.INSTANCE);
+
+	@Before
+	public void setUp() throws Exception {
+		_liveGroup = GroupTestUtil.addGroup();
+
+		GroupTestUtil.enableLocalStaging(
+			_liveGroup, TestPropsValues.getUserId());
+
+		_stagingGroup = _liveGroup.getStagingGroup();
+
+		_layout = LayoutTestUtil.addTypePortletLayout(_stagingGroup);
+
+		_siteNavigationMenu = SiteNavigationMenuTestUtil.addSiteNavigationMenu(
+			_stagingGroup);
+
+		_siteNavigationMenuItem =
+			SiteNavigationMenuItemTestUtil.addSiteNavigationMenuItem(
+				_siteNavigationMenu);
+	}
+
+	@FeatureFlags("LPD-23048")
+	@Test
+	public void testExportImport() throws Exception {
+		String portletId = LayoutTestUtil.addPortletToLayout(
+			_layout, SiteNavigationMenuPortletKeys.SITE_NAVIGATION_MENU,
+			HashMapBuilder.put(
+				"rootMenuItemExternalReferenceCode",
+				new String[] {
+					_siteNavigationMenuItem.getExternalReferenceCode()
+				}
+			).put(
+				"siteNavigationMenuExternalReferenceCode",
+				new String[] {_siteNavigationMenu.getExternalReferenceCode()}
+			).build());
+
+		_publishLayouts();
+
+		_siteNavigationMenuLocalService.
+			getSiteNavigationMenuByExternalReferenceCode(
+				_siteNavigationMenu.getExternalReferenceCode(),
+				_liveGroup.getGroupId());
+
+		Layout layout = _layoutLocalService.getLayoutByUuidAndGroupId(
+			_layout.getUuid(), _liveGroup.getGroupId(),
+			_layout.isPrivateLayout());
+
+		PortletPreferences portletPreferences =
+			_portletPreferencesLocalService.getPreferences(
+				_liveGroup.getCompanyId(), PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
+				portletId);
+
+		Assert.assertEquals(
+			_siteNavigationMenu.getExternalReferenceCode(),
+			portletPreferences.getValue(
+				"siteNavigationMenuExternalReferenceCode", StringPool.BLANK));
+		Assert.assertEquals(
+			_siteNavigationMenuItem.getExternalReferenceCode(),
+			portletPreferences.getValue(
+				"rootMenuItemExternalReferenceCode", StringPool.BLANK));
+	}
+
+	@FeatureFlags("LPD-23048")
+	@Test
+	public void testExportImportEmptyPortletPreferences() throws Exception {
+		String portletId = LayoutTestUtil.addPortletToLayout(
+			_layout, SiteNavigationMenuPortletKeys.SITE_NAVIGATION_MENU);
+
+		_publishLayouts();
+
+		Layout layout = _layoutLocalService.getLayoutByUuidAndGroupId(
+			_layout.getUuid(), _liveGroup.getGroupId(),
+			_layout.isPrivateLayout());
+
+		PortletPreferences portletPreferences =
+			_portletPreferencesLocalService.getPreferences(
+				_liveGroup.getCompanyId(), PortletKeys.PREFS_OWNER_ID_DEFAULT,
+				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid(),
+				portletId);
+
+		Assert.assertEquals(
+			_portletPreferencesLocalService.toString(), 0,
+			portletPreferences.getMap(
+			).size());
+	}
+
+	private void _publishLayouts() throws Exception {
+		Map<String, String[]> parameterMap =
+			ExportImportConfigurationParameterMapFactoryUtil.
+				buildParameterMap();
+
+		parameterMap.put(
+			PortletDataHandlerKeys.PORTLET_DATA,
+			new String[] {Boolean.FALSE.toString()});
+
+		parameterMap.put(
+			PortletDataHandlerKeys.PORTLET_DATA_ALL,
+			new String[] {Boolean.FALSE.toString()});
+
+		StagingUtil.publishLayouts(
+			TestPropsValues.getUserId(), _stagingGroup.getGroupId(),
+			_liveGroup.getGroupId(), false, parameterMap);
+	}
+
+	private Layout _layout;
+
+	@Inject
+	private LayoutLocalService _layoutLocalService;
+
+	@DeleteAfterTestRun
+	private Group _liveGroup;
+
+	@Inject
+	private PortletPreferencesLocalService _portletPreferencesLocalService;
+
+	private SiteNavigationMenu _siteNavigationMenu;
+	private SiteNavigationMenuItem _siteNavigationMenuItem;
+
+	@Inject
+	private SiteNavigationMenuLocalService _siteNavigationMenuLocalService;
+
+	private Group _stagingGroup;
+
+}


### PR DESCRIPTION
Just handle the export import of preferences. There will be a next pr including the upgrade process and the removal of the FF.

Had to add method _importSiteNavigationMenuReference to the processor because the staging framework needs a classPK to import a reference and considering that internal ids won't be stored in preferences I had to obtain the classPK from the xml.