### PR TITLE
LPD-37803 Add test to check that only the parent item is selected when pasting

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/LayoutBreadcrumbs.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/LayoutBreadcrumbs.js
@@ -191,10 +191,6 @@ function useEllipsisBuffer(breacrumbItems, containerRef) {
 	const [ellipsisBuffer, setEllipsisBuffer] = useState(0);
 
 	useEffect(() => {
-		setEllipsisBuffer(0);
-	}, [breacrumbItems]);
-
-	useEffect(() => {
 		const containerElement = containerRef.current;
 
 		if (ellipsisBuffer !== 0) {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/MultiSelectManager.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/MultiSelectManager.js
@@ -6,6 +6,8 @@
 import {useEffect, useRef} from 'react';
 
 import {
+	ARROW_DOWN_KEY_CODE,
+	ARROW_UP_KEY_CODE,
 	CONTROL_KEY_CODE,
 	ENTER_KEY_CODE,
 	ESCAPE_KEY_CODE,
@@ -35,8 +37,9 @@ export default function MultiSelectManager() {
 				activateMultiSelect(MULTI_SELECT_TYPES.range);
 			},
 			disableKeyCombination: (event) => event.key === SHIFT_KEY_CODE,
-			keyCombination: (event) => event.shiftKey,
-			keyboardActivation: () => true,
+			keyCombination: (event) => event.shiftKey && !isCtrlOrMeta(event),
+			keyboardActivation: (event) =>
+				[ARROW_DOWN_KEY_CODE, ARROW_UP_KEY_CODE].includes(event.key),
 		},
 		simpleMultiSelect: {
 			action: () => {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/TopperItemActions.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/components/topper/TopperItemActions.js
@@ -231,6 +231,7 @@ export default function TopperItemActions({disabled, item}) {
 		<>
 			<ClayDropDown
 				alignmentPosition={Align.BottomRight}
+				closeOnClick
 				hasLeftSymbols
 				menuElementAttrs={{
 					containerProps: {

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/pasteItem.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/thunks/pasteItem.js
@@ -50,9 +50,12 @@ export default function pasteItem({
 						})
 					);
 
-					selectItems(itemIds, {
-						origin: ITEM_ACTIVATION_ORIGINS.itemActions,
-					});
+					selectItems(
+						filterSelectedItems(itemIds, nextLayoutData.items),
+						{
+							origin: ITEM_ACTIVATION_ORIGINS.itemActions,
+						}
+					);
 				}
 			}
 		);

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/canBeCopied.js
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/resources/META-INF/resources/page_editor/app/utils/canBeCopied.js
@@ -56,9 +56,7 @@ export default function canBeCopied(
 		fragmentEntryLinks
 	);
 	if (!isChildAllowed || isUnmappedCollection(target)) {
-		let error = Liferay.Language.get(
-			'element-can-not-be-copied-please-try-again'
-		);
+		let error = Liferay.Language.get('element-cannot-be-copied');
 
 		const isForm = (item) => item.type === LAYOUT_DATA_ITEM_TYPES.form;
 

--- a/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/MultiSelectManager.test.js
+++ b/modules/apps/layout/layout-content-page-editor-web/test/page_editor/app/components/MultiSelectManager.test.js
@@ -136,6 +136,7 @@ describe('MultiSelectManager', () => {
 			document.body.dispatchEvent(
 				new KeyboardEvent('keydown', {
 					ctrlKey: false,
+					key: 'ArrowUp',
 					shiftKey: true,
 				})
 			);

--- a/modules/test/playwright/tests/layout-content-page-editor-web/grid.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/grid.spec.ts
@@ -305,9 +305,15 @@ test('Can cut and paste a grid inside a container', async ({
 
 	// Create a container with a grid inside
 
+	const headingDefinition = getFragmentDefinition({
+		id: getRandomString(),
+		key: 'BASIC_COMPONENT-heading',
+	});
+
 	const gridId = getRandomString();
 
 	const gridDefinition = getGridDefinition({
+		columns: [{pageElements: [headingDefinition], size: 12}],
 		id: gridId,
 	});
 
@@ -328,7 +334,7 @@ test('Can cut and paste a grid inside a container', async ({
 
 	await pageEditorPage.goto(layout, pageManagementSite.friendlyUrlPath);
 
-	// Cut grid and check if on paste is added properly inside the container
+	// Cut grid and check that it has been pasted inside the container
 
 	const grid = page.locator('[data-name="Grid"]');
 
@@ -343,4 +349,12 @@ test('Can cut and paste a grid inside a container', async ({
 	await expect(
 		page.locator('[data-name="Container"]').locator('.page-editor__row')
 	).toBeVisible();
+
+	// Only the parent item (Grid) is activated
+
+	const pastedGridId = await pageEditorPage.getFragmentId('Grid');
+	const pastedHeadingId = await pageEditorPage.getFragmentId('Heading');
+
+	expect(await pageEditorPage.isActive(pastedGridId)).toBe(true);
+	expect(await pageEditorPage.isActive(pastedHeadingId)).toBe(false);
 });


### PR DESCRIPTION
### What to check?
- Close the topper actions dropdown when an action is selected-
- Show the breadcrumb when a grid with content inside is copied and then, an item from the previously copied grid is selected.
- When a grid with elements inside is pasted only the parent (grid) is selected when pasting.
- Prevent when a fragment is selected and press shift the configuration panel is reloaded.