### PR TITLE
LPD-38268 Configuration should only always be translated in the user language

### DIFF
--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/CopyItemsMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/CopyItemsMVCActionCommandTest.java
@@ -445,6 +445,7 @@ public class CopyItemsMVCActionCommandTest {
 		themeDisplay.setCompany(_company);
 		themeDisplay.setLayout(_layout);
 		themeDisplay.setLayoutSet(_layout.getLayoutSet());
+		themeDisplay.setLocale(LocaleUtil.US);
 		themeDisplay.setPermissionChecker(
 			PermissionThreadLocal.getPermissionChecker());
 		themeDisplay.setPlid(_layout.getPlid());

--- a/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DuplicateItemMVCActionCommandTest.java
+++ b/modules/apps/layout/layout-content-page-editor-web-test/src/testIntegration/java/com/liferay/layout/content/page/editor/web/internal/portlet/action/test/DuplicateItemMVCActionCommandTest.java
@@ -439,6 +439,7 @@ public class DuplicateItemMVCActionCommandTest {
 		themeDisplay.setCompany(_company);
 		themeDisplay.setLayout(_layout);
 		themeDisplay.setLayoutSet(_layout.getLayoutSet());
+		themeDisplay.setLocale(LocaleUtil.US);
 		themeDisplay.setPermissionChecker(
 			PermissionThreadLocal.getPermissionChecker());
 		themeDisplay.setPlid(_layout.getPlid());

--- a/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentEntryLinkManager.java
+++ b/modules/apps/layout/layout-content-page-editor-web/src/main/java/com/liferay/layout/content/page/editor/web/internal/manager/FragmentEntryLinkManager.java
@@ -210,6 +210,8 @@ public class FragmentEntryLinkManager {
 				);
 			}
 
+			defaultFragmentRendererContext.setLocale(themeDisplay.getLocale());
+
 			String configuration = _fragmentRendererController.getConfiguration(
 				defaultFragmentRendererContext);
 

--- a/modules/test/playwright/tests/layout-content-page-editor-web/formContainer.spec.ts
+++ b/modules/test/playwright/tests/layout-content-page-editor-web/formContainer.spec.ts
@@ -1472,7 +1472,7 @@ test.describe('Edit mode language changes', () => {
 		});
 
 		await pageEditorPage.changeFragmentConfiguration({
-			fieldLabel: 'Marcador de posición',
+			fieldLabel: 'Placeholder',
 			fragmentId,
 			tab: 'General',
 			value: 'Spanish Placeholder',


### PR DESCRIPTION
There is already a test that covers this. This is how this got discovered