### PR TITLE
LPD-36432 Improve range multiselection with keyboard

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/MultiSelectManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/MultiSelectManager.js
@@ -11,6 +11,7 @@ import {
 	ESCAPE_KEY_CODE,
 	META_KEY_CODE,
 	SHIFT_KEY_CODE,
+	SPACE_KEY_CODE,
 } from '../config/constants/keyboardCodes';
 import {MULTI_SELECT_TYPES} from '../config/constants/multiSelectTypes';
 import {
@@ -35,6 +36,7 @@ export default function MultiSelectManager() {
 			},
 			disableKeyCombination: (event) => event.key === SHIFT_KEY_CODE,
 			keyCombination: (event) => event.shiftKey,
+			keyboardActivation: () => true,
 		},
 		simpleMultiSelect: {
 			action: () => {
@@ -43,6 +45,8 @@ export default function MultiSelectManager() {
 			disableKeyCombination: (event) =>
 				event.key === CONTROL_KEY_CODE || event.key === META_KEY_CODE,
 			keyCombination: (event) => isCtrlOrMeta(event),
+			keyboardActivation: (event) =>
+				event.key === ENTER_KEY_CODE || event.key === SPACE_KEY_CODE,
 		},
 	};
 
@@ -68,7 +72,7 @@ export default function MultiSelectManager() {
 					!multiSelectType && multiSelection.keyCombination(event)
 			);
 
-			if (multiSelection && event.key === ENTER_KEY_CODE) {
+			if (multiSelection && multiSelection.keyboardActivation(event)) {
 				multiSelection.action(event);
 			}
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/MultiSelectManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/MultiSelectManager.js
@@ -16,7 +16,7 @@ import {MULTI_SELECT_TYPES} from '../config/constants/multiSelectTypes';
 import {
 	useActivateMultiSelect,
 	useActiveItemIds,
-	useMultiSelectIsActivated,
+	useMultiSelectType,
 	useSelectItem,
 } from '../contexts/ControlsContext';
 import isCtrlOrMeta from '../utils/isCtrlOrMeta';
@@ -25,7 +25,7 @@ export default function MultiSelectManager() {
 	const activeItemIds = useActiveItemIds();
 	const activateMultiSelect = useActivateMultiSelect();
 	const keymapRef = useRef(null);
-	const multiSelectIsActivated = useMultiSelectIsActivated();
+	const multiSelectType = useMultiSelectType();
 	const selectItem = useSelectItem();
 
 	keymapRef.current = {
@@ -54,8 +54,7 @@ export default function MultiSelectManager() {
 		const onClick = (event) => {
 			const multiSelection = Object.values(keymapRef.current).find(
 				(multiSelection) =>
-					!multiSelectIsActivated &&
-					multiSelection.keyCombination(event)
+					!multiSelectType && multiSelection.keyCombination(event)
 			);
 
 			if (multiSelection) {
@@ -66,8 +65,7 @@ export default function MultiSelectManager() {
 		const onKeydown = (event) => {
 			const multiSelection = Object.values(keymapRef.current).find(
 				(multiSelection) =>
-					!multiSelectIsActivated &&
-					multiSelection.keyCombination(event)
+					!multiSelectType && multiSelection.keyCombination(event)
 			);
 
 			if (multiSelection && event.key === ENTER_KEY_CODE) {
@@ -82,7 +80,7 @@ export default function MultiSelectManager() {
 		const onKeyup = (event) => {
 			const multiSelection = Object.values(keymapRef.current).find(
 				(multiSelection) =>
-					multiSelectIsActivated &&
+					multiSelectType &&
 					multiSelection.disableKeyCombination(event)
 			);
 
@@ -100,12 +98,7 @@ export default function MultiSelectManager() {
 			window.removeEventListener('keydown', onKeydown, true);
 			window.removeEventListener('keyup', onKeyup, true);
 		};
-	}, [
-		activeItemIds,
-		activateMultiSelect,
-		multiSelectIsActivated,
-		selectItem,
-	]);
+	}, [activeItemIds, activateMultiSelect, multiSelectType, selectItem]);
 
 	return null;
 }

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/ControlsContext.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/ControlsContext.js
@@ -174,18 +174,27 @@ const reducer = (state, action) => {
 
 			rangeLimitIds = {end: itemId, start: startLimitId};
 
-			const root =
-				state.layoutData.items[state.layoutData.rootItems.main];
+			if (rangeLimitIds.end === rangeLimitIds.start) {
 
-			nextActiveItemIds = getItemsWithinRange({
-				itemIds: root.children,
-				layoutDataItems: state.layoutData.items,
-				rangeLimitIds,
-			});
+				// If the start and end of the range are the same id, only
+				// this item is selected
 
-			nextActiveItemIds = [
-				...new Set([...initialActiveItemIds, ...nextActiveItemIds]),
-			];
+				nextActiveItemIds = [itemId];
+			}
+			else {
+				const root =
+					state.layoutData.items[state.layoutData.rootItems.main];
+
+				nextActiveItemIds = getItemsWithinRange({
+					itemIds: root.children,
+					layoutDataItems: state.layoutData.items,
+					rangeLimitIds,
+				});
+
+				nextActiveItemIds = [
+					...new Set([...initialActiveItemIds, ...nextActiveItemIds]),
+				];
+			}
 		}
 
 		nextState = {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/ControlsContext.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/ControlsContext.js
@@ -161,7 +161,7 @@ const reducer = (state, action) => {
 				// the range is kept and the activeItemIds from the last range
 				// selection are removed.
 
-				startLimitId = state.rangeLimitIds.start;
+				startLimitId = state.rangeLimitIds.start || startLimitId;
 
 				initialActiveItemIds = state.activeItemIds.slice(
 					0,
@@ -174,7 +174,10 @@ const reducer = (state, action) => {
 
 			rangeLimitIds = {end: itemId, start: startLimitId};
 
-			if (rangeLimitIds.end === rangeLimitIds.start) {
+			if (
+				!rangeLimitIds.start ||
+				rangeLimitIds.end === rangeLimitIds.start
+			) {
 
 				// If the start and end of the range are the same id, only
 				// this item is selected

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/ControlsContext.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/ControlsContext.js
@@ -147,6 +147,14 @@ const reducer = (state, action) => {
 			);
 		}
 		else if (state.multiSelect === MULTI_SELECT_TYPES.range) {
+
+			// Avoid selection in range when directly selecting an item that
+			// is not a layout data item, such as editables.
+
+			if (!state.layoutData.items[itemId]) {
+				return nextState;
+			}
+
 			let initialActiveItemIds = state.activeItemIds;
 
 			// The last active item id is taken when the first item in the

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/ControlsContext.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/contexts/ControlsContext.js
@@ -357,8 +357,7 @@ const useSelectMultipleItems = () => {
 	);
 };
 
-const useMultiSelectIsActivated = () =>
-	useContext(ActiveStateContext).multiSelect;
+const useMultiSelectType = () => useContext(ActiveStateContext).multiSelect;
 
 export {
 	ControlsProvider,
@@ -373,7 +372,7 @@ export {
 	useHoverItem,
 	useIsActive,
 	useIsHovered,
-	useMultiSelectIsActivated,
+	useMultiSelectType,
 	useSelectItem,
 	useSelectMultipleItems,
 };

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/hooks/app_hooks/useLayoutKeyboardNavigation.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/hooks/app_hooks/useLayoutKeyboardNavigation.js
@@ -8,25 +8,42 @@ import {useContext, useEffect, useRef} from 'react';
 
 import {ITEM_ACTIVATION_ORIGINS} from '../../config/constants/itemActivationOrigins';
 import {ITEM_TYPES} from '../../config/constants/itemTypes';
-import {useHoverItem, useSelectItem} from '../../contexts/ControlsContext';
+import {MULTI_SELECT_TYPES} from '../../config/constants/multiSelectTypes';
+import {
+	useHoverItem,
+	useMultiSelectType,
+	useSelectItem,
+} from '../../contexts/ControlsContext';
 import {LayoutKeyboardContext} from '../../contexts/LayoutKeyboardContext';
 
 export function useLayoutKeyboardNavigation(item) {
 	const elementRef = useRef(null);
 
 	const hoverItem = useHoverItem();
+	const multiSelectType = useMultiSelectType();
 	const selectItem = useSelectItem();
 
 	const {itemList, setTargetId, targetId} = useContext(LayoutKeyboardContext);
 
-	// Focus and hover when changing target
+	// Focus when changing target, and if the multiselection in range is
+	// activated in range the element is selected, if not it is hovered.
 
 	useEffect(() => {
 		if (targetId === item.itemId) {
 			elementRef.current.focus();
-			hoverItem(item.itemId);
+
+			if (multiSelectType === MULTI_SELECT_TYPES.range) {
+				selectItem(item.itemId, {
+					origin: ITEM_ACTIVATION_ORIGINS.keyboard,
+				});
+			}
+			else {
+				hoverItem(item.itemId);
+			}
 		}
-	}, [hoverItem, item, targetId]);
+
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [hoverItem, item, selectItem, targetId]);
 
 	// Hover and set target when focusing first item
 

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTreeContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTreeContent.js
@@ -5,8 +5,9 @@
 
 import ClayAlert from '@clayui/alert';
 import {TreeView as ClayTreeView} from '@clayui/core';
+import {useEventListener} from '@liferay/frontend-js-react-web';
 import classNames from 'classnames';
-import React, {useCallback, useEffect, useMemo, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 
 import getAllEditables from '../../../../../app/components/fragment_content/getAllEditables';
 import {fromControlsId} from '../../../../../app/components/layout_data_items/Collection';
@@ -28,11 +29,13 @@ import {
 } from '../../../../../app/config/constants/keyboardCodes';
 import {LAYOUT_DATA_ITEM_TYPES} from '../../../../../app/config/constants/layoutDataItemTypes';
 import {LAYOUT_TYPES} from '../../../../../app/config/constants/layoutTypes';
+import {MULTI_SELECT_TYPES} from '../../../../../app/config/constants/multiSelectTypes';
 import {config} from '../../../../../app/config/index';
 import {
 	useActiveItemIds,
 	useHoverItem,
 	useHoveredItemId,
+	useMultiSelectType,
 	useSelectItem,
 } from '../../../../../app/contexts/ControlsContext';
 import {useEditedNodeId} from '../../../../../app/contexts/ShortcutContext';
@@ -95,10 +98,12 @@ export default function StructureTreeContent({expandedKeys, setExpandedKeys}) {
 	);
 	const fragmentEntryLinks = useSelector((state) => state.fragmentEntryLinks);
 	const layoutData = useSelector((state) => state.layoutData);
+	const multiSelectType = useMultiSelectType();
 	const pageContents = usePageContents();
 	const hoverItem = useHoverItem();
 	const hoveredItemId = useHoveredItemId();
 	const selectItem = useSelectItem();
+	const treeRef = useRef(null);
 
 	const mappingFields = useSelector((state) => state.mappingFields);
 	const masterLayoutData = useSelector(
@@ -285,10 +290,35 @@ export default function StructureTreeContent({expandedKeys, setExpandedKeys}) {
 		}
 	};
 
+	// Each time an item is focused on, if range multiselect is enabled,
+	// the item is selected.
+
+	useEventListener(
+		'focusin',
+		(event) => {
+			if (multiSelectType === MULTI_SELECT_TYPES.range) {
+				const itemId = event.target.querySelector(
+					'.page-editor__page-structure__tree-node__mask'
+				).dataset.itemId;
+
+				const item = layoutData.items[itemId];
+
+				if (item) {
+					selectItem(itemId, {
+						origin: ITEM_ACTIVATION_ORIGINS.sidebar,
+					});
+				}
+			}
+		},
+		false,
+		treeRef.current
+	);
+
 	return (
 		<div
 			className="overflow-auto page-editor__page-structure__structure-tree pt-4"
 			onFocus={handleNodeFocus}
+			ref={treeRef}
 		>
 			{!nodes.length && (
 				<ClayAlert

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTreeContent.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/plugins/browser/components/page_structure/components/StructureTreeContent.js
@@ -167,17 +167,6 @@ export default function StructureTreeContent({expandedKeys, setExpandedKeys}) {
 		]
 	);
 
-	const handleNodeFocus = () => {
-		const focusedItem =
-			document.activeElement?.querySelector('[data-item-id]');
-
-		if (focusedItem) {
-			hoverItem(focusedItem.dataset.itemId, {
-				origin: ITEM_ACTIVATION_ORIGINS.sidebar,
-			});
-		}
-	};
-
 	const handleButtonsKeyDown = (event) => {
 		if (
 			[
@@ -317,7 +306,6 @@ export default function StructureTreeContent({expandedKeys, setExpandedKeys}) {
 	return (
 		<div
 			className="overflow-auto page-editor__page-structure__structure-tree pt-4"
-			onFocus={handleNodeFocus}
 			ref={treeRef}
 		>
 			{!nodes.length && (
@@ -345,7 +333,6 @@ export default function StructureTreeContent({expandedKeys, setExpandedKeys}) {
 					{(item) => (
 						<ClayTreeView.Item
 							actions={<ItemActions item={item} />}
-							active={item.active && item.activable}
 						>
 							<ClayTreeView.ItemStack
 								className={classNames(

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Controls.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/Controls.test.js
@@ -66,7 +66,6 @@ const LAYOUT_DATA = {
 			parentId: 'column',
 			type: LAYOUT_DATA_ITEM_TYPES.fragmentDropZone,
 		},
-
 		formStep: {
 			children: [],
 			itemId: 'formStep',
@@ -440,6 +439,55 @@ describe('Reducer', () => {
 							'fragment02',
 							'container02',
 						],
+					})
+				);
+
+				Liferay.FeatureFlags['LPD-18221'] = false;
+			});
+
+			it('selects the item when the range multiselection is activated before there are any items selected', () => {
+				Liferay.FeatureFlags['LPD-18221'] = true;
+
+				const action = {
+					...ACTION,
+					itemId: 'fragment01',
+					type: SELECT_ITEM,
+				};
+				const state = {
+					...STATE,
+					activeItemIds: [],
+					layoutData: LAYOUT_DATA,
+					multiSelect: 'range',
+				};
+
+				expect(reducer(state, action)).toEqual(
+					expect.objectContaining({
+						activeItemIds: ['fragment01'],
+					})
+				);
+
+				Liferay.FeatureFlags['LPD-18221'] = false;
+			});
+
+			it('selects a single item when the start and the end of the range are the same id', () => {
+				Liferay.FeatureFlags['LPD-18221'] = true;
+
+				const action = {
+					...ACTION,
+					itemId: 'fragment01',
+					type: SELECT_ITEM,
+				};
+				const state = {
+					...STATE,
+					activeItemIds: ['fragment01', 'fragment02'],
+					layoutData: LAYOUT_DATA,
+					multiSelect: 'range',
+					rangeLimitIds: {end: 'fragment01', start: 'fragment01'},
+				};
+
+				expect(reducer(state, action)).toEqual(
+					expect.objectContaining({
+						activeItemIds: ['fragment01'],
 					})
 				);
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/MultiSelectManager.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/MultiSelectManager.test.js
@@ -46,6 +46,10 @@ describe('MultiSelectManager', () => {
 		Liferay.FeatureFlags['LPD-18221'] = false;
 	});
 
+	afterEach(() => {
+		jest.clearAllMocks();
+	});
+
 	describe('Simple multiselect', () => {
 		it('activates simple multiselect when pressing ctrl + click', () => {
 			renderComponent();
@@ -68,6 +72,21 @@ describe('MultiSelectManager', () => {
 				new KeyboardEvent('keydown', {
 					ctrlKey: true,
 					key: 'Enter',
+				})
+			);
+
+			const activateMultiSelect = useActivateMultiSelect();
+
+			expect(activateMultiSelect).toBeCalledWith('simple');
+		});
+
+		it('activates simple multiselect when pressing ctrl + "Space"', () => {
+			renderComponent();
+
+			document.body.dispatchEvent(
+				new KeyboardEvent('keydown', {
+					ctrlKey: true,
+					key: 'Space',
 				})
 			);
 
@@ -111,13 +130,12 @@ describe('MultiSelectManager', () => {
 			expect(activateMultiSelect).toBeCalledWith('range');
 		});
 
-		it('activates range multiselect when pressing shift + "Enter"', () => {
+		it('activates range multiselect when pressing shift', () => {
 			renderComponent();
 
 			document.body.dispatchEvent(
 				new KeyboardEvent('keydown', {
 					ctrlKey: false,
-					key: 'Enter',
 					shiftKey: true,
 				})
 			);

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/MultiSelectManager.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/MultiSelectManager.test.js
@@ -10,7 +10,7 @@ import MultiSelectManager from '../../../../src/main/resources/META-INF/resource
 import {
 	useActivateMultiSelect,
 	useActiveItemIds,
-	useMultiSelectIsActivated,
+	useMultiSelectType,
 	useSelectItem,
 } from '../../../../src/main/resources/META-INF/resources/page_editor/app/contexts/ControlsContext';
 import StoreMother from '../../../../src/main/resources/META-INF/resources/page_editor/test_utils/StoreMother';
@@ -24,7 +24,7 @@ jest.mock(
 		return {
 			useActivateMultiSelect: () => activateMultiSelect,
 			useActiveItemIds: jest.fn(() => []),
-			useMultiSelectIsActivated: jest.fn(() => false),
+			useMultiSelectType: jest.fn(() => null),
 			useSelectItem: () => selectItem,
 		};
 	}
@@ -77,7 +77,7 @@ describe('MultiSelectManager', () => {
 		});
 
 		it('disable simple multiselect when the ctrl key is released', () => {
-			useMultiSelectIsActivated.mockImplementation(() => true);
+			useMultiSelectType.mockImplementation(() => 'simple');
 
 			renderComponent();
 
@@ -91,7 +91,7 @@ describe('MultiSelectManager', () => {
 
 			expect(activateMultiSelect).toBeCalledWith(null);
 
-			useMultiSelectIsActivated.mockImplementation(() => false);
+			useMultiSelectType.mockImplementation(() => null);
 		});
 	});
 
@@ -128,7 +128,7 @@ describe('MultiSelectManager', () => {
 		});
 
 		it('disable range multiselect when the shift key is released', () => {
-			useMultiSelectIsActivated.mockImplementation(() => true);
+			useMultiSelectType.mockImplementation(() => 'range');
 
 			renderComponent();
 
@@ -142,7 +142,7 @@ describe('MultiSelectManager', () => {
 
 			expect(activateMultiSelect).toBeCalledWith(null);
 
-			useMultiSelectIsActivated.mockImplementation(() => false);
+			useMultiSelectType.mockImplementation(() => null);
 		});
 	});
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/keyboard.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/keyboard.spec.ts
@@ -11,12 +11,14 @@ import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import getRandomString from '../../utils/getRandomString';
+import getContainerDefinition from './utils/getContainerDefinition';
 import getFragmentDefinition from './utils/getFragmentDefinition';
 import getPageDefinition from './utils/getPageDefinition';
 
 const test = mergeTests(
 	apiHelpersTest,
 	featureFlagsTest({
+		'LPD-18221': true,
 		'LPS-178052': true,
 	}),
 	isolatedSiteTest,
@@ -271,3 +273,194 @@ test('Checks that a fragment is selected when it is added and the panel does not
 
 	await expect(page.getByLabel('Fragments and Widgets Panel')).toBeVisible();
 });
+
+test(
+	'Check that the range multiselection by keyboard from the page structure tree works correctly',
+	{
+		tag: '@LPD-36432',
+	},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+		const firstHeadingId = getRandomString();
+
+		const firstHeading = getFragmentDefinition({
+			id: firstHeadingId,
+			key: 'BASIC_COMPONENT-heading',
+		});
+
+		const secondHeadingId = getRandomString();
+
+		const secondHeading = getFragmentDefinition({
+			id: secondHeadingId,
+			key: 'BASIC_COMPONENT-heading',
+		});
+
+		const thirdHeadingId = getRandomString();
+
+		const thirdHeading = getFragmentDefinition({
+			id: thirdHeadingId,
+			key: 'BASIC_COMPONENT-heading',
+		});
+
+		const fourthHeadingId = getRandomString();
+
+		const fourthHeading = getFragmentDefinition({
+			id: fourthHeadingId,
+			key: 'BASIC_COMPONENT-heading',
+		});
+
+		const containerId = getRandomString();
+
+		const container = getContainerDefinition({
+			id: containerId,
+			pageElements: [secondHeading, thirdHeading],
+		});
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				firstHeading,
+				container,
+				fourthHeading,
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToSidebarTab('Browser');
+
+		// Select the first heading inside the container by keyboard
+
+		await page.locator('.page-editor__page-structure').press('Tab');
+		await page.keyboard.press('Tab');
+		await page.keyboard.press('ArrowDown');
+		await page.keyboard.press('Enter');
+		await page.keyboard.press('ArrowDown');
+		await page.keyboard.press('Enter');
+
+		// Activate the range multiselection
+
+		await page.keyboard.down('Shift');
+		await page.keyboard.press('ArrowDown');
+		await page.keyboard.press('ArrowDown');
+		await page.keyboard.press('ArrowDown');
+		await page.keyboard.press('ArrowDown');
+
+		// Check that the 3 last headings are selected
+
+		expect(await pageEditorPage.isActive(secondHeadingId)).toBe(true);
+		expect(await pageEditorPage.isActive(thirdHeadingId)).toBe(true);
+		expect(await pageEditorPage.isActive(fourthHeadingId)).toBe(true);
+
+		// Select the container, first and second heading without deactivate the range multiselection
+
+		await page.keyboard.press('ArrowUp');
+		await page.keyboard.press('ArrowUp');
+		await page.keyboard.press('ArrowUp');
+		await page.keyboard.press('ArrowUp');
+		await page.keyboard.press('ArrowUp');
+		await page.keyboard.press('ArrowUp');
+
+		// Check that the container, first and second heading are selected
+
+		expect(await pageEditorPage.isActive(containerId)).toBe(true);
+		expect(await pageEditorPage.isActive(firstHeadingId)).toBe(true);
+		expect(await pageEditorPage.isActive(secondHeadingId)).toBe(true);
+	}
+);
+
+test(
+	'Check that the range multiselection by keyboard from the layout works correctly',
+	{
+		tag: '@LPD-36432',
+	},
+	async ({apiHelpers, page, pageEditorPage, site}) => {
+		const firstHeadingId = getRandomString();
+
+		const firstHeading = getFragmentDefinition({
+			id: firstHeadingId,
+			key: 'BASIC_COMPONENT-heading',
+		});
+
+		const secondHeadingId = getRandomString();
+
+		const secondHeading = getFragmentDefinition({
+			id: secondHeadingId,
+			key: 'BASIC_COMPONENT-heading',
+		});
+
+		const thirdHeadingId = getRandomString();
+
+		const thirdHeading = getFragmentDefinition({
+			id: thirdHeadingId,
+			key: 'BASIC_COMPONENT-heading',
+		});
+
+		const fourthHeadingId = getRandomString();
+
+		const fourthHeading = getFragmentDefinition({
+			id: fourthHeadingId,
+			key: 'BASIC_COMPONENT-heading',
+		});
+
+		const containerId = getRandomString();
+
+		const container = getContainerDefinition({
+			id: containerId,
+			pageElements: [secondHeading, thirdHeading],
+		});
+
+		const layout = await apiHelpers.headlessDelivery.createSitePage({
+			pageDefinition: getPageDefinition([
+				firstHeading,
+				container,
+				fourthHeading,
+			]),
+			siteId: site.id,
+			title: getRandomString(),
+		});
+
+		await pageEditorPage.goto(layout, site.friendlyUrlPath);
+
+		await pageEditorPage.goToSidebarTab('Browser');
+
+		// Select the first heading inside the container by keyboard
+
+		await page.locator('.page-editor__sidebar__resizer').focus();
+
+		await page.keyboard.press('Tab');
+		await page.keyboard.press('ArrowDown');
+		await page.keyboard.press('Enter');
+		await page.keyboard.press('ArrowDown');
+		await page.keyboard.press('Enter');
+
+		// Activate the range multiselection
+
+		await page.keyboard.down('Shift');
+		await page.keyboard.press('ArrowDown');
+		await page.keyboard.press('ArrowDown');
+		await page.keyboard.press('ArrowDown');
+		await page.keyboard.press('ArrowDown');
+
+		// Check that the 3 last headings are selected
+
+		expect(await pageEditorPage.isActive(secondHeadingId)).toBe(true);
+		expect(await pageEditorPage.isActive(thirdHeadingId)).toBe(true);
+		expect(await pageEditorPage.isActive(fourthHeadingId)).toBe(true);
+
+		// Select the container, first and second heading without deactivate the range multiselection
+
+		await page.keyboard.press('ArrowUp');
+		await page.keyboard.press('ArrowUp');
+		await page.keyboard.press('ArrowUp');
+		await page.keyboard.press('ArrowUp');
+		await page.keyboard.press('ArrowUp');
+		await page.keyboard.press('ArrowUp');
+
+		// Check that the container, first and second heading are selected
+
+		expect(await pageEditorPage.isActive(containerId)).toBe(true);
+		expect(await pageEditorPage.isActive(firstHeadingId)).toBe(true);
+		expect(await pageEditorPage.isActive(secondHeadingId)).toBe(true);
+	}
+);


### PR DESCRIPTION
Improvements have been made to range multiselection. To select multiple items using the keyboard navigation, press `Shift + ArrowUp/ArrowDown`. The items will automatically be selected.