### PR TITLE
LPD-34916 revert LPD-27776

### DIFF
--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/PortletPreferencesUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/PortletPreferencesUpgradeProcess.java
@@ -80,7 +80,7 @@ public class PortletPreferencesUpgradeProcess extends UpgradeProcess {
 	}
 
 	private Map<Long, Long> _getPortletPreferencesMap(
-			long companyId, long ctCollectionId, long groupId, String namespace)
+			long companyId, long groupId, String namespace)
 		throws Exception {
 
 		Map<Long, Long> portletPreferencesMap = new HashMap<>();
@@ -89,19 +89,15 @@ public class PortletPreferencesUpgradeProcess extends UpgradeProcess {
 				StringBundler.concat(
 					"select PortletPreferences.portletPreferencesId, ",
 					"PortletPreferences.plid from PortletPreferences inner ",
-					"join Layout on Layout.ctCollectionId = ? and ",
-					"PortletPreferences.plid = Layout.plid where ",
-					"PortletPreferences.ctCollectionId = ? and ",
-					"PortletPreferences.portletId like CONCAT('%_INSTANCE_', ",
-					"?) and (Layout.groupId = ? or PortletPreferences.plid = ",
-					"?)"))) {
+					"join Layout on PortletPreferences.plid = Layout.plid ",
+					"where PortletPreferences.portletId like ",
+					"CONCAT('%_INSTANCE_', ?) and (Layout.groupId = ? or ",
+					"PortletPreferences.plid = ?)"))) {
 
-			preparedStatement.setLong(1, ctCollectionId);
-			preparedStatement.setString(2, namespace);
-			preparedStatement.setLong(3, ctCollectionId);
-			preparedStatement.setLong(4, groupId);
+			preparedStatement.setString(1, namespace);
+			preparedStatement.setLong(2, groupId);
 			preparedStatement.setLong(
-				5, _companyControlPanelPlids.get(companyId));
+				3, _companyControlPanelPlids.get(companyId));
 
 			ResultSet resultSet = preparedStatement.executeQuery();
 
@@ -120,31 +116,30 @@ public class PortletPreferencesUpgradeProcess extends UpgradeProcess {
 
 	private void _upgradePortletPreferences() throws Exception {
 		try (PreparedStatement preparedStatement1 = connection.prepareStatement(
-				"select ctCollectionId, groupId, companyId, classPK, " +
-					"namespace from FragmentEntryLink");
+				"select groupId, companyId, classPK, namespace from " +
+					"FragmentEntryLink");
 			PreparedStatement preparedStatement2 =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
-					"delete from PortletPreferences where ctCollectionId = ? " +
-						"and portletPreferencesId = ?");
+					"delete from PortletPreferences where " +
+						"portletPreferencesId = ?");
 			PreparedStatement preparedStatement3 =
 				AutoBatchPreparedStatementUtil.autoBatch(
 					connection,
 					"update PortletPreferences set plid = ? where " +
-						"ctCollectionId = ? and portletPreferencesId = ?");
+						"portletPreferencesId = ?");
 			ResultSet resultSet = preparedStatement1.executeQuery()) {
 
 			while (resultSet.next()) {
 				long groupId = resultSet.getLong("groupId");
 				long companyId = resultSet.getLong("companyId");
 				long classPK = resultSet.getLong("classPK");
-				long ctCollectionId = resultSet.getLong("ctCollectionId");
 				String namespace = resultSet.getString("namespace");
 
 				try {
 					Map<Long, Long> portletPreferencesMap =
 						_getPortletPreferencesMap(
-							companyId, ctCollectionId, groupId, namespace);
+							companyId, groupId, namespace);
 
 					if (portletPreferencesMap.isEmpty()) {
 						continue;
@@ -181,38 +176,33 @@ public class PortletPreferencesUpgradeProcess extends UpgradeProcess {
 
 					if (groupPortletPreferencesId != null) {
 						if (companyPortletPreferencesId != null) {
-							preparedStatement2.setLong(1, ctCollectionId);
 							preparedStatement2.setLong(
-								2, companyPortletPreferencesId);
+								1, companyPortletPreferencesId);
 							preparedStatement2.addBatch();
 						}
 
 						if (layoutPortletPreferencesId != null) {
-							preparedStatement2.setLong(1, ctCollectionId);
 							preparedStatement2.setLong(
-								2, layoutPortletPreferencesId);
+								1, layoutPortletPreferencesId);
 							preparedStatement2.addBatch();
 						}
 
 						preparedStatement3.setLong(1, classPK);
-						preparedStatement3.setLong(2, ctCollectionId);
 						preparedStatement3.setLong(
-							3, groupPortletPreferencesId);
+							2, groupPortletPreferencesId);
 
 						preparedStatement3.addBatch();
 					}
 					else if (companyPortletPreferencesId != null) {
 						if (layoutPortletPreferencesId != null) {
-							preparedStatement2.setLong(1, ctCollectionId);
 							preparedStatement2.setLong(
-								2, layoutPortletPreferencesId);
+								1, layoutPortletPreferencesId);
 							preparedStatement2.addBatch();
 						}
 
 						preparedStatement3.setLong(1, classPK);
-						preparedStatement3.setLong(2, ctCollectionId);
 						preparedStatement3.setLong(
-							3, companyPortletPreferencesId);
+							2, companyPortletPreferencesId);
 
 						preparedStatement3.addBatch();
 					}

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/PortletPreferencesUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/PortletPreferencesUpgradeProcess.java
@@ -97,8 +97,8 @@ public class PortletPreferencesUpgradeProcess extends UpgradeProcess {
 					"?)"))) {
 
 			preparedStatement.setLong(1, ctCollectionId);
-			preparedStatement.setLong(2, ctCollectionId);
-			preparedStatement.setString(3, namespace);
+			preparedStatement.setString(2, namespace);
+			preparedStatement.setLong(3, ctCollectionId);
 			preparedStatement.setLong(4, groupId);
 			preparedStatement.setLong(
 				5, _companyControlPanelPlids.get(companyId));

--- a/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/PortletPreferencesUpgradeProcess.java
+++ b/modules/apps/fragment/fragment-service/src/main/java/com/liferay/fragment/internal/upgrade/v1_1_0/PortletPreferencesUpgradeProcess.java
@@ -135,10 +135,10 @@ public class PortletPreferencesUpgradeProcess extends UpgradeProcess {
 			ResultSet resultSet = preparedStatement1.executeQuery()) {
 
 			while (resultSet.next()) {
-				long classPK = resultSet.getLong("classPK");
-				long companyId = resultSet.getLong("companyId");
-				long ctCollectionId = resultSet.getLong("ctCollectionId");
 				long groupId = resultSet.getLong("groupId");
+				long companyId = resultSet.getLong("companyId");
+				long classPK = resultSet.getLong("classPK");
+				long ctCollectionId = resultSet.getLong("ctCollectionId");
 				String namespace = resultSet.getString("namespace");
 
 				try {

--- a/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v1_1_0/test/PortletPreferencesUpgradeProcessTest.java
+++ b/modules/apps/fragment/fragment-test/src/testIntegration/java/com/liferay/fragment/internal/upgrade/v1_1_0/test/PortletPreferencesUpgradeProcessTest.java
@@ -6,32 +6,24 @@
 package com.liferay.fragment.internal.upgrade.v1_1_0.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
-import com.liferay.change.tracking.test.util.BaseCTUpgradeProcessTestCase;
-import com.liferay.fragment.entry.processor.constants.FragmentEntryProcessorConstants;
-import com.liferay.fragment.model.FragmentEntryLink;
-import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.journal.constants.JournalContentPortletKeys;
 import com.liferay.layout.test.util.ContentLayoutTestUtil;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.portal.kernel.cache.MultiVMPool;
 import com.liferay.portal.kernel.dao.orm.EntityCache;
 import com.liferay.portal.kernel.json.JSONObject;
-import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.PortletPreferences;
-import com.liferay.portal.kernel.model.change.tracking.CTModel;
 import com.liferay.portal.kernel.portlet.PortletIdCodec;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
-import com.liferay.portal.kernel.service.change.tracking.CTService;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
-import com.liferay.portal.kernel.test.util.RandomTestUtil;
-import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.upgrade.UpgradeProcess;
+import com.liferay.portal.kernel.version.Version;
 import com.liferay.portal.test.log.LogCapture;
 import com.liferay.portal.test.log.LogEntry;
 import com.liferay.portal.test.log.LoggerTestUtil;
@@ -55,8 +47,7 @@ import org.junit.runner.RunWith;
  * @author Eudaldo Alonso
  */
 @RunWith(Arquillian.class)
-public class PortletPreferencesUpgradeProcessTest
-	extends BaseCTUpgradeProcessTestCase {
+public class PortletPreferencesUpgradeProcessTest {
 
 	@ClassRule
 	@Rule
@@ -68,18 +59,14 @@ public class PortletPreferencesUpgradeProcessTest
 	@Before
 	public void setUp() throws Exception {
 		_group = GroupTestUtil.addGroup();
-
-		_layout = LayoutTestUtil.addTypeContentLayout(_group);
-
-		_segmentsExperienceId =
-			_segmentsExperienceLocalService.fetchDefaultSegmentsExperienceId(
-				_layout.getPlid());
 	}
 
 	@Test
 	public void testUpgrade() throws Exception {
+		Layout layout = LayoutTestUtil.addTypeContentLayout(_group);
+
 		PortletPreferences portletPreferences = _getPortletPreferences(
-			_addPortletFragmentEntryLink());
+			layout, _addPortletFragmentEntryLink(layout));
 
 		Layout controlPanelLayout = LayoutTestUtil.addTypeContentLayout(_group);
 
@@ -100,7 +87,7 @@ public class PortletPreferencesUpgradeProcessTest
 					"PortletPreferencesUpgradeProcess",
 				LoggerTestUtil.ALL)) {
 
-			runUpgrade();
+			_runUpgrade();
 
 			List<LogEntry> logEntries = logCapture.getLogEntries();
 
@@ -114,50 +101,15 @@ public class PortletPreferencesUpgradeProcessTest
 			_portletPreferencesLocalService.fetchPortletPreferences(
 				portletPreferences.getPortletPreferencesId());
 
-		Assert.assertEquals(_layout.getPlid(), portletPreferences.getPlid());
+		Assert.assertEquals(layout.getPlid(), portletPreferences.getPlid());
 	}
 
-	@Override
-	protected CTModel<?> addCTModel() throws Exception {
-		return ContentLayoutTestUtil.addFragmentEntryLinkToLayout(
-			"{}", _layout.fetchDraftLayout(), _segmentsExperienceId);
-	}
+	private String _addPortletFragmentEntryLink(Layout layout)
+		throws Exception {
 
-	@Override
-	protected CTService<?> getCTService() {
-		return _fragmentEntryLinkLocalService;
-	}
-
-	protected void runUpgrade() throws Exception {
-		UpgradeProcess upgradeProcess = UpgradeTestUtil.getUpgradeStep(
-			_upgradeStepRegistrator, _CLASS_NAME);
-
-		upgradeProcess.upgrade();
-
-		_entityCache.clearCache();
-		_multiVMPool.clear();
-	}
-
-	@Override
-	protected CTModel<?> updateCTModel(CTModel<?> ctModel) throws Exception {
-		FragmentEntryLink fragmentEntryLink = (FragmentEntryLink)ctModel;
-
-		return _fragmentEntryLinkLocalService.updateFragmentEntryLink(
-			TestPropsValues.getUserId(),
-			fragmentEntryLink.getFragmentEntryLinkId(),
-			JSONUtil.put(
-				FragmentEntryProcessorConstants.
-					KEY_FREEMARKER_FRAGMENT_ENTRY_PROCESSOR,
-				JSONUtil.put(
-					RandomTestUtil.randomString(),
-					RandomTestUtil.randomString())
-			).toString());
-	}
-
-	private String _addPortletFragmentEntryLink() throws Exception {
 		JSONObject processAddPortletJSONObject =
 			ContentLayoutTestUtil.addPortletToLayout(
-				_layout, JournalContentPortletKeys.JOURNAL_CONTENT);
+				layout, JournalContentPortletKeys.JOURNAL_CONTENT);
 
 		JSONObject fragmentEntryLinkJSONObject =
 			processAddPortletJSONObject.getJSONObject("fragmentEntryLink");
@@ -170,12 +122,13 @@ public class PortletPreferencesUpgradeProcessTest
 			editableValuesJSONObject.getString("instanceId"));
 	}
 
-	private PortletPreferences _getPortletPreferences(String portletId)
+	private PortletPreferences _getPortletPreferences(
+			Layout layout, String portletId)
 		throws Exception {
 
 		List<PortletPreferences> portletPreferences =
 			_portletPreferencesLocalService.getPortletPreferences(
-				_layout.getPlid(), portletId);
+				layout.getPlid(), portletId);
 
 		Assert.assertEquals(
 			portletPreferences.toString(), 1, portletPreferences.size());
@@ -183,9 +136,17 @@ public class PortletPreferencesUpgradeProcessTest
 		return portletPreferences.get(0);
 	}
 
-	private static final String _CLASS_NAME =
-		"com.liferay.fragment.internal.upgrade.v1_1_0." +
-			"PortletPreferencesUpgradeProcess";
+	private void _runUpgrade() throws Exception {
+		UpgradeProcess[] upgradeProcesses = UpgradeTestUtil.getUpgradeSteps(
+			_upgradeStepRegistrator, new Version(1, 1, 0));
+
+		for (UpgradeProcess upgradeProcess : upgradeProcesses) {
+			upgradeProcess.upgrade();
+		}
+
+		_entityCache.clearCache();
+		_multiVMPool.clear();
+	}
 
 	@Inject(
 		filter = "(&(component.name=com.liferay.fragment.internal.upgrade.registry.FragmentServiceUpgradeStepRegistrator))"
@@ -195,13 +156,8 @@ public class PortletPreferencesUpgradeProcessTest
 	@Inject
 	private EntityCache _entityCache;
 
-	@Inject
-	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
-
 	@DeleteAfterTestRun
 	private Group _group;
-
-	private Layout _layout;
 
 	@Inject
 	private LayoutLocalService _layoutLocalService;
@@ -211,8 +167,6 @@ public class PortletPreferencesUpgradeProcessTest
 
 	@Inject
 	private PortletPreferencesLocalService _portletPreferencesLocalService;
-
-	private long _segmentsExperienceId;
 
 	@Inject
 	private SegmentsExperienceLocalService _segmentsExperienceLocalService;


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-34916

In this PR, I am reverting https://liferay.atlassian.net/browse/LPD-27776. The changes requested in that ticket should never have been applied because at that point in the schema, version 1.1.0, there is no data related to publications at the fragments tables. The module only integrates with publications starting with schema version 2.7.0.

I am only keeping the modifications to the integration test made before applying the changes because they provide value.