### PR TITLE
LPD-38816 Redirect explicitly to the home URL

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/LayoutAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LayoutAction.java
@@ -135,8 +135,7 @@ public class LayoutAction implements Action {
 				httpServletResponse.sendRedirect(authLoginURL);
 			}
 			else {
-				String redirect = PortalUtil.getLayoutURL(
-					themeDisplay.getLayout(), themeDisplay);
+				String redirect = themeDisplay.getURLHome();
 
 				if (_log.isDebugEnabled()) {
 					_log.debug("Redirect default layout to " + redirect);


### PR DESCRIPTION
Hi Team,
I'm sending the fix for https://liferay.atlassian.net/browse/LPD-38816 as per https://github.com/liferay-appsec/liferay-portal/pull/1995#issuecomment-2404380029
The full discussion about who is the owner of this component can be found here: https://liferay.atlassian.net/browse/LPP-55587

I'm sending this PR for review and also test writing.

Issue:
While logged in, you're redirected to the company default home URL, even when there's an explicitly set home URL, when you click for a second time on the password reset URL which is in the email to newly created users.

Solution:
Redirect explicitly to the home URL.

Please review it, thank you!