### PR TITLE
LPD-35649 Liferay Experience Selector Color is not visible

### DIFF
--- a/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/experience_selector/ExperienceSelector.tsx
+++ b/modules/apps/layout/layout-js-components-web/src/main/resources/META-INF/resources/js/components/experience_selector/ExperienceSelector.tsx
@@ -43,14 +43,14 @@ const TriggerLabel = React.forwardRef(
 			<button
 				{...otherProps}
 				className={classNames(
-					'btn btn-block btn-sm form-control-select layout__experience-selector',
+					'btn btn-block btn-sm c-ml-1 c-py-1 form-control-select layout__experience-selector',
 					{'btn-secondary': displayType === 'light'}
 				)}
 				ref={ref}
 			>
 				<Layout.ContentRow verticalAlign="center">
 					<Layout.ContentCol className="c-mr-2 text-truncate" expand>
-						<Text size={3} weight="normal">
+						<Text color="secondary" size={4} weight="normal">
 							{selectedItem.segmentsExperienceName}
 						</Text>
 					</Layout.ContentCol>

--- a/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/product/navigation/control/menu/SegmentsExperienceSelectorProductNavigationControlMenuEntry.java
+++ b/modules/apps/segments/segments-web/src/main/java/com/liferay/segments/web/internal/product/navigation/control/menu/SegmentsExperienceSelectorProductNavigationControlMenuEntry.java
@@ -93,7 +93,7 @@ public class SegmentsExperienceSelectorProductNavigationControlMenuEntry
 			PrintWriter printWriter = httpServletResponse.getWriter();
 
 			printWriter.write("<div class=\"border-left border-secondary ");
-			printWriter.write("control-menu-nav-item c-ml-3 c-pl-md-3\">");
+			printWriter.write("control-menu-nav-item\">");
 
 			_reactRenderer.renderReact(
 				new ComponentDescriptor("{ExperiencePicker} from segments-web"),


### PR DESCRIPTION
> [!NOTE]
> Not needed to test the styles

## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPD-35649)

### Changes

Adapt styles to see the text

## Steps to reproduce

1. Start a clean bundle of Liferay DXP QR 2024.Q2.2
2. Edit the home page on the default site and create a new experience named test
3. Publish the home page

<img width="368" alt="image" src="https://github.com/user-attachments/assets/07398ca4-1cfd-4d48-b913-ad5c3a1dcd3a">
