### PR TITLE
LPD-36041 Reverse Order Direction button does not work in [Site Builder > Pages]

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/display/context/LayoutsAdminManagementToolbarDisplayContext.java
@@ -261,6 +261,11 @@ public class LayoutsAdminManagementToolbarDisplayContext
 	}
 
 	@Override
+	public String getSortingURL() {
+		return null;
+	}
+
+	@Override
 	public Boolean isDisabled() {
 		if (Objects.equals(
 				_layoutsAdminDisplayContext.getDisplayStyle(),

--- a/modules/test/playwright/tests/layout-admin-web/pagesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pagesAdmin.spec.ts
@@ -327,3 +327,29 @@ test(
 		);
 	}
 );
+
+test(
+	'The sort button for pages is not shown',
+	{
+		tag: '@LPD-36041',
+	},
+	async ({apiHelpers, page, pagesAdminPage, site}) => {
+
+		// Create a page
+
+		await apiHelpers.jsonWebServicesLayout.addLayout({
+			groupId: site.id,
+			title: getRandomString(),
+		});
+
+		// Go to admin page
+
+		await pagesAdminPage.goto(site.friendlyUrlPath);
+
+		// Check the button is not shown
+
+		await expect(
+			page.getByLabel('Reverse Order Direction:')
+		).not.toBeAttached();
+	}
+);


### PR DESCRIPTION
## Motivation

[Link to ticket](https://liferay.atlassian.net/browse/LPD-36041)

## Changes

The button will never work because of the drag and drop (we can reorder the pages) and also because they are sorted by creation date.

## Test Scenario

1. Go to Site Builder > Pages
2. Create a test page
3. Check that the button doesn't appear now

![image](https://github.com/user-attachments/assets/3706f9c1-4122-467b-8bc8-40f678113efe)

