### PR TITLE
LPD-32919 Adapt usages

### DIFF
--- a/modules/test/playwright/pages/asset-list-web/CollectionsPage.ts
+++ b/modules/test/playwright/pages/asset-list-web/CollectionsPage.ts
@@ -6,7 +6,7 @@
 import {Page} from '@playwright/test';
 
 import {PORTLET_URLS} from '../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class CollectionsPage {
 	readonly page: Page;
@@ -32,7 +32,7 @@ export class CollectionsPage {
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 
 		return {
 			classPK: await this.getCollectionClassPK(name, siteUrl),
@@ -54,7 +54,7 @@ export class CollectionsPage {
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	/**

--- a/modules/test/playwright/pages/asset-publisher-web/AssetPublisherPage.ts
+++ b/modules/test/playwright/pages/asset-publisher-web/AssetPublisherPage.ts
@@ -5,7 +5,7 @@
 
 import {FrameLocator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class AssetPublisherPage {
 	readonly page: Page;
@@ -23,7 +23,7 @@ export class AssetPublisherPage {
 	async changeAssetSelection(type: 'Collection' | 'Dynamic' | 'Manual') {
 		await this.configurationIframe.getByLabel(type, {exact: true}).click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.configurationIframe,
 			'Success:You have successfully updated the setup.'
 		);
@@ -43,7 +43,7 @@ export class AssetPublisherPage {
 			.getByRole('button', {name: 'Save'})
 			.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.configurationIframe,
 			'Success:The collection was created successfully.'
 		);

--- a/modules/test/playwright/pages/calendar-web/CalendarWidgetPage.ts
+++ b/modules/test/playwright/pages/calendar-web/CalendarWidgetPage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {ModalRecurrencePage} from './ModalRecurrencePage';
 
 export class CalendarWidgetPage {
@@ -87,7 +87,7 @@ export class CalendarWidgetPage {
 
 	async publishEvent() {
 		await this.publishEventButton.click();
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page.frameLocator('iframe'),
 			`Success:Your request completed successfully.`
 		);

--- a/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
+++ b/modules/test/playwright/pages/change-tracking-web/ChangeTrackingPage.ts
@@ -9,7 +9,7 @@ import {ApiHelpers} from '../../helpers/ApiHelpers';
 import getRandomString from '../../utils/getRandomString';
 import {userData} from '../../utils/performLogin';
 import {PORTLET_URLS} from '../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {InstanceSettingsPage} from '../configuration-admin-web/InstanceSettingsPage';
 
 export class ChangeTrackingPage {
@@ -68,7 +68,7 @@ export class ChangeTrackingPage {
 
 		await this.page.getByLabel('Submit').click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:Users were invited successfully.'
 		);
@@ -274,7 +274,7 @@ export class ChangeTrackingPage {
 
 		await this.instanceSettingsPage.saveButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			`Success:Your request completed successfully.`
 		);
@@ -295,7 +295,7 @@ export class ChangeTrackingPage {
 
 			await this.instanceSettingsPage.saveButton.click();
 
-			await waitForSuccessAlert(
+			await waitForAlert(
 				this.page,
 				`Success:Your request completed successfully.`
 			);
@@ -305,7 +305,7 @@ export class ChangeTrackingPage {
 
 			await this.instanceSettingsPage.saveButton.click();
 
-			await waitForSuccessAlert(
+			await waitForAlert(
 				this.page,
 				`Success:Your request completed successfully.`
 			);

--- a/modules/test/playwright/pages/commerce/commerceAdminChannelDetailsPage.ts
+++ b/modules/test/playwright/pages/commerce/commerceAdminChannelDetailsPage.ts
@@ -5,7 +5,7 @@
 
 import {FrameLocator, Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';
 import {searchTableRowByValue} from './commerceDNDTablePage';
 
@@ -290,9 +290,7 @@ export class CommerceAdminChannelDetailsPage {
 			.getByLabel('Key')
 			.fill(name);
 		await (await this.frameSaveButton(true, tableName)).click();
-		await waitForSuccessAlert(
-			await this.sidePanelNestedFrame('Shipping Methods')
-		);
+		await waitForAlert(await this.sidePanelNestedFrame('Shipping Methods'));
 		await (
 			await this.closeSidePanelFrame(true, 'Shipping Methods')
 		).click();
@@ -324,9 +322,7 @@ export class CommerceAdminChannelDetailsPage {
 		}
 
 		await (await this.frameSaveButton(true, tableName)).click();
-		await waitForSuccessAlert(
-			await this.sidePanelNestedFrame('Shipping Methods')
-		);
+		await waitForAlert(await this.sidePanelNestedFrame('Shipping Methods'));
 	}
 
 	async setEntryEligibility(
@@ -357,7 +353,7 @@ export class CommerceAdminChannelDetailsPage {
 			await (
 				await this.frameSaveButton(isNestedFrame, tableName)
 			).click();
-			await waitForSuccessAlert(await this.sidePanelFrame(tableName));
+			await waitForAlert(await this.sidePanelFrame(tableName));
 			await (
 				await this.closeSidePanelFrame(isNestedFrame, tableName)
 			).click();
@@ -389,9 +385,7 @@ export class CommerceAdminChannelDetailsPage {
 			await (
 				await this.frameSaveButton(isNestedFrame, tableName)
 			).click();
-			await waitForSuccessAlert(
-				await this.sidePanelNestedFrame(tableName)
-			);
+			await waitForAlert(await this.sidePanelNestedFrame(tableName));
 			await (
 				await this.closeSidePanelFrame(isNestedFrame, tableName)
 			).click();

--- a/modules/test/playwright/pages/commerce/commerceAdminChannelsPage.ts
+++ b/modules/test/playwright/pages/commerce/commerceAdminChannelsPage.ts
@@ -5,7 +5,7 @@
 
 import {FrameLocator, Locator, Page, expect} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {ApplicationsMenuPage} from '../product-navigation-applications-menu/ApplicationsMenuPage';
 import {searchTableRowByValue} from './commerceDNDTablePage';
 
@@ -132,7 +132,7 @@ export class CommerceAdminChannelsPage {
 		});
 		await this.headerActionsSaveButton.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async changeCommerceChannelSellerOrderAcceptanceWorkflow(
@@ -151,7 +151,7 @@ export class CommerceAdminChannelsPage {
 		});
 		await this.headerActionsSaveButton.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async changeCommerceChannelSiteType(

--- a/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
+++ b/modules/test/playwright/pages/document-library-web/DocumentLibraryEditFilePage.ts
@@ -8,7 +8,7 @@ import {Locator, Page} from '@playwright/test';
 import {clickAndExpectToBeHidden} from '../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {expandSection} from '../../utils/expandSection';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {DocumentLibraryPage} from './DocumentLibraryPage';
 
 export class DocumentLibraryEditFilePage {
@@ -95,7 +95,7 @@ export class DocumentLibraryEditFilePage {
 			await this.publishButton.click();
 		}
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async publishNewBasicFileEntry(
@@ -112,7 +112,7 @@ export class DocumentLibraryEditFilePage {
 		else {
 			await this.publishButton.click();
 		}
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:Your request completed successfully.'
 		);

--- a/modules/test/playwright/pages/fragment-web/FragmentEditorPage.ts
+++ b/modules/test/playwright/pages/fragment-web/FragmentEditorPage.ts
@@ -5,7 +5,7 @@
 
 import {Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class FragmentEditorPage {
 	readonly page: Page;
@@ -60,6 +60,6 @@ export class FragmentEditorPage {
 	async publish() {
 		await this.page.getByRole('button', {name: 'Publish'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/pages/fragment-web/FragmentsPage.ts
+++ b/modules/test/playwright/pages/fragment-web/FragmentsPage.ts
@@ -8,7 +8,7 @@ import {FrameLocator, Page, expect} from '@playwright/test';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import {PORTLET_URLS} from '../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class FragmentsPage {
 	readonly page: Page;
@@ -104,7 +104,7 @@ export class FragmentsPage {
 	async copyFragment(title: string) {
 		await this.clickAction('Make a Copy', title);
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The fragment was copied successfully.'
 		);
@@ -137,7 +137,7 @@ export class FragmentsPage {
 			.getByRole('button', {exact: true, name: 'Save'})
 			.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The fragment was copied successfully.'
 		);
@@ -164,7 +164,7 @@ export class FragmentsPage {
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async createFragment(
@@ -198,7 +198,7 @@ export class FragmentsPage {
 
 		await this.page.getByText('Add', {exact: true}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async deleteFragment(title: string) {
@@ -206,7 +206,7 @@ export class FragmentsPage {
 
 		await this.page.getByRole('button', {name: 'Delete'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async deleteFragmentSet(setName: string) {
@@ -221,7 +221,7 @@ export class FragmentsPage {
 
 		await this.page.getByRole('button', {name: 'Delete'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async markAsCacheable(title: string) {
@@ -229,7 +229,7 @@ export class FragmentsPage {
 
 		await this.clickAction('Mark as Cacheable', title);
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async renameFragment(newName: string, oldName: string) {
@@ -239,6 +239,6 @@ export class FragmentsPage {
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
+++ b/modules/test/playwright/pages/friendly-url-web/FriendlyUrlInstanceSettingsPage.ts
@@ -6,7 +6,7 @@
 import {Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeHidden} from '../../utils/clickAndExpectToBeHidden';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {InstanceSettingsPage} from '../configuration-admin-web/InstanceSettingsPage';
 
 export class FriendlyUrlInstanceSettingsPage {
@@ -33,7 +33,7 @@ export class FriendlyUrlInstanceSettingsPage {
 		await separatorInput.fill(value);
 
 		await this.saveButton.click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async resetSeparator(label: string) {
@@ -46,6 +46,6 @@ export class FriendlyUrlInstanceSettingsPage {
 		});
 
 		await this.saveButton.click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/pages/layout-admin-web/PagesAdminPage.ts
+++ b/modules/test/playwright/pages/layout-admin-web/PagesAdminPage.ts
@@ -9,7 +9,7 @@ import {clickAndExpectToBeHidden} from '../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import {PORTLET_URLS} from '../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {PageEditorPage} from '../layout-content-page-editor-web/PageEditorPage';
 
 export class PagesAdminPage {
@@ -222,7 +222,7 @@ export class PagesAdminPage {
 		await this.addButton.hover();
 		await this.addButton.click();
 
-		await waitForSuccessAlert(this.page, successMessage);
+		await waitForAlert(this.page, successMessage);
 	}
 
 	private async addThemeFaviconClientExtension(clientExtensionName: string) {
@@ -305,7 +305,7 @@ export class PagesAdminPage {
 
 		await this.configurationSaveButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The page was updated successfully.'
 		);
@@ -361,10 +361,10 @@ export class PagesAdminPage {
 		await this.configurationSaveButton.click();
 
 		if (!layoutTitle) {
-			await waitForSuccessAlert(this.page);
+			await waitForAlert(this.page);
 		}
 		else {
-			await waitForSuccessAlert(
+			await waitForAlert(
 				this.page,
 				'Success:The page was updated successfully.'
 			);
@@ -433,7 +433,7 @@ export class PagesAdminPage {
 
 		await this.page.getByRole('button', {name: 'Delete'}).click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:Your request completed successfully.'
 		);
@@ -521,10 +521,10 @@ export class PagesAdminPage {
 		}
 
 		if (!layoutTitle) {
-			await waitForSuccessAlert(this.page);
+			await waitForAlert(this.page);
 		}
 		else {
-			await waitForSuccessAlert(
+			await waitForAlert(
 				this.page,
 				'Success:The page was updated successfully.'
 			);
@@ -616,7 +616,7 @@ export class PagesAdminPage {
 				? `Success:${pageNames.length} permissions were updated successfully.`
 				: undefined;
 
-		await waitForSuccessAlert(permissionsFrame, successMessage);
+		await waitForAlert(permissionsFrame, successMessage);
 
 		await this.page.getByLabel('close', {exact: true}).click();
 

--- a/modules/test/playwright/pages/layout-admin-web/WidgetPagePage.ts
+++ b/modules/test/playwright/pages/layout-admin-web/WidgetPagePage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class WidgetPagePage {
 	readonly page: Page;
@@ -50,7 +50,7 @@ export class WidgetPagePage {
 			.getByRole('button', {name: 'Add Content'})
 			.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The application was added to the page.'
 		);
@@ -90,7 +90,7 @@ export class WidgetPagePage {
 				.click();
 		}
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The application was added to the page.'
 		);
@@ -168,7 +168,7 @@ export class WidgetPagePage {
 
 		await configurationIFrame.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			configurationIFrame,
 			'Success:You have successfully updated the setup.'
 		);

--- a/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
+++ b/modules/test/playwright/pages/layout-content-page-editor-web/PageEditorPage.ts
@@ -13,7 +13,7 @@ import {expandSection} from '../../utils/expandSection';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import {hoverAndExpectToBeVisible} from '../../utils/hoverAndExpectToBeVisible';
 import {selectElement} from '../../utils/selectElement';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {SegmentEditorPage} from '../segments-web/SegmentEditorPage';
 
 const VIEWPORTS_CLASSNAMES = {
@@ -391,7 +391,7 @@ export class PageEditorPage {
 
 		await this.closeExperienceSelector();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The experience was created successfully.',
 			{autoClose: false}
@@ -420,7 +420,7 @@ export class PageEditorPage {
 
 		await this.closeExperienceSelector();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The experience was deleted successfully.',
 			{autoClose: false}
@@ -442,7 +442,7 @@ export class PageEditorPage {
 			.getByLabel('Duplicate Experience')
 			.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The experience was duplicated successfully.',
 			{autoClose: false}
@@ -559,7 +559,7 @@ export class PageEditorPage {
 
 		await this.closeExperienceSelector();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The experience was updated successfully.',
 			{autoClose: false}
@@ -606,7 +606,7 @@ export class PageEditorPage {
 
 		await this.closeExperienceSelector();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The experience was updated successfully.',
 			{autoClose: false}
@@ -754,7 +754,7 @@ export class PageEditorPage {
 			trigger: this.page.locator('.modal-footer').getByText('Save'),
 		});
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:Your form has been successfully loaded.'
 		);
@@ -826,7 +826,7 @@ export class PageEditorPage {
 		await button.waitFor();
 		await button.click();
 
-		await waitForSuccessAlert(this.page, successMessage);
+		await waitForAlert(this.page, successMessage);
 	}
 
 	async removeFragment(fragmentId: string) {

--- a/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/DisplayPageTemplatesPage.ts
@@ -7,7 +7,7 @@ import {Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class DisplayPageTemplatesPage {
 	readonly page: Page;
@@ -48,7 +48,7 @@ export class DisplayPageTemplatesPage {
 
 		await this.page.getByRole('button', {name: 'Delete'}).click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:You successfully deleted 1 display page template(s).'
 		);
@@ -114,7 +114,7 @@ export class DisplayPageTemplatesPage {
 			.getByRole('button', {exact: true, name: 'Save'})
 			.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The page was updated successfully.'
 		);
@@ -127,7 +127,7 @@ export class DisplayPageTemplatesPage {
 
 		await this.clickMoreActions(name, 'Mark as Default');
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async renameTemplate(newName: string, oldName: string) {
@@ -137,7 +137,7 @@ export class DisplayPageTemplatesPage {
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async createFolder(name: string) {
@@ -153,7 +153,7 @@ export class DisplayPageTemplatesPage {
 
 		await this.page.getByRole('button', {name: 'Create'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async createTemplate({
@@ -209,7 +209,7 @@ export class DisplayPageTemplatesPage {
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The display page template was created successfully.'
 		);
@@ -221,7 +221,7 @@ export class DisplayPageTemplatesPage {
 		await this.publishButton.waitFor();
 		await this.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The display page template was published successfully.'
 		);

--- a/modules/test/playwright/pages/layout-page-template-admin-web/PageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/PageTemplatesPage.ts
@@ -8,7 +8,7 @@ import {Locator, Page} from '@playwright/test';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import {PORTLET_URLS} from '../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class PageTemplatesPage {
 	readonly page: Page;
@@ -58,7 +58,7 @@ export class PageTemplatesPage {
 			.getByRole('button', {exact: true, name: 'Save'})
 			.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async clickAction(action: string, title: string) {
@@ -73,6 +73,6 @@ export class PageTemplatesPage {
 
 		await this.page.getByRole('button', {name: 'Delete'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/pages/layout-page-template-admin-web/WidgetPageTemplatesPage.ts
+++ b/modules/test/playwright/pages/layout-page-template-admin-web/WidgetPageTemplatesPage.ts
@@ -6,7 +6,7 @@
 import {Locator, Page} from '@playwright/test';
 
 import {PORTLET_URLS} from '../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class WidgetPageTemplatesPage {
 	readonly page: Page;
@@ -28,7 +28,7 @@ export class WidgetPageTemplatesPage {
 		await this.page.getByPlaceholder('Name').fill(name);
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async deactivateGlobalWidgetPageTemplate(name: string) {
@@ -38,7 +38,7 @@ export class WidgetPageTemplatesPage {
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async clickMoreActions(name: string, actionName: string) {
@@ -61,7 +61,7 @@ export class WidgetPageTemplatesPage {
 
 		await this.page.getByRole('button', {name: 'Delete'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async renameGlobalWidgetPageTemplate(newName: string, oldName: string) {
@@ -70,6 +70,6 @@ export class WidgetPageTemplatesPage {
 		await this.page.getByPlaceholder('Name').fill(newName);
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/pages/login-web/LoginInstanceSettingsPage.ts
+++ b/modules/test/playwright/pages/login-web/LoginInstanceSettingsPage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {InstanceSettingsPage} from '../configuration-admin-web/InstanceSettingsPage';
 
 export class LoginInstanceSettingsPage {
@@ -28,13 +28,13 @@ export class LoginInstanceSettingsPage {
 	async enableLoginPrompt() {
 		await this.page.getByLabel('Prompt Enabled').check();
 		await this.saveConfiguration();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async disableLoginPrompt() {
 		await this.page.getByLabel('Prompt Enabled').uncheck();
 		await this.saveConfiguration();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async saveConfiguration() {

--- a/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
+++ b/modules/test/playwright/pages/portal-language-override-web/LanguageOverridePage.ts
@@ -8,7 +8,7 @@ import {Locator, Page, expect} from '@playwright/test';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import {PORTLET_URLS} from '../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export type TTranslation = {
 	key: string;
@@ -54,7 +54,7 @@ export class LanguageOverridePage {
 
 		await this.saveButton.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async addTranslations(languageOverrides: TTranslation[]) {

--- a/modules/test/playwright/pages/portal-search-web/SearchPage.ts
+++ b/modules/test/playwright/pages/portal-search-web/SearchPage.ts
@@ -6,7 +6,7 @@
 import {FrameLocator, Locator, Page, expect} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class SearchPage {
 	readonly page: Page;
@@ -151,7 +151,7 @@ export class SearchPage {
 	async savePortletConfiguration() {
 		await this.modalIFrame.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.modalIFrame,
 			'Success:You have successfully updated the setup.'
 		);

--- a/modules/test/playwright/pages/portal-settings-authentication-openid-connect-web/SingleSignOnSettingsPage.ts
+++ b/modules/test/playwright/pages/portal-settings-authentication-openid-connect-web/SingleSignOnSettingsPage.ts
@@ -6,7 +6,7 @@
 import {Locator, Page} from '@playwright/test';
 
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {InstanceSettingsPage} from '../configuration-admin-web/InstanceSettingsPage';
 
 export class SingleSignOnSettingsPage {
@@ -69,7 +69,7 @@ export class SingleSignOnSettingsPage {
 		await this.clickSetupOpenIdConnectionMenuItem();
 		await this.enabledCheckbox.check();
 		await this.saveButton.click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async AddOpenIDConnectProviderConnectionConfiguration(
@@ -83,7 +83,7 @@ export class SingleSignOnSettingsPage {
 		await this.openIDConnectClientIDField.fill(getRandomString());
 		await this.openIDConnectClientSecret.fill(getRandomString());
 		await this.saveButton.click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async removeOpenIDConnectProviderConnectionConfiguration(
@@ -96,6 +96,6 @@ export class SingleSignOnSettingsPage {
 			.getByTitle('Actions')
 			.click();
 		await this.page.getByText('Delete').click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-kaleo-designer-web/ConfigurationTabPage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {ProcessBuilderPage} from './ProcessBuilderPage';
 
 export class ConfigurationTabPage {
@@ -52,7 +52,7 @@ export class ConfigurationTabPage {
 		await saveButton.click();
 
 		if (actionResult === 'assigned') {
-			await waitForSuccessAlert(
+			await waitForAlert(
 				this.page,
 				`Success:Workflow ${actionResult} to ${assetType}.`
 			);

--- a/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTaskDetailsPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTaskDetailsPage.ts
@@ -5,7 +5,7 @@
 
 import {FrameLocator, Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {WorkflowTasksPage} from './WorkflowTasksPage';
 
 export class WorkflowTaskDetailsPage {
@@ -74,7 +74,7 @@ export class WorkflowTaskDetailsPage {
 	async clickDoneButton() {
 		await this.doneButton.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async goTo(assetTitle: string) {

--- a/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTasksPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-task-web/WorkflowTasksPage.ts
@@ -7,7 +7,7 @@ import {Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class WorkflowTasksPage {
 	readonly assignedToMyRolesLink: Locator;
@@ -49,7 +49,7 @@ export class WorkflowTasksPage {
 
 		await this.page.getByRole('button', {name: 'Done'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async assignToMe(articleTitle: string) {
@@ -75,7 +75,7 @@ export class WorkflowTasksPage {
 			.getByRole('button', {name: 'Done'})
 			.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async reject(articleTitle: string) {
@@ -93,7 +93,7 @@ export class WorkflowTasksPage {
 
 		await this.page.getByRole('button', {name: 'Done'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async resubmit(articleTitle: string) {
@@ -115,6 +115,6 @@ export class WorkflowTasksPage {
 
 		await this.page.getByRole('button', {name: 'Done'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/pages/portal-workflow-web/WorkflowPage.ts
+++ b/modules/test/playwright/pages/portal-workflow-web/WorkflowPage.ts
@@ -7,7 +7,7 @@ import {Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class WorkflowPage {
 	readonly page: Page;
@@ -40,7 +40,7 @@ export class WorkflowPage {
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			disable
 				? `Success:Workflow unassigned from ${asset}.`

--- a/modules/test/playwright/pages/product-navigation-applications-menu/AICreatorSettingsPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/AICreatorSettingsPage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {ApplicationsMenuPage} from './ApplicationsMenuPage';
 
 const MOCK_API_KEY = 'VALID_API_KEY';
@@ -39,7 +39,7 @@ export class AICreatorInstanceSettingsPage {
 		await this.dalleCheckbox.check();
 		await this.saveButton.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async disableDalleCreateImages() {
@@ -48,7 +48,7 @@ export class AICreatorInstanceSettingsPage {
 		await this.dalleCheckbox.uncheck();
 		await this.saveButton.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async addApiKey() {
@@ -64,6 +64,6 @@ export class AICreatorInstanceSettingsPage {
 
 		await this.apiKeyInput.fill(apikey);
 		await this.saveButton.click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/pages/product-navigation-applications-menu/GogoShellPage.ts
+++ b/modules/test/playwright/pages/product-navigation-applications-menu/GogoShellPage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {ApplicationsMenuPage} from './ApplicationsMenuPage';
 
 export class GogoShellPage {
@@ -32,6 +32,6 @@ export class GogoShellPage {
 		await this.commandInput.waitFor();
 		await this.commandInput.fill(command);
 		await this.executeButton.click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/pages/site-admin-web/SiteSettingsLocalizationPage.ts
+++ b/modules/test/playwright/pages/site-admin-web/SiteSettingsLocalizationPage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {SiteSettingsPage} from './SiteSettingsPage';
 
 export class SiteSettingsLocalizationPage {
@@ -39,7 +39,7 @@ export class SiteSettingsLocalizationPage {
 
 	async saveConfiguration() {
 		this.saveButton.click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async selectCustomDefaultLanguageOption() {

--- a/modules/test/playwright/pages/style-book-web/StyleBooksPage.ts
+++ b/modules/test/playwright/pages/style-book-web/StyleBooksPage.ts
@@ -7,7 +7,7 @@ import {Locator, Page, expect} from '@playwright/test';
 
 import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import {PORTLET_URLS} from '../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class StyleBooksPage {
 	readonly page: Page;
@@ -71,7 +71,7 @@ export class StyleBooksPage {
 			.getByRole('button', {name: 'Publish'})
 			.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async search(styleBookName: string) {

--- a/modules/test/playwright/pages/users-admin-web/UserPersonalSitePage.ts
+++ b/modules/test/playwright/pages/users-admin-web/UserPersonalSitePage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export class UserPersonalSitePage {
 	readonly addWidgetButton: Locator;
@@ -43,7 +43,7 @@ export class UserPersonalSitePage {
 			await this.page.keyboard.press('Enter');
 			await this.languageSelectorMenuItem.waitFor({state: 'visible'});
 			await this.languageSelectorMenuItem.click();
-			await waitForSuccessAlert(
+			await waitForAlert(
 				this.page,
 				'Success:The application was added to the page.'
 			);

--- a/modules/test/playwright/tests/account-admin-web/accounts.spec.ts
+++ b/modules/test/playwright/tests/account-admin-web/accounts.spec.ts
@@ -13,7 +13,7 @@ import {loginTest} from '../../fixtures/loginTest';
 import {serverAdministrationPageTest} from '../../fixtures/serverAdministrationPageTest';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout, userData} from '../../utils/performLogin';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	accountsPagesTest,
@@ -344,7 +344,7 @@ test('LPD-33636 Email address is not deleted by saving in the UI', async ({
 	await accountsPage.goto();
 	await (await accountsPage.accountsTableRowLink(account.name)).click();
 	await editAccountPage.saveButton.click();
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	await applicationsMenuPage.goToServerAdministration();
 

--- a/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
+++ b/modules/test/playwright/tests/blogs-web/pages/BlogsEditBlogEntryPage.ts
@@ -7,7 +7,7 @@ import {Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeHidden} from '../../../utils/clickAndExpectToBeHidden';
 import {openFieldset} from '../../../utils/openFieldset';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {BlogsPage} from './BlogsPage';
 
 import type {postTaxonomyVocabularyTaxonomyCategoryProps} from '../../../helpers/HeadlessAdminTaxonomyApiHelper';
@@ -121,7 +121,7 @@ export class BlogsEditBlogEntryPage {
 
 	async publishBlogEntry() {
 		await this.publishButton.click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async selectSpecificDisplayPage(displayPageName: string) {
@@ -157,6 +157,6 @@ export class BlogsEditBlogEntryPage {
 
 	async submitBlogEntryToWorkflow() {
 		await this.submitToWorkflowButton.click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
+++ b/modules/test/playwright/tests/blogs-web/utils/createAssetPublisherAndConfigure.ts
@@ -8,7 +8,7 @@ import {Page} from '@playwright/test';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../../utils/getRandomString';
 import {openFieldset} from '../../../utils/openFieldset';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import getPageDefinition from '../../layout-content-page-editor-web/utils/getPageDefinition';
 import getWidgetDefinition from '../../layout-content-page-editor-web/utils/getWidgetDefinition';
 
@@ -70,7 +70,7 @@ export async function createAssetPublisherAndConfigure({
 	if (!(await configurationDynamicInput.isChecked())) {
 		await configurationDynamicInput.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			configurationModal,
 			'Success:You have successfully updated the setup.'
 		);
@@ -82,7 +82,7 @@ export async function createAssetPublisherAndConfigure({
 	});
 
 	await configurationModal.getByRole('button', {name: 'Save'}).click();
-	await waitForSuccessAlert(
+	await waitForAlert(
 		configurationModal,
 		'Success:You have successfully updated the setup.'
 	);

--- a/modules/test/playwright/tests/change-tracking-web/changeTrackingTimeline.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/changeTrackingTimeline.spec.ts
@@ -13,7 +13,7 @@ import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout, userData} from '../../utils/performLogin';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	documentLibraryPagesTest,
@@ -59,7 +59,7 @@ test.beforeEach(
 
 		await documentLibraryEditFilePage.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			'Success:Your request completed successfully.'
 		);
@@ -312,10 +312,7 @@ test('LPD-26155 Conflict warning is visible when content is edited in more than 
 
 	await documentLibraryEditFilePage.publishButton.click();
 
-	await waitForSuccessAlert(
-		page,
-		'Success:Your request completed successfully.'
-	);
+	await waitForAlert(page, 'Success:Your request completed successfully.');
 
 	const timelineButton = page.locator('.change-tracking-timeline-button svg');
 	await timelineButton.waitFor();
@@ -374,10 +371,7 @@ test('LPD-26155 Production conflict info is visible when new changes have been m
 
 	await documentLibraryEditFilePage.publishButton.click();
 
-	await waitForSuccessAlert(
-		page,
-		'Success:Your request completed successfully.'
-	);
+	await waitForAlert(page, 'Success:Your request completed successfully.');
 
 	await changeTrackingPage.workOnPublication(ctCollection);
 

--- a/modules/test/playwright/tests/change-tracking-web/changeTrackingTimelineModal.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/changeTrackingTimelineModal.spec.ts
@@ -10,7 +10,7 @@ import {changeTrackingPagesTest} from '../../fixtures/changeTrackingPagesTest';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 import {JournalPage} from '../journal-web/pages/JournalPage';
 
@@ -43,7 +43,7 @@ test.beforeEach(
 		await page.locator('div[data-qa-id="content"]').waitFor();
 		await journalEditArticlePage.fillTitle(articleTitle);
 		await page.getByRole('button', {name: 'Publish'}).click();
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			`Success:${articleTitle} was created successfully.`
 		);
@@ -76,7 +76,7 @@ test.beforeEach(
 					'Delete',
 					articleTitle
 				);
-				await waitForSuccessAlert(
+				await waitForAlert(
 					page,
 					`Success: The element ${articleTitle} was moved to the Recycle Bin.`
 				);
@@ -97,7 +97,7 @@ test.afterEach(async ({apiHelpers, changeTrackingPage, journalPage, page}) => {
 	await journalPage.goto();
 	await page.getByRole('heading', {name: 'Web Content'}).waitFor();
 	await journalPage.goToJournalArticleAction('Delete', articleTitle);
-	await waitForSuccessAlert(
+	await waitForAlert(
 		page,
 		`Success: The element ${articleTitle} was moved to the Recycle Bin.`
 	);

--- a/modules/test/playwright/tests/change-tracking-web/ctCollectionPublish.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/ctCollectionPublish.spec.ts
@@ -10,7 +10,7 @@ import {changeTrackingPagesTest} from '../../fixtures/changeTrackingPagesTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import getRandomString from '../../utils/getRandomString';
 import getBasicWebContentStructureId from '../../utils/structured-content/getBasicWebContentStructureId';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {blogsPagesTest} from '../blogs-web/fixtures/blogsPagesTest';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 
@@ -148,10 +148,7 @@ test('Publish Parallel Publications', async ({
 
 	await publishButton.click();
 
-	await waitForSuccessAlert(
-		page,
-		`Success:${title1} was created successfully.`
-	);
+	await waitForAlert(page, `Success:${title1} was created successfully.`);
 
 	const ctCollection2 =
 		await apiHelpers.headlessChangeTracking.createCTCollection(
@@ -178,10 +175,7 @@ test('Publish Parallel Publications', async ({
 
 	await publishButton.click();
 
-	await waitForSuccessAlert(
-		page,
-		`Success:${title2} was created successfully.`
-	);
+	await waitForAlert(page, `Success:${title2} was created successfully.`);
 
 	await apiHelpers.headlessChangeTracking.publishCTCollection(
 		ctCollection.id

--- a/modules/test/playwright/tests/change-tracking-web/ctComments.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/ctComments.spec.ts
@@ -10,7 +10,7 @@ import {changeTrackingPagesTest} from '../../fixtures/changeTrackingPagesTest';
 import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout} from '../../utils/performLogin';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 
 export const test = mergeTests(
@@ -63,7 +63,7 @@ test('LPD-17130 Only comment owners are allowed to perform actions on the commen
 	await journalEditArticlePage.goto();
 	await journalEditArticlePage.fillTitle(journalName);
 	await page.getByRole('button', {name: 'Publish'}).click();
-	await waitForSuccessAlert(
+	await waitForAlert(
 		page,
 		`Success:${journalName} was created successfully.`
 	);

--- a/modules/test/playwright/tests/change-tracking-web/publicationsConfiguration.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/publicationsConfiguration.spec.ts
@@ -10,7 +10,7 @@ import {changeTrackingPagesTest} from '../../fixtures/changeTrackingPagesTest';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout} from '../../utils/performLogin';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 
 export const test = mergeTests(
@@ -81,7 +81,7 @@ test.beforeEach(async ({journalEditArticlePage, page, site}) => {
 
 	await page.getByRole('button', {name: 'Publish'}).click();
 
-	await waitForSuccessAlert(
+	await waitForAlert(
 		page,
 		`Success:${journalArticleTitle} was created successfully.`
 	);

--- a/modules/test/playwright/tests/change-tracking-web/publicationsConflict.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/publicationsConflict.spec.ts
@@ -9,7 +9,7 @@ import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {changeTrackingPagesTest} from '../../fixtures/changeTrackingPagesTest';
 import {productMenuPageTest} from '../../fixtures/productMenuPageTest';
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {blogsPagesTest} from '../blogs-web/fixtures/blogsPagesTest';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 
@@ -42,10 +42,7 @@ test('Resolve deletion modification conflict publications by discarding', async 
 
 	await page.getByRole('button', {name: 'Publish'}).click();
 
-	await waitForSuccessAlert(
-		page,
-		`Success:${title} was created successfully.`
-	);
+	await waitForAlert(page, `Success:${title} was created successfully.`);
 
 	await changeTrackingPage.workOnPublication(ctCollection);
 
@@ -72,10 +69,7 @@ test('Resolve deletion modification conflict publications by discarding', async 
 
 	await page.getByRole('button', {name: 'Publish'}).click();
 
-	await waitForSuccessAlert(
-		page,
-		`Success:${title} was updated successfully.`
-	);
+	await waitForAlert(page, `Success:${title} was updated successfully.`);
 
 	await blogsEditBlogEntryPage.goto();
 
@@ -164,8 +158,5 @@ test('Resolve deletion modification conflict publications by discarding', async 
 		.getByRole('button', {name: 'Delete'})
 		.click();
 
-	await waitForSuccessAlert(
-		page,
-		'Success:Your request completed successfully.'
-	);
+	await waitForAlert(page, 'Success:Your request completed successfully.');
 });

--- a/modules/test/playwright/tests/change-tracking-web/publicationsThreading.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/publicationsThreading.spec.ts
@@ -15,7 +15,7 @@ import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import {PORTLET_URLS} from '../../utils/portletUrls';
 import {getTempDir} from '../../utils/temp';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 
 export const test = mergeTests(
@@ -84,7 +84,7 @@ test('LPS-117642 NoSuchTagException throws when adding a web content with tag wi
 	const tagName = getRandomString();
 	await page.getByPlaceholder('Name').fill(tagName);
 	await page.getByRole('button', {name: 'Save'}).click();
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	await journalPage.goto();
 	await journalPage.goToCreateArticle();

--- a/modules/test/playwright/tests/change-tracking-web/publicationsUserCollaboration.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/publicationsUserCollaboration.spec.ts
@@ -11,7 +11,7 @@ import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {productMenuPageTest} from '../../fixtures/productMenuPageTest';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout} from '../../utils/performLogin';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 
 export const test = mergeTests(
@@ -48,10 +48,7 @@ test('LPD-30098 Invite user as admin', async ({
 
 	await page.getByRole('button', {name: 'Publish'}).click();
 
-	await waitForSuccessAlert(
-		page,
-		`Success:${title} was created successfully.`
-	);
+	await waitForAlert(page, `Success:${title} was created successfully.`);
 
 	await performLogout(page);
 
@@ -79,7 +76,7 @@ test('LPD-30098 Invite user as admin', async ({
 
 	await page.getByRole('button', {name: 'Save'}).click();
 
-	await waitForSuccessAlert(page, 'Success:Successfully updated');
+	await waitForAlert(page, 'Success:Successfully updated');
 
 	await changeTrackingPage.addUserToPublication(title, 'Admin', user2);
 
@@ -97,10 +94,7 @@ test('LPD-30098 Invite user as admin', async ({
 		page.locator('div').filter({hasText: title}).first()
 	).toBeVisible();
 
-	await waitForSuccessAlert(
-		page,
-		'Success:Your request completed successfully.'
-	);
+	await waitForAlert(page, 'Success:Your request completed successfully.');
 
 	await performLogout(page);
 

--- a/modules/test/playwright/tests/change-tracking-web/viewChangesWorkflow.spec.ts
+++ b/modules/test/playwright/tests/change-tracking-web/viewChangesWorkflow.spec.ts
@@ -10,7 +10,7 @@ import {apiHelpersTest} from '../../fixtures/apiHelpersTest';
 import {changeTrackingPagesTest} from '../../fixtures/changeTrackingPagesTest';
 import {workflowPagesTest} from '../../fixtures/workflowPagesTest';
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 
 export const test = mergeTests(
@@ -647,10 +647,7 @@ test('LPD-28975 Workflow tab shows unexpected error for asset added in publicati
 
 	await page.getByRole('button', {name: 'Publish'}).click();
 
-	await waitForSuccessAlert(
-		page,
-		`Success:${title1} was created successfully.`
-	);
+	await waitForAlert(page, `Success:${title1} was created successfully.`);
 
 	await workflowPage.goto();
 

--- a/modules/test/playwright/tests/client-extension-web/pages/EditClientExtensionsPage.ts
+++ b/modules/test/playwright/tests/client-extension-web/pages/EditClientExtensionsPage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {ClientExtensionsPage} from './ClientExtensionsPage';
 
 const EDIT_CLIENT_EXTENSION_BASE_URL =
@@ -56,6 +56,6 @@ export class EditClientExtensionsPage {
 	async publish() {
 		await this.publishButton.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/tests/commerce/commerce-checkout-web/checkout.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-checkout-web/checkout.spec.ts
@@ -12,7 +12,7 @@ import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
 import {notificationPagesTest} from '../../../fixtures/notificationPagesTest';
 import getRandomString from '../../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export const test = mergeTests(
 	applicationsMenuPageTest,
@@ -130,7 +130,7 @@ test('LPD-25860 Checkout widget configuration to display full addresses and phon
 	await checkoutPage.configurationIFrameShowFullAddressToggle.check();
 	await checkoutPage.configurationIFrameShowPhoneNumberToggle.check();
 	await checkoutPage.configurationIFrameSaveButton.click();
-	await waitForSuccessAlert(checkoutPage.configurationIFrame);
+	await waitForAlert(checkoutPage.configurationIFrame);
 
 	await page.reload();
 

--- a/modules/test/playwright/tests/commerce/commerce-order-content-web/placedOrder.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-order-content-web/placedOrder.spec.ts
@@ -16,7 +16,7 @@ import performLogin, {
 	performLogout,
 	userData,
 } from '../../../utils/performLogin';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {miniumSetUp} from '../utils/commerce';
 
 export const test = mergeTests(
@@ -135,7 +135,7 @@ test('LPD-25831 Placed orders widget configuration to display full addresses and
 	await placedOrdersPage.configurationIFrameShowFullAddressToggle.check();
 	await placedOrdersPage.configurationIFrameShowPhoneNumberToggle.check();
 	await placedOrdersPage.configurationIFrameSaveButton.click();
-	await waitForSuccessAlert(placedOrdersPage.configurationIFrame);
+	await waitForAlert(placedOrdersPage.configurationIFrame);
 	await page.reload();
 
 	await placedOrdersPage.viewButton.click();

--- a/modules/test/playwright/tests/commerce/commerce-product-content-web/productDetails.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-content-web/productDetails.spec.ts
@@ -18,7 +18,7 @@ import performLogin, {
 	userData,
 } from '../../../utils/performLogin';
 import {getTempDir} from '../../../utils/temp';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export const test = mergeTests(
 	applicationsMenuPageTest,
@@ -719,7 +719,7 @@ test(`LPD-29993 Users can view and download a product's attachments`, async ({
 		'B2B'
 	);
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	await applicationsMenuPage.goToSite(site.name);
 	await commerceLayoutsPage.goToPages(false);

--- a/modules/test/playwright/tests/commerce/commerce-product-definitions-web/commerceAdminVirtualProducts.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerce-product-definitions-web/commerceAdminVirtualProducts.spec.ts
@@ -10,7 +10,7 @@ import {applicationsMenuPageTest} from '../../../fixtures/applicationsMenuPageTe
 import {commercePagesTest} from '../../../fixtures/commercePagesTest';
 import {dataApiHelpersTest} from '../../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../../fixtures/loginTest';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -77,7 +77,7 @@ test('LPD-21637 Virtual item details section visible for product and sku', async
 	);
 	await commerceAdminProductPage.productSkuVirtualFileEntrySaveButton.click();
 
-	await waitForSuccessAlert(
+	await waitForAlert(
 		page.frameLocator('iframe').frameLocator('iframe >> nth=1')
 	);
 

--- a/modules/test/playwright/tests/commerce/commerceAdminDiscounts.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceAdminDiscounts.spec.ts
@@ -10,7 +10,7 @@ import {commercePagesTest} from '../../fixtures/commercePagesTest';
 import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../fixtures/loginTest';
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -101,7 +101,7 @@ test('LPD-26243 Verify that discount rule field Cart Total Minimum Amount only a
 
 	await commerceAdminDiscountDetailsPage.saveButton.click();
 
-	waitForSuccessAlert(
+	waitForAlert(
 		commerceAdminDiscountDetailsPage.editDiscountRuleFrame,
 		'Success:Your request completed successfully.',
 		{autoClose: false}

--- a/modules/test/playwright/tests/commerce/commerceAdminOrderDetails.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceAdminOrderDetails.spec.ts
@@ -13,7 +13,7 @@ import {loginTest} from '../../fixtures/loginTest';
 import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout} from '../../utils/performLogin';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {miniumSetUp} from './utils/commerce';
 
 export const test = mergeTests(
@@ -662,7 +662,7 @@ test('LPD-30856 Can update order status by deleting unshipped items', async ({
 	await commerceAdminOrdersPage.orderStatusLink('Accept Order').click();
 	await commerceAdminOrdersPage.orderStatusLink('Create Shipment').click();
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	await commerceAdminShipmentsPage.addProductsToShipment.click();
 	await (
@@ -679,7 +679,7 @@ test('LPD-30856 Can update order status by deleting unshipped items', async ({
 		.click();
 	await commerceAdminShipmentsPage.shipmentStatusLink('Ship').click();
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	const shipments =
 		await apiHelpers.headlessCommerceAdminShipment.getShipments();
@@ -697,7 +697,7 @@ test('LPD-30856 Can update order status by deleting unshipped items', async ({
 	await (await commerceAdminOrdersPage.itemsTableRowAction(sku2.sku)).click();
 	await commerceAdminOrdersPage.deleteItemMenuItem.click();
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	await commerceAdminOrdersPage.backLink.click();
 	await commerceAdminOrdersPage

--- a/modules/test/playwright/tests/commerce/commerceLayouts.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceLayouts.spec.ts
@@ -16,7 +16,7 @@ import {liferayConfig} from '../../liferay.config';
 import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout} from '../../utils/performLogin';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -120,7 +120,7 @@ test('LPD-33439 Default order display page template is accessible via friendly U
 		await commerceLayoutsPage.moreActionsButton.click();
 		await commerceLayoutsPage.markAsDefaultMenuItem.click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 
 		await expect(
 			commerceLayoutsPage.defaultDisplayPageTemplateIcon
@@ -233,7 +233,7 @@ test('LPD-32227 Order info box fragment configuration', async ({
 		await commerceLayoutsPage.infoBoxLabelInput.fill('PON');
 		await commerceLayoutsPage.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			'The display page template was published successfully.'
 		);
@@ -241,7 +241,7 @@ test('LPD-32227 Order info box fragment configuration', async ({
 		await commerceLayoutsPage.moreActionsButton.click();
 		await commerceLayoutsPage.markAsDefaultMenuItem.click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 
 		await expect(
 			commerceLayoutsPage.defaultDisplayPageTemplateIcon
@@ -319,7 +319,7 @@ test('LPD-32227 Order info box fragment configuration', async ({
 		await commerceLayoutsPage.infoBoxLabelInput.fill('Account Info');
 		await commerceLayoutsPage.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			'The display page template was published successfully.'
 		);
@@ -385,7 +385,7 @@ test('LPD-32236 Order Step Tracker fragment configuration', async ({
 		await commerceLayoutsPage.addFragment('Step Tracker', 'Order');
 		await commerceLayoutsPage.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			'The display page template was published successfully.'
 		);
@@ -393,7 +393,7 @@ test('LPD-32236 Order Step Tracker fragment configuration', async ({
 		await commerceLayoutsPage.moreActionsButton.click();
 		await commerceLayoutsPage.markAsDefaultMenuItem.click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 
 		await expect(
 			commerceLayoutsPage.defaultDisplayPageTemplateIcon
@@ -521,7 +521,7 @@ test('LPD-32232 Edit Requested Delivery Date in Open Order Details', async ({
 		);
 		await commerceLayoutsPage.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			'The display page template was published successfully.'
 		);
@@ -529,7 +529,7 @@ test('LPD-32232 Edit Requested Delivery Date in Open Order Details', async ({
 		await commerceLayoutsPage.moreActionsButton.click();
 		await commerceLayoutsPage.markAsDefaultMenuItem.click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 
 		await expect(
 			commerceLayoutsPage.defaultDisplayPageTemplateIcon
@@ -666,7 +666,7 @@ test('LPD-33808 Edit Shipping Method in Open Order Details', async ({
 
 		await commerceLayoutsPage.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			'The display page template was published successfully.'
 		);
@@ -674,7 +674,7 @@ test('LPD-33808 Edit Shipping Method in Open Order Details', async ({
 		await commerceLayoutsPage.moreActionsButton.click();
 		await commerceLayoutsPage.markAsDefaultMenuItem.click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 
 		await expect(
 			commerceLayoutsPage.defaultDisplayPageTemplateIcon
@@ -874,7 +874,7 @@ test('LPD-33809 Edit Payment Method in Open Order Details', async ({
 
 		await commerceLayoutsPage.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			'The display page template was published successfully.'
 		);
@@ -882,7 +882,7 @@ test('LPD-33809 Edit Payment Method in Open Order Details', async ({
 		await commerceLayoutsPage.moreActionsButton.click();
 		await commerceLayoutsPage.markAsDefaultMenuItem.click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 
 		await expect(
 			commerceLayoutsPage.defaultDisplayPageTemplateIcon
@@ -1127,7 +1127,7 @@ test('LPD-35558 Order Details - Order Summary', async ({
 
 		await commerceLayoutsPage.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			'The display page template was published successfully.'
 		);
@@ -1135,7 +1135,7 @@ test('LPD-35558 Order Details - Order Summary', async ({
 		await commerceLayoutsPage.moreActionsButton.click();
 		await commerceLayoutsPage.markAsDefaultMenuItem.click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 
 		await expect(
 			commerceLayoutsPage.defaultDisplayPageTemplateIcon
@@ -1262,7 +1262,7 @@ test('LPD-32237 Order actions and redirect fragments', async ({
 
 		await commerceLayoutsPage.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			'The display page template was published successfully.'
 		);
@@ -1270,7 +1270,7 @@ test('LPD-32237 Order actions and redirect fragments', async ({
 		await commerceLayoutsPage.moreActionsButton.click();
 		await commerceLayoutsPage.markAsDefaultMenuItem.click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 
 		await expect(
 			commerceLayoutsPage.defaultDisplayPageTemplateIcon

--- a/modules/test/playwright/tests/commerce/commerceOrganizationManagement.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceOrganizationManagement.spec.ts
@@ -11,7 +11,7 @@ import {loginTest} from '../../fixtures/loginTest';
 import {usersAndOrganizationsPagesTest} from '../../fixtures/usersAndOrganizationsPagesTest';
 import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	commercePagesTest,
@@ -189,7 +189,7 @@ test('LPD-31011 Can associate existing user using the widget', async ({
 	await waitForAnimationEnd(organizationManagementPage.addNode);
 
 	await organizationManagementPage.addUserToOrganization();
-	await waitForSuccessAlert(page, `1 user was added to ${organization.name}`);
+	await waitForAlert(page, `1 user was added to ${organization.name}`);
 
 	apiHelpers.data.push({
 		id: `${organization.id}_test@liferay.com`,
@@ -238,7 +238,7 @@ test('LPD-31026 Can add new user using the widget', async ({
 	await organizationManagementPage.addUserToOrganization({
 		email: userEmailAddress,
 	});
-	await waitForSuccessAlert(page, `1 user was added to ${organization.name}`);
+	await waitForAlert(page, `1 user was added to ${organization.name}`);
 
 	const user =
 		await apiHelpers.headlessAdminUser.getUserAccountByEmailAddress(
@@ -303,10 +303,7 @@ test('LPD-31052 Can associate existing account using the widget', async ({
 		accountName: account.name,
 		isNew: false,
 	});
-	await waitForSuccessAlert(
-		page,
-		`1 account was added to ${organization.name}`
-	);
+	await waitForAlert(page, `1 account was added to ${organization.name}`);
 
 	await page.reload();
 
@@ -351,10 +348,7 @@ test('LPD-31052 Can add new account using the widget', async ({
 		accountName,
 		isNew: true,
 	});
-	await waitForSuccessAlert(
-		page,
-		`1 account was added to ${organization.name}`
-	);
+	await waitForAlert(page, `1 account was added to ${organization.name}`);
 
 	const account =
 		await apiHelpers.headlessAdminUser.getAccountByName(accountName);
@@ -403,7 +397,7 @@ test('LPD-31403 Can add new organization using the widget', async ({
 	await organizationManagementPage.addOrganizationToOrganization({
 		organizationName,
 	});
-	await waitForSuccessAlert(
+	await waitForAlert(
 		page,
 		`1 organization was added to ${organization1.name}`
 	);

--- a/modules/test/playwright/tests/commerce/commerceProducts.spec.ts
+++ b/modules/test/playwright/tests/commerce/commerceProducts.spec.ts
@@ -12,7 +12,7 @@ import {loginTest} from '../../fixtures/loginTest';
 import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout} from '../../utils/performLogin';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	applicationsMenuPageTest,
@@ -709,7 +709,7 @@ test('LPD-33075 Verify buyers can view the SKU of a product on the product card 
 		'B2B'
 	);
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	await applicationsMenuPage.goToSite(site.name);
 

--- a/modules/test/playwright/tests/cookies-banner-web/cookiesBannerAccessibility.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/cookiesBannerAccessibility.spec.ts
@@ -7,7 +7,7 @@ import {expect, mergeTests} from '@playwright/test';
 
 import {loginTest} from '../../fixtures/loginTest';
 import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(loginTest(), systemSettingsPageTest);
 
@@ -48,7 +48,7 @@ test('LPD-30822 Cookie Banner Accessibility', async ({
 			await updateButton.click();
 		}
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 	});
 
 	await test.step('Check aria-label, role, and paragraph', async () => {

--- a/modules/test/playwright/tests/cookies-banner-web/cookiesBannerCadmin.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/cookiesBannerCadmin.spec.ts
@@ -8,7 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {isolatedLayoutTest} from '../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	isolatedLayoutTest(),
@@ -50,7 +50,7 @@ test('LPD-25440 Cookie Banner Cadmin', async ({page, systemSettingsPage}) => {
 			await updateButton.click();
 		}
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 	});
 
 	await test.step('Open Configuration', async () => {

--- a/modules/test/playwright/tests/cookies-banner-web/cookiesBannerCookiePolicy.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/cookiesBannerCookiePolicy.spec.ts
@@ -8,7 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	featureFlagsTest({
@@ -75,7 +75,7 @@ test('LPD-30561 Cookie Banner Cookie Policy Page', async ({
 			await updateButton.click();
 		}
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 	});
 
 	await test.step('Go to Cookie Policy page', async () => {

--- a/modules/test/playwright/tests/cookies-banner-web/cookiesBannerScript.spec.ts
+++ b/modules/test/playwright/tests/cookies-banner-web/cookiesBannerScript.spec.ts
@@ -8,7 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {isolatedLayoutTest} from '../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	isolatedLayoutTest(),
@@ -79,7 +79,7 @@ test('@LPD-25701 Cookie Banner Script', async ({
 
 		await page.getByLabel('Publish', {exact: true}).click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			`Success:The page was published successfully.`
 		);
@@ -118,7 +118,7 @@ test('@LPD-25701 Cookie Banner Script', async ({
 			await updateButton.click();
 		}
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 	});
 
 	await test.step('Accept Cookies', async () => {

--- a/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/dmAICreator.spec.ts
@@ -8,7 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {documentLibraryPagesTest} from '../../fixtures/documentLibraryPages.fixtures';
 import {isolatedSiteTest} from '../../fixtures/isolatedSiteTest';
 import {loginTest} from '../../fixtures/loginTest';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 const MOCKED_IMAGE_PATH =
 	'USER_IMAGES_URL_https://images.freeimages.com/images/large-previews/83f/paris-1213603.jpg';
@@ -90,10 +90,7 @@ test(
 		await createAIImageModalPage
 			.getByRole('button', {name: 'Add Selected'})
 			.click();
-		await waitForSuccessAlert(
-			page,
-			'Success:1 files were successfully added.'
-		);
+		await waitForAlert(page, 'Success:1 files were successfully added.');
 		await expect(
 			page.getByRole('link').filter({hasText: 'AI-image-'})
 		).toHaveCount(1);

--- a/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
+++ b/modules/test/playwright/tests/document-library-web/fileEntry.spec.ts
@@ -16,7 +16,7 @@ import {createCategories} from '../../helpers/CreateCategories';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
 import {performLogout} from '../../utils/performLogin';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
 import getWidgetDefinition from '../layout-content-page-editor-web/utils/getWidgetDefinition';
 
@@ -88,7 +88,7 @@ test(
 			getRandomString()
 		);
 		await documentLibraryEditFilePage.publishButton.click();
-		await waitForSuccessAlert(
+		await waitForAlert(
 			page,
 			'Success:Your request completed successfully.'
 		);
@@ -386,7 +386,7 @@ test(
 			[{categoryNames: ['Furniture'], vocabularyName}]
 		);
 
-		await waitForSuccessAlert(page, 'Success:Changes Saved');
+		await waitForAlert(page, 'Success:Changes Saved');
 
 		for (const document of [document1, document2]) {
 			await documentLibraryPage.goto(site.friendlyUrlPath);

--- a/modules/test/playwright/tests/document-library-web/pages/FileSizeLimitsInstanceSettingsPage.ts
+++ b/modules/test/playwright/tests/document-library-web/pages/FileSizeLimitsInstanceSettingsPage.ts
@@ -6,7 +6,7 @@
 import {Locator, Page} from '@playwright/test';
 
 import {InstanceSettingsPage} from '../../../pages/configuration-admin-web/InstanceSettingsPage';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export class FileSizeLimitsInstanceSettingsPage {
 	readonly page: Page;
@@ -32,6 +32,6 @@ export class FileSizeLimitsInstanceSettingsPage {
 		await inputField.fill(value);
 
 		await this.saveButton.click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/tests/document-library-web/pages/FileSizeLimitsSiteSettingsPage.ts
+++ b/modules/test/playwright/tests/document-library-web/pages/FileSizeLimitsSiteSettingsPage.ts
@@ -6,7 +6,7 @@
 import {Locator, Page} from '@playwright/test';
 
 import {SiteSettingsPage} from '../../../pages/configuration-admin-web/SiteSettingsPage';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export class FileSizeLimitsSiteSettingsPage {
 	readonly page: Page;
@@ -33,6 +33,6 @@ export class FileSizeLimitsSiteSettingsPage {
 		await inputField.fill(value);
 
 		await this.saveButton.click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/tests/document-library-web/pages/FileSizeLimitsSystemSettingsPage.ts
+++ b/modules/test/playwright/tests/document-library-web/pages/FileSizeLimitsSystemSettingsPage.ts
@@ -6,7 +6,7 @@
 import {Locator, Page} from '@playwright/test';
 
 import {SystemSettingsPage} from '../../../pages/configuration-admin-web/SystemSettingsPage';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export class FileSizeLimitsSystemSettingsPage {
 	readonly page: Page;
@@ -32,6 +32,6 @@ export class FileSizeLimitsSystemSettingsPage {
 		await inputField.fill(value);
 
 		await this.saveButton.click();
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/tests/fragment-web/fragmentsAdmin.spec.ts
+++ b/modules/test/playwright/tests/fragment-web/fragmentsAdmin.spec.ts
@@ -16,7 +16,7 @@ import {clickAndExpectToBeHidden} from '../../utils/clickAndExpectToBeHidden';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getGlobalSiteId from '../../utils/getGlobalSiteId';
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import getFormContainerDefinition from '../layout-content-page-editor-web/utils/getFormContainerDefinition';
 import getFragmentDefinition from '../layout-content-page-editor-web/utils/getFragmentDefinition';
 import getPageDefinition from '../layout-content-page-editor-web/utils/getPageDefinition';
@@ -380,7 +380,7 @@ test(
 
 		await page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 
 		const fragmentInput = page
 			.locator('tr')

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/creationActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/creationActions.spec.ts
@@ -8,7 +8,7 @@ import {Locator, expect, mergeTests} from '@playwright/test';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../../utils/waitForAlert';
 import {dataSetManagerApiHelpersTest} from '../../fixtures/dataSetManagerApiHelpersTest';
 import checkHelperTooltip from '../../utils/checkHelperTooltip';
 import checkLocalized from '../../utils/checkLocalized';
@@ -224,7 +224,7 @@ test(
 
 			await actionsPage.actionForm.saveButton.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 		});
 
 		await test.step('Open edit page of the saved item', async () => {
@@ -346,7 +346,7 @@ test(
 
 			await actionsPage.actionForm.saveButton.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 		});
 
 		await test.step('Open edit page of the saved item', async () => {
@@ -463,7 +463,7 @@ test(
 
 			await actionsPage.actionForm.saveButton.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 		});
 
 		await test.step('Open edit page of the saved item', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/details.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/details.spec.ts
@@ -8,7 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../../utils/waitForAlert';
 import {dataSetManagerApiHelpersTest} from '../../fixtures/dataSetManagerApiHelpersTest';
 import {dataSetManagerSetupTest} from './fixtures/dataSetManagerSetupTest';
 import {detailsPageTest} from './fixtures/detailsPageTest';
@@ -61,7 +61,7 @@ test.describe('Data Set Details', () => {
 			await test.step('Save the data set', async () => {
 				await detailsPage.saveButton.click();
 
-				await waitForSuccessAlert(page);
+				await waitForAlert(page);
 			});
 
 			await test.step('Reload the page', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/itemActions.spec.ts
@@ -8,7 +8,7 @@ import {Locator, expect, mergeTests} from '@playwright/test';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../../utils/waitForAlert';
 import {dataSetManagerApiHelpersTest} from '../../fixtures/dataSetManagerApiHelpersTest';
 import checkHelperTooltip from '../../utils/checkHelperTooltip';
 import checkLocalized from '../../utils/checkLocalized';
@@ -437,7 +437,7 @@ test(
 
 			await actionsPage.actionForm.saveButton.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 		});
 
 		await test.step('Open edit page of the saved item', async () => {
@@ -577,7 +577,7 @@ test(
 
 			await actionsPage.actionForm.saveButton.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 		});
 
 		await test.step('Open edit page of the saved item', async () => {
@@ -706,7 +706,7 @@ test(
 
 			await actionsPage.actionForm.saveButton.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 		});
 
 		await test.step('Open edit page of the saved item', async () => {
@@ -842,7 +842,7 @@ test(
 
 			await actionsPage.actionForm.saveButton.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 		});
 
 		await test.step('Open edit page of the saved item', async () => {
@@ -970,7 +970,7 @@ test(
 
 			await actionsPage.actionForm.saveButton.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 		});
 
 		await test.step('Open edit page of the saved item', async () => {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pages/data_set/tabs/ActionsPage.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/pages/data_set/tabs/ActionsPage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page, expect} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../../../../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../../../../../utils/waitForAlert';
 import {ICreationAction, IItemAction} from '../../../../../utils/types';
 import {DataSetPage} from '../DataSetPage';
 
@@ -140,7 +140,7 @@ export class ActionsPage {
 
 		await this.actionForm.saveButton.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async createItemAction(itemActionProps: IItemAction) {
@@ -150,7 +150,7 @@ export class ActionsPage {
 
 		await this.actionForm.saveButton.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async fillCreationActionFormValues(creationActionProps: ICreationAction) {

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/sorting.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-admin/sorting.spec.ts
@@ -8,7 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../../utils/waitForAlert';
 import {dataSetManagerApiHelpersTest} from '../../fixtures/dataSetManagerApiHelpersTest';
 import saveFromModal from '../../utils/saveFromModal';
 import {dataSetsPageTest} from './fixtures/dataSetsPageTest';
@@ -112,7 +112,7 @@ test.describe('Sorting in Data Set Manager', () => {
 		});
 
 		await test.step('Wait for success message to be displayed', async () => {
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 		});
 	});
 
@@ -560,7 +560,7 @@ test.describe('Sorting in Data Set Manager', () => {
 
 				await page.getByRole('button', {name: 'Save'}).click();
 
-				await waitForSuccessAlert(page);
+				await waitForAlert(page);
 
 				spanishLanguage = true;
 
@@ -623,7 +623,7 @@ test.describe('Sorting in Data Set Manager', () => {
 
 					await page.getByRole('button', {name: 'Save'}).click();
 
-					await waitForSuccessAlert(page);
+					await waitForAlert(page);
 				});
 			}
 		}

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/itemActions.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/itemActions.spec.ts
@@ -10,7 +10,7 @@ import {isolatedLayoutTest} from '../../../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import {liferayConfig} from '../../../../liferay.config';
 import getRandomString from '../../../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../../utils/waitForAlert';
 import {dataSetManagerApiHelpersTest} from '../../fixtures/dataSetManagerApiHelpersTest';
 import {
 	EAsyncActionMethod,
@@ -441,7 +441,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 				})
 				.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 		});
 
 		await test.step('Click in the async item action executes the action', async () => {
@@ -473,7 +473,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 				})
 				.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 		});
 	});
 
@@ -583,7 +583,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 				})
 				.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 
 			await expect(page.getByText(headlessItemNewLabel)).toBeVisible();
 		});
@@ -617,7 +617,7 @@ test.describe('Item Actions in Data Set fragment', () => {
 				})
 				.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 
 			await expect(page.getByText(asyncItemNewLabel)).toBeVisible();
 		});

--- a/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/sorting.spec.ts
+++ b/modules/test/playwright/tests/frontend-data-set-admin-web/tests/data-set-fragment/sorting.spec.ts
@@ -10,7 +10,7 @@ import {featureFlagsTest} from '../../../../fixtures/featureFlagsTest';
 import {isolatedLayoutTest} from '../../../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../../../fixtures/loginTest';
 import getRandomString from '../../../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../../utils/waitForAlert';
 import {dataSetManagerApiHelpersTest} from '../../fixtures/dataSetManagerApiHelpersTest';
 import {fdsFragmentPageTest} from './fixtures/fdsFragmentPageTest';
 
@@ -280,7 +280,7 @@ test.describe('Sorting Dropdown in Data Set Fragment', () => {
 
 					await page.getByRole('button', {name: 'Guardar'}).click();
 
-					await waitForSuccessAlert(page);
+					await waitForAlert(page);
 				});
 			}
 		}

--- a/modules/test/playwright/tests/frontend-js-spa-web/customExcludePaths.spec.ts
+++ b/modules/test/playwright/tests/frontend-js-spa-web/customExcludePaths.spec.ts
@@ -8,7 +8,7 @@ import {expect, mergeTests} from '@playwright/test';
 import {isolatedLayoutTest} from '../../fixtures/isolatedLayoutTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {systemSettingsPageTest} from '../../fixtures/systemSettingsPageTest';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	isolatedLayoutTest(),
@@ -63,7 +63,7 @@ test('@LPD-26354 Custom Exclude Path', async ({
 			await updateButton.click();
 		}
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 	});
 
 	await test.step('Go to page and check SPA', async () => {

--- a/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
+++ b/modules/test/playwright/tests/journal-web/journalArticle.spec.ts
@@ -18,7 +18,7 @@ import fillAndClickOutside from '../../utils/fillAndClickOutside';
 import getRandomString from '../../utils/getRandomString';
 import addApprovedStructuredContent from '../../utils/structured-content/addApprovedStructuredContent';
 import getBasicWebContentStructureId from '../../utils/structured-content/getBasicWebContentStructureId';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {journalPagesTest} from './fixtures/journalPagesTest';
 import getDataStructureDefinition from './utils/getDataStructureDefinition';
 
@@ -639,10 +639,7 @@ baseTest(
 
 		await journalEditArticlePage.publishButton.click();
 
-		await waitForSuccessAlert(
-			page,
-			`Success:${title} was created successfully.`
-		);
+		await waitForAlert(page, `Success:${title} was created successfully.`);
 
 		await journalPage.goToJournalArticleAction(
 			'Delete Translations',
@@ -663,7 +660,7 @@ baseTest(
 
 		await page.getByRole('button', {name: 'Delete'}).click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 	}
 );
 
@@ -1047,10 +1044,7 @@ translationTest(
 
 		await journalEditArticlePage.publishButton.click();
 
-		await waitForSuccessAlert(
-			page,
-			`Success:${title} was created successfully.`
-		);
+		await waitForAlert(page, `Success:${title} was created successfully.`);
 
 		await page.getByRole('link', {name: title}).click();
 
@@ -1260,10 +1254,7 @@ baseTest(
 
 		await journalEditArticlePage.publishButton.click();
 
-		await waitForSuccessAlert(
-			page,
-			`Success:${title} was created successfully.`
-		);
+		await waitForAlert(page, `Success:${title} was created successfully.`);
 
 		await page.getByLabel('Close', {exact: true});
 
@@ -1314,10 +1305,7 @@ scheduleTest(
 
 		await page.getByRole('button', {exact: true, name: 'Publish'}).click();
 
-		await waitForSuccessAlert(
-			page,
-			`Success:${title} was created successfully.`
-		);
+		await waitForAlert(page, `Success:${title} was created successfully.`);
 
 		await page.getByLabel(`Actions for ${title}`).waitFor();
 
@@ -1527,10 +1515,7 @@ baseTest(
 
 		await journalEditArticlePage.publishButton.click();
 
-		await waitForSuccessAlert(
-			page,
-			`Success:${title} was created successfully.`
-		);
+		await waitForAlert(page, `Success:${title} was created successfully.`);
 
 		await pagesAdminPage.goto(site.friendlyUrlPath);
 

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditArticlePage.ts
@@ -9,7 +9,7 @@ import {clickAndExpectToBeHidden} from '../../../utils/clickAndExpectToBeHidden'
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../../utils/fillAndClickOutside';
 import getRandomString from '../../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {JournalPage} from './JournalPage';
 
 export class JournalEditArticlePage {
@@ -110,7 +110,7 @@ export class JournalEditArticlePage {
 
 		await this.publishArticle();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			`Success:${title} was created successfully.`
 		);
@@ -177,7 +177,7 @@ export class JournalEditArticlePage {
 		await this.publishButton.waitFor();
 		await this.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			`Success:${articleTitle} was created successfully.`
 		);
@@ -198,7 +198,7 @@ export class JournalEditArticlePage {
 
 		await this.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			`Success:${title} was updated successfully.`
 		);
@@ -310,7 +310,7 @@ export class JournalEditArticlePage {
 			})
 			.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			workflow
 				? `Success:${title} has been scheduled and submitted for workflow.`

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditStructureDefaultValuesPage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditStructureDefaultValuesPage.ts
@@ -6,7 +6,7 @@
 import {Locator, Page} from '@playwright/test';
 
 import fillAndClickOutside from '../../../utils/fillAndClickOutside';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {JournalStructuresPage} from './JournalStructuresPage';
 
 export class JournalEditStructureDefaultValuesPage {
@@ -53,7 +53,7 @@ export class JournalEditStructureDefaultValuesPage {
 	async save() {
 		await this.saveButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			`Success:Your request completed successfully.`
 		);

--- a/modules/test/playwright/tests/journal-web/pages/JournalEditStructurePage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalEditStructurePage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {JournalStructuresPage} from './JournalStructuresPage';
 
 export enum FIELD_TYPES {
@@ -61,7 +61,7 @@ export class JournalEditStructurePage {
 	async save() {
 		await this.saveButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			`Success:Your request completed successfully.`
 		);

--- a/modules/test/playwright/tests/journal-web/pages/JournalPage.ts
+++ b/modules/test/playwright/tests/journal-web/pages/JournalPage.ts
@@ -8,7 +8,7 @@ import {FrameLocator, Locator, Page, expect} from '@playwright/test';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {expandSection} from '../../../utils/expandSection';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export class JournalPage {
 	readonly page: Page;
@@ -178,7 +178,7 @@ export class JournalPage {
 	async publishArticle() {
 		await this.publishButton.click();
 
-		await waitForSuccessAlert(this.page, `was created successfully.`);
+		await waitForAlert(this.page, `was created successfully.`);
 	}
 
 	async setJournalArticlePermissions(

--- a/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
+++ b/modules/test/playwright/tests/knowledge-base-web/knowledge-base-web.spec.ts
@@ -15,7 +15,7 @@ import {KnowledgeBaseEditArticlePage} from '../../pages/knowledge-base-web/Knowl
 import getLoggedInPage from '../../utils/getLoggedInPage';
 import getRandomString from '../../utils/getRandomString';
 import {performLogout} from '../../utils/performLogin';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {KnowledgeBaseUrls} from './utils/knowledgeBaseUrls';
 
 const test = mergeTests(
@@ -138,10 +138,7 @@ test('can publish and delete an article', async ({
 		title
 	);
 
-	await waitForSuccessAlert(
-		page,
-		`Success:${title} was successfully published.`
-	);
+	await waitForAlert(page, `Success:${title} was successfully published.`);
 
 	await expect(kbArticle).toBeVisible();
 	await expect(page.locator('.workflow-status-approved')).toBeVisible();
@@ -172,10 +169,7 @@ test('can delete all articles (recycle bin enabled)', async ({
 		title
 	);
 
-	await waitForSuccessAlert(
-		page,
-		`Success:${title} was successfully published.`
-	);
+	await waitForAlert(page, `Success:${title} was successfully published.`);
 
 	await knowledgeBasePage.goto(site.friendlyUrlPath);
 	await knowledgeBasePage.deleteAll(true);
@@ -207,7 +201,7 @@ test('can schedule and delete an article', async ({
 		title
 	);
 
-	await waitForSuccessAlert(page, `Success:${title} will be published on`);
+	await waitForAlert(page, `Success:${title} will be published on`);
 
 	await expect(kbArticle).toBeVisible();
 	await expect(page.locator('.workflow-status-scheduled')).toBeVisible();

--- a/modules/test/playwright/tests/layout-admin-web/pageConfiguration.spec.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pageConfiguration.spec.ts
@@ -20,7 +20,7 @@ import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
 import {performLogout} from '../../utils/performLogin';
 import {selectAndExpectToHaveValue} from '../../utils/selectAndExpectToHaveValue';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {pagesPagesTest} from './fixtures/pagesPagesTest';
 
 const test = mergeTests(
@@ -394,7 +394,7 @@ test.describe('SEO configuration', () => {
 
 		await page.locator('.btn-primary').click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 
 		// Assert open graph section is not present
 
@@ -416,7 +416,7 @@ test.describe('SEO configuration', () => {
 
 		await page.locator('.btn-primary').click();
 
-		await waitForSuccessAlert(page);
+		await waitForAlert(page);
 
 		// Assert open graph section is present
 

--- a/modules/test/playwright/tests/layout-admin-web/pages/PageConfigurationPage.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pages/PageConfigurationPage.ts
@@ -8,7 +8,7 @@ import {Locator, Page} from '@playwright/test';
 import {PagesAdminPage} from '../../../pages/layout-admin-web/PagesAdminPage';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../../utils/fillAndClickOutside';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export class PageConfigurationPage {
 	readonly page: Page;
@@ -54,7 +54,7 @@ export class PageConfigurationPage {
 	async save() {
 		await this.saveButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The page was updated successfully.'
 		);

--- a/modules/test/playwright/tests/layout-admin-web/pages/UtilityPageConfigurationPage.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pages/UtilityPageConfigurationPage.ts
@@ -5,7 +5,7 @@
 
 import {Locator, Page} from '@playwright/test';
 
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {UtilityPagesPage} from '../../layout-admin-web/pages/UtilityPagesPage';
 
 export class UtilityPageConfigurationPage {
@@ -43,9 +43,6 @@ export class UtilityPageConfigurationPage {
 
 		await this.saveButton.click();
 
-		await waitForSuccessAlert(
-			this.page,
-			'The page was updated successfully.'
-		);
+		await waitForAlert(this.page, 'The page was updated successfully.');
 	}
 }

--- a/modules/test/playwright/tests/layout-admin-web/pages/UtilityPagesPage.ts
+++ b/modules/test/playwright/tests/layout-admin-web/pages/UtilityPagesPage.ts
@@ -8,7 +8,7 @@ import {Locator, Page, expect} from '@playwright/test';
 import {PageEditorPage} from '../../../pages/layout-content-page-editor-web/PageEditorPage';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export class UtilityPagesPage {
 	readonly page: Page;
@@ -60,7 +60,7 @@ export class UtilityPagesPage {
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The utility page was created successfully.'
 		);
@@ -118,7 +118,7 @@ export class UtilityPagesPage {
 
 		await this.page.getByRole('button', {name: 'Delete'}).click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:You successfully deleted 1 utility page(s).'
 		);
@@ -146,7 +146,7 @@ export class UtilityPagesPage {
 
 		await this.clickOnAction('Make a Copy', name);
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async markAsDefault(name: string) {
@@ -156,7 +156,7 @@ export class UtilityPagesPage {
 
 		await this.clickOnAction('Mark as Default', name);
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async previewPage(name: string) {
@@ -173,7 +173,7 @@ export class UtilityPagesPage {
 		await this.publishButton.waitFor();
 		await this.publishButton.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			this.page,
 			'Success:The utility page was published successfully.'
 		);
@@ -186,7 +186,7 @@ export class UtilityPagesPage {
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async unmarkAsDefault(name: string) {
@@ -196,6 +196,6 @@ export class UtilityPagesPage {
 
 		await this.clickOnAction('Unmark as Default', name);
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/tests/layout-content-page-editor-web/formContainer.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/formContainer.spec.ts
@@ -12,7 +12,7 @@ import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import {pageManagementSiteTest} from '../../fixtures/pageManagementSiteTest';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {
 	LEMON_OBJECT_ERC,
 	POTATO_OBJECT_ERC,
@@ -1317,7 +1317,7 @@ test.describe('Multistep', () => {
 
 			await page.locator('.modal-footer').getByText('Publish').click();
 
-			await waitForSuccessAlert(
+			await waitForAlert(
 				page,
 				'Success:The page was published successfully.'
 			);

--- a/modules/test/playwright/tests/layout-content-page-editor-web/pageContentPanel.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/pageContentPanel.spec.ts
@@ -12,7 +12,7 @@ import {loginTest} from '../../fixtures/loginTest';
 import {pageEditorPagesTest} from '../../fixtures/pageEditorPagesTest';
 import {pageManagementSiteTest} from '../../fixtures/pageManagementSiteTest';
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 import {ANIMALS_COLLECTION_NAME} from '../setup/page-management-site/constants';
 import getCollectionDefinition from './utils/getCollectionDefinition';
@@ -161,7 +161,7 @@ test(
 			.getByRole('button', {exact: true, name: 'Save'})
 			.click();
 
-		await waitForSuccessAlert(permissionsFrame);
+		await waitForAlert(permissionsFrame);
 
 		await expect(guestActionViewCheckBox).not.toBeChecked();
 	}

--- a/modules/test/playwright/tests/layout-page-template-admin-web/displayPagesAdmin.spec.ts
+++ b/modules/test/playwright/tests/layout-page-template-admin-web/displayPagesAdmin.spec.ts
@@ -17,7 +17,7 @@ import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import {performLogout} from '../../utils/performLogin';
 import getBasicWebContentStructureId from '../../utils/structured-content/getBasicWebContentStructureId';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {blogsPagesTest} from '../blogs-web/fixtures/blogsPagesTest';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 import {JournalEditArticlePage} from '../journal-web/pages/JournalEditArticlePage';
@@ -70,7 +70,7 @@ async function addBasicJournalArticleWithSpecificDisplayPageTemplate(
 
 	await page.getByRole('button', {name: 'Publish'}).click();
 
-	await waitForSuccessAlert(
+	await waitForAlert(
 		page,
 		`Success:${journalArticleTitle} was updated successfully.`
 	);

--- a/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithWebContent.spec.ts
+++ b/modules/test/playwright/tests/layout-set-prototype-web/siteTemplatesWithWebContent.spec.ts
@@ -29,7 +29,7 @@ import {ProductMenuPage} from '../../pages/product-navigation-control-menu-web/P
 import {UIElementsPage} from '../../pages/uielements/UIElementsPage';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {journalPagesTest} from '../journal-web/fixtures/journalPagesTest';
 import {JournalPage} from '../journal-web/pages/JournalPage';
 import {pagesPagesTest} from '../layout-admin-web/fixtures/pagesPagesTest';
@@ -611,7 +611,7 @@ async function createSiteTemplateWithContentPageAndAssetPublisher({
 	if (!(await configurationManualInput.isChecked())) {
 		await configurationManualInput.click();
 
-		await waitForSuccessAlert(
+		await waitForAlert(
 			configurationModal,
 			'Success:You have successfully updated the setup.'
 		);
@@ -633,7 +633,7 @@ async function createSiteTemplateWithContentPageAndAssetPublisher({
 	});
 	await globalOption.click();
 
-	await waitForSuccessAlert(
+	await waitForAlert(
 		configurationModal,
 		'Success:You have successfully updated the setup.'
 	);
@@ -643,7 +643,7 @@ async function createSiteTemplateWithContentPageAndAssetPublisher({
 		.getByLabel('Delete');
 	await currentSiteDeleteButton.click();
 
-	await waitForSuccessAlert(
+	await waitForAlert(
 		configurationModal,
 		'Success:You have successfully updated the setup.'
 	);
@@ -684,14 +684,14 @@ async function createSiteTemplateWithContentPageAndAssetPublisher({
 	const addButton = configurationModal.getByRole('button', {name: 'Add'});
 	await addButton.click();
 
-	await waitForSuccessAlert(
+	await waitForAlert(
 		configurationModal,
 		'Success:You have successfully updated the setup.'
 	);
 
 	await configurationModal.getByRole('button', {name: 'Save'}).click();
 
-	await waitForSuccessAlert(
+	await waitForAlert(
 		configurationModal,
 		'Success:You have successfully updated the setup.'
 	);

--- a/modules/test/playwright/tests/object-web/objectActions.spec.ts
+++ b/modules/test/playwright/tests/object-web/objectActions.spec.ts
@@ -11,7 +11,7 @@ import {editObjectDefinitionPagesTest} from '../../fixtures/editObjectDefinition
 import {loginTest} from '../../fixtures/loginTest';
 import {objectPagesTest} from '../../fixtures/objectPagesTest';
 import {getRandomInt} from '../../utils/getRandomInt';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {mockedObjectFields} from './dependencies/objectMockedFields';
 
 export const test = mergeTests(
@@ -282,7 +282,7 @@ test('can send notification email via download action', async ({
 
 	await viewObjectEntriesPage.saveObjectEntryButton.click();
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	// Download attachment from object entry
 

--- a/modules/test/playwright/tests/osb-faro-web/segment.spec.ts
+++ b/modules/test/playwright/tests/osb-faro-web/segment.spec.ts
@@ -14,7 +14,7 @@ import {loginTest} from '../../fixtures/loginTest';
 import {liferayConfig} from '../../liferay.config';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout, userData} from '../../utils/performLogin';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {syncAnalyticsCloud} from '../analytics-settings-web/utils/analytics-settings';
 import {createChannel, switchChannel} from './utils/channel';
 import {
@@ -1435,7 +1435,7 @@ test(
 			);
 			await defaultUserAssociationsPage.saveButton.click();
 
-			await waitForSuccessAlert(page);
+			await waitForAlert(page);
 		});
 
 		const user = await apiHelpers.headlessAdminUser.postUserAccount();

--- a/modules/test/playwright/tests/portal-default-permissions-web/defaultPermissionsConfiguration.spec.ts
+++ b/modules/test/playwright/tests/portal-default-permissions-web/defaultPermissionsConfiguration.spec.ts
@@ -10,7 +10,7 @@ import {featureFlagsTest} from '../../fixtures/featureFlagsTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {portalDefaultPermissionsPagesTest} from '../../fixtures/portalDefaultPermissionsPagesTest';
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	dataApiHelpersTest,
@@ -53,7 +53,7 @@ const setupInstanceDefaultPermissions = async ({
 		state: 'detached',
 	});
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 };
 
 const setupSiteDefaultPermissions = async ({
@@ -86,7 +86,7 @@ const setupSiteDefaultPermissions = async ({
 		state: 'detached',
 	});
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 };
 
 test('LPD-21645 Set up the default permissions for pages', async ({
@@ -125,7 +125,7 @@ test('LPD-21645 Set up the default permissions for pages', async ({
 		state: 'detached',
 	});
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 });
 
 test('LPD-22038 Set up the default site permissions for pages', async ({
@@ -171,7 +171,7 @@ test('LPD-22038 Set up the default site permissions for pages', async ({
 		state: 'detached',
 	});
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	const dialogPromise = page.waitForEvent('dialog').then(async (dialog) => {
 		await dialog.accept();
@@ -184,7 +184,7 @@ test('LPD-22038 Set up the default site permissions for pages', async ({
 
 	await dialogPromise;
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	await defaultPermissionsSiteConfigurationPage.actionsPageButton.click();
 	await defaultPermissionsSiteConfigurationPage.editPageButton.click();

--- a/modules/test/playwright/tests/saml-web/saml.spec.ts
+++ b/modules/test/playwright/tests/saml-web/saml.spec.ts
@@ -31,7 +31,7 @@ import {getRandomInt} from '../../utils/getRandomInt';
 import getRandomString from '../../utils/getRandomString';
 import performLogin, {performLogout} from '../../utils/performLogin';
 import {reloadUntilVisible} from '../../utils/reloadUntilVisible';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 import {
 	TIdentityProvider,
 	configureIdentityProvider,
@@ -1320,7 +1320,7 @@ test('Verify SSO login and logout mechanism works the same when having multiple 
 
 	await siteSettingsPage.page.getByRole('button', {name: 'Save'}).click();
 
-	await waitForSuccessAlert(siteSettingsPage.page);
+	await waitForAlert(siteSettingsPage.page);
 
 	await secondarySpAdminPage.goto(`/web/${site2Name}`);
 
@@ -1338,7 +1338,7 @@ test('Verify SSO login and logout mechanism works the same when having multiple 
 
 	await siteSettingsPage.page.getByRole('button', {name: 'Save'}).click();
 
-	await waitForSuccessAlert(siteSettingsPage.page);
+	await waitForAlert(siteSettingsPage.page);
 
 	// Create users for both IdP virtual instances
 
@@ -1606,7 +1606,7 @@ test('Verify the SAML configuration is not applied to the sites when ACS is disa
 
 	await siteSettingsPage.page.getByRole('button', {name: 'Save'}).click();
 
-	await waitForSuccessAlert(siteSettingsPage.page);
+	await waitForAlert(siteSettingsPage.page);
 
 	// Create IdP user
 

--- a/modules/test/playwright/tests/saml-web/utils/samlVirtualInstanceUtil.ts
+++ b/modules/test/playwright/tests/saml-web/utils/samlVirtualInstanceUtil.ts
@@ -15,7 +15,7 @@ import {SamlAdminPage} from '../../../pages/saml-web/SamlAdminPage';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {getRandomInt} from '../../../utils/getRandomInt';
 import performLogin, {userData} from '../../../utils/performLogin';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 import {
 	deleteAfterTestProviderConnections,
 	deleteAfterTestVirtualInstances,
@@ -194,7 +194,7 @@ export async function resetSamlConfiguration(page: Page) {
 			}),
 		});
 
-		await waitForSuccessAlert(systemSettingsPage.page);
+		await waitForAlert(systemSettingsPage.page);
 	}
 }
 
@@ -214,7 +214,7 @@ export async function resetSamlKeystoreManagerTarget(page: Page) {
 		trigger: systemSettingsPage.page.getByRole('button', {name: 'Actions'}),
 	});
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 }
 
 export async function setupSamlInstances(
@@ -283,7 +283,7 @@ export async function updateRuntimeMetadataRefreshInterval(
 
 	await updateButton.click();
 
-	await waitForSuccessAlert(systemSettingsPage.page);
+	await waitForAlert(systemSettingsPage.page);
 }
 
 export async function updateSamlKeystoreManagerTarget(
@@ -313,5 +313,5 @@ export async function updateSamlKeystoreManagerTarget(
 
 	await updateButton.click();
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 }

--- a/modules/test/playwright/tests/site-navigation-admin-web/pages/NavigationMenusPage.ts
+++ b/modules/test/playwright/tests/site-navigation-admin-web/pages/NavigationMenusPage.ts
@@ -7,7 +7,7 @@ import {Locator, Page} from '@playwright/test';
 
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export class NavigationMenusPage {
 	readonly page: Page;
@@ -39,7 +39,7 @@ export class NavigationMenusPage {
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async openAddPageModal() {

--- a/modules/test/playwright/tests/site-navigation-language-web/languageWidget.spec.ts
+++ b/modules/test/playwright/tests/site-navigation-language-web/languageWidget.spec.ts
@@ -13,7 +13,7 @@ import {WidgetPagePage} from '../../pages/layout-admin-web/WidgetPagePage';
 import {clickAndExpectToBeVisible} from '../../utils/clickAndExpectToBeVisible';
 import {expandSection} from '../../utils/expandSection';
 import getRandomString from '../../utils/getRandomString';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 const test = mergeTests(
 	apiHelpersTest,
@@ -157,7 +157,7 @@ test('The user can choose which languages will be available to site via language
 
 	await configurationIFrame.getByRole('button', {name: 'Save'}).click();
 
-	await waitForSuccessAlert(
+	await waitForAlert(
 		configurationIFrame,
 		'Success:You have successfully updated the setup.'
 	);

--- a/modules/test/playwright/tests/staging-configuration-web/pages/StagingConfigurationPage.ts
+++ b/modules/test/playwright/tests/staging-configuration-web/pages/StagingConfigurationPage.ts
@@ -6,7 +6,7 @@
 import {Locator, Page} from '@playwright/test';
 
 import {PORTLET_URLS} from '../../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export class StagingConfigurationPage {
 	readonly page: Page;
@@ -41,10 +41,7 @@ export class StagingConfigurationPage {
 
 		await this.saveButton.click();
 
-		await waitForSuccessAlert(
-			this.page,
-			`Local staging is successfully enabled.`
-		);
+		await waitForAlert(this.page, `Local staging is successfully enabled.`);
 
 		const succesfull = this.page.getByText('Successful');
 

--- a/modules/test/playwright/tests/template-web/pages/TemplatesPage.ts
+++ b/modules/test/playwright/tests/template-web/pages/TemplatesPage.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import {clickAndExpectToBeVisible} from '../../../utils/clickAndExpectToBeVisible';
 import fillAndClickOutside from '../../../utils/fillAndClickOutside';
 import {PORTLET_URLS} from '../../../utils/portletUrls';
-import {waitForSuccessAlert} from '../../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../../utils/waitForAlert';
 
 export class TemplatesPage {
 	readonly page: Page;
@@ -50,7 +50,7 @@ export class TemplatesPage {
 
 		await this.page.getByRole('button', {name: 'Copy'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async createInformationTemplate({
@@ -76,7 +76,7 @@ export class TemplatesPage {
 
 		await this.page.getByRole('button', {name: 'Save'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async deleteInformationTemplate(title: string) {
@@ -84,7 +84,7 @@ export class TemplatesPage {
 
 		await this.page.getByRole('button', {name: 'Delete'}).click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 
 	async editInformationTemplate(name: string) {
@@ -110,7 +110,7 @@ export class TemplatesPage {
 			path.join(dirname, '/dependencies/' + fileName)
 		);
 
-		await waitForSuccessAlert(this.page, `Success:${fileName} Imported`);
+		await waitForAlert(this.page, `Success:${fileName} Imported`);
 	}
 
 	async saveInformationTemplate() {
@@ -118,6 +118,6 @@ export class TemplatesPage {
 			.getByRole('button', {exact: true, name: 'Save'})
 			.click();
 
-		await waitForSuccessAlert(this.page);
+		await waitForAlert(this.page);
 	}
 }

--- a/modules/test/playwright/tests/users-admin-web/defaultUserAssociations.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/defaultUserAssociations.spec.ts
@@ -9,7 +9,7 @@ import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
 import {instanceSettingsPagesTest} from '../../fixtures/instanceSettingsPagesTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {usersAndOrganizationsPagesTest} from '../../fixtures/usersAndOrganizationsPagesTest';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	dataApiHelpersTest,
@@ -36,7 +36,7 @@ test('LPD-30006 Configure default userGroup associations', async ({
 	await defaultUserAssociationsPage.userGroupsInput.fill(userGroup.name);
 	await defaultUserAssociationsPage.saveButton.click();
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	const user = await apiHelpers.headlessAdminUser.postUserAccount();
 

--- a/modules/test/playwright/tests/users-admin-web/usersAndOrganizations.spec.ts
+++ b/modules/test/playwright/tests/users-admin-web/usersAndOrganizations.spec.ts
@@ -10,7 +10,7 @@ import {dataApiHelpersTest} from '../../fixtures/dataApiHelpersTest';
 import {loginTest} from '../../fixtures/loginTest';
 import {usersAndOrganizationsPagesTest} from '../../fixtures/usersAndOrganizationsPagesTest';
 import {getRandomInt} from '../../utils/getRandomInt';
-import {waitForSuccessAlert} from '../../utils/waitForSuccessAlert';
+import {waitForAlert} from '../../utils/waitForAlert';
 
 export const test = mergeTests(
 	apiHelpersTest,
@@ -179,7 +179,7 @@ test('LPD-30589 Add Organization Team', async ({
 	await siteConfigurationDetailsPage.allowManualMembershipManagementToggle.check();
 	await siteConfigurationDetailsPage.saveButton.click();
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	await teamsPage.goTo('/' + organization.name);
 
@@ -189,7 +189,7 @@ test('LPD-30589 Add Organization Team', async ({
 	await teamsPage.nameInput.fill(newTeamName);
 	await teamsPage.saveButton.click();
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	await expect(
 		(await teamsPage.teamsTableRow(1, newTeamName, true)).row
@@ -219,7 +219,7 @@ test('LPD-31669 Check whether admin user is redirected to organization page afte
 	await (await assignUsersPage.usersTableRowCheckbox(userName)).check();
 	await assignUsersPage.doneButton.click();
 
-	await waitForSuccessAlert(page);
+	await waitForAlert(page);
 
 	await expect(
 		await organizationUsersPage.usersTableRowLink(userName)

--- a/modules/test/playwright/utils/waitForAlert.ts
+++ b/modules/test/playwright/utils/waitForAlert.ts
@@ -4,12 +4,25 @@ import {FrameLocator, Page} from '@playwright/test';
  * SPDX-FileCopyrightText: (c) 2000 Liferay, Inc. https://liferay.com
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
-export async function waitForSuccessAlert(
-	page: Page | FrameLocator,
+
+interface waitForAlert {
+	autoClose?: boolean;
+	displayType?:
+		| '.alert-success'
+		| '.alert-info'
+		| '.alert-warning'
+		| '.alert-danger';
+	page: Page | FrameLocator;
+	text?: string;
+}
+
+export async function waitForAlert({
+	autoClose = true,
+	displayType = '.alert-success',
+	page,
 	text = 'Success:Your request completed successfully.',
-	{autoClose} = {autoClose: true}
-) {
-	const alert = page.locator('.alert-success', {
+}: waitForAlert) {
+	const alert = page.locator(displayType, {
 		hasText: text,
 	});
 

--- a/modules/test/playwright/utils/waitForAlert.ts
+++ b/modules/test/playwright/utils/waitForAlert.ts
@@ -5,24 +5,27 @@ import {FrameLocator, Page} from '@playwright/test';
  * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
  */
 
-interface waitForAlert {
+type Options = {
 	autoClose?: boolean;
-	displayType?:
-		| '.alert-success'
-		| '.alert-info'
-		| '.alert-warning'
-		| '.alert-danger';
-	page: Page | FrameLocator;
-	text?: string;
-}
+	type?: 'success' | 'info' | 'warning' | 'danger';
+};
 
-export async function waitForAlert({
-	autoClose = true,
-	displayType = '.alert-success',
-	page,
+const CSS_CLASSES = {
+	danger: '.alert-danger',
+	info: '.alert-info',
+	success: '.alert-success',
+	warning: '.alert-warning',
+};
+
+export async function waitForAlert(
+	parent: Page | FrameLocator,
 	text = 'Success:Your request completed successfully.',
-}: waitForAlert) {
-	const alert = page.locator(displayType, {
+	{autoClose = true, type = 'success'}: Options = {
+		autoClose: true,
+		type: 'success',
+	}
+) {
+	const alert = parent.locator(CSS_CLASSES[type], {
 		hasText: text,
 	});
 


### PR DESCRIPTION
Hey @igor-franca, as I said in the previous PR, I'm suggesting a change so we keep the previous api we had in the function, with the params like `(page, text, options)`. I just moved the new `type` prop inside the `options`, and I also renamed `page` to `parent` because it can also be a `FrameLocator`. 

This way, the previous calls continue working the same way, and we only have to rename the function on the usages.

I also typed the `type` as `'success' | 'info' | 'warning' | 'danger'` so it's easier to use, and then inside the function I map it to the CSS class.

Could you tell me what you think?

Anyway, when sending this PR I think we should put a message in the Playwright channel letting the people know it, because as you said, it could cause conflicts.